### PR TITLE
Update CTAs to app and docs links

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,9 +397,9 @@
 <nav>
   <a href="#" class="nav-logo">Open Sandbox</a>
   <div class="nav-links">
-    <a href="#">Docs</a>
-    <a href="#">GitHub</a>
-    <a href="#" class="nav-btn">Get started</a>
+    <a href="https://docs.opensandbox.ai">Docs</a>
+    <a href="https://github.com/diggerhq/opensandbox">GitHub</a>
+    <a href="https://app.opensandbox.ai" class="nav-btn">Try now</a>
   </div>
 </nav>
 
@@ -408,11 +408,8 @@
   <h1>Serverless sandbox that <em>never</em> times out</h1>
   <p class="hero-sub">Self-hostable execution environments with built-in hibernation, secret management, and local-first development.</p>
   <div class="hero-actions">
-    <a href="#" class="btn btn-dark">
-      <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-      Star on GitHub
-    </a>
-    <a href="#" class="btn btn-outline">Read the docs</a>
+    <a href="https://app.opensandbox.ai" class="btn btn-dark">Try now</a>
+    <a href="https://docs.opensandbox.ai" class="btn btn-outline">Documentation</a>
   </div>
 </section>
 
@@ -473,12 +470,12 @@
   <p>One command to run your own sandbox.</p>
   <div class="cta-code"><span>$</span> docker run -d ghcr.io/opensandbox/sandbox</div>
   <div>
-    <a href="#" class="btn btn-dark">View on GitHub</a>
+    <a href="https://app.opensandbox.ai" class="btn btn-dark">Try now</a>
   </div>
 </section>
 
 <footer>
-  <p>MIT License &middot; <a href="#">GitHub</a> &middot; <a href="#">Documentation</a></p>
+  <p>MIT License &middot; <a href="https://github.com/diggerhq/opensandbox">GitHub</a> &middot; <a href="https://docs.opensandbox.ai">Documentation</a></p>
 </footer>
 
 </body>


### PR DESCRIPTION
## Summary
- Primary CTA changed from "Star on GitHub" to "Try now" → https://app.opensandbox.ai
- Secondary CTA changed from "Read the docs" to "Documentation" → https://docs.opensandbox.ai
- Updated nav, hero, bottom CTA, and footer links

## Test plan
- [ ] Verify all links point to correct destinations
- [ ] Check nav, hero, CTA section, and footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)