### PR TITLE
Fix Python SDK docs: replace invalid async with Sandbox.create() usage

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -58,9 +58,10 @@ await sandbox.kill();
 ```python Python
 from opensandbox import Sandbox
 
-async with Sandbox.create(template='base') as sandbox:
-    result = await sandbox.commands.run('echo "Hello from OpenSandbox!"')
-    print(result.stdout)  # Hello from OpenSandbox!
+sandbox = await Sandbox.create(template='base')
+result = await sandbox.commands.run('echo "Hello from OpenSandbox!"')
+print(result.stdout)  # Hello from OpenSandbox!
+await sandbox.kill()
 ```
 
 </CodeGroup>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -115,10 +115,13 @@ await sandbox.kill();
 ```python Python
 await sandbox.kill()
 
-# Or use the context manager for automatic cleanup:
-async with Sandbox.create() as sandbox:
-    # sandbox is automatically killed when the block exits
+# Or use try/finally for automatic cleanup:
+sandbox = await Sandbox.create()
+try:
     result = await sandbox.commands.run('whoami')
+finally:
+    await sandbox.kill()
+    await sandbox.close()
 ```
 
 </CodeGroup>

--- a/docs/sdks/python/overview.mdx
+++ b/docs/sdks/python/overview.mdx
@@ -32,21 +32,25 @@ import asyncio
 from opensandbox import Sandbox
 
 async def main():
-    async with Sandbox.create(template='base') as sandbox:
-        # Run a command
-        result = await sandbox.commands.run('python3 --version')
-        print(result.stdout)
+    sandbox = await Sandbox.create(template='base')
 
-        # Work with files
-        await sandbox.files.write('/app/main.py', 'print("hello")')
-        output = await sandbox.commands.run('python3 /app/main.py')
-        print(output.stdout)  # hello
+    # Run a command
+    result = await sandbox.commands.run('python3 --version')
+    print(result.stdout)
+
+    # Work with files
+    await sandbox.files.write('/app/main.py', 'print("hello")')
+    output = await sandbox.commands.run('python3 /app/main.py')
+    print(output.stdout)  # hello
+
+    await sandbox.kill()
+    await sandbox.close()
 
 asyncio.run(main())
 ```
 
 <Note>
-  All SDK operations are async. Use `async with` for automatic cleanup, or call `await sandbox.kill()` manually.
+  All SDK operations are async. Call `await sandbox.kill()` to stop the sandbox and `await sandbox.close()` to clean up the HTTP client.
 </Note>
 
 ## Exports

--- a/docs/sdks/python/sandbox.mdx
+++ b/docs/sdks/python/sandbox.mdx
@@ -43,15 +43,13 @@ Creates a new sandbox and returns a connected `Sandbox` instance.
 
 **Returns:** `Sandbox`
 
-## Async Context Manager
-
-The recommended way to use sandboxes in Python — the sandbox is automatically killed when the block exits:
+## Usage
 
 ```python
-async with Sandbox.create(template='base') as sandbox:
-    result = await sandbox.commands.run('echo "hello"')
-    print(result.stdout)
-# sandbox is automatically killed here
+sandbox = await Sandbox.create(template='base')
+result = await sandbox.commands.run('echo "hello"')
+print(result.stdout)
+await sandbox.kill()
 ```
 
 ## Connecting to an Existing Sandbox

--- a/docs/sdks/python/templates.mdx
+++ b/docs/sdks/python/templates.mdx
@@ -99,9 +99,10 @@ Deletes a template by name.
 Once built, pass the template name when creating a sandbox:
 
 ```python
-async with Sandbox.create(template='python-ml') as sandbox:
-    result = await sandbox.commands.run(
-        'python3 -c "import numpy; print(numpy.__version__)"'
-    )
-    print(result.stdout)  # 1.24.0
+sandbox = await Sandbox.create(template='python-ml')
+result = await sandbox.commands.run(
+    'python3 -c "import numpy; print(numpy.__version__)"'
+)
+print(result.stdout)  # 1.24.0
+await sandbox.kill()
 ```


### PR DESCRIPTION
## Summary
- `Sandbox.create()` is an async classmethod returning a coroutine, not an async context manager
- All Python docs examples incorrectly used `async with Sandbox.create(...)` which raises `TypeError` at runtime
- Replaced with the correct `sandbox = await Sandbox.create(...)` pattern with explicit `kill()`/`close()` cleanup

**Files changed:** `docs/introduction.mdx`, `docs/quickstart.mdx`, `docs/sdks/python/overview.mdx`, `docs/sdks/python/sandbox.mdx`, `docs/sdks/python/templates.mdx`

## Test plan
- [ ] Verify the example from `introduction.mdx` runs without error
- [ ] Verify the quickstart cleanup example works
- [ ] Review all changed snippets for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)