### PR TITLE
Add default template image with Python 3, Node.js 20, and build tools

### DIFF
--- a/deploy/firecracker/rootfs/Dockerfile.default
+++ b/deploy/firecracker/rootfs/Dockerfile.default
@@ -1,0 +1,86 @@
+# Default rootfs for OpenSandbox Firecracker VMs
+# Includes Python 3, Node.js 20 LTS, build tools, and common utilities.
+# Build: scripts/build-rootfs.sh default
+FROM ubuntu:22.04
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ── System packages ──────────────────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Shell & core
+    bash \
+    busybox \
+    ca-certificates \
+    locales \
+    sudo \
+    # Editors
+    nano \
+    vim-tiny \
+    # Networking
+    curl \
+    wget \
+    openssh-client \
+    iproute2 \
+    iputils-ping \
+    net-tools \
+    dnsutils \
+    # Version control
+    git \
+    git-lfs \
+    # Archive / compression
+    tar \
+    gzip \
+    bzip2 \
+    xz-utils \
+    zip \
+    unzip \
+    # Build tools
+    build-essential \
+    pkg-config \
+    cmake \
+    # Common C headers needed by pip/npm native modules
+    libssl-dev \
+    libffi-dev \
+    zlib1g-dev \
+    # JSON / text
+    jq \
+    less \
+    # Process tools
+    procps \
+    # Database
+    sqlite3 \
+    libsqlite3-dev \
+    # Python 3
+    python3 \
+    python3-pip \
+    python3-venv \
+    python3-dev \
+    # Misc useful
+    file \
+    strace \
+    htop \
+    tree \
+    rsync \
+    man-db \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Python setup ─────────────────────────────────────────────────────────────
+RUN ln -sf /usr/bin/python3 /usr/bin/python \
+    && pip3 install --no-cache-dir --upgrade \
+       pip setuptools wheel
+
+# ── Node.js 20 LTS ──────────────────────────────────────────────────────────
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g npm@latest
+
+# ── Locale ───────────────────────────────────────────────────────────────────
+RUN locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
+# ── Workspace ────────────────────────────────────────────────────────────────
+RUN mkdir -p /workspace
+WORKDIR /workspace

--- a/internal/db/migrations/008_default_template.up.sql
+++ b/internal/db/migrations/008_default_template.up.sql
@@ -1,0 +1,10 @@
+-- Add "default" as the primary public template (Python 3 + Node.js 20 + build tools).
+-- The old "base" template remains for backward compatibility but new sandboxes use "default".
+INSERT INTO templates (org_id, name, tag, image_ref, is_public) VALUES
+    (NULL, 'default', 'latest', 'opensandbox/default:latest', true)
+ON CONFLICT DO NOTHING;
+
+-- Also seed "ubuntu" as the bare-bones option (was previously only available as "base")
+INSERT INTO templates (org_id, name, tag, image_ref, is_public) VALUES
+    (NULL, 'ubuntu', 'latest', 'docker.io/library/ubuntu:22.04', true)
+ON CONFLICT DO NOTHING;

--- a/scripts/build-rootfs.sh
+++ b/scripts/build-rootfs.sh
@@ -2,7 +2,7 @@
 # build-rootfs.sh — Build ext4 rootfs images for Firecracker VMs
 #
 # Usage:
-#   ./scripts/build-rootfs.sh [ubuntu|python|node|all]
+#   ./scripts/build-rootfs.sh [default|ubuntu|python|node|all]
 #   IMAGES_DIR=/data/firecracker/images ./scripts/build-rootfs.sh all
 #
 # Requirements:
@@ -245,16 +245,17 @@ main() {
     for target in "${targets[@]}"; do
         case "$target" in
             all)
+                build_image default
                 build_image ubuntu
                 build_image python
                 build_image node
                 ;;
-            ubuntu|python|node)
+            default|ubuntu|python|node)
                 build_image "$target"
                 ;;
             *)
                 err "Unknown target: $target"
-                echo "Usage: $0 [ubuntu|python|node|all]"
+                echo "Usage: $0 [default|ubuntu|python|node|all]"
                 exit 1
                 ;;
         esac


### PR DESCRIPTION
## Summary
- Adds `deploy/firecracker/rootfs/Dockerfile.default` — a batteries-included rootfs image bundling Python 3, Node.js 20 LTS, build-essential, git, and common dev utilities
- Updates `scripts/build-rootfs.sh` to support the new `default` build target
- Adds DB migration to seed the "default" and "ubuntu" templates

Extracted from #17 to deploy independently.

## Test plan
- [ ] `./scripts/build-rootfs.sh default` builds successfully
- [ ] Migration applies cleanly on existing database
- [ ] Sandbox creation with `template: "default"` uses the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)