### PR TITLE
Fix Python SDK package name in docs

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -35,7 +35,7 @@ npm install @opencomputer/sdk
 ```
 
 ```bash pip
-pip install opencomputer
+pip install opencomputer-sdk
 ```
 
 </CodeGroup>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -16,7 +16,7 @@ npm install @opencomputer/sdk
 ```
 
 ```bash pip
-pip install opencomputer
+pip install opencomputer-sdk
 ```
 
 </CodeGroup>

--- a/docs/sdks/python/overview.mdx
+++ b/docs/sdks/python/overview.mdx
@@ -6,7 +6,7 @@ description: "Full reference for the OpenComputer Python SDK"
 ## Installation
 
 ```bash
-pip install opencomputer
+pip install opencomputer-sdk
 ```
 
 **Requirements:** Python 3.10+


### PR DESCRIPTION
fix the references of opencomputer-sdk in the documentation