### PR TITLE
Fix: remove Windows from CLI release targets

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -70,16 +70,12 @@ jobs:
             "linux/arm64"
             "darwin/amd64"
             "darwin/arm64"
-            "windows/amd64"
           )
 
           for platform in "${platforms[@]}"; do
             GOOS="${platform%/*}"
             GOARCH="${platform#*/}"
             output="dist/oc-${GOOS}-${GOARCH}"
-            if [ "$GOOS" = "windows" ]; then
-              output="${output}.exe"
-            fi
             echo "Building ${GOOS}/${GOARCH}..."
             CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" go build \
               -ldflags "$LDFLAGS" \

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -31,10 +31,6 @@ curl -fsSL https://github.com/diggerhq/opencomputer/releases/latest/download/oc-
 chmod +x /usr/local/bin/oc
 ```
 
-```bash Windows (PowerShell)
-Invoke-WebRequest -Uri https://github.com/diggerhq/opencomputer/releases/latest/download/oc-windows-amd64.exe -OutFile oc.exe
-```
-
 </CodeGroup>
 
 Verify the installation:


### PR DESCRIPTION
## Summary

- Remove Windows from CLI build matrix — `syscall.SIGWINCH` (used for PTY resize) is not available on Windows
- Remove Windows install instructions from CLI docs

Fixes the build failure from #41.

## Test plan

- [ ] Verify release workflow builds successfully for linux/darwin (amd64+arm64)
- [ ] Confirm GitHub release is created with 4 binaries + checksums

🤖 Generated with [Claude Code](https://claude.com/claude-code)