### PR TITLE
Rewrite docs to focus on Claude Agent SDK

### DIFF
--- a/docs/agents.mdx
+++ b/docs/agents.mdx
@@ -1,0 +1,166 @@
+---
+title: "Agents"
+description: "Run Claude Agent SDK sessions inside a sandbox"
+---
+
+The `Agent` module lets you start and manage Claude Agent SDK sessions that run inside the sandbox. The agent has full access to the sandbox filesystem and shell. Access it via `sandbox.agent`.
+
+## Starting an agent session
+
+```typescript
+const session = await sandbox.agent.start({
+  prompt: "Set up a React project with TypeScript and Tailwind CSS",
+  onEvent: (event) => {
+    switch (event.type) {
+      case "assistant":
+        console.log(event.content);
+        break;
+      case "tool_use_summary":
+        console.log(`Tool: ${event.tool} — ${event.summary}`);
+        break;
+      case "result":
+        console.log("Done:", event.result);
+        break;
+      case "error":
+        console.error("Error:", event.error);
+        break;
+    }
+  },
+});
+
+const exitCode = await session.done;
+```
+
+### `sandbox.agent.start(opts?)`
+
+Starts a new agent session inside the sandbox.
+
+<ParamField body="prompt" type="string" optional>
+  The task for the agent to perform.
+</ParamField>
+<ParamField body="model" type="string" optional>
+  Claude model to use (e.g. `"claude-sonnet-4-20250514"`).
+</ParamField>
+<ParamField body="systemPrompt" type="string" optional>
+  Custom system prompt for the agent.
+</ParamField>
+<ParamField body="allowedTools" type="string[]" optional>
+  List of tools the agent is allowed to use.
+</ParamField>
+<ParamField body="permissionMode" type="string" optional>
+  Permission mode for the agent session.
+</ParamField>
+<ParamField body="maxTurns" type="number" optional>
+  Maximum number of turns before the agent stops.
+</ParamField>
+<ParamField body="cwd" type="string" optional>
+  Working directory for the agent.
+</ParamField>
+<ParamField body="mcpServers" type="Record&lt;string, McpServerConfig&gt;" optional>
+  MCP servers to make available to the agent.
+</ParamField>
+<ParamField body="onEvent" type="(event: AgentEvent) => void" optional>
+  Callback for agent events (assistant messages, tool use, results, errors).
+</ParamField>
+<ParamField body="onError" type="(data: string) => void" optional>
+  Callback for stderr output from the agent process.
+</ParamField>
+<ParamField body="onExit" type="(exitCode: number) => void" optional>
+  Callback when the agent process exits.
+</ParamField>
+
+**Returns:** `Promise<AgentSession>`
+
+## AgentSession
+
+The object returned by `sandbox.agent.start()`.
+
+| Property / Method | Type | Description |
+| --- | --- | --- |
+| `sessionId` | `string` | Unique session identifier |
+| `done` | `Promise<number>` | Resolves with the exit code when the agent finishes |
+| `sendPrompt(text)` | `(text: string) => void` | Send a follow-up prompt to the agent |
+| `interrupt()` | `() => void` | Interrupt the agent's current turn |
+| `configure(config)` | `(config: AgentConfig) => void` | Update agent configuration mid-session |
+| `kill(signal?)` | `(signal?: number) => Promise<void>` | Kill the agent process |
+| `close()` | `() => void` | Close the WebSocket connection |
+
+## Agent events
+
+Events are delivered via the `onEvent` callback. Each event has a `type` field:
+
+| Event type | Description |
+| --- | --- |
+| `ready` | Agent process is ready |
+| `configured` | Configuration has been applied |
+| `assistant` | Assistant message (text output from the agent) |
+| `tool_use_summary` | Summary of a tool the agent used |
+| `result` | Final result from the agent |
+| `turn_complete` | A single turn has completed |
+| `interrupted` | Agent was interrupted |
+| `error` | An error occurred |
+
+## Examples
+
+### Send follow-up prompts
+
+```typescript
+const session = await sandbox.agent.start({
+  prompt: "Create a Node.js REST API with Express",
+  onEvent: (event) => {
+    if (event.type === "assistant") console.log(event.content);
+  },
+});
+
+// Wait for the first task, then send a follow-up
+await session.done;
+
+const session2 = await sandbox.agent.start({
+  prompt: "Now add tests using Jest for the API you just created",
+  onEvent: (event) => {
+    if (event.type === "assistant") console.log(event.content);
+  },
+});
+
+await session2.done;
+```
+
+### Configure MCP servers
+
+```typescript
+const session = await sandbox.agent.start({
+  prompt: "Use the database tool to query all users",
+  mcpServers: {
+    database: {
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-sqlite", "/data/app.db"],
+    },
+  },
+  onEvent: (event) => {
+    if (event.type === "assistant") console.log(event.content);
+  },
+});
+```
+
+### List active agent sessions
+
+```typescript
+const sessions = await sandbox.agent.list();
+for (const s of sessions) {
+  console.log(`${s.sessionID} — running: ${s.running}`);
+}
+```
+
+### Attach to an existing session
+
+Reconnect to a running agent session by its ID:
+
+```typescript
+const session = await sandbox.agent.attach("session-id", {
+  onEvent: (event) => {
+    if (event.type === "assistant") console.log(event.content);
+  },
+});
+
+await session.done;
+```

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,52 +1,30 @@
 ---
 title: "Introduction"
-description: "Secure cloud sandboxes for AI agents and developers"
+description: "Cloud sandboxes dedicated to running AI agents"
 ---
 
 # OpenComputer
 
-OpenComputer gives you **secure, isolated cloud sandboxes** that spin up in milliseconds. Run untrusted code, build AI agent tooling, or create interactive development environments — all within containerized sandboxes you fully control.
+OpenComputer is a cloud sandbox platform dedicated to running the **Claude Agent SDK** inside isolated virtual machines. Each sandbox is a full Linux environment where agents can execute commands, read and write files, and run for as long as they need.
 
-## Why OpenComputer?
+## Built for AI agents
 
 <CardGroup cols={2}>
-  <Card title="Fast Startup" icon="bolt">
-    Sandboxes boot in under a second. Your agents and users never wait.
+  <Card title="Claude Agent SDK inside the sandbox" icon="robot">
+    Start a Claude agent session with `sandbox.agent.start()`. The agent runs directly inside the VM with full access to the filesystem and shell.
   </Card>
-  <Card title="Secure Isolation" icon="shield">
-    Every sandbox runs in its own container with strict resource limits and network isolation.
+  <Card title="Optimised for long-running agents" icon="clock">
+    Sandboxes stay alive for hours or days. Agents can install packages, build projects, run tests, and iterate — without time pressure.
   </Card>
-  <Card title="Full Environment" icon="terminal">
-    Each sandbox includes a filesystem, command execution, and interactive terminal (PTY) access.
+  <Card title="Run agent tasks easily" icon="play">
+    Pass a prompt to `sandbox.agent.start()` and get back a stream of events — assistant messages, tool calls, and results — as the agent works.
   </Card>
-  <Card title="Custom Templates" icon="layer-group">
-    Build reusable templates from Dockerfiles with pre-installed tools and dependencies.
+  <Card title="Snapshot, restore, fork any VM" icon="code-branch">
+    Create checkpoints of a running sandbox, restore to any previous state, or fork new sandboxes from a checkpoint. Branch your agent's work like git branches.
   </Card>
 </CardGroup>
 
-## CLI
-
-Download the `oc` binary from [GitHub Releases](https://github.com/diggerhq/opencomputer/releases):
-
-```bash
-curl -fsSL https://github.com/diggerhq/opencomputer/releases/latest/download/oc-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') -o /usr/local/bin/oc && chmod +x /usr/local/bin/oc
-```
-
-See the [CLI Reference](/cli/overview) for full usage.
-
-## Agent Skill
-
-Install the OpenComputer skill for Claude Code and other AI agents:
-
-```bash
-npx skills add diggerhq/opencomputer
-```
-
-This gives your AI agent the ability to create and manage cloud sandboxes using the `oc` CLI.
-
-## SDKs
-
-OpenComputer provides first-class SDKs for TypeScript and Python with identical API surfaces.
+## Install
 
 <CodeGroup>
 
@@ -60,46 +38,41 @@ pip install opencomputer-sdk
 
 </CodeGroup>
 
-## Quick Example
+## Quick example
 
-<CodeGroup>
+```typescript
+import { Sandbox } from "@opencomputer/sdk";
 
-```typescript TypeScript
-import { Sandbox } from '@opencomputer/sdk';
+const sandbox = await Sandbox.create({ template: "default" });
 
-const sandbox = await Sandbox.create({ template: 'default' });
+const session = await sandbox.agent.start({
+  prompt: "Create a hello world Express server and test it",
+  onEvent: (event) => {
+    if (event.type === "assistant") {
+      console.log(event.content);
+    }
+  },
+});
 
-const result = await sandbox.commands.run('echo "Hello from OpenComputer!"');
-console.log(result.stdout); // Hello from OpenComputer!
+const exitCode = await session.done;
+console.log(`Agent finished with exit code: ${exitCode}`);
 
 await sandbox.kill();
 ```
 
-```python Python
-import asyncio
-from opencomputer import Sandbox
-
-async def main():
-    sandbox = await Sandbox.create(template='default')
-    result = await sandbox.commands.run('echo "Hello from OpenComputer!"')
-    print(result.stdout)  # Hello from OpenComputer!
-    await sandbox.kill()
-
-asyncio.run(main())
-```
-
-</CodeGroup>
-
-## Next Steps
+## Next steps
 
 <CardGroup cols={2}>
   <Card title="Quickstart" icon="rocket" href="/quickstart">
-    Get up and running in 5 minutes.
+    Run your first agent in 5 minutes.
   </Card>
-  <Card title="TypeScript SDK" icon="js" href="/sdks/typescript/overview">
-    Full TypeScript/JavaScript SDK reference.
+  <Card title="Agents" icon="robot" href="/agents">
+    Full reference for sandbox.agent.
   </Card>
-  <Card title="Python SDK" icon="python" href="/sdks/python/overview">
-    Full Python SDK reference.
+  <Card title="Running Commands" icon="terminal" href="/running-commands">
+    Execute shell commands directly.
+  </Card>
+  <Card title="Working with Files" icon="file" href="/working-with-files">
+    Read, write, and manage files in the sandbox.
   </Card>
 </CardGroup>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -2,7 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "quill",
   "name": "OpenComputer",
-  "description": "Secure cloud sandboxes for AI agents and developers",
+  "description": "Cloud sandboxes for running AI agents",
   "colors": {
     "primary": "#6366F1",
     "light": "#818CF8",
@@ -48,10 +48,17 @@
       ]
     },
     {
+      "group": "Using OpenComputer",
+      "pages": [
+        "agents",
+        "running-commands",
+        "working-with-files"
+      ]
+    },
+    {
       "group": "Guides",
       "pages": [
-        "guides/build-a-lovable-clone",
-        "guides/agent-skill"
+        "guides/build-a-lovable-clone"
       ]
     },
     {

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,19 +1,15 @@
 ---
 title: "Quickstart"
-description: "Get up and running with OpenComputer in 5 minutes"
+description: "Run your first AI agent inside a sandbox"
 ---
 
-## 1. Get Your API Key
+## 1. Get your API key
 
 Sign up at [app.opencomputer.dev](https://app.opencomputer.dev) and grab your API key from the dashboard.
 
-## 2. Install
+## 2. Install the SDK
 
 <CodeGroup>
-
-```bash CLI
-curl -fsSL https://github.com/diggerhq/opencomputer/releases/latest/download/oc-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') -o /usr/local/bin/oc && chmod +x /usr/local/bin/oc
-```
 
 ```bash npm
 npm install @opencomputer/sdk
@@ -23,121 +19,66 @@ npm install @opencomputer/sdk
 pip install opencomputer-sdk
 ```
 
-```bash Agent Skill
-npx skills add diggerhq/opencomputer
-```
-
 </CodeGroup>
 
-## 3. Set Your API Key
+## 3. Set your API key
 
 ```bash
 export OPENCOMPUTER_API_KEY="your-api-key"
 ```
 
-## 4. Create a Sandbox
+## 4. Run your first agent
 
 <CodeGroup>
 
 ```typescript TypeScript
-import { Sandbox } from '@opencomputer/sdk';
+import { Sandbox } from "@opencomputer/sdk";
 
-const sandbox = await Sandbox.create({
-  template: 'default',
-  timeout: 300,
+// Create a sandbox
+const sandbox = await Sandbox.create({ template: "default" });
+
+// Start an agent session with a task
+const session = await sandbox.agent.start({
+  prompt: "Create a Python script that prints the Fibonacci sequence up to 100, then run it",
+  onEvent: (event) => {
+    if (event.type === "assistant") {
+      console.log(event.content);
+    }
+    if (event.type === "result") {
+      console.log("Result:", event.result);
+    }
+  },
 });
 
-console.log(`Sandbox created: ${sandbox.sandboxId}`);
-```
+// Wait for the agent to finish
+const exitCode = await session.done;
+console.log(`Agent exited with code: ${exitCode}`);
 
-```python Python
-from opencomputer import Sandbox
-
-sandbox = await Sandbox.create(template='default', timeout=300)
-print(f"Sandbox created: {sandbox.sandbox_id}")
-```
-
-</CodeGroup>
-
-## 5. Run a Command
-
-<CodeGroup>
-
-```typescript TypeScript
-const result = await sandbox.commands.run('echo "Hello, World!"');
-
-console.log(result.stdout);   // Hello, World!
-console.log(result.exitCode); // 0
-```
-
-```python Python
-result = await sandbox.commands.run('echo "Hello, World!"')
-
-print(result.stdout)     # Hello, World!
-print(result.exit_code)  # 0
-```
-
-</CodeGroup>
-
-## 6. Read and Write Files
-
-<CodeGroup>
-
-```typescript TypeScript
-// Write a file
-await sandbox.files.write('/tmp/hello.txt', 'Hello from OpenComputer!');
-
-// Read it back
-const content = await sandbox.files.read('/tmp/hello.txt');
-console.log(content); // Hello from OpenComputer!
-
-// List a directory
-const entries = await sandbox.files.list('/tmp');
-entries.forEach(e => console.log(`${e.isDir ? 'd' : 'f'} ${e.name}`));
-```
-
-```python Python
-# Write a file
-await sandbox.files.write('/tmp/hello.txt', 'Hello from OpenComputer!')
-
-# Read it back
-content = await sandbox.files.read('/tmp/hello.txt')
-print(content)  # Hello from OpenComputer!
-
-# List a directory
-entries = await sandbox.files.list('/tmp')
-for e in entries:
-    print(f"{'d' if e.is_dir else 'f'} {e.name}")
-```
-
-</CodeGroup>
-
-## 7. Clean Up
-
-<CodeGroup>
-
-```typescript TypeScript
+// Clean up
 await sandbox.kill();
 ```
 
 ```python Python
-await sandbox.kill()
+import asyncio
+from opencomputer import Sandbox
 
-# Or use try/finally for automatic cleanup:
 async def main():
-    sandbox = await Sandbox.create()
-    try:
-        result = await sandbox.commands.run('whoami')
-    finally:
-        await sandbox.kill()
-        await sandbox.close()
+    sandbox = await Sandbox.create(template="default")
+
+    result = await sandbox.commands.run('echo "Hello from OpenComputer!"')
+    print(result.stdout)
+
+    await sandbox.kill()
 
 asyncio.run(main())
 ```
 
 </CodeGroup>
 
-## Next Steps
+The agent will create the file, write the code, and execute it — all inside the sandbox.
 
-- [TypeScript SDK Reference](/sdks/typescript/overview) — full API docs for the TypeScript SDK
-- [Python SDK Reference](/sdks/python/overview) — full API docs for the Python SDK
+## Next steps
+
+- [Agents](/agents) — full reference for `sandbox.agent`
+- [Running Commands](/running-commands) — run shell commands directly with `sandbox.exec`
+- [Working with Files](/working-with-files) — read, write, and manage files

--- a/docs/running-commands.mdx
+++ b/docs/running-commands.mdx
@@ -1,0 +1,207 @@
+---
+title: "Running Commands"
+description: "Execute shell commands inside a sandbox"
+---
+
+The `Exec` module lets you run shell commands inside a sandbox. Access it via `sandbox.exec`.
+
+There are two ways to run commands:
+
+- **`sandbox.exec.run()`** — run a command and wait for it to finish (simple, synchronous)
+- **`sandbox.exec.start()`** — start a long-running command and stream its output (async, with callbacks)
+
+## Quick commands with `sandbox.exec.run`
+
+Run a shell command and get the result when it completes.
+
+<CodeGroup>
+
+```typescript TypeScript
+const result = await sandbox.exec.run('echo "Hello, World!"');
+
+console.log(result.stdout);   // Hello, World!
+console.log(result.stderr);   // (empty)
+console.log(result.exitCode); // 0
+```
+
+```python Python
+result = await sandbox.commands.run('echo "Hello, World!"')
+
+print(result.stdout)     # Hello, World!
+print(result.stderr)     # (empty)
+print(result.exit_code)  # 0
+```
+
+</CodeGroup>
+
+### `sandbox.exec.run(command, opts?)`
+
+Executes a shell command and waits for it to complete.
+
+<ParamField body="command" type="string" required>
+  The shell command to execute.
+</ParamField>
+
+<ParamField body="opts" type="RunOpts" optional>
+  <Expandable title="properties">
+    <ParamField body="timeout" type="number" default="60">
+      Maximum execution time in seconds. The command is killed if it exceeds this.
+    </ParamField>
+    <ParamField body="env" type="Record<string, string>" optional>
+      Additional environment variables for this command.
+    </ParamField>
+    <ParamField body="cwd" type="string" optional>
+      Working directory for the command.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+**Returns:** `Promise<ProcessResult>`
+
+### ProcessResult
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `exitCode` | `number` | Exit code of the process (0 = success) |
+| `stdout` | `string` | Standard output |
+| `stderr` | `string` | Standard error |
+
+### Examples
+
+```typescript
+// Run with a working directory
+const result = await sandbox.exec.run('ls -la', { cwd: '/app' });
+
+// Run with environment variables
+const result = await sandbox.exec.run('echo $MY_VAR', {
+  env: { MY_VAR: 'hello' },
+});
+
+// Run with a timeout
+const result = await sandbox.exec.run('sleep 30', { timeout: 5 });
+
+// Chain commands
+const result = await sandbox.exec.run(
+  'cd /app && npm install && npm run build'
+);
+```
+
+---
+
+## Async commands with `sandbox.exec.start`
+
+Start a long-running command and stream its output via callbacks. The command runs in the background and you get a session handle to interact with it.
+
+```typescript
+const session = await sandbox.exec.start("npm run dev", {
+  cwd: "/app",
+  onStdout: (data) => {
+    console.log("stdout:", new TextDecoder().decode(data));
+  },
+  onStderr: (data) => {
+    console.error("stderr:", new TextDecoder().decode(data));
+  },
+  onExit: (exitCode) => {
+    console.log(`Process exited with code: ${exitCode}`);
+  },
+});
+
+// Send input to the process
+session.sendStdin("some input\n");
+
+// Kill the process later
+await session.kill();
+
+// Or wait for it to finish
+const exitCode = await session.done;
+```
+
+### `sandbox.exec.start(command, opts?)`
+
+Starts a command and returns an interactive session.
+
+<ParamField body="command" type="string" required>
+  The command to execute.
+</ParamField>
+
+<ParamField body="opts" type="ExecStartOpts" optional>
+  <Expandable title="properties">
+    <ParamField body="args" type="string[]" optional>
+      Arguments to pass to the command.
+    </ParamField>
+    <ParamField body="env" type="Record<string, string>" optional>
+      Additional environment variables.
+    </ParamField>
+    <ParamField body="cwd" type="string" optional>
+      Working directory.
+    </ParamField>
+    <ParamField body="timeout" type="number" optional>
+      Maximum execution time in seconds.
+    </ParamField>
+    <ParamField body="maxRunAfterDisconnect" type="number" optional>
+      How long (in seconds) the process continues running after the WebSocket disconnects.
+    </ParamField>
+    <ParamField body="onStdout" type="(data: Uint8Array) => void" optional>
+      Callback for stdout data.
+    </ParamField>
+    <ParamField body="onStderr" type="(data: Uint8Array) => void" optional>
+      Callback for stderr data.
+    </ParamField>
+    <ParamField body="onExit" type="(exitCode: number) => void" optional>
+      Callback when the process exits.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+**Returns:** `Promise<ExecSession>`
+
+### ExecSession
+
+| Property / Method | Type | Description |
+| --- | --- | --- |
+| `sessionId` | `string` | Unique session identifier |
+| `done` | `Promise<number>` | Resolves with the exit code when the process exits |
+| `sendStdin(data)` | `(data: string \| Uint8Array) => void` | Send input to the process |
+| `kill(signal?)` | `(signal?: number) => Promise<void>` | Kill the process |
+| `close()` | `() => void` | Close the WebSocket connection |
+
+### Examples
+
+#### Start a dev server and keep it running
+
+```typescript
+const devServer = await sandbox.exec.start("npm run dev", {
+  cwd: "/app",
+  onStdout: (data) => {
+    const text = new TextDecoder().decode(data);
+    if (text.includes("ready")) {
+      console.log("Dev server is ready!");
+    }
+  },
+});
+
+// Do other work while the server runs...
+
+// Stop it when done
+await devServer.kill();
+```
+
+#### List running exec sessions
+
+```typescript
+const sessions = await sandbox.exec.list();
+for (const s of sessions) {
+  console.log(`${s.sessionID} — ${s.command} — running: ${s.running}`);
+}
+```
+
+#### Attach to an existing session
+
+Reconnect to a running exec session by its ID:
+
+```typescript
+const session = await sandbox.exec.attach("session-id", {
+  onStdout: (data) => console.log(new TextDecoder().decode(data)),
+  onExit: (code) => console.log(`Exited: ${code}`),
+});
+```

--- a/docs/working-with-files.mdx
+++ b/docs/working-with-files.mdx
@@ -1,0 +1,194 @@
+---
+title: "Working with Files"
+description: "Read, write, and manage files inside a sandbox"
+---
+
+The `Filesystem` module provides full file I/O within a sandbox. Access it via `sandbox.files`.
+
+## Reading files
+
+<CodeGroup>
+
+```typescript TypeScript
+// Read as text
+const content = await sandbox.files.read('/app/config.json');
+const config = JSON.parse(content);
+
+// Read as bytes
+const bytes = await sandbox.files.readBytes('/app/image.png');
+console.log(`File size: ${bytes.length} bytes`);
+```
+
+```python Python
+# Read as text
+content = await sandbox.files.read('/app/config.json')
+config = json.loads(content)
+
+# Read as bytes
+data = await sandbox.files.read_bytes('/app/image.png')
+print(f"File size: {len(data)} bytes")
+```
+
+</CodeGroup>
+
+### `sandbox.files.read(path)`
+
+Reads a file as a UTF-8 string.
+
+<ParamField body="path" type="string" required>
+  Absolute path to the file.
+</ParamField>
+
+**Returns:** `Promise<string>`
+
+### `sandbox.files.readBytes(path)`
+
+Reads a file as raw bytes.
+
+<ParamField body="path" type="string" required>
+  Absolute path to the file.
+</ParamField>
+
+**Returns:** `Promise<Uint8Array>`
+
+## Writing files
+
+<CodeGroup>
+
+```typescript TypeScript
+// Write text
+await sandbox.files.write('/app/hello.txt', 'Hello, World!');
+
+// Write binary
+const encoder = new TextEncoder();
+await sandbox.files.write('/app/data.bin', encoder.encode('binary data'));
+```
+
+```python Python
+# Write text
+await sandbox.files.write('/app/hello.txt', 'Hello, World!')
+
+# Write binary
+await sandbox.files.write('/app/data.bin', b'\x00\x01\x02')
+```
+
+</CodeGroup>
+
+### `sandbox.files.write(path, content)`
+
+Writes a string or binary content to a file. Creates parent directories if needed.
+
+<ParamField body="path" type="string" required>
+  Absolute path to the file.
+</ParamField>
+<ParamField body="content" type="string | Uint8Array" required>
+  File content to write.
+</ParamField>
+
+**Returns:** `Promise<void>`
+
+## Listing directories
+
+<CodeGroup>
+
+```typescript TypeScript
+const entries = await sandbox.files.list('/app');
+
+for (const entry of entries) {
+  console.log(`${entry.isDir ? 'DIR ' : 'FILE'} ${entry.name} (${entry.size} bytes)`);
+}
+```
+
+```python Python
+entries = await sandbox.files.list('/app')
+
+for entry in entries:
+    kind = 'd' if entry.is_dir else 'f'
+    print(f"{kind} {entry.name} ({entry.size} bytes)")
+```
+
+</CodeGroup>
+
+### `sandbox.files.list(path?)`
+
+Lists the contents of a directory.
+
+<ParamField body="path" type="string" default="/">
+  Directory path to list.
+</ParamField>
+
+**Returns:** `Promise<EntryInfo[]>`
+
+### EntryInfo
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | File or directory name |
+| `isDir` | `boolean` | `true` if this entry is a directory |
+| `path` | `string` | Full path to the entry |
+| `size` | `number` | Size in bytes (0 for directories) |
+
+## Managing files and directories
+
+### `sandbox.files.makeDir(path)`
+
+Creates a directory and any necessary parent directories.
+
+```typescript
+await sandbox.files.makeDir('/app/src/components');
+```
+
+### `sandbox.files.remove(path)`
+
+Deletes a file or directory.
+
+```typescript
+await sandbox.files.remove('/app/temp.txt');
+```
+
+### `sandbox.files.exists(path)`
+
+Checks whether a file or directory exists.
+
+```typescript
+if (await sandbox.files.exists('/app/package.json')) {
+  console.log('Node.js project detected');
+}
+```
+
+## Examples
+
+### Upload and run a script
+
+<CodeGroup>
+
+```typescript TypeScript
+await sandbox.files.write('/tmp/script.sh', `#!/bin/bash
+echo "Running setup..."
+apt-get update -qq
+echo "Done!"
+`);
+
+const result = await sandbox.exec.run('bash /tmp/script.sh');
+console.log(result.stdout);
+```
+
+```python Python
+await sandbox.files.write('/tmp/setup.sh', """#!/bin/bash
+echo "Running setup..."
+apt-get update -qq
+echo "Done!"
+""")
+
+result = await sandbox.commands.run('bash /tmp/setup.sh')
+print(result.stdout)
+```
+
+</CodeGroup>
+
+### Copy files between paths
+
+```typescript
+const content = await sandbox.files.readBytes('/app/original.dat');
+await sandbox.files.write('/backup/original.dat', content);
+```


### PR DESCRIPTION
## Summary
- Rewrites Introduction and Quickstart to position OpenComputer as a platform for running Claude Agent SDK inside sandboxes
- Adds new **Agents** page with full `sandbox.agent` API reference (start, attach, events, MCP servers)
- Adds new **Running Commands** page covering `sandbox.exec.run()` (synchronous) and `sandbox.exec.start()` (async/streaming)
- Adds new **Working with Files** page consolidating filesystem operations with TypeScript + Python examples
- Keeps existing TypeScript/Python SDK reference tabs and the Build a Lovable Clone guide

## Test plan
- [ ] Verify Mintlify builds successfully with `mintlify dev`
- [ ] Check all navigation links resolve (no broken pages)
- [ ] Review new pages render correctly: agents, running-commands, working-with-files
- [ ] Confirm SDK tabs (TypeScript/Python) and CLI tab still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)