### PR TITLE
Fix deploy-worker to rebuild rootfs with updated agent

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -7,6 +7,10 @@ on:
       - 'cmd/worker/**'
       - 'cmd/agent/**'
       - 'internal/**'
+      - 'proto/**'
+      - 'deploy/firecracker/rootfs/**'
+      - 'deploy/ec2/build-rootfs-docker.sh'
+      - 'scripts/claude-agent-wrapper/**'
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/deploy-worker.yml'
@@ -45,13 +49,40 @@ jobs:
           scp -i ~/.ssh/deploy.pem bin/opensandbox-worker ${{ env.SSH_USER }}@${{ secrets.WORKER_IP }}:/tmp/opensandbox-worker
           scp -i ~/.ssh/deploy.pem bin/osb-agent ${{ env.SSH_USER }}@${{ secrets.WORKER_IP }}:/tmp/osb-agent
 
-      - name: Install and restart
+      - name: Sync rootfs build context to instance
+        run: |
+          rsync -az \
+            -e "ssh -i ~/.ssh/deploy.pem" \
+            --include='deploy/ec2/build-rootfs-docker.sh' \
+            --include='deploy/firecracker/rootfs/***' \
+            --include='scripts/claude-agent-wrapper/***' \
+            --include='deploy/' \
+            --include='deploy/ec2/' \
+            --include='deploy/firecracker/' \
+            --include='scripts/' \
+            --exclude='*' \
+            ./ ${{ env.SSH_USER }}@${{ secrets.WORKER_IP }}:/tmp/osb-rootfs-ctx/
+
+      - name: Install binaries, rebuild rootfs, and restart
         run: |
           ssh -i ~/.ssh/deploy.pem ${{ env.SSH_USER }}@${{ secrets.WORKER_IP }} '
+            set -euo pipefail
+
+            # Install binaries
             sudo mv /tmp/opensandbox-worker /usr/local/bin/opensandbox-worker
             sudo chmod +x /usr/local/bin/opensandbox-worker
             sudo mv /tmp/osb-agent /usr/local/bin/osb-agent
             sudo chmod +x /usr/local/bin/osb-agent
+
+            # Rebuild rootfs with new agent baked in
+            cd /tmp/osb-rootfs-ctx
+            sudo rm -f /data/firecracker/images/default.ext4
+            sudo bash deploy/ec2/build-rootfs-docker.sh /usr/local/bin/osb-agent /data/firecracker/images default
+
+            # Cleanup
+            rm -rf /tmp/osb-rootfs-ctx
+
+            # Restart worker
             sudo systemctl restart opensandbox-worker
           '
 


### PR DESCRIPTION
## Summary
- The deploy-worker GitHub Action was only updating the `osb-agent` binary on the host filesystem, but not rebuilding the `default.ext4` rootfs image that gets baked into Firecracker VMs
- This caused VMs to keep running the old agent, leading to `unknown method ExecSessionCreate` errors
- Now the workflow rsyncs the rootfs build context (Dockerfiles, `build-rootfs-docker.sh`, `claude-agent-wrapper`) to the instance and rebuilds `default.ext4` with the new agent on every deploy
- Worker restart triggers `PrepareGoldenSnapshot()` which automatically creates a fresh golden snapshot from the new rootfs
- Added path triggers for `proto/**`, `deploy/firecracker/rootfs/**`, `deploy/ec2/build-rootfs-docker.sh`, and `scripts/claude-agent-wrapper/**`

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch`
- [ ] Verify rootfs rebuild completes successfully in the action logs
- [ ] Verify worker restarts and golden snapshot is created
- [ ] Run `delme/test-agent.ts` and confirm `ExecSessionCreate` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)