### PR TITLE
Fix deploy-worker to use correct IMAGES_DIR

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -75,9 +75,13 @@ jobs:
             sudo chmod +x /usr/local/bin/osb-agent
 
             # Rebuild rootfs with new agent baked in
+            # Read IMAGES_DIR from the worker systemd unit (matches OPENSANDBOX_IMAGES_DIR)
+            IMAGES_DIR=$(systemctl show opensandbox-worker -p Environment --value | tr " " "\n" | grep OPENSANDBOX_IMAGES_DIR | cut -d= -f2-)
+            IMAGES_DIR="${IMAGES_DIR:-/data/sandboxes/firecracker/images}"
+            echo "Rebuilding rootfs in $IMAGES_DIR"
             cd /tmp/osb-rootfs-ctx
-            sudo rm -f /data/firecracker/images/default.ext4
-            sudo bash deploy/ec2/build-rootfs-docker.sh /usr/local/bin/osb-agent /data/firecracker/images default
+            sudo rm -f "$IMAGES_DIR/default.ext4"
+            sudo bash deploy/ec2/build-rootfs-docker.sh /usr/local/bin/osb-agent "$IMAGES_DIR" default
 
             # Cleanup
             rm -rf /tmp/osb-rootfs-ctx


### PR DESCRIPTION
## Summary
- The rootfs rebuild in deploy-worker was writing to `/data/firecracker/images/` but the worker is configured with `OPENSANDBOX_IMAGES_DIR=/data/sandboxes/firecracker/images`
- Now reads the images directory from the worker's systemd unit config, with the correct default fallback
- This was the root cause of the `ExecSessionCreate` errors after PR #56 — the new rootfs was built to the wrong path

## Test plan
- [x] Verified all 7 agent tests pass after manually copying rootfs to correct path
- [ ] Trigger `workflow_dispatch` after merge to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)