### PR TITLE
Add agent resume, fix exec/run route, dev deploy improvements

### DIFF
--- a/deploy/ec2/deploy-aws-dev.sh
+++ b/deploy/ec2/deploy-aws-dev.sh
@@ -377,6 +377,11 @@ cmd_deploy() {
     log "Step 4: Installing env files..."
     ssh -o StrictHostKeyChecking=no -i "$key_file" ubuntu@"$public_ip" \
         "sudo bash ~/opensandbox/deploy/ec2/setup-dev-env.sh $API_KEY"
+    # Add sandbox domain for preview URLs (nip.io resolves to the public IP)
+    ssh -o StrictHostKeyChecking=no -i "$key_file" ubuntu@"$public_ip" "
+        echo 'OPENSANDBOX_SANDBOX_DOMAIN=${public_ip}.nip.io' | sudo tee -a /etc/opensandbox/server.env
+        echo 'OPENSANDBOX_SANDBOX_DOMAIN=${public_ip}.nip.io' | sudo tee -a /etc/opensandbox/worker.env
+    "
 
     log "Step 5: Starting/restarting services..."
     ssh -o StrictHostKeyChecking=no -i "$key_file" ubuntu@"$public_ip" "

--- a/internal/api/agent_session.go
+++ b/internal/api/agent_session.go
@@ -49,7 +49,8 @@ func (s *Server) createAgentSession(c echo.Context) error {
 
 	// Send configure command if any config options provided
 	hasConfig := req.Model != "" || req.SystemPrompt != "" || len(req.AllowedTools) > 0 ||
-		req.PermissionMode != "" || req.MaxTurns > 0 || req.Cwd != "" || len(req.McpServers) > 0
+		req.PermissionMode != "" || req.MaxTurns > 0 || req.Cwd != "" || len(req.McpServers) > 0 ||
+		req.Resume != ""
 	if hasConfig && session.StdinWriter != nil {
 		configCmd := map[string]interface{}{"type": "configure"}
 		if req.Model != "" {
@@ -73,6 +74,9 @@ func (s *Server) createAgentSession(c echo.Context) error {
 		if len(req.McpServers) > 0 {
 			configCmd["mcpServers"] = req.McpServers
 		}
+		if req.Resume != "" {
+			configCmd["resume"] = req.Resume
+		}
 		configJSON, _ := json.Marshal(configCmd)
 		session.StdinWriter.Write(append(configJSON, '\n'))
 	}
@@ -82,6 +86,9 @@ func (s *Server) createAgentSession(c echo.Context) error {
 		promptCmd := map[string]interface{}{
 			"type": "prompt",
 			"text": req.Prompt,
+		}
+		if req.Resume != "" {
+			promptCmd["resume"] = req.Resume
 		}
 		promptJSON, _ := json.Marshal(promptCmd)
 		session.StdinWriter.Write(append(promptJSON, '\n'))

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -633,7 +633,8 @@ func (s *HTTPServer) createAgentSession(c echo.Context) error {
 
 	// Send configure command if any config options provided
 	hasConfig := req.Model != "" || req.SystemPrompt != "" || len(req.AllowedTools) > 0 ||
-		req.PermissionMode != "" || req.MaxTurns > 0 || req.Cwd != "" || len(req.McpServers) > 0
+		req.PermissionMode != "" || req.MaxTurns > 0 || req.Cwd != "" || len(req.McpServers) > 0 ||
+		req.Resume != ""
 	if hasConfig && session.StdinWriter != nil {
 		configCmd := map[string]interface{}{"type": "configure"}
 		if req.Model != "" {
@@ -656,6 +657,9 @@ func (s *HTTPServer) createAgentSession(c echo.Context) error {
 		}
 		if len(req.McpServers) > 0 {
 			configCmd["mcpServers"] = req.McpServers
+		}
+		if req.Resume != "" {
+			configCmd["resume"] = req.Resume
 		}
 		configJSON, _ := jsonMarshal(configCmd)
 		session.StdinWriter.Write(append(configJSON, '\n'))

--- a/internal/worker/http_server.go
+++ b/internal/worker/http_server.go
@@ -82,11 +82,11 @@ func NewHTTPServer(mgr sandbox.Manager, ptyMgr *sandbox.PTYManager, execMgr *san
 	api.GET("/sandboxes/:id", s.getSandbox)
 
 	// Exec sessions (replaces old /commands)
+	api.POST("/sandboxes/:id/exec/run", s.execRun) // static path before parameterized
 	api.POST("/sandboxes/:id/exec", s.createExecSession)
 	api.GET("/sandboxes/:id/exec", s.listExecSessions)
 	api.GET("/sandboxes/:id/exec/:sessionID", s.execSessionWebSocket)
 	api.POST("/sandboxes/:id/exec/:sessionID/kill", s.killExecSession)
-	api.POST("/sandboxes/:id/exec/run", s.execRun)
 
 	// Timeout
 	api.POST("/sandboxes/:id/timeout", s.setTimeout)

--- a/pkg/types/agent_session.go
+++ b/pkg/types/agent_session.go
@@ -10,14 +10,16 @@ type AgentSessionCreateRequest struct {
 	MaxTurns       int                    `json:"maxTurns,omitempty"`
 	Cwd            string                 `json:"cwd,omitempty"`
 	McpServers     map[string]interface{} `json:"mcpServers,omitempty"`
+	Resume         string                 `json:"resume,omitempty"`
 }
 
 // AgentSessionInfo is the response body for agent session metadata.
 type AgentSessionInfo struct {
-	SessionID string `json:"sessionID"`
-	SandboxID string `json:"sandboxID"`
-	Running   bool   `json:"running"`
-	StartedAt string `json:"startedAt"`
+	SessionID      string `json:"sessionID"`
+	SandboxID      string `json:"sandboxID"`
+	Running        bool   `json:"running"`
+	StartedAt      string `json:"startedAt"`
+	ClaudeSessionID string `json:"claudeSessionID,omitempty"`
 }
 
 // AgentPromptRequest is the request body for sending a prompt to an agent session.

--- a/scripts/claude-agent-wrapper/index.ts
+++ b/scripts/claude-agent-wrapper/index.ts
@@ -37,11 +37,13 @@ interface ConfigureCommand {
   maxTurns?: number;
   cwd?: string;
   mcpServers?: Record<string, unknown>;
+  resume?: string;
 }
 
 interface PromptCommand {
   type: "prompt";
   text: string;
+  resume?: string;
 }
 
 interface InterruptCommand {
@@ -60,6 +62,8 @@ let config: ConfigureCommand = {
 };
 
 let activeQuery: Query | null = null;
+// Track the Claude session ID so we can resume later
+let claudeSessionId: string | null = null;
 
 // --- Helpers ---
 
@@ -109,21 +113,69 @@ async function handlePrompt(cmd: PromptCommand): Promise<void> {
     options.mcpServers = config.mcpServers as Options["mcpServers"];
   }
 
+  // Resume from a previous Claude session if requested
+  // Priority: prompt command resume > config resume > auto-captured session ID
+  const resumeId = cmd.resume || config.resume || claudeSessionId;
+  if (resumeId) {
+    options.resume = resumeId;
+    const source = cmd.resume ? "prompt" : config.resume ? "config" : "auto";
+    logError(`resuming from session: ${resumeId} (from ${source})`);
+    // Clear config.resume after first use so subsequent prompts don't re-resume from config
+    if (config.resume) {
+      config.resume = undefined;
+    }
+  }
+
+  logError(`handlePrompt: prompt="${cmd.text.slice(0, 100)}", resume=${resumeId || "none"}, model=${options.model}, cwd=${options.cwd}`);
+
   try {
     activeQuery = query({ prompt: cmd.text, options });
 
     for await (const message of activeQuery) {
+      // Capture the Claude session ID from messages for future resumption
+      if ("session_id" in message && typeof message.session_id === "string") {
+        if (!claudeSessionId || claudeSessionId !== message.session_id) {
+          claudeSessionId = message.session_id;
+          logError(`captured claude session_id: ${claudeSessionId}`);
+        }
+      }
       emitMessage(message);
     }
 
-    emit({ type: "turn_complete" });
+    logError(`turn complete, claude_session_id=${claudeSessionId}`);
+    emit({ type: "turn_complete", claude_session_id: claudeSessionId });
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message.includes("abort") || message.includes("interrupt")) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    const errStack = err instanceof Error ? err.stack : "";
+    logError(`prompt error: ${errMsg}\n${errStack}`);
+    if (errMsg.includes("abort") || errMsg.includes("interrupt")) {
       emit({ type: "interrupted" });
     } else {
-      logError(`prompt error: ${message}`);
-      emit({ type: "error", message });
+      // If resume failed, try again without resume
+      if (resumeId) {
+        logError(`resume failed, retrying without resume...`);
+        options.resume = undefined;
+        try {
+          activeQuery = query({ prompt: cmd.text, options });
+          for await (const message of activeQuery) {
+            if ("session_id" in message && typeof message.session_id === "string") {
+              if (!claudeSessionId || claudeSessionId !== message.session_id) {
+                claudeSessionId = message.session_id;
+                logError(`captured claude session_id (retry): ${claudeSessionId}`);
+              }
+            }
+            emitMessage(message);
+          }
+          logError(`retry turn complete, claude_session_id=${claudeSessionId}`);
+          emit({ type: "turn_complete", claude_session_id: claudeSessionId });
+        } catch (retryErr: unknown) {
+          const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+          logError(`retry also failed: ${retryMsg}`);
+          emit({ type: "error", message: retryMsg });
+        }
+      } else {
+        emit({ type: "error", message: errMsg });
+      }
     }
   } finally {
     activeQuery = null;
@@ -200,7 +252,18 @@ async function main(): Promise<void> {
   }
 }
 
+process.on("uncaughtException", (err) => {
+  logError(`uncaughtException: ${err.message}\n${err.stack}`);
+  emit({ type: "error", message: `uncaughtException: ${err.message}` });
+});
+
+process.on("unhandledRejection", (reason) => {
+  logError(`unhandledRejection: ${reason}`);
+  emit({ type: "error", message: `unhandledRejection: ${String(reason)}` });
+});
+
 main().catch((err) => {
   logError(`fatal: ${err}`);
+  emit({ type: "error", message: `fatal: ${err instanceof Error ? err.message : String(err)}` });
   process.exit(1);
 });

--- a/sdks/typescript/src/agent.ts
+++ b/sdks/typescript/src/agent.ts
@@ -27,6 +27,7 @@ export interface AgentConfig {
   maxTurns?: number;
   cwd?: string;
   mcpServers?: Record<string, McpServerConfig>;
+  resume?: string;
 }
 
 export interface AgentStartOpts extends AgentConfig {
@@ -75,6 +76,7 @@ export class Agent {
     if (opts.maxTurns != null) body.maxTurns = opts.maxTurns;
     if (opts.cwd) body.cwd = opts.cwd;
     if (opts.mcpServers) body.mcpServers = opts.mcpServers;
+    if (opts.resume) body.resume = opts.resume;
 
     const resp = await fetch(`${this.apiUrl}/sandboxes/${this.sandboxId}/agent`, {
       method: "POST",


### PR DESCRIPTION
## Summary
- **Agent session resume**: Add `resume` field to agent sessions so Claude conversations can continue across turns (API, worker, wrapper, TypeScript SDK)
- **Fix exec/run 404**: Move static `/exec/run` route before parameterized `/exec/:sessionID` routes in worker to prevent Echo from matching `run` as a session ID
- **Dev deploy**: Add `OPENSANDBOX_SANDBOX_DOMAIN` via nip.io to `deploy-aws-dev.sh` so preview URLs work on dev servers
- **Wrapper improvements**: Add session ID tracking, error handling with resume fallback, and uncaught exception handlers to `claude-agent-wrapper`

## Test plan
- [x] Deployed to dev server and verified exec/run works
- [x] Verified preview URLs resolve via `sb-xxx-p80.{ip}.nip.io:8081`
- [ ] Test agent session resume via SDK
- [ ] Test agent session create with resume field via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)