### PR TITLE
Fix duplicate CORS headers on proxied responses

### DIFF
--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -1061,6 +1061,11 @@ func (s *Server) proxyWorkerHTTP(c echo.Context, session *db.SandboxSession, met
 	// Forward the worker's response back to the dashboard
 	respBody, _ := io.ReadAll(resp.Body)
 	for k, vals := range resp.Header {
+		// Skip CORS headers — the API server's own CORS middleware adds these,
+		// so forwarding them from the worker causes duplicates (*, *).
+		if strings.HasPrefix(strings.ToLower(k), "access-control-") {
+			continue
+		}
 		for _, v := range vals {
 			c.Response().Header().Add(k, v)
 		}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -302,6 +302,11 @@ func (r *responseRecorder) WriteHeader(statusCode int) {
 
 func (r *responseRecorder) writeTo(w http.ResponseWriter) {
 	for k, vals := range r.header {
+		// Skip CORS headers — the outer server's CORS middleware adds these,
+		// so forwarding them from the proxied response causes duplicates (*, *).
+		if strings.HasPrefix(strings.ToLower(k), "access-control-") {
+			continue
+		}
 		for _, v := range vals {
 			w.Header().Add(k, v)
 		}


### PR DESCRIPTION
## Summary
- Both the API server and worker run Echo's CORS middleware, each adding `Access-Control-Allow-Origin: *`
- When the API proxies worker responses, it forwards all headers via `Add()`, resulting in duplicate `*, *` which browsers reject as invalid CORS
- Fix: skip `Access-Control-*` headers when forwarding proxied responses — the outer server's own CORS middleware already handles these

## Test plan
- [ ] Verify browser requests to `/api/sandboxes/{id}/files` no longer get duplicate CORS headers
- [ ] Verify WebSocket connections still work through the proxy
- [ ] Verify cross-origin requests from openlovable studio succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)