### PR TITLE
Fix golden snapshot virtio-net virtqueue corruption

### DIFF
--- a/internal/firecracker/snapshot.go
+++ b/internal/firecracker/snapshot.go
@@ -2129,12 +2129,18 @@ func (m *Manager) PrepareGoldenSnapshot() error {
 	// Step 3: Flush filesystem, quiesce network, close agent, pause VM, snapshot
 	_ = agent.SyncFS(context.Background())
 
-	// Quiesce eth0 before snapshotting to ensure clean virtio-net virtqueues.
-	// Flush all addresses first so the host stops sending ARP/IPv6 ND traffic to
-	// this TAP, eliminating the race where a packet arrives in the RX used ring
-	// while NAPI is draining. Without this, snapshot restore triggers
-	// "input.0:id 0 is not a head!" (vq->broken=true) which permanently breaks
-	// virtio-net RX for every sandbox created from this golden snapshot.
+	// Quiesce networking before snapshotting to ensure clean virtio-net virtqueues.
+	//
+	// The host-side TAP must be brought down FIRST to stop all packet delivery
+	// into the guest's virtio-net RX ring. Only then is the guest side flushed
+	// and downed. Without this ordering, the host can push ARP/IPv6 ND packets
+	// into the RX used ring between the guest flush and the VM pause, corrupting
+	// the virtqueue state. On restore this manifests as:
+	//   "virtio_net virtio2: input.0:id 0 is not a head!"
+	// (vq->broken=true) which permanently breaks virtio-net RX for every
+	// sandbox created from this golden snapshot.
+	_ = run("ip", "link", "set", netCfg.TAPName, "down")
+
 	_, _ = agent.Exec(context.Background(), &pb.ExecRequest{
 		Command:        "/bin/sh",
 		Args:           []string{"-c", "ip addr flush dev eth0 && ip link set eth0 down"},


### PR DESCRIPTION
## Summary

- Bring the host-side TAP device down **before** flushing the guest eth0 during golden snapshot creation
- Fixes a race where the host pushes ARP/IPv6 ND packets into the virtio-net RX ring between the guest flush and VM pause, corrupting the virtqueue state
- Without this fix, restored VMs get `virtio_net virtio2: input.0:id 0 is not a head!` (`vq->broken=true`) which **permanently breaks networking** for every sandbox created from the golden snapshot

## Root cause

During `PrepareGoldenSnapshot()`, the quiesce sequence was:
1. Guest: `ip addr flush dev eth0 && ip link set eth0 down`
2. Close agent, sleep 500ms
3. Pause VM + snapshot

The host-side TAP remained up, allowing packets to enter the RX ring during steps 1-3. The fix adds `ip link set <TAP> down` on the **host** before step 1.

## Test plan

- [x] Verified on prod: restarted worker, created sandbox, confirmed ping/DNS/HTTPS all work
- [ ] Deploy this fix and verify golden snapshot survives multiple worker restarts without virtqueue corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)