### PR TITLE
Point docs to app.opencomputer.dev for API keys and Get Started

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -43,6 +43,8 @@ curl -fsSL https://github.com/diggerhq/opencomputer/releases/latest/download/oc-
 export OPENCOMPUTER_API_KEY=your-api-key
 ```
 
+<Tip>Grab your API key from [app.opencomputer.dev](https://app.opencomputer.dev)</Tip>
+
 ## Quick Example
 
 <CodeGroup>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -23,7 +23,7 @@
   "topbarCtaButton": {
     "type": "link",
     "name": "Get Started",
-    "url": "/quickstart"
+    "url": "https://app.opencomputer.dev"
   },
   "tabs": [],
   "navigation": [

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -11,6 +11,8 @@ An OpenComputer API key and the SDK installed. See [Introduction](/introduction)
 export OPENCOMPUTER_API_KEY=your-api-key
 ```
 
+<Tip>Grab your API key from [app.opencomputer.dev](https://app.opencomputer.dev)</Tip>
+
 ## Run an Agent
 
 <CodeGroup>


### PR DESCRIPTION
- Update "Get Started" CTA button to link to app.opencomputer.dev
- Add API key hint in introduction and quickstart guides

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
