### PR TITLE
docs: Update Mintlify theme with custom branding and neutral color palette

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -4,15 +4,34 @@
   "name": "OpenComputer",
   "description": "Cloud sandboxes for running AI agents",
   "colors": {
-    "primary": "#6366F1",
-    "light": "#818CF8",
-    "dark": "#4F46E5"
+    "primary": "#131311",
+    "light": "#dfdfdf",
+    "dark": "#131311"
+  },
+  "background": {
+    "color": {
+      "light": "#f8f6f1",
+      "dark": "#0f0f0f"
+    }
+  },
+  "fonts": {
+    "heading": {
+      "family": "Newsreader",
+      "weight": 400
+    },
+    "body": {
+      "family": "Inter",
+      "weight": 400
+    }
   },
   "favicon": "/images/favicon.svg",
   "logo": {
     "light": "/images/logo-light.svg",
     "dark": "/images/logo-dark.svg",
     "href": "https://opencomputer.dev"
+  },
+  "modeToggle": {
+    "default": "light"
   },
   "topbarLinks": [
     {
@@ -29,11 +48,7 @@
   "navigation": [
     {
       "group": "Getting Started",
-      "pages": [
-        "introduction",
-        "quickstart",
-        "how-it-works"
-      ]
+      "pages": ["introduction", "quickstart", "how-it-works"]
     },
     {
       "group": "Agents",
@@ -73,10 +88,7 @@
     },
     {
       "group": "Guides",
-      "pages": [
-        "guides/build-a-lovable-clone",
-        "guides/agent-skill"
-      ]
+      "pages": ["guides/build-a-lovable-clone", "guides/agent-skill"]
     },
     {
       "group": "Reference",
@@ -89,9 +101,7 @@
     },
     {
       "group": "Resources",
-      "pages": [
-        "troubleshooting"
-      ]
+      "pages": ["troubleshooting"]
     }
   ],
   "footerSocials": {

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -1,0 +1,22 @@
+h5 {
+  font-family: 'Inter', sans-serif;
+}
+#navbar .nav-logo {
+  display: none;
+}
+#navbar a.select-none::before {
+  content: 'opencomputer';
+  font-family: 'Newsreader', serif;
+  font-size: 24px;
+  font-weight: 400;
+  letter-spacing: 0.01em;
+  transition: letter-spacing 0.3s ease;
+  color: #131311;
+}
+#navbar a:hover::before {
+  letter-spacing: 0.06em;
+}
+
+.dark #navbar a.select-none::before {
+  color: #dfdfdf;
+}


### PR DESCRIPTION
**Summary**
Updates the OpenComputer docs site (Mintlify) with a new design system: neutral color palette, custom typography, and text-based navbar branding.
