### PR TITLE
ci: Add Palmer documentation testing workflow

### DIFF
--- a/.github/workflows/palmer-docs-test.yml
+++ b/.github/workflows/palmer-docs-test.yml
@@ -19,7 +19,7 @@ jobs:
           prompt: |
             Explore the docs/ directory and read every documentation page (.mdx files). Identify every testable code example and verifiable claim — cover every code snippet, every CLI command, every SDK usage example. For each test, include the source file path and section heading in the name. Be thorough.
           branch: ${{ github.event.pull_request.head.ref }}
-          browser_enabled: false
+          browser-enabled: false
           timeout: 7200
         env:
           PALMER_API_URL: https://api.generalvolition.com


### PR DESCRIPTION
This workflow runs tests on pull requests to the main branch using the Palmer action to verify documentation and code examples.

You need to get your API key here - https://palmer.generalvolition.com/ ; set it in GitHub
Finally you also an OpenComputer API key set in GitHUb