### PR TITLE
Add Sessions API docs

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -67,6 +67,15 @@
       ]
     },
     {
+      "group": "Sessions API",
+      "pages": [
+        "sessions-api/overview",
+        "sessions-api/sessions",
+        "sessions-api/messages",
+        "sessions-api/events"
+      ]
+    },
+    {
       "group": "Sandboxes",
       "pages": [
         "sandboxes/overview",

--- a/docs/sessions-api/events.mdx
+++ b/docs/sessions-api/events.mdx
@@ -1,0 +1,60 @@
+---
+title: "Events"
+description: "Stream real-time agent activity via Server-Sent Events"
+---
+
+## Stream events
+
+```
+GET /v1/sessions/{sessionId}/events
+```
+
+Server-Sent Events (SSE) stream of real-time agent activity. On connect, replays all past events from the session, then streams live events as the agent works.
+
+<ParamField query="api_key" type="string" required>
+  OpenComputer API key (since `EventSource` can't set headers)
+</ParamField>
+
+<ParamField query="user_id" type="string">
+  Filter by user ownership
+</ParamField>
+
+### Example
+
+```javascript
+const es = new EventSource(
+  "https://api.opencomputer.dev/v1/sessions/session_abc123/events?api_key=osb_your_api_key"
+);
+
+es.onmessage = (event) => {
+  const data = JSON.parse(event.data);
+  console.log(data.type, data);
+};
+```
+
+## Event types
+
+| Type | Description |
+|------|-------------|
+| `assistant` | Agent response with `message.content` blocks (text, tool_use) |
+| `tool_use_summary` | Summary of a tool call (`tool` field) |
+| `turn_complete` | Agent finished processing the current message |
+| `result` | Final result of a turn |
+| `error` | Something went wrong |
+| `ready` | Agent process initialized |
+| `configured` | Agent configured with tools/prompt |
+
+## Example `assistant` event
+
+```json
+{
+  "type": "assistant",
+  "message": {
+    "content": [
+      { "type": "text", "text": "I'll create a Next.js app with a todo list..." },
+      { "type": "tool_use", "name": "bash", "input": { "command": "npx create-next-app@latest . --ts --tailwind --yes" } }
+    ]
+  },
+  "session_id": "claude_session_xxx"
+}
+```

--- a/docs/sessions-api/messages.mdx
+++ b/docs/sessions-api/messages.mdx
@@ -1,0 +1,68 @@
+---
+title: "Messages"
+description: "Send follow-up messages to an agent session"
+---
+
+## Send a message
+
+```
+POST /v1/sessions/{sessionId}/messages
+```
+
+Send a follow-up message to the agent. The agent receives the message in the same sandbox with full conversation context. Returns immediately — the agent works asynchronously and emits events via the [SSE stream](/sessions-api/events).
+
+<ParamField body="message" type="string" required>
+  The user's message
+</ParamField>
+
+<ParamField body="user_id" type="string" required>
+  Must match the session owner
+</ParamField>
+
+### Example
+
+```bash
+curl -X POST https://api.opencomputer.dev/v1/sessions/session_abc123/messages \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: osb_your_api_key" \
+  -d '{
+    "message": "Add a dark mode toggle to the header",
+    "user_id": "user_123"
+  }'
+```
+
+### Response `200`
+
+Returns the full session object (same shape as [create](/sessions-api/sessions#create-a-session)).
+
+```json
+{
+  "id": "session_abc123",
+  "status": "running",
+  "sandboxId": "sb-31317626",
+  "previewUrl": "https://sb-31317626-p3000.preview.opencomputer.dev",
+  "project": {
+    "title": "Build a todo app",
+    "framework": "nextjs",
+    "artifacts": []
+  },
+  "messages": [
+    {
+      "id": "msg_xxx",
+      "role": "user",
+      "content": "Build a todo app with Next.js and Tailwind",
+      "createdAt": "2026-03-18T17:00:00.000Z"
+    },
+    {
+      "id": "msg_yyy",
+      "role": "user",
+      "content": "Add a dark mode toggle to the header",
+      "createdAt": "2026-03-18T17:05:00.000Z"
+    }
+  ],
+  "events": [],
+  "userId": "user_123",
+  "createdAt": "2026-03-18T17:00:00.000Z",
+  "updatedAt": "2026-03-18T17:05:00.000Z"
+}
+```

--- a/docs/sessions-api/overview.mdx
+++ b/docs/sessions-api/overview.mdx
@@ -1,0 +1,75 @@
+---
+title: "Sessions API Overview"
+description: "Interactive AI agent sessions on OpenComputer — create a session, send messages, stream real-time events, and get a live preview URL"
+---
+
+The Sessions API lets you create cloud sandboxes with AI agents that build and modify apps in real time. Each session gives you a live preview URL, an SSE event stream, and multi-turn conversation support — all through a simple REST + SSE API.
+
+## Base URL
+
+```
+https://api.opencomputer.dev
+```
+
+## Authentication
+
+All requests require an OpenComputer API key via the `X-API-Key` header:
+
+```
+X-API-Key: osb_your_api_key
+```
+
+Get your API key from the [OpenComputer dashboard](https://app.opencomputer.dev).
+
+## Session object
+
+All endpoints that return sessions use this shape:
+
+```typescript
+{
+  id: string;                  // "session_abc123"
+  status: "ready" | "running" | "error";
+  sandboxId: string | null;    // "sb-31317626"
+  previewUrl: string;          // "https://sb-xxx-p3000.preview.opencomputer.dev"
+  userId: string;
+  project: {
+    title: string;
+    framework: string;
+    artifacts: { path: string; summary: string }[];
+  };
+  messages: {
+    id: string;
+    role: "user" | "assistant" | "system";
+    content: string;
+    createdAt: string;         // ISO 8601
+  }[];
+  events: {
+    id: string;
+    type: string;
+    level: "info" | "warning" | "error";
+    message: string;
+    createdAt: string;
+  }[];
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+## Preview URL
+
+The `previewUrl` field points to a live dev server running inside the sandbox. Embed it in an iframe or open it directly — it updates in real-time as the agent edits files via HMR.
+
+The URL is available once the agent starts a dev server on port 3000. If the agent hasn't started one yet, `previewUrl` will be empty.
+
+## Errors
+
+All errors return:
+
+```json
+{
+  "error": {
+    "type": "invalid_request | not_found | internal_error",
+    "message": "Human-readable description"
+  }
+}
+```

--- a/docs/sessions-api/sessions.mdx
+++ b/docs/sessions-api/sessions.mdx
@@ -1,0 +1,157 @@
+---
+title: "Sessions"
+description: "Create, retrieve, and delete agent sessions"
+---
+
+## Create a session
+
+```
+POST /v1/sessions
+```
+
+Creates a cloud sandbox, starts an AI agent with your prompt, and returns a session with a live preview URL. The agent begins working immediately — stream events to follow its progress.
+
+### Request body
+
+<ParamField body="prompt" type="string" required>
+  What the agent should build or do
+</ParamField>
+
+<ParamField body="user_id" type="string" required>
+  Your user's ID (for session ownership)
+</ParamField>
+
+<ParamField body="user_email" type="string">
+  User email (stored for reference)
+</ParamField>
+
+<ParamField body="user_name" type="string">
+  User name (stored for reference)
+</ParamField>
+
+<ParamField body="agent_config" type="object">
+  Agent configuration
+
+  <Expandable title="agent_config fields">
+    <ParamField body="agent_config.system_prompt" type="string">
+      System prompt for the AI agent
+    </ParamField>
+
+    <ParamField body="agent_config.skills" type="object">
+      Map of `path → content` — files synced into the sandbox at `/workspace/agent/`
+    </ParamField>
+
+    <ParamField body="agent_config.allowed_tools" type="string[]">
+      Tools the agent can use. Default: `["bash", "read", "write", "edit", "glob", "grep"]`
+    </ParamField>
+
+    <ParamField body="agent_config.cwd" type="string">
+      Agent working directory. Default: `/workspace/app`
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+### Example
+
+```bash
+curl -X POST https://api.opencomputer.dev/v1/sessions \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: osb_your_api_key" \
+  -d '{
+    "prompt": "Build a todo app with Next.js and Tailwind",
+    "user_id": "user_123",
+    "agent_config": {
+      "system_prompt": "You are a web app builder. Work in /workspace/app.",
+      "skills": {
+        ".claude/skills/build-app/SKILL.md": "# Build App\n\nScaffold, install, edit, verify."
+      }
+    }
+  }'
+```
+
+### Response `201`
+
+```json
+{
+  "id": "session_abc123",
+  "status": "running",
+  "sandboxId": "sb-31317626",
+  "previewUrl": "https://sb-31317626-p3000.preview.opencomputer.dev",
+  "project": {
+    "title": "Build a todo app",
+    "framework": "nextjs",
+    "artifacts": []
+  },
+  "messages": [
+    {
+      "id": "msg_xxx",
+      "role": "user",
+      "content": "Build a todo app with Next.js and Tailwind",
+      "createdAt": "2026-03-18T17:00:00.000Z"
+    }
+  ],
+  "events": [
+    {
+      "id": "evt_xxx",
+      "type": "session_started",
+      "level": "info",
+      "message": "Bootstrapping sandbox...",
+      "createdAt": "2026-03-18T17:00:00.000Z"
+    }
+  ],
+  "userId": "user_123",
+  "createdAt": "2026-03-18T17:00:00.000Z",
+  "updatedAt": "2026-03-18T17:00:02.000Z"
+}
+```
+
+---
+
+## Get a session
+
+```
+GET /v1/sessions/{sessionId}
+```
+
+Returns the full session state including messages, events, and preview URL.
+
+<ParamField query="user_id" type="string">
+  Filter by user ownership
+</ParamField>
+
+### Example
+
+```bash
+curl https://api.opencomputer.dev/v1/sessions/session_abc123?user_id=user_123 \
+  -H "X-API-Key: osb_your_api_key"
+```
+
+---
+
+## Delete a session
+
+```
+DELETE /v1/sessions/{sessionId}
+```
+
+Kills the sandbox and ends the session.
+
+<ParamField query="user_id" type="string">
+  Filter by user ownership
+</ParamField>
+
+### Example
+
+```bash
+curl -X DELETE https://api.opencomputer.dev/v1/sessions/session_abc123?user_id=user_123 \
+  -H "X-API-Key: osb_your_api_key"
+```
+
+### Response `200`
+
+```json
+{
+  "id": "session_abc123",
+  "status": "ended"
+}
+```


### PR DESCRIPTION
## Summary
- Add new "Sessions API" nav section (after Agents) with 4 pages: overview, sessions, messages, events
- Documents the REST + SSE API from sessions-api for creating agent sessions, sending messages, and streaming real-time events
- Uses standard Mintlify components (ParamField, Expandable) matching existing docs style

## Test plan
- [x] Run `mintlify dev` and verify the new nav group renders correctly
- [x] Check all 4 pages load without errors
- [ ] Verify cross-links between pages work (messages → events, messages → sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)