### PR TITLE
Mark Sessions API docs as experimental

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -82,7 +82,7 @@
       ]
     },
     {
-      "group": "Sessions API",
+      "group": "Sessions API (Experimental)",
       "pages": [
         "sessions-api/overview",
         "sessions-api/sessions",

--- a/docs/sessions-api/events.mdx
+++ b/docs/sessions-api/events.mdx
@@ -3,6 +3,8 @@ title: "Events"
 description: "Stream real-time agent activity via Server-Sent Events"
 ---
 
+<Warning>The Sessions API is experimental. Endpoints and behavior may change without notice.</Warning>
+
 ## Stream events
 
 ```

--- a/docs/sessions-api/messages.mdx
+++ b/docs/sessions-api/messages.mdx
@@ -3,6 +3,8 @@ title: "Messages"
 description: "Send follow-up messages to an agent session"
 ---
 
+<Warning>The Sessions API is experimental. Endpoints and behavior may change without notice.</Warning>
+
 ## Send a message
 
 ```

--- a/docs/sessions-api/sessions.mdx
+++ b/docs/sessions-api/sessions.mdx
@@ -3,6 +3,8 @@ title: "Sessions"
 description: "Create, retrieve, and delete agent sessions"
 ---
 
+<Warning>The Sessions API is experimental. Endpoints and behavior may change without notice.</Warning>
+
 ## Create a session
 
 ```


### PR DESCRIPTION
## Summary
- Rename sidebar nav group to "Sessions API (Experimental)"
- Add experimental warning banner to sessions, messages, and events pages (overview already had one)

## Test plan
- [ ] Verify sidebar shows "(Experimental)" label
- [ ] Confirm warning banner renders on all 4 Sessions API pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)