### PR TITLE
Add Desktop SDK, export Image/Snapshots from entrypoint

### DIFF
--- a/deploy/firecracker/rootfs/Dockerfile.desktop
+++ b/deploy/firecracker/rootfs/Dockerfile.desktop
@@ -1,0 +1,212 @@
+# Desktop rootfs for OpenSandbox VMs
+# Includes Xvfb, x11vnc, noVNC, Google Chrome, and xdotool for AI computer-use agents.
+# Build: scripts/build-rootfs.sh desktop
+FROM ubuntu:22.04
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ── System packages ──────────────────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Shell & core
+    bash \
+    busybox \
+    ca-certificates \
+    kmod \
+    locales \
+    sudo \
+    # Editors
+    nano \
+    vim-tiny \
+    # Networking
+    curl \
+    wget \
+    openssh-client \
+    iproute2 \
+    iputils-ping \
+    net-tools \
+    dnsutils \
+    # Version control
+    git \
+    # Archive / compression
+    tar \
+    gzip \
+    unzip \
+    # Build tools (minimal — desktop image doesn't need full build-essential)
+    pkg-config \
+    # JSON / text
+    jq \
+    less \
+    # Process tools
+    procps \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Display server & desktop environment ─────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Virtual framebuffer
+    xvfb \
+    # X11 utilities
+    x11-utils \
+    x11-xserver-utils \
+    xauth \
+    # Window manager (lightweight)
+    openbox \
+    # VNC server
+    x11vnc \
+    # Desktop utilities
+    xdg-utils \
+    dbus-x11 \
+    xclip \
+    # Programmatic input/screenshots for AI agents
+    xdotool \
+    scrot \
+    # Screen info
+    x11-apps \
+    # Fonts (needed for readable text in browser/desktop)
+    fonts-liberation \
+    fonts-noto-color-emoji \
+    fonts-dejavu-core \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── noVNC + websockify (VNC-over-WebSocket) ──────────────────────────────────
+RUN git clone --depth 1 https://github.com/novnc/noVNC.git /opt/noVNC \
+    && git clone --depth 1 --branch v0.12.0 https://github.com/novnc/websockify.git /opt/noVNC/utils/websockify \
+    && ln -sf /opt/noVNC/vnc.html /opt/noVNC/index.html \
+    && rm -rf /opt/noVNC/.git /opt/noVNC/utils/websockify/.git
+
+# ── Google Chrome (Ubuntu 22.04 chromium-browser is a snap stub) ─────────────
+RUN wget -qO /tmp/google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+    && apt-get update && apt-get install -y --no-install-recommends /tmp/google-chrome.deb \
+    && rm -f /tmp/google-chrome.deb \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Python 3 (for agent SDKs) ───────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3 /usr/bin/python
+
+# ── Node.js 20 LTS (for agent SDKs) ─────────────────────────────────────────
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g npm@latest
+
+# ── Desktop start script ────────────────────────────────────────────────────
+# Launches Xvfb + openbox. VNC streaming is started on-demand via the SDK.
+COPY --chmod=755 <<'DESKTOP_START' /usr/local/bin/start-desktop
+#!/bin/bash
+# start-desktop — Launches the desktop environment inside the sandbox VM.
+# Called on sandbox creation for desktop template.
+# VNC/noVNC streaming is separate — started on-demand via stream.start().
+
+set -euo pipefail
+
+DISPLAY="${DISPLAY:-:99}"
+export DISPLAY
+SCREEN_WIDTH="${SCREEN_WIDTH:-1024}"
+SCREEN_HEIGHT="${SCREEN_HEIGHT:-768}"
+SCREEN_DEPTH="${SCREEN_DEPTH:-24}"
+SCREEN_DPI="${SCREEN_DPI:-96}"
+
+# Start Xvfb
+Xvfb "$DISPLAY" -ac -screen 0 "${SCREEN_WIDTH}x${SCREEN_HEIGHT}x${SCREEN_DEPTH}" \
+    -retro -dpi "$SCREEN_DPI" -nolisten tcp -nolisten unix &
+XVFB_PID=$!
+
+# Wait for X to be ready
+for i in $(seq 1 50); do
+    if xdpyinfo -display "$DISPLAY" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.1
+done
+
+# Start openbox window manager
+openbox &
+
+echo "desktop: Xvfb + openbox running on $DISPLAY (${SCREEN_WIDTH}x${SCREEN_HEIGHT})"
+
+# Keep running (wait for Xvfb)
+wait $XVFB_PID
+DESKTOP_START
+
+# ── VNC stream start script ─────────────────────────────────────────────────
+# Called on-demand when SDK calls stream.start()
+COPY --chmod=755 <<'VNC_START' /usr/local/bin/start-vnc
+#!/bin/bash
+# start-vnc — Starts x11vnc + noVNC for WebSocket-based VNC streaming.
+# Usage: start-vnc [--password PASSWORD] [--vnc-port PORT] [--novnc-port PORT] [--window-id ID]
+
+set -euo pipefail
+
+DISPLAY="${DISPLAY:-:99}"
+export DISPLAY
+VNC_PORT="${VNC_PORT:-5900}"
+NOVNC_PORT="${NOVNC_PORT:-6080}"
+PASSWORD=""
+WINDOW_ID=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --password) PASSWORD="$2"; shift 2 ;;
+        --vnc-port) VNC_PORT="$2"; shift 2 ;;
+        --novnc-port) NOVNC_PORT="$2"; shift 2 ;;
+        --window-id) WINDOW_ID="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+# Configure auth
+PWD_FLAG="-nopw"
+if [ -n "$PASSWORD" ]; then
+    mkdir -p ~/.vnc
+    x11vnc -storepasswd "$PASSWORD" ~/.vnc/passwd
+    PWD_FLAG="-usepw"
+fi
+
+# Window targeting
+WINDOW_FLAG=""
+if [ -n "$WINDOW_ID" ]; then
+    WINDOW_FLAG="-id $WINDOW_ID"
+fi
+
+# Start x11vnc
+x11vnc -bg -display "$DISPLAY" -forever -wait 50 -shared \
+    -rfbport "$VNC_PORT" $PWD_FLAG $WINDOW_FLAG 2>/tmp/x11vnc_stderr.log
+
+# Start noVNC proxy (backgrounded so the script returns immediately)
+cd /opt/noVNC/utils
+nohup ./novnc_proxy --vnc "127.0.0.1:${VNC_PORT}" \
+    --listen "$NOVNC_PORT" --web /opt/noVNC > /tmp/novnc.log 2>&1 &
+
+# Wait for noVNC to be listening
+for i in $(seq 1 20); do
+    netstat -tuln 2>/dev/null | grep -q ":${NOVNC_PORT} " && exit 0
+    sleep 0.5
+done
+echo "WARNING: noVNC may not have started" >&2
+VNC_START
+
+# ── Stop VNC script ─────────────────────────────────────────────────────────
+COPY --chmod=755 <<'VNC_STOP' /usr/local/bin/stop-vnc
+#!/bin/bash
+# stop-vnc — Stops x11vnc and noVNC processes.
+pkill x11vnc 2>/dev/null || true
+pkill -f novnc_proxy 2>/dev/null || true
+VNC_STOP
+
+# ── Locale ───────────────────────────────────────────────────────────────────
+RUN locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
+# ── Sandbox user (non-root with passwordless sudo) ───────────────────────────
+RUN useradd -m -s /bin/bash -G sudo,audio,video sandbox \
+    && echo "sandbox ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/sandbox \
+    && chmod 440 /etc/sudoers.d/sandbox
+
+# ── Overlay mount points ────────────────────────────────────────────────────
+RUN mkdir -p /mnt/data /mnt/overlay
+WORKDIR /home/sandbox

--- a/examples/demo-desktop.ts
+++ b/examples/demo-desktop.ts
@@ -1,0 +1,175 @@
+/**
+ * Desktop Sandbox Demo
+ *
+ * Demonstrates the remote desktop functionality:
+ * 1. Creates a desktop sandbox with Xvfb + openbox
+ * 2. Starts VNC streaming (viewable in browser via noVNC)
+ * 3. Launches Google Chrome
+ * 4. Takes screenshots
+ * 5. Programmatic mouse/keyboard input
+ * 6. Window management
+ *
+ * Usage:
+ *   npx tsx examples/demo-desktop.ts
+ *
+ * Environment:
+ *   OPENCOMPUTER_API_URL  (default: http://localhost:8080)
+ *   OPENCOMPUTER_API_KEY  (default: opensandbox-dev)
+ */
+
+import { writeFileSync } from "fs";
+import { Desktop } from "../sdks/typescript/src/desktop.js";
+
+const API_URL = process.env.OPENCOMPUTER_API_URL ?? "http://20.101.100.215:8080";
+const API_KEY = process.env.OPENCOMPUTER_API_KEY ?? "opensandbox-dev";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function log(msg: string) {
+  console.log(`\n${"=".repeat(60)}\n  ${msg}\n${"=".repeat(60)}`);
+}
+
+async function saveScreenshot(desktop: Desktop, name: string) {
+  const png = await desktop.screenshot();
+  const path = `/tmp/${name}.png`;
+  writeFileSync(path, png);
+  console.log(`  Screenshot saved: ${path} (${(png.length / 1024).toFixed(1)} KB)`);
+}
+
+async function main() {
+  // ── Step 1: Create desktop sandbox ─────────────────────────────────
+  log("Step 1: Creating desktop sandbox...");
+  const desktop = await Desktop.create({
+    apiUrl: API_URL,
+    apiKey: API_KEY,
+    memoryMB: 4096,
+    timeout: 600,
+  });
+  console.log(`  Sandbox ID: ${desktop.sandboxId}`);
+  console.log(`  Status: ${desktop.status}`);
+
+  // ── Step 2: Start VNC streaming ────────────────────────────────────
+  log("Step 2: Starting VNC stream...");
+  await desktop.stream.start();
+  const streamUrl = `http://${desktop.sandboxId}-p6080.20.101.100.215.nip.io:8081/vnc.html?autoconnect=true&resize=scale`;
+  console.log(`  Stream URL: ${streamUrl}`);
+  console.log(`  Open the URL above in your browser to watch live!`);
+
+  await sleep(2000);
+
+  // ── Step 3: Take initial screenshot (empty desktop) ────────────────
+  log("Step 3: Screenshot of empty desktop...");
+  await saveScreenshot(desktop, "01-empty-desktop");
+
+  // ── Step 4: Get screen info ────────────────────────────────────────
+  log("Step 4: Screen info...");
+  const screenSize = await desktop.getScreenSize();
+  console.log(`  Resolution: ${screenSize.width}x${screenSize.height}`);
+  const cursorPos = await desktop.getCursorPosition();
+  console.log(`  Cursor: (${cursorPos.x}, ${cursorPos.y})`);
+
+  await sleep(1000);
+
+  // ── Step 5: Launch Google Chrome ───────────────────────────────────
+  log("Step 5: Launching Google Chrome...");
+  await desktop.exec.run(
+    "google-chrome --no-sandbox --disable-gpu --no-first-run --start-maximized https://example.com > /dev/null 2>&1 &",
+    { env: { DISPLAY: ":99" } },
+  );
+  console.log("  Waiting for Chrome to load...");
+  await sleep(5000);
+  await saveScreenshot(desktop, "02-chrome-example");
+
+  // ── Step 6: Interact with the browser ──────────────────────────────
+  log("Step 6: Clicking in the browser and typing...");
+
+  // Click on the Chrome address bar (approximate position)
+  await desktop.leftClick(400, 52);
+  await sleep(500);
+
+  // Select all text in the address bar and type a new URL
+  await desktop.press(["ctrl", "a"]);
+  await sleep(300);
+  await desktop.write("https://news.ycombinator.com", { delayMs: 30 });
+  await sleep(300);
+  await desktop.press("enter");
+  console.log("  Navigating to Hacker News...");
+  await sleep(5000);
+  await saveScreenshot(desktop, "03-hackernews");
+
+  // ── Step 7: Scroll down the page ───────────────────────────────────
+  log("Step 7: Scrolling down...");
+  // Click in the page content area first
+  await desktop.leftClick(500, 400);
+  await sleep(300);
+  await desktop.scroll("down", 5);
+  await sleep(1000);
+  await saveScreenshot(desktop, "04-scrolled");
+
+  // ── Step 8: Open a new tab ─────────────────────────────────────────
+  log("Step 8: Opening new tab...");
+  await desktop.press(["ctrl", "t"]);
+  await sleep(1000);
+  await desktop.write("https://wikipedia.org", { delayMs: 30 });
+  await desktop.press("enter");
+  console.log("  Navigating to Wikipedia...");
+  await sleep(5000);
+  await saveScreenshot(desktop, "05-wikipedia");
+
+  // ── Step 9: Window management ──────────────────────────────────────
+  log("Step 9: Window management...");
+  const windowId = await desktop.getCurrentWindowId();
+  const title = await desktop.getWindowTitle(windowId);
+  console.log(`  Current window: ${windowId} - "${title}"`);
+
+  const chromeWindows = await desktop.getApplicationWindows("chrome");
+  console.log(`  Chrome windows: ${chromeWindows.length}`);
+
+  // ── Step 10: Right-click context menu ──────────────────────────────
+  log("Step 10: Right-click demo...");
+  await desktop.rightClick(500, 400);
+  await sleep(1000);
+  await saveScreenshot(desktop, "06-context-menu");
+  // Dismiss the menu
+  await desktop.press("escape");
+  await sleep(500);
+
+  // ── Step 11: Drag demo ─────────────────────────────────────────────
+  log("Step 11: Mouse drag demo...");
+  // Move mouse to show cursor movement
+  for (let i = 0; i < 5; i++) {
+    await desktop.moveMouse(200 + i * 100, 300);
+    await sleep(200);
+  }
+  await saveScreenshot(desktop, "07-final");
+
+  // ── Summary ────────────────────────────────────────────────────────
+  log("Demo complete!");
+  console.log(`
+  Screenshots saved in /tmp/:
+    01-empty-desktop.png  - Bare openbox desktop
+    02-chrome-example.png - Chrome showing example.com
+    03-hackernews.png     - Navigated to Hacker News
+    04-scrolled.png       - Scrolled down
+    05-wikipedia.png      - Wikipedia in new tab
+    06-context-menu.png   - Right-click context menu
+    07-final.png          - Final state
+
+  Stream URL (still live):
+    ${streamUrl}
+
+  Sandbox will auto-terminate in 10 minutes.
+  Press Ctrl+C to exit (sandbox keeps running).
+  `);
+
+  // Keep the process alive so the user can interact via noVNC
+  console.log("  Keeping sandbox alive... Press Ctrl+C to exit.");
+  await new Promise(() => {}); // block forever
+}
+
+main().catch((err) => {
+  console.error("Demo failed:", err);
+  process.exit(1);
+});

--- a/sdks/python/opencomputer/__init__.py
+++ b/sdks/python/opencomputer/__init__.py
@@ -1,6 +1,7 @@
 """OpenComputer Python SDK - cloud sandbox platform."""
 
 from opencomputer.sandbox import Sandbox
+from opencomputer.desktop import Desktop
 from opencomputer.agent import Agent, AgentEvent, AgentSession, AgentSessionInfo
 from opencomputer.filesystem import Filesystem
 from opencomputer.exec import Exec, ProcessResult, ExecSessionInfo
@@ -12,6 +13,7 @@ from opencomputer.snapshot import Snapshots
 
 __all__ = [
     "Sandbox",
+    "Desktop",
     "Agent",
     "AgentEvent",
     "AgentSession",

--- a/sdks/python/opencomputer/desktop.py
+++ b/sdks/python/opencomputer/desktop.py
@@ -1,0 +1,363 @@
+"""Desktop sandbox with remote display streaming, screenshots, and input control.
+
+Uses Xvfb + x11vnc + noVNC inside the VM. The desktop environment (Xvfb + openbox)
+is auto-started at sandbox creation. VNC streaming is started on-demand via stream.start().
+
+Example::
+
+    from opencomputer.desktop import Desktop
+
+    desktop = await Desktop.create()
+    await desktop.stream.start()
+    print(desktop.stream.get_url())
+
+    # Take a screenshot for AI agent
+    png = await desktop.screenshot()
+
+    # Programmatic input
+    await desktop.left_click(500, 300)
+    await desktop.write("hello world")
+    await desktop.press("enter")
+
+    await desktop.stream.stop()
+    await desktop.kill()
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+import string
+from shlex import quote as shell_quote
+from typing import Literal
+
+from opencomputer.sandbox import Sandbox
+
+MOUSE_BUTTONS = {"left": 1, "right": 3, "middle": 2}
+
+KEYS: dict[str, str] = {
+    "alt": "Alt_L",
+    "backspace": "BackSpace",
+    "caps_lock": "Caps_Lock",
+    "ctrl": "Control_L",
+    "control": "Control_L",
+    "del": "Delete",
+    "delete": "Delete",
+    "down": "Down",
+    "end": "End",
+    "enter": "Return",
+    "esc": "Escape",
+    "escape": "Escape",
+    "f1": "F1", "f2": "F2", "f3": "F3", "f4": "F4", "f5": "F5", "f6": "F6",
+    "f7": "F7", "f8": "F8", "f9": "F9", "f10": "F10", "f11": "F11", "f12": "F12",
+    "home": "Home",
+    "insert": "Insert",
+    "left": "Left",
+    "page_down": "Page_Down",
+    "page_up": "Page_Up",
+    "right": "Right",
+    "shift": "Shift_L",
+    "space": "space",
+    "super": "Super_L",
+    "tab": "Tab",
+    "up": "Up",
+}
+
+
+def _map_key(key: str) -> str:
+    return KEYS.get(key.lower(), key.lower())
+
+
+def _random_string(length: int = 16) -> str:
+    chars = string.ascii_letters + string.digits
+    return "".join(secrets.choice(chars) for _ in range(length))
+
+
+DISPLAY = ":99"
+
+
+class VNCStream:
+    """On-demand VNC streaming via x11vnc + noVNC."""
+
+    def __init__(self, desktop: Desktop) -> None:
+        self._desktop = desktop
+        self._vnc_port = 5900
+        self._port = 6080
+        self._password: str | None = None
+        self._running = False
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    def get_auth_key(self) -> str:
+        """Get the auto-generated authentication key (only if require_auth was set)."""
+        if not self._password:
+            raise RuntimeError("No auth key — stream was started without require_auth")
+        return self._password
+
+    def get_url(
+        self,
+        auto_connect: bool = True,
+        view_only: bool = False,
+        resize: str = "scale",
+        auth_key: str | None = None,
+    ) -> str:
+        """Get the noVNC URL for viewing the remote desktop in a browser."""
+        # Build URL from sandbox's preview domain
+        hostname = f"{self._desktop.sandbox_id}-p{self._port}.{self._desktop._sandbox_domain}"
+        base = f"https://{hostname}/vnc.html"
+        params = []
+        if auto_connect:
+            params.append("autoconnect=true")
+        if view_only:
+            params.append("view_only=true")
+        if resize:
+            params.append(f"resize={resize}")
+        if auth_key:
+            params.append(f"password={auth_key}")
+        return f"{base}?{'&'.join(params)}" if params else base
+
+    async def start(
+        self,
+        vnc_port: int | None = None,
+        port: int | None = None,
+        require_auth: bool = False,
+        window_id: str | None = None,
+    ) -> None:
+        """Start VNC streaming. Launches x11vnc + noVNC inside the VM."""
+        if self._running:
+            raise RuntimeError("Stream is already running")
+
+        self._vnc_port = vnc_port or self._vnc_port
+        self._port = port or self._port
+        self._password = _random_string() if require_auth else None
+
+        args: list[str] = []
+        if self._password:
+            args.extend(["--password", self._password])
+        if vnc_port:
+            args.extend(["--vnc-port", str(vnc_port)])
+        if port:
+            args.extend(["--novnc-port", str(port)])
+        if window_id:
+            args.extend(["--window-id", window_id])
+
+        await self._desktop.exec.run(
+            f"/usr/local/bin/start-vnc {' '.join(args)}",
+            timeout=15,
+            env={"DISPLAY": DISPLAY},
+        )
+
+        # Verify noVNC is listening
+        check = await self._desktop.exec.run(
+            f'for i in $(seq 1 20); do netstat -tuln 2>/dev/null | grep -q ":{self._port} " && echo ready && exit 0; sleep 0.5; done; echo timeout',
+            timeout=15,
+        )
+        if "ready" not in check.stdout:
+            raise TimeoutError("noVNC failed to start")
+
+        self._running = True
+
+    async def stop(self) -> None:
+        """Stop VNC streaming."""
+        await self._desktop.exec.run("/usr/local/bin/stop-vnc", env={"DISPLAY": DISPLAY})
+        self._running = False
+
+
+class Desktop(Sandbox):
+    """Desktop sandbox with display streaming and programmatic input control."""
+
+    display: str = DISPLAY
+    _sandbox_domain: str = ""
+
+    @classmethod
+    async def create(
+        cls,
+        template: str = "desktop",
+        timeout: int = 300,
+        api_key: str | None = None,
+        api_url: str | None = None,
+        envs: dict[str, str] | None = None,
+        resolution: tuple[int, int] | None = None,
+        dpi: int | None = None,
+        **kwargs,
+    ) -> Desktop:
+        """Create a new desktop sandbox with a running display server.
+
+        Args:
+            template: Template to use (default "desktop").
+            timeout: Sandbox timeout in seconds.
+            api_key: API key (or OPENCOMPUTER_API_KEY env var).
+            api_url: API URL (or OPENCOMPUTER_API_URL env var).
+            envs: Extra environment variables.
+            resolution: Screen resolution (width, height). Default (1024, 768).
+            dpi: Display DPI. Default 96.
+        """
+        merged_envs = {"DISPLAY": DISPLAY}
+        if envs:
+            merged_envs.update(envs)
+
+        sandbox = await Sandbox.create(
+            template=template,
+            timeout=timeout,
+            api_key=api_key,
+            api_url=api_url,
+            envs=merged_envs,
+            **kwargs,
+        )
+
+        # "Upgrade" the Sandbox instance to a Desktop
+        desktop = cls.__new__(cls)
+        desktop.__dict__.update(sandbox.__dict__)
+        desktop.display = DISPLAY
+        desktop.stream = VNCStream(desktop)
+
+        return desktop
+
+    @classmethod
+    async def connect(
+        cls,
+        sandbox_id: str,
+        api_key: str | None = None,
+        api_url: str | None = None,
+    ) -> Desktop:
+        """Connect to an existing desktop sandbox."""
+        sandbox = await Sandbox.connect(sandbox_id, api_key=api_key, api_url=api_url)
+        desktop = cls.__new__(cls)
+        desktop.__dict__.update(sandbox.__dict__)
+        desktop.display = DISPLAY
+        desktop.stream = VNCStream(desktop)
+        return desktop
+
+    async def screenshot(self) -> bytes:
+        """Take a screenshot and return it as PNG bytes."""
+        path = f"/tmp/screenshot-{_random_string(8)}.png"
+        await self.exec.run(f"scrot --pointer {path}", env={"DISPLAY": DISPLAY})
+        content = await self.files.read(path)
+        await self.exec.run(f"rm -f {path}")
+        return content if isinstance(content, bytes) else content.encode("latin-1")
+
+    async def move_mouse(self, x: int, y: int) -> None:
+        """Move the mouse to (x, y)."""
+        await self.exec.run(f"xdotool mousemove --sync {x} {y}", env={"DISPLAY": DISPLAY})
+
+    async def left_click(self, x: int | None = None, y: int | None = None) -> None:
+        """Left click at the current position, or at (x, y) if provided."""
+        if x is not None and y is not None:
+            await self.move_mouse(x, y)
+        await self.exec.run("xdotool click 1", env={"DISPLAY": DISPLAY})
+
+    async def double_click(self, x: int | None = None, y: int | None = None) -> None:
+        """Double left click."""
+        if x is not None and y is not None:
+            await self.move_mouse(x, y)
+        await self.exec.run("xdotool click --repeat 2 1", env={"DISPLAY": DISPLAY})
+
+    async def right_click(self, x: int | None = None, y: int | None = None) -> None:
+        """Right click."""
+        if x is not None and y is not None:
+            await self.move_mouse(x, y)
+        await self.exec.run("xdotool click 3", env={"DISPLAY": DISPLAY})
+
+    async def middle_click(self, x: int | None = None, y: int | None = None) -> None:
+        """Middle click."""
+        if x is not None and y is not None:
+            await self.move_mouse(x, y)
+        await self.exec.run("xdotool click 2", env={"DISPLAY": DISPLAY})
+
+    async def scroll(self, direction: Literal["up", "down"] = "down", amount: int = 1) -> None:
+        """Scroll the mouse wheel."""
+        button = "4" if direction == "up" else "5"
+        await self.exec.run(f"xdotool click --repeat {amount} {button}", env={"DISPLAY": DISPLAY})
+
+    async def mouse_press(self, button: Literal["left", "right", "middle"] = "left") -> None:
+        """Press and hold a mouse button."""
+        await self.exec.run(f"xdotool mousedown {MOUSE_BUTTONS[button]}", env={"DISPLAY": DISPLAY})
+
+    async def mouse_release(self, button: Literal["left", "right", "middle"] = "left") -> None:
+        """Release a mouse button."""
+        await self.exec.run(f"xdotool mouseup {MOUSE_BUTTONS[button]}", env={"DISPLAY": DISPLAY})
+
+    async def drag(self, fr: tuple[int, int], to: tuple[int, int]) -> None:
+        """Drag from one position to another."""
+        await self.move_mouse(fr[0], fr[1])
+        await self.mouse_press()
+        await self.move_mouse(to[0], to[1])
+        await self.mouse_release()
+
+    async def get_cursor_position(self) -> tuple[int, int]:
+        """Get the current cursor position as (x, y)."""
+        result = await self.exec.run("xdotool getmouselocation", env={"DISPLAY": DISPLAY})
+        match = re.search(r"x:(\d+)\s+y:(\d+)", result.stdout)
+        if not match:
+            raise RuntimeError(f"Failed to parse cursor position: {result.stdout}")
+        return int(match.group(1)), int(match.group(2))
+
+    async def get_screen_size(self) -> tuple[int, int]:
+        """Get the screen resolution as (width, height)."""
+        result = await self.exec.run("xrandr", env={"DISPLAY": DISPLAY})
+        match = re.search(r"(\d+)x(\d+)", result.stdout)
+        if not match:
+            raise RuntimeError(f"Failed to parse screen size: {result.stdout}")
+        return int(match.group(1)), int(match.group(2))
+
+    async def write(self, text: str, *, chunk_size: int = 25, delay_ms: int = 75) -> None:
+        """Type text at the current cursor position.
+
+        Args:
+            text: Text to type.
+            chunk_size: Characters per xdotool call.
+            delay_ms: Delay between keystrokes in milliseconds.
+        """
+        for i in range(0, len(text), chunk_size):
+            chunk = text[i : i + chunk_size]
+            await self.exec.run(
+                f"xdotool type --delay {delay_ms} -- {shell_quote(chunk)}",
+                env={"DISPLAY": DISPLAY},
+            )
+
+    async def press(self, key: str | list[str]) -> None:
+        """Press a key or key combination.
+
+        Args:
+            key: Key name (e.g. "enter") or list for combos (e.g. ["ctrl", "c"]).
+        """
+        if isinstance(key, list):
+            mapped = "+".join(_map_key(k) for k in key)
+        else:
+            mapped = _map_key(key)
+        await self.exec.run(f"xdotool key {mapped}", env={"DISPLAY": DISPLAY})
+
+    async def open(self, file_or_url: str) -> None:
+        """Open a file or URL in the default application."""
+        await self.exec.run(f"xdg-open {shell_quote(file_or_url)}", env={"DISPLAY": DISPLAY})
+
+    async def launch(self, application: str, uri: str | None = None) -> None:
+        """Launch a .desktop application by name."""
+        await self.exec.run(
+            f"gtk-launch {application} {uri or ''}",
+            env={"DISPLAY": DISPLAY},
+        )
+
+    async def get_current_window_id(self) -> str:
+        """Get the currently focused window ID."""
+        result = await self.exec.run("xdotool getwindowfocus", env={"DISPLAY": DISPLAY})
+        return result.stdout.strip()
+
+    async def get_application_windows(self, application: str) -> list[str]:
+        """Get all visible window IDs for an application class."""
+        result = await self.exec.run(
+            f"xdotool search --onlyvisible --class {application}",
+            env={"DISPLAY": DISPLAY},
+        )
+        return [w for w in result.stdout.strip().split("\n") if w]
+
+    async def get_window_title(self, window_id: str) -> str:
+        """Get the title of a window by ID."""
+        result = await self.exec.run(f"xdotool getwindowname {window_id}", env={"DISPLAY": DISPLAY})
+        return result.stdout.strip()
+
+    async def wait(self, ms: int) -> None:
+        """Wait for a given duration (in milliseconds)."""
+        await self.exec.run(f"sleep {ms / 1000}")

--- a/sdks/typescript/src/desktop.ts
+++ b/sdks/typescript/src/desktop.ts
@@ -1,0 +1,398 @@
+/**
+ * Desktop sandbox with remote display streaming, screenshots, and input control.
+ *
+ * Uses Xvfb + x11vnc + noVNC inside the VM. The desktop environment (Xvfb + openbox)
+ * is auto-started at sandbox creation. VNC streaming is started on-demand via stream.start().
+ *
+ * @example
+ * ```ts
+ * import { Desktop } from "@opencomputer/sdk/dist/desktop.js";
+ *
+ * const desktop = await Desktop.create();
+ * await desktop.stream.start();
+ * console.log(desktop.stream.getUrl());
+ *
+ * // Take a screenshot for AI agent
+ * const png = await desktop.screenshot();
+ *
+ * // Programmatic input
+ * await desktop.leftClick(500, 300);
+ * await desktop.write("hello world");
+ * await desktop.press("enter");
+ *
+ * await desktop.stream.stop();
+ * await desktop.kill();
+ * ```
+ */
+
+import { Sandbox, type SandboxOpts } from "./sandbox.js";
+import type { Exec, ProcessResult, RunOpts } from "./exec.js";
+import type { Filesystem } from "./filesystem.js";
+import type { Agent } from "./agent.js";
+import type { Pty } from "./pty.js";
+
+const MOUSE_BUTTONS = { left: 1, right: 3, middle: 2 } as const;
+
+const KEYS: Record<string, string> = {
+  alt: "Alt_L",
+  backspace: "BackSpace",
+  caps_lock: "Caps_Lock",
+  ctrl: "Control_L",
+  control: "Control_L",
+  del: "Delete",
+  delete: "Delete",
+  down: "Down",
+  end: "End",
+  enter: "Return",
+  esc: "Escape",
+  escape: "Escape",
+  f1: "F1", f2: "F2", f3: "F3", f4: "F4", f5: "F5", f6: "F6",
+  f7: "F7", f8: "F8", f9: "F9", f10: "F10", f11: "F11", f12: "F12",
+  home: "Home",
+  insert: "Insert",
+  left: "Left",
+  page_down: "Page_Down",
+  page_up: "Page_Up",
+  right: "Right",
+  shift: "Shift_L",
+  space: "space",
+  super: "Super_L",
+  tab: "Tab",
+  up: "Up",
+};
+
+function mapKey(key: string): string {
+  return KEYS[key.toLowerCase()] ?? key.toLowerCase();
+}
+
+function randomString(length = 16): string {
+  const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  let result = "";
+  const arr = new Uint8Array(length);
+  crypto.getRandomValues(arr);
+  for (const b of arr) result += chars[b % chars.length];
+  return result;
+}
+
+export interface DesktopOpts extends SandboxOpts {
+  /** Screen resolution [width, height]. Defaults to [1024, 768]. */
+  resolution?: [number, number];
+  /** Display DPI. Defaults to 96. */
+  dpi?: number;
+}
+
+export interface StreamStartOpts {
+  /** VNC server port inside the VM. Defaults to 5900. */
+  vncPort?: number;
+  /** noVNC HTTP/WebSocket port inside the VM. Defaults to 6080. */
+  port?: number;
+  /** Require password authentication for the stream. */
+  requireAuth?: boolean;
+  /** Stream a specific X11 window instead of the full desktop. */
+  windowId?: string;
+}
+
+export interface StreamUrlOpts {
+  autoConnect?: boolean;
+  viewOnly?: boolean;
+  resize?: "off" | "scale" | "remote";
+  authKey?: string;
+}
+
+class VNCStream {
+  private _vncPort = 5900;
+  private _port = 6080;
+  private _password: string | undefined;
+  private _running = false;
+
+  constructor(private desktop: Desktop) {}
+
+  get running(): boolean {
+    return this._running;
+  }
+
+  /**
+   * Get the authentication key for the stream.
+   * Only available when `requireAuth` was set in `start()`.
+   */
+  getAuthKey(): string {
+    if (!this._password) {
+      throw new Error("No auth key — stream was started without requireAuth");
+    }
+    return this._password;
+  }
+
+  /**
+   * Get the URL to access the remote desktop via noVNC in a browser.
+   */
+  getUrl(opts: StreamUrlOpts = {}): string {
+    const domain = this.desktop.sandbox.getPreviewDomain(this._port);
+    if (!domain) {
+      throw new Error("No sandbox domain available — cannot construct stream URL");
+    }
+    const base = `https://${domain}/vnc.html`;
+    const params = new URLSearchParams();
+    if (opts.autoConnect !== false) params.set("autoconnect", "true");
+    if (opts.viewOnly) params.set("view_only", "true");
+    if (opts.resize) params.set("resize", opts.resize);
+    if (opts.authKey) params.set("password", opts.authKey);
+    const qs = params.toString();
+    return qs ? `${base}?${qs}` : base;
+  }
+
+  /**
+   * Start VNC streaming. Launches x11vnc + noVNC inside the VM.
+   */
+  async start(opts: StreamStartOpts = {}): Promise<void> {
+    if (this._running) {
+      throw new Error("Stream is already running");
+    }
+
+    this._vncPort = opts.vncPort ?? this._vncPort;
+    this._port = opts.port ?? this._port;
+    this._password = opts.requireAuth ? randomString() : undefined;
+
+    const args: string[] = [];
+    if (this._password) args.push("--password", this._password);
+    if (opts.vncPort) args.push("--vnc-port", String(opts.vncPort));
+    if (opts.port) args.push("--novnc-port", String(opts.port));
+    if (opts.windowId) args.push("--window-id", opts.windowId);
+
+    await this.desktop.exec.run(
+      `/usr/local/bin/start-vnc ${args.join(" ")}`,
+      { timeout: 15, env: { DISPLAY: ":99" } },
+    );
+
+    // Verify noVNC is listening
+    const check = await this.desktop.exec.run(
+      `for i in $(seq 1 20); do netstat -tuln 2>/dev/null | grep -q ":${this._port} " && echo ready && exit 0; sleep 0.5; done; echo timeout`,
+      { timeout: 15 },
+    );
+    if (!check.stdout.includes("ready")) {
+      throw new Error("noVNC failed to start");
+    }
+
+    this._running = true;
+  }
+
+  /** Stop VNC streaming. */
+  async stop(): Promise<void> {
+    await this.desktop.exec.run("/usr/local/bin/stop-vnc", {
+      env: { DISPLAY: ":99" },
+    });
+    this._running = false;
+  }
+}
+
+/**
+ * Desktop sandbox with remote display, screenshots, and programmatic input.
+ *
+ * Wraps a standard Sandbox created with the "desktop" template and adds
+ * display-specific methods (screenshot, mouse, keyboard, streaming).
+ */
+export class Desktop {
+  /** The underlying Sandbox instance. Use this for exec, files, agent, pty, etc. */
+  readonly sandbox: Sandbox;
+  readonly stream: VNCStream;
+  readonly display = ":99";
+
+  private constructor(sandbox: Sandbox) {
+    this.sandbox = sandbox;
+    this.stream = new VNCStream(this);
+  }
+
+  // ── Delegate core sandbox properties ───────────────────────────────────
+
+  get sandboxId(): string { return this.sandbox.sandboxId; }
+  get status(): string { return this.sandbox.status; }
+  get domain(): string { return this.sandbox.domain; }
+  get exec(): Exec { return this.sandbox.exec; }
+  get files(): Filesystem { return this.sandbox.files; }
+  get agent(): Agent { return this.sandbox.agent; }
+  get pty(): Pty { return this.sandbox.pty; }
+
+  getPreviewDomain(port: number): string { return this.sandbox.getPreviewDomain(port); }
+  async kill(): Promise<void> { return this.sandbox.kill(); }
+  async isRunning(): Promise<boolean> { return this.sandbox.isRunning(); }
+  async hibernate(): Promise<void> { return this.sandbox.hibernate(); }
+  async wake(opts?: { timeout?: number }): Promise<void> { return this.sandbox.wake(opts); }
+  async setTimeout(timeout: number): Promise<void> { return this.sandbox.setTimeout(timeout); }
+
+  // ── Factory methods ────────────────────────────────────────────────────
+
+  /**
+   * Create a new desktop sandbox with a running display server.
+   *
+   * The VM boots with the "desktop" template which includes Xvfb, openbox,
+   * x11vnc, noVNC, Chromium, xdotool, and scrot. The display environment
+   * is auto-started by the worker.
+   */
+  static async create(opts: DesktopOpts = {}): Promise<Desktop> {
+    const sandbox = await Sandbox.create({
+      ...opts,
+      template: opts.template ?? "desktop",
+      envs: {
+        DISPLAY: ":99",
+        ...opts.envs,
+      },
+    });
+
+    return new Desktop(sandbox);
+  }
+
+  /** Connect to an existing desktop sandbox. */
+  static async connect(sandboxId: string, opts: Pick<SandboxOpts, "apiKey" | "apiUrl"> = {}): Promise<Desktop> {
+    const sandbox = await Sandbox.connect(sandboxId, opts);
+    return new Desktop(sandbox);
+  }
+
+  // ── Screenshot ─────────────────────────────────────────────────────────
+
+  /** Take a screenshot and return it as a Uint8Array (PNG). */
+  async screenshot(): Promise<Uint8Array> {
+    const path = `/tmp/screenshot-${randomString(8)}.png`;
+    await this.exec.run(`scrot --pointer ${path}`, { env: { DISPLAY: ":99" } });
+    const content = await this.files.readBytes(path);
+    await this.exec.run(`rm -f ${path}`);
+    return content;
+  }
+
+  // ── Mouse ──────────────────────────────────────────────────────────────
+
+  /** Move the mouse to (x, y). */
+  async moveMouse(x: number, y: number): Promise<void> {
+    await this.exec.run(`xdotool mousemove --sync ${x} ${y}`, { env: { DISPLAY: ":99" } });
+  }
+
+  /** Left click at the current position, or at (x, y) if provided. */
+  async leftClick(x?: number, y?: number): Promise<void> {
+    if (x != null && y != null) await this.moveMouse(x, y);
+    await this.exec.run("xdotool click 1", { env: { DISPLAY: ":99" } });
+  }
+
+  /** Double left click. */
+  async doubleClick(x?: number, y?: number): Promise<void> {
+    if (x != null && y != null) await this.moveMouse(x, y);
+    await this.exec.run("xdotool click --repeat 2 1", { env: { DISPLAY: ":99" } });
+  }
+
+  /** Right click. */
+  async rightClick(x?: number, y?: number): Promise<void> {
+    if (x != null && y != null) await this.moveMouse(x, y);
+    await this.exec.run("xdotool click 3", { env: { DISPLAY: ":99" } });
+  }
+
+  /** Middle click. */
+  async middleClick(x?: number, y?: number): Promise<void> {
+    if (x != null && y != null) await this.moveMouse(x, y);
+    await this.exec.run("xdotool click 2", { env: { DISPLAY: ":99" } });
+  }
+
+  /** Scroll the mouse wheel. */
+  async scroll(direction: "up" | "down" = "down", amount = 1): Promise<void> {
+    const button = direction === "up" ? "4" : "5";
+    await this.exec.run(`xdotool click --repeat ${amount} ${button}`, { env: { DISPLAY: ":99" } });
+  }
+
+  /** Press and hold a mouse button. */
+  async mousePress(button: "left" | "right" | "middle" = "left"): Promise<void> {
+    await this.exec.run(`xdotool mousedown ${MOUSE_BUTTONS[button]}`, { env: { DISPLAY: ":99" } });
+  }
+
+  /** Release a mouse button. */
+  async mouseRelease(button: "left" | "right" | "middle" = "left"): Promise<void> {
+    await this.exec.run(`xdotool mouseup ${MOUSE_BUTTONS[button]}`, { env: { DISPLAY: ":99" } });
+  }
+
+  /** Drag from one position to another. */
+  async drag(from: [number, number], to: [number, number]): Promise<void> {
+    await this.moveMouse(from[0], from[1]);
+    await this.mousePress();
+    await this.moveMouse(to[0], to[1]);
+    await this.mouseRelease();
+  }
+
+  /** Get the current cursor position. */
+  async getCursorPosition(): Promise<{ x: number; y: number }> {
+    const result = await this.exec.run("xdotool getmouselocation", { env: { DISPLAY: ":99" } });
+    const match = result.stdout.match(/x:(\d+)\s+y:(\d+)/);
+    if (!match) throw new Error(`Failed to parse cursor position: ${result.stdout}`);
+    return { x: parseInt(match[1]), y: parseInt(match[2]) };
+  }
+
+  /** Get the screen resolution. */
+  async getScreenSize(): Promise<{ width: number; height: number }> {
+    const result = await this.exec.run("xrandr", { env: { DISPLAY: ":99" } });
+    const match = result.stdout.match(/(\d+)x(\d+)/);
+    if (!match) throw new Error(`Failed to parse screen size: ${result.stdout}`);
+    return { width: parseInt(match[1]), height: parseInt(match[2]) };
+  }
+
+  // ── Keyboard ───────────────────────────────────────────────────────────
+
+  /**
+   * Type text at the current cursor position.
+   * @param text - Text to type.
+   * @param opts.chunkSize - Characters per xdotool call (default 25).
+   * @param opts.delayMs - Delay between keystrokes in ms (default 75).
+   */
+  async write(text: string, opts: { chunkSize?: number; delayMs?: number } = {}): Promise<void> {
+    const chunkSize = opts.chunkSize ?? 25;
+    const delay = opts.delayMs ?? 75;
+
+    for (let i = 0; i < text.length; i += chunkSize) {
+      const chunk = text.slice(i, i + chunkSize);
+      const escaped = "'" + chunk.replace(/'/g, "'\"'\"'") + "'";
+      await this.exec.run(`xdotool type --delay ${delay} -- ${escaped}`, { env: { DISPLAY: ":99" } });
+    }
+  }
+
+  /**
+   * Press a key or key combination.
+   * @param key - Key name (e.g. "enter", "ctrl") or array for combos (e.g. ["ctrl", "c"]).
+   */
+  async press(key: string | string[]): Promise<void> {
+    const mapped = Array.isArray(key)
+      ? key.map(mapKey).join("+")
+      : mapKey(key);
+    await this.exec.run(`xdotool key ${mapped}`, { env: { DISPLAY: ":99" } });
+  }
+
+  // ── Window management ──────────────────────────────────────────────────
+
+  /** Open a file or URL in the default application. */
+  async open(fileOrUrl: string): Promise<void> {
+    await this.exec.run(`xdg-open ${fileOrUrl}`, { env: { DISPLAY: ":99" } });
+  }
+
+  /** Launch a .desktop application by name. */
+  async launch(application: string, uri?: string): Promise<void> {
+    await this.exec.run(`gtk-launch ${application} ${uri ?? ""}`, { env: { DISPLAY: ":99" } });
+  }
+
+  /** Get the currently focused window ID. */
+  async getCurrentWindowId(): Promise<string> {
+    const result = await this.exec.run("xdotool getwindowfocus", { env: { DISPLAY: ":99" } });
+    return result.stdout.trim();
+  }
+
+  /** Get all visible window IDs for an application class. */
+  async getApplicationWindows(application: string): Promise<string[]> {
+    const result = await this.exec.run(
+      `xdotool search --onlyvisible --class ${application}`,
+      { env: { DISPLAY: ":99" } },
+    );
+    return result.stdout.trim().split("\n").filter(Boolean);
+  }
+
+  /** Get the title of a window by ID. */
+  async getWindowTitle(windowId: string): Promise<string> {
+    const result = await this.exec.run(`xdotool getwindowname ${windowId}`, { env: { DISPLAY: ":99" } });
+    return result.stdout.trim();
+  }
+
+  /** Wait for a given duration (in milliseconds). */
+  async wait(ms: number): Promise<void> {
+    await this.exec.run(`sleep ${ms / 1000}`);
+  }
+}

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -1,12 +1,10 @@
 export { Sandbox, type SandboxOpts, type CheckpointInfo, type PatchInfo, type PatchResult } from "./sandbox.js";
+export { Desktop, type DesktopOpts, type StreamStartOpts, type StreamUrlOpts } from "./desktop.js";
 export { Agent, type AgentEvent, type AgentConfig, type AgentStartOpts, type AgentSession, type McpServerConfig } from "./agent.js";
 export { Filesystem, type EntryInfo } from "./filesystem.js";
 export { Exec, type ProcessResult, type RunOpts, type ExecSession, type ExecSessionInfo, type ExecStartOpts, type ExecAttachOpts } from "./exec.js";
 export { Pty, type PtySession, type PtyOpts } from "./pty.js";
 export { Templates, type TemplateInfo } from "./template.js";
 export { SecretStore, type SecretStoreInfo, type SecretEntryInfo, type SecretStoreOpts, type CreateSecretStoreOpts, type UpdateSecretStoreOpts } from "./project.js";
-// Node.js-only modules (use crypto, fs, path) — import directly if needed:
-//   import { Image } from "@opencomputer/sdk/dist/image.js";
-//   import { Snapshots } from "@opencomputer/sdk/dist/snapshot.js";
-export type { ImageManifest, ImageStep } from "./image.js";
-export type { SnapshotInfo, CreateSnapshotOpts } from "./snapshot.js";
+export { Image, type ImageManifest, type ImageStep } from "./image.js";
+export { Snapshots, type SnapshotInfo, type CreateSnapshotOpts } from "./snapshot.js";


### PR DESCRIPTION
## Summary
- Adds `Desktop` class to both TypeScript and Python SDKs (remote display, screenshots, mouse/keyboard, VNC streaming)
- Exports `Image` and `Snapshots` as **value exports** from the main SDK entrypoint — fixes `import { Image, Snapshots } from '@opencomputer/sdk'` which is documented but currently broken (they were type-only exports)
- Adds `Dockerfile.desktop` for the desktop rootfs template
- Adds `demo-desktop.ts` example

## Test plan
- [ ] `npm run build` in `sdks/typescript/` succeeds
- [ ] `import { Desktop, Image, Snapshots } from '@opencomputer/sdk'` resolves at runtime
- [ ] `npx tsx examples/demo-desktop.ts` against a running instance
- [ ] Python: `from opencomputer import Desktop` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)