### PR TITLE
docs: Add Agents API (agents, instances, sessions)

### DIFF
--- a/docs/agents-api/agents.mdx
+++ b/docs/agents-api/agents.mdx
@@ -1,0 +1,77 @@
+---
+title: "Agents"
+description: "Create and manage agent definitions — snapshot, entrypoint, secrets, elasticity"
+---
+
+An Agent is configuration, not compute. It defines what snapshot to boot, what entrypoint to run, which secrets to inject, and how elasticity works. The same agent can back both Instances and Sessions.
+
+## Create agent
+
+```
+POST /v1/agents
+```
+
+```json
+{
+  "id": "issue-resolver",
+  "display_name": "Issue Resolver",
+  "config": {
+    "snapshot": "agent-snapshot-v1",
+    "entrypoint": "node /workspace/agent/index.js",
+    "env": { "LOG_LEVEL": "info" },
+    "elasticity": { "baseline_mb": 1024, "max_mb": 8192 },
+    "idle_timeout_s": 600
+  }
+}
+```
+
+`id` must be DNS-safe (lowercase alphanumeric + hyphens). Returns `201` with the agent object.
+
+**Entrypoint vs agent_config**: if `config.entrypoint` is set, the platform runs it via `sandbox.exec.start()`. If `config.agent_config` is set instead, the platform uses `sandbox.agent.start()` with the provided `system_prompt` and `allowed_tools`. They are mutually exclusive.
+
+## CRUD
+
+```
+GET    /v1/agents                  List all agents
+GET    /v1/agents/:agentId         Get agent
+PATCH  /v1/agents/:agentId         Update (accepts display_name, config)
+DELETE /v1/agents/:agentId         Delete (cascades to instances and sessions)
+```
+
+## Agent object
+
+```json
+{
+  "id": "issue-resolver",
+  "display_name": "Issue Resolver",
+  "secret_store": "agent:issue-resolver",
+  "config": { ... },
+  "created_at": "2026-04-09T...",
+  "updated_at": "2026-04-09T..."
+}
+```
+
+## Secrets
+
+Convenience wrapper over OpenComputer's [secret store](/sandboxes/secrets). Values are AES-256-GCM encrypted at rest, injected as sealed tokens at sandbox creation. Values are never returned via API.
+
+```
+PUT    /v1/agents/:agentId/secrets/:key     Set a secret
+GET    /v1/agents/:agentId/secrets          List keys (values never returned)
+DELETE /v1/agents/:agentId/secrets/:key     Remove a secret
+```
+
+**Set secret:**
+
+```json
+PUT /v1/agents/issue-resolver/secrets/ANTHROPIC_API_KEY
+{ "value": "sk-ant-...", "allowed_hosts": ["api.anthropic.com"] }
+```
+
+The first `PUT` auto-creates a backing OC secret store named `agent:{agentId}`. `allowed_hosts` is optional — restricts which outbound hosts can receive the decrypted value.
+
+**List secrets** returns keys and metadata only:
+
+```json
+{ "secrets": [{ "key": "ANTHROPIC_API_KEY", "allowed_hosts": ["api.anthropic.com"], "set_at": "..." }] }
+```

--- a/docs/agents-api/instances.mdx
+++ b/docs/agents-api/instances.mdx
@@ -1,0 +1,67 @@
+---
+title: "Instances"
+description: "Persistent sandboxes that multiplex conversations, hibernate when idle, and wake on demand"
+---
+
+An Instance is a persistent sandbox bound to an Agent. It stays alive across conversations, accumulates state (filesystem, installed tools, running processes), and hibernates when idle. Multiple conversations are multiplexed onto one instance via `conversation_id`.
+
+**Typical mapping:** one Instance per user or team. The caller owns conversation identity (e.g., Slack thread timestamp).
+
+## Create instance
+
+```
+POST /v1/agents/:agentId/instances
+```
+
+```json
+{ "metadata": { "slack_user": "U123", "team": "engineering" } }
+```
+
+Returns `201` with `status: "creating"`. The platform provisions a sandbox from the agent's snapshot in the background. Status becomes `"running"` once ready.
+
+## List / Get / Delete
+
+```
+GET    /v1/agents/:agentId/instances        List instances for an agent
+GET    /v1/agents/:agentId/instances/:id    Get instance
+DELETE /v1/agents/:agentId/instances/:id    Destroy (kills sandbox)
+```
+
+## Instance object
+
+```json
+{
+  "id": "inst_98adcc7e...",
+  "agent_id": "slack-coworker",
+  "status": "creating | running | error",
+  "metadata": { "slack_user": "U123" },
+  "created_at": "2026-04-09T...",
+  "updated_at": "2026-04-09T..."
+}
+```
+
+## Send message
+
+```
+POST /v1/agents/:agentId/instances/:id/messages
+```
+
+```json
+{ "content": "analyze the auth service repo", "conversation_id": "1712345678.123456" }
+```
+
+Returns `200` with `Content-Type: text/event-stream`. If the instance is still `creating`, waits up to 30s for it to become ready.
+
+**SSE events:**
+
+```
+data: {"type":"text","content":"Cloning the repo now...","conversation_id":"1712345678.123456"}
+data: {"type":"text","content":"Found 3 issues...","conversation_id":"1712345678.123456"}
+data: {"type":"done"}
+```
+
+The stream closes after the agent completes one turn. The caller collects `text` events and concatenates their `content` for the full response.
+
+## Recovery
+
+If the caller process restarts, rebuild instance mappings from `GET /v1/agents/:agentId/instances` using `metadata` to match external identities (e.g., Slack user IDs) back to instance IDs.

--- a/docs/agents-api/overview.mdx
+++ b/docs/agents-api/overview.mdx
@@ -1,0 +1,37 @@
+---
+title: "Agents API"
+description: "Define agents, run persistent instances or ephemeral sessions on OpenComputer sandboxes"
+---
+
+The Agents API is a higher-level interface for running AI agents on OpenComputer. Instead of managing sandboxes directly, you define an **Agent** (configuration) and then create **Instances** (persistent) or **Sessions** (ephemeral) from it.
+
+| Concept | What it is | Lifecycle | Use case |
+|---------|-----------|-----------|----------|
+| **Agent** | Configuration — snapshot, entrypoint, secrets, elasticity | Indefinite | Define once, reuse |
+| **Instance** | Persistent sandbox, hibernates/wakes, multiplexes conversations | Long-lived | AI coworkers (Slack, Teams) |
+| **Session** | Ephemeral sandbox, runs to completion | Bounded | Batch jobs, webhook handlers |
+
+## Base URL
+
+```
+https://api.opencomputer.dev
+```
+
+## Authentication
+
+All requests require an OpenComputer API key via `X-API-Key`. The key is passed through to the OC SDK for sandbox operations.
+
+```
+X-API-Key: osb_your_api_key
+```
+
+## Errors
+
+```json
+{
+  "error": {
+    "type": "invalid_request | not_found | conflict | internal_error",
+    "message": "Human-readable description"
+  }
+}
+```

--- a/docs/agents-api/sessions.mdx
+++ b/docs/agents-api/sessions.mdx
@@ -1,0 +1,74 @@
+---
+title: "Sessions"
+description: "Ephemeral sandboxes for fire-and-forget agent tasks with input/result"
+---
+
+A Session is an ephemeral sandbox bound to an Agent. One session = one task = one sandbox. The sandbox is created, the agent runs to completion, and the sandbox is destroyed. For process-mode agents that take input and produce a result.
+
+**Typical mapping:** one Session per webhook, API call, or batch job.
+
+## Create session
+
+```
+POST /v1/agents/:agentId/sessions
+```
+
+```json
+{
+  "input": {
+    "repo": "acme/backend",
+    "issue_number": 42,
+    "webhook_payload": { "..." }
+  },
+  "metadata": { "trigger": "github_webhook" }
+}
+```
+
+The platform creates a sandbox, writes `input` to `/tmp/agent_input.json`, sets `AGENT_INPUT_PATH` as an env var, and runs the agent's entrypoint. The agent reads input, does work, writes its result to `/tmp/agent_result.json`, and exits.
+
+Returns `201` with `status: "creating"`.
+
+## Get / Delete
+
+```
+GET    /v1/agents/:agentId/sessions/:id    Get session
+DELETE /v1/agents/:agentId/sessions/:id    End session (kills sandbox)
+```
+
+## Get result
+
+```
+GET /v1/agents/:agentId/sessions/:id/result
+```
+
+Returns the agent's output after completion. The platform reads `/tmp/agent_result.json` from the sandbox.
+
+```
+-- While running:         409 { "error": { "type": "conflict", "message": "Session still running" } }
+-- When complete:         200 { "data": { "pr_url": "https://..." }, "completed_at": "2026-04-09T..." }
+-- If no result written:  200 { "data": null, "completed_at": "2026-04-09T..." }
+```
+
+## Session object
+
+```json
+{
+  "id": "sess_98adcc7e...",
+  "agent_id": "issue-resolver",
+  "status": "creating | running | completed | failed",
+  "input": { "..." },
+  "result": null,
+  "preview_url": null,
+  "metadata": {},
+  "created_at": "2026-04-09T...",
+  "updated_at": "2026-04-09T..."
+}
+```
+
+## Lifecycle
+
+```
+creating → running → completed (exit 0) | failed (non-zero exit)
+```
+
+Terminal states are final. The sandbox is destroyed when the session ends.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -74,12 +74,12 @@
       ]
     },
     {
-      "group": "Sessions API (Experimental)",
+      "group": "Agents API",
       "pages": [
-        "sessions-api/overview",
-        "sessions-api/sessions",
-        "sessions-api/messages",
-        "sessions-api/events"
+        "agents-api/overview",
+        "agents-api/agents",
+        "agents-api/instances",
+        "agents-api/sessions"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Adds new `docs/agents-api/` section with 4 pages: overview, agents, instances, sessions
- Replaces the "Sessions API (Experimental)" nav group in mint.json with "Agents API"
- Documents the full API surface deployed at api.opencomputer.dev: agent CRUD + secrets, persistent instances with SSE messaging, ephemeral sessions with input/result

Old `docs/sessions-api/` files are left in place (not deleted) in case anything links to them.

## Test plan
- [ ] Verify Mintlify build passes
- [ ] Check nav renders correctly with the new section
- [ ] Review content against sessions-api README for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)