### PR TITLE
onready fires after upload

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -910,6 +910,14 @@ func (s *Store) SetCheckpointReady(ctx context.Context, checkpointID uuid.UUID, 
 	return err
 }
 
+// UpdateCheckpointS3Keys sets the S3 keys without changing the checkpoint status.
+func (s *Store) UpdateCheckpointS3Keys(ctx context.Context, checkpointID uuid.UUID, rootfsKey, workspaceKey string) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE sandbox_checkpoints SET rootfs_s3_key = $2, workspace_s3_key = $3 WHERE id = $1`,
+		checkpointID, rootfsKey, workspaceKey)
+	return err
+}
+
 // SetCheckpointFailed marks a checkpoint as failed.
 func (s *Store) SetCheckpointFailed(ctx context.Context, checkpointID uuid.UUID, reason string) error {
 	_, err := s.pool.Exec(ctx,

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -1973,28 +1973,21 @@ func (m *Manager) CreateCheckpoint(ctx context.Context, sandboxID, checkpointID 
 			archiveFiles = append(archiveFiles, filepath.Join("snapshot", "snapshot-meta.json"))
 		}
 
-		m.uploadWg.Add(1)
-		go func() {
-			defer m.uploadWg.Done()
-			t1 := time.Now()
-
-			archivePath := filepath.Join(cacheDir, "checkpoint.tar.zst")
-			if err := createArchive(archivePath, cacheDir, archiveFiles); err != nil {
-				log.Printf("qemu: checkpoint %s: archive failed: %v", checkpointID, err)
-				return
-			}
-			defer os.Remove(archivePath)
-
+		t1 := time.Now()
+		archivePath := filepath.Join(cacheDir, "checkpoint.tar.zst")
+		if err := createArchive(archivePath, cacheDir, archiveFiles); err != nil {
+			log.Printf("qemu: checkpoint %s: archive failed: %v", checkpointID, err)
+		} else {
 			uploadCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-			defer cancel()
-			if _, err := checkpointStore.Upload(uploadCtx, rootfsKey, archivePath); err != nil {
-				log.Printf("qemu: checkpoint %s: S3 upload failed: %v", checkpointID, err)
-				return
+			if _, uerr := checkpointStore.Upload(uploadCtx, rootfsKey, archivePath); uerr != nil {
+				log.Printf("qemu: checkpoint %s: S3 upload failed: %v", checkpointID, uerr)
+			} else {
+				log.Printf("qemu: checkpoint %s: S3 upload complete (%dms, files=%v)",
+					checkpointID, time.Since(t1).Milliseconds(), archiveFiles)
 			}
-
-			log.Printf("qemu: checkpoint %s: S3 upload complete (%dms, files=%v)",
-				checkpointID, time.Since(t1).Milliseconds(), archiveFiles)
-		}()
+			cancel()
+			os.Remove(archivePath)
+		}
 	}
 
 	if onReady != nil {

--- a/internal/worker/grpc_server.go
+++ b/internal/worker/grpc_server.go
@@ -657,23 +657,14 @@ func (s *GRPCServer) CreateCheckpoint(ctx context.Context, req *pb.CreateCheckpo
 		}
 	}
 
-	// Don't fire onReady until S3 upload completes. Otherwise the CP sees
-	// "ready" and dispatches a fork before the upload finishes — cross-worker
-	// forks fail because S3 doesn't have the data yet.
-	rootfsKey, workspaceKey, err := s.manager.CreateCheckpoint(ctx, req.SandboxId, checkpointID, s.checkpointStore, nil)
+	// onReady is called by CreateCheckpoint AFTER S3 upload completes (inside
+	// the upload goroutine). This ensures the checkpoint data is in S3 before
+	// it's marked "ready" — forks poll for "ready" before downloading.
+	// The gRPC call returns immediately with the S3 keys — the CP's fork path
+	// polls for checkpoint readiness and blocks until onReady fires.
+	rootfsKey, workspaceKey, err := s.manager.CreateCheckpoint(ctx, req.SandboxId, checkpointID, s.checkpointStore, onReady)
 	if err != nil {
 		return nil, fmt.Errorf("create checkpoint failed: %w", err)
-	}
-
-	// Wait for S3 upload to complete, THEN signal ready.
-	type uploader interface {
-		WaitUploads(timeout time.Duration)
-	}
-	if u, ok := s.manager.(uploader); ok {
-		u.WaitUploads(5 * time.Minute)
-	}
-	if onReady != nil {
-		onReady()
 	}
 
 	return &pb.CreateCheckpointResponse{


### PR DESCRIPTION
S3 upload happens synchronously inside CreateCheckpoint before onReady fires. The checkpoint isn't marked "ready" until S3 has the data. Forks poll for "ready" and only proceed when the data is guaranteed to be there