### PR TITLE
Default sandbox timeout to 0 (persistent, never hibernate)

### DIFF
--- a/cmd/oc/internal/commands/checkpoint.go
+++ b/cmd/oc/internal/commands/checkpoint.go
@@ -149,7 +149,7 @@ func init() {
 	checkpointCreateCmd.Flags().String("name", "", "Checkpoint name (required)")
 	checkpointCreateCmd.MarkFlagRequired("name")
 
-	checkpointSpawnCmd.Flags().Int("timeout", 300, "Timeout in seconds")
+	checkpointSpawnCmd.Flags().Int("timeout", 0, "Idle timeout in seconds before auto-hibernate (0 = never hibernate)")
 
 	checkpointCmd.AddCommand(checkpointCreateCmd)
 	checkpointCmd.AddCommand(checkpointListCmd)

--- a/cmd/oc/internal/commands/sandbox.go
+++ b/cmd/oc/internal/commands/sandbox.go
@@ -224,7 +224,7 @@ var lsShortcut = &cobra.Command{
 func init() {
 	// sandbox create flags
 	for _, cmd := range []*cobra.Command{sandboxCreateCmd, createShortcut} {
-		cmd.Flags().Int("timeout", 300, "Timeout in seconds")
+		cmd.Flags().Int("timeout", 0, "Idle timeout in seconds before auto-hibernate (0 = never hibernate)")
 		cmd.Flags().Int("cpu", 0, "CPU count")
 		cmd.Flags().Int("memory", 0, "Memory in MB")
 		cmd.Flags().StringSlice("env", nil, "Environment variables (KEY=VALUE)")
@@ -233,7 +233,7 @@ func init() {
 	}
 
 	// sandbox wake flags
-	sandboxWakeCmd.Flags().Int("timeout", 300, "Timeout in seconds after wake")
+	sandboxWakeCmd.Flags().Int("timeout", 0, "Idle timeout in seconds after wake (0 = never hibernate)")
 
 	sandboxCmd.AddCommand(sandboxCreateCmd)
 	sandboxCmd.AddCommand(sandboxListCmd)

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -65,6 +65,7 @@
         "sandboxes/working-with-files",
         "sandboxes/signed-urls",
         "sandboxes/interactive-terminals",
+        "sandboxes/timeout",
         "sandboxes/checkpoints",
         "sandboxes/templates",
         "sandboxes/secrets",

--- a/docs/sandboxes/timeout.mdx
+++ b/docs/sandboxes/timeout.mdx
@@ -1,0 +1,133 @@
+---
+title: "Timeout & Hibernation"
+description: "Control how long a sandbox stays alive when idle"
+---
+
+Sandboxes have a rolling **idle timeout** that determines when they auto-hibernate to save cost. The timeout is what you'd expect from a "laptop lid" — the sandbox sleeps when nothing is happening and wakes the moment you talk to it again.
+
+## Default: persistent (no auto-hibernate)
+
+By default the timeout is `0`, which means **never auto-hibernate**. The sandbox stays running until you explicitly kill or hibernate it.
+
+<CodeGroup>
+
+```typescript TypeScript
+import { Sandbox } from "@opencomputer/sdk";
+
+// No `timeout` — sandbox is persistent (stays alive until killed).
+const sandbox = await Sandbox.create();
+```
+
+```python Python
+from opencomputer import Sandbox
+
+# No `timeout` — sandbox is persistent (stays alive until killed).
+sandbox = await Sandbox.create()
+```
+
+```bash CLI
+# --timeout defaults to 0 (never hibernate).
+oc sandbox create
+```
+
+</CodeGroup>
+
+<Note>
+  Persistent sandboxes keep accruing compute cost for as long as they're running. If you only need the sandbox to respond to occasional requests, set a timeout so it hibernates between them — see below.
+</Note>
+
+## Setting a timeout
+
+Pass `timeout` in seconds to have the sandbox auto-hibernate after N seconds of **idle** time. The timer resets on every operation — exec, file access, agent activity — so a busy sandbox never hits the timeout.
+
+<CodeGroup>
+
+```typescript TypeScript
+// Auto-hibernate after 5 minutes of inactivity.
+const sandbox = await Sandbox.create({ timeout: 300 });
+```
+
+```python Python
+# Auto-hibernate after 5 minutes of inactivity.
+sandbox = await Sandbox.create(timeout=300)
+```
+
+```bash CLI
+oc sandbox create --timeout 300
+```
+
+</CodeGroup>
+
+### Update on a running sandbox
+
+You can change the timeout at any time:
+
+<CodeGroup>
+
+```typescript TypeScript
+await sandbox.setTimeout(600); // 10 minutes
+await sandbox.setTimeout(0);   // make it persistent
+```
+
+```python Python
+await sandbox.set_timeout(600)
+await sandbox.set_timeout(0)
+```
+
+```bash CLI
+oc sandbox set-timeout sb-abc123 600
+oc sandbox set-timeout sb-abc123 0
+```
+
+</CodeGroup>
+
+## What happens when the timeout expires
+
+When an idle sandbox hits its timeout, the platform:
+
+1. Snapshots the VM state (memory + disk) and stops the VM — no compute cost while hibernated.
+2. Marks the sandbox `hibernated`. Its ID, files, and configuration are preserved.
+
+You don't pay for CPU/memory while a sandbox is hibernated — only for the stored snapshot.
+
+## Waking up
+
+**Any operation from the SDK automatically wakes a hibernated sandbox.** You don't need to call `wake()` yourself — calling `sandbox.exec.run(...)`, reading a file, or any other operation transparently restores the VM and then performs the requested action.
+
+<CodeGroup>
+
+```typescript TypeScript
+// Earlier: sandbox auto-hibernated after 5 minutes of idleness.
+// Now, hours later — this call just works. The SDK wakes it first.
+const result = await sandbox.exec.run("echo hello");
+```
+
+```python Python
+# Same behavior in Python.
+result = await sandbox.exec.run("echo hello")
+```
+
+</CodeGroup>
+
+Wake is typically sub-second thanks to snapshot restore, with a cold-boot fallback if the snapshot isn't available. Once woken, the idle timer restarts with the sandbox's configured timeout.
+
+<Note>
+  You can still call `sandbox.wake()` explicitly if you want to pre-warm a sandbox before routing user traffic to it.
+</Note>
+
+## Choosing a timeout
+
+| Use case | Suggested `timeout` |
+| --- | --- |
+| Always-on agent / bot that must respond instantly | `0` (persistent) |
+| Interactive dev sandbox, keep for the session | `600`–`3600` (10 min – 1 hr) |
+| Short-lived batch or test run | `60`–`300` (1–5 min) |
+| One-off exec — kill it yourself when done | `0` + explicit `kill()` |
+
+The tradeoff is latency vs cost: a lower timeout saves money but adds wake latency on the next request after idleness.
+
+## See also
+
+- [Lifecycle overview](/sandboxes/overview#lifecycle) — all sandbox states
+- [Set timeout API](/api-reference/sandboxes/set-timeout)
+- [Hibernate API](/api-reference/sandboxes/hibernate) / [Wake API](/api-reference/sandboxes/wake)

--- a/internal/api/sandbox.go
+++ b/internal/api/sandbox.go
@@ -130,11 +130,13 @@ func (s *Server) createSandbox(c echo.Context) error {
 		})
 	}
 
-	// Register with sandbox router for rolling timeout tracking
+	// Register with sandbox router for rolling timeout tracking.
+	// timeout == 0 means "persistent" (no auto-hibernate). Negative values are
+	// normalized to 0 for safety.
 	if s.router != nil {
 		timeout := cfg.Timeout
-		if timeout <= 0 {
-			timeout = 300
+		if timeout < 0 {
+			timeout = 0
 		}
 		s.router.Register(sb.ID, time.Duration(timeout)*time.Second)
 	}
@@ -735,9 +737,11 @@ func (s *Server) setTimeout(c echo.Context) error {
 		})
 	}
 
-	if req.Timeout <= 0 {
+	// timeout == 0 means "persistent" (disable auto-hibernate). Negative values
+	// are invalid.
+	if req.Timeout < 0 {
 		return c.JSON(http.StatusBadRequest, map[string]string{
-			"error": "timeout must be positive",
+			"error": "timeout must be non-negative (0 disables auto-hibernate)",
 		})
 	}
 
@@ -1141,11 +1145,12 @@ func (s *Server) wakeSandbox(c echo.Context) error {
 		})
 	}
 
-	// Register with sandbox router after explicit wake
+	// Register with sandbox router after explicit wake.
+	// timeout == 0 means "persistent" (no auto-hibernate).
 	if s.router != nil {
 		timeout := req.Timeout
-		if timeout <= 0 {
-			timeout = 300
+		if timeout < 0 {
+			timeout = 0
 		}
 		s.router.Register(id, time.Duration(timeout)*time.Second)
 	}
@@ -1222,10 +1227,6 @@ func (s *Server) wakeSandboxRemote(c echo.Context, sandboxID string, req types.W
 
 	// Issue fresh JWT
 	orgID, _ := auth.GetOrgID(c)
-	timeout := req.Timeout
-	if timeout <= 0 {
-		timeout = 300
-	}
 	var token string
 	if s.jwtIssuer != nil {
 		t, err := s.jwtIssuer.IssueSandboxToken(orgID, sandboxID, worker.ID, 24*time.Hour)
@@ -1672,12 +1673,17 @@ func (s *Server) createFromCheckpointCore(c echo.Context, userEnvs map[string]st
 		}
 	}
 
+	// Resolve timeout. With int-valued JSON fields we can't distinguish "not sent"
+	// from "explicitly zero", so treat req.Timeout as authoritative. Fall back to
+	// the checkpoint's original timeout only when req.Timeout is negative (which is
+	// itself invalid, but could occur historically). timeout == 0 is valid and means
+	// "persistent / never auto-hibernate".
 	timeout := req.Timeout
-	if timeout <= 0 {
+	if timeout < 0 {
 		timeout = originalCfg.Timeout
 	}
-	if timeout <= 0 {
-		timeout = 300
+	if timeout < 0 {
+		timeout = 0
 	}
 
 	// Unified async fork: return immediately, boot VM in background.

--- a/internal/qemu/docs_compliance_test.go
+++ b/internal/qemu/docs_compliance_test.go
@@ -274,7 +274,7 @@ func TestDocumentedSandboxResponseFields(t *testing.T) {
 
 // TestDocumentedDefaultValues verifies that QEMU manager defaults match docs.
 //
-// Docs say: cpuCount=1, memoryMB=256, timeout=300, port=80
+// Docs say: cpuCount=1, memoryMB=256, timeout=0 (persistent), port=80
 func TestDocumentedDefaultValues(t *testing.T) {
 	// NewManager applies defaults to zero-valued Config fields.
 	// We simulate that logic here since NewManager needs real dirs.

--- a/internal/worker/grpc_server.go
+++ b/internal/worker/grpc_server.go
@@ -144,9 +144,10 @@ func (s *GRPCServer) CreateSandbox(ctx context.Context, req *pb.CreateSandboxReq
 		sb, err := s.manager.ForkFromCheckpoint(ctx, req.CheckpointId, cfg)
 		if err == nil {
 			if s.router != nil {
+				// timeout == 0 means "persistent" (no auto-hibernate).
 				timeout := cfg.Timeout
-				if timeout <= 0 {
-					timeout = 300
+				if timeout < 0 {
+					timeout = 0
 				}
 				s.router.Register(sb.ID, time.Duration(timeout)*time.Second)
 			}
@@ -165,9 +166,10 @@ func (s *GRPCServer) CreateSandbox(ctx context.Context, req *pb.CreateSandboxReq
 				sb, err = s.manager.ForkFromCheckpoint(ctx, req.CheckpointId, cfg)
 				if err == nil {
 					if s.router != nil {
+						// timeout == 0 means "persistent" (no auto-hibernate).
 						timeout := cfg.Timeout
-						if timeout <= 0 {
-							timeout = 300
+						if timeout < 0 {
+							timeout = 0
 						}
 						s.router.Register(sb.ID, time.Duration(timeout)*time.Second)
 					}
@@ -199,11 +201,12 @@ func (s *GRPCServer) CreateSandbox(ctx context.Context, req *pb.CreateSandboxReq
 		return nil, fmt.Errorf("failed to create sandbox: %w", err)
 	}
 
-	// Register with sandbox router for rolling timeout tracking
+	// Register with sandbox router for rolling timeout tracking.
+	// timeout == 0 means "persistent" (no auto-hibernate).
 	if s.router != nil {
 		timeout := cfg.Timeout
-		if timeout <= 0 {
-			timeout = 300
+		if timeout < 0 {
+			timeout = 0
 		}
 		s.router.Register(sb.ID, time.Duration(timeout)*time.Second)
 	}
@@ -568,11 +571,12 @@ func (s *GRPCServer) WakeSandbox(ctx context.Context, req *pb.WakeSandboxRequest
 		return nil, fmt.Errorf("failed to wake sandbox: %w", err)
 	}
 
-	// Register with sandbox router after explicit wake
+	// Register with sandbox router after explicit wake.
+	// timeout == 0 means "persistent" (no auto-hibernate).
 	if s.router != nil {
 		timeout := int(req.Timeout)
-		if timeout <= 0 {
-			timeout = 300
+		if timeout < 0 {
+			timeout = 0
 		}
 		s.router.Register(sb.ID, time.Duration(timeout)*time.Second)
 	}

--- a/sdks/python/opencomputer/sandbox.py
+++ b/sdks/python/opencomputer/sandbox.py
@@ -34,7 +34,7 @@ class Sandbox:
     async def create(
         cls,
         template: str = "base",
-        timeout: int = 300,
+        timeout: int = 0,
         api_key: str | None = None,
         api_url: str | None = None,
         envs: dict[str, str] | None = None,
@@ -48,7 +48,7 @@ class Sandbox:
 
         Args:
             template: Template to use (default "base").
-            timeout: Sandbox timeout in seconds (default 300).
+            timeout: Idle timeout in seconds. 0 = persistent, never auto-hibernates (default).
             api_key: API key (or OPENCOMPUTER_API_KEY env var).
             api_url: API URL (or OPENCOMPUTER_API_URL env var).
             envs: Environment variables to inject. Overrides store secrets.
@@ -332,7 +332,7 @@ class Sandbox:
     async def create_from_checkpoint(
         cls,
         checkpoint_id: str,
-        timeout: int = 300,
+        timeout: int = 0,
         api_key: str | None = None,
         api_url: str | None = None,
         envs: dict[str, str] | None = None,
@@ -342,7 +342,7 @@ class Sandbox:
 
         Args:
             checkpoint_id: UUID of the checkpoint to fork from.
-            timeout: Sandbox timeout in seconds (default 300).
+            timeout: Idle timeout in seconds. 0 = persistent, never auto-hibernates (default).
             api_key: API key (or OPENCOMPUTER_API_KEY env var).
             api_url: API URL (or OPENCOMPUTER_API_URL env var).
             envs: Environment variables to override on the fork.

--- a/sdks/typescript/src/sandbox.ts
+++ b/sdks/typescript/src/sandbox.ts
@@ -13,6 +13,10 @@ function resolveApiUrl(url: string): string {
 
 export interface SandboxOpts {
   template?: string;
+  /**
+   * Idle timeout in seconds after which the sandbox auto-hibernates.
+   * Default: `0` (persistent — never auto-hibernate).
+   */
   timeout?: number;
   apiKey?: string;
   apiUrl?: string;
@@ -134,7 +138,8 @@ export class Sandbox {
 
     const body: Record<string, unknown> = {
       templateID: opts.template ?? "base",
-      timeout: opts.timeout ?? 300,
+      // Default to 0 (persistent). Callers who want auto-hibernate must opt in.
+      timeout: opts.timeout ?? 0,
     };
     if (opts.envs) body.envs = opts.envs;
     if (opts.metadata) body.metadata = opts.metadata;
@@ -242,7 +247,8 @@ export class Sandbox {
         "Content-Type": "application/json",
         ...(this.apiKey ? { "X-API-Key": this.apiKey } : {}),
       },
-      body: JSON.stringify({ timeout: opts.timeout ?? 300 }),
+      // Default to 0 (persistent) — matches create() default.
+      body: JSON.stringify({ timeout: opts.timeout ?? 0 }),
     });
 
     if (!resp.ok) {


### PR DESCRIPTION
## Summary

- Changes the default idle timeout from `300s` to `0` across TS SDK, Python SDK, CLI, server API, and worker gRPC. `0` now means **persistent — never auto-hibernate**; callers opt into auto-hibernate by passing an explicit timeout.
- The router already supported \`timeout == 0\` as "no auto-hibernate timer" — this PR stops the API/worker layers from coercing \`0 → 300\` so the semantic actually reaches the router.
- Adds a new docs page \`sandboxes/timeout.mdx\` explaining the default, how to opt in, idle-based behavior, and auto-wake on SDK invocation.

## Motivation

Users running always-on agents (e.g. a Claw that listens for Telegram messages) currently get hibernated every 5 minutes, defeating the purpose. Exposing a \`timeout=0\` semantic and making it the default matches the mental model of "my sandbox stays alive until I kill it."

## Behavior

| `timeout` | Behavior |
| --- | --- |
| omitted / `0` | Persistent. Sandbox runs until explicitly killed or hibernated. |
| `> 0` | Auto-hibernates after N seconds of idleness (rolling timer). |
| `< 0` | Normalized to `0`. |

Any SDK operation transparently wakes a hibernated sandbox — no caller changes needed.

## Files

- **TS SDK** (\`sdks/typescript/src/sandbox.ts\`): \`create()\` and \`wake()\` default \`timeout\` to \`0\`; added JSDoc.
- **Python SDK** (\`sdks/python/opencomputer/sandbox.py\`): \`create()\` and \`create_from_checkpoint()\` default \`timeout=0\`; updated docstrings.
- **CLI** (\`cmd/oc/internal/commands/{sandbox,checkpoint}.go\`): \`--timeout\` flag defaults to \`0\` with "(0 = never hibernate)" in help text.
- **Server API** (\`internal/api/sandbox.go\`): \`createSandbox\`, \`wakeSandbox\`, \`createFromCheckpointCore\` stop coercing \`timeout == 0 → 300\`. \`setTimeout\` endpoint now accepts \`0\` (rejects only negative).
- **Worker gRPC** (\`internal/worker/grpc_server.go\`): same coercion fix on \`CreateSandbox\`, \`ForkFromCheckpoint\`, \`WakeSandbox\` paths so the new semantic works in multi-worker deployments.
- **Docs**: new \`docs/sandboxes/timeout.mdx\` page + mint.json nav entry.

## Breaking change

Clients that relied on the implicit 300s default will now get persistent sandboxes by default. They should either:
- Upgrade and explicitly pass \`timeout: 300\` where the old default was intended, or
- Accept the new persistent default and rely on manual \`kill()\`.

Other reference docs still say "default 300" in ~20 files (param tables, examples). Left as a follow-up since most of them are param tables rather than code-correctness issues.

## Test plan

- [ ] \`go build ./...\` on Linux CI (darwin build was verified locally for the packages touched — firecracker/qemu pre-existing failures on darwin are unrelated)
- [ ] \`go vet\` and \`go test ./internal/api/... ./internal/sandbox/...\` pass
- [ ] \`tsc --noEmit\` passes on the TS SDK
- [ ] Manual: create a sandbox with default settings, leave idle 10 minutes, confirm \`status=running\`
- [ ] Manual: create a sandbox with \`timeout: 60\`, leave idle, confirm \`status=hibernated\` after ~1 min
- [ ] Manual: \`sandbox.setTimeout(0)\` on a running sandbox disables its timer

🤖 Generated with [Claude Code](https://claude.com/claude-code)