### PR TITLE
Flatten rootfs qcow2 before archiving (cross-worker portability)

### DIFF
--- a/deploy/ec2/build-rootfs-docker.sh
+++ b/deploy/ec2/build-rootfs-docker.sh
@@ -230,7 +230,20 @@ docker rm -f osb-rootfs-tmp
 log "Converting to ext4 (${EXT4_SIZE_MB}MB sparse)..."
 EXT4_PATH="$TMPDIR/rootfs.ext4"
 truncate -s "${EXT4_SIZE_MB}M" "$EXT4_PATH"
-mkfs.ext4 -q -F -L rootfs "$EXT4_PATH"
+# Pin UUID, directory-hash seed, and creation time so mkfs.ext4 produces a
+# byte-identical default.ext4 on every worker. This lets qcow2 overlays that
+# reference this file as their backing remain portable across workers — without
+# it, each worker's default.ext4 has a random UUID + inode layout, so overlays
+# resolve unchanged clusters through different bytes on different workers and
+# the guest's restored ext4 metadata fails checksum verification (EBADMSG).
+#
+# The companion change in manager.go flattens rootfs.qcow2 on upload as a
+# safety net; the fixed UUID here keeps that safety net from being required
+# in the common case and keeps archives small.
+mkfs.ext4 -q -F -L rootfs \
+    -U 00000000-0000-4000-8000-000000000001 \
+    -E "hash_seed=00000000-0000-4000-8000-000000000002,mkfs_time=0" \
+    "$EXT4_PATH"
 
 MNT_DIR="$TMPDIR/mnt"
 mkdir -p "$MNT_DIR"

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -1981,20 +1981,70 @@ func (m *Manager) CreateCheckpoint(ctx context.Context, sandboxID, checkpointID 
 		}
 
 		t1 := time.Now()
-		archivePath := filepath.Join(cacheDir, "checkpoint.tar.zst")
-		if err := createArchive(archivePath, cacheDir, archiveFiles); err != nil {
-			log.Printf("qemu: checkpoint %s: archive failed: %v", checkpointID, err)
-		} else {
-			uploadCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-			if _, uerr := checkpointStore.Upload(uploadCtx, rootfsKey, archivePath); uerr != nil {
-				log.Printf("qemu: checkpoint %s: S3 upload failed: %v", checkpointID, uerr)
-			} else {
-				log.Printf("qemu: checkpoint %s: S3 upload complete (%dms, files=%v)",
-					checkpointID, time.Since(t1).Milliseconds(), archiveFiles)
-			}
-			cancel()
-			os.Remove(archivePath)
+		// Stage a self-contained copy of the rootfs for upload. The cached
+		// rootfs.qcow2 is a thin overlay on top of /data/firecracker/images/default.ext4
+		// — that backing file's exact byte content differs per worker (ext4 UUID is
+		// random on each build), so the overlay is non-portable across workers. On
+		// a cross-worker fork, the target worker resolves unchanged clusters through
+		// a DIFFERENT default.ext4 and the guest's restored ext4 metadata fails
+		// checksum verification → EBADMSG ("Bad message") on every file read.
+		//
+		// `qemu-img rebase -b ""` merges the backing file into the overlay so the
+		// qcow2 is fully self-contained. Unlike `qemu-img convert`, rebase preserves
+		// internal savevm snapshots — critical because loadvm on the destination
+		// needs the "cp-<id>" snapshot intact.
+		archiveStaging := filepath.Join(cacheDir, "archive-upload")
+		_ = os.RemoveAll(archiveStaging)
+		if err := os.MkdirAll(archiveStaging, 0755); err != nil {
+			log.Printf("qemu: checkpoint %s: mkdir archive staging: %v", checkpointID, err)
 		}
+		// Reflink-copy each archive member into staging. For rootfs.qcow2, flatten
+		// after copying; others go as-is.
+		var stagedFiles []string
+		archiveOk := true
+		for _, f := range archiveFiles {
+			src := filepath.Join(cacheDir, f)
+			dst := filepath.Join(archiveStaging, f)
+			if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+				log.Printf("qemu: checkpoint %s: stage mkdir: %v", checkpointID, err)
+				archiveOk = false
+				break
+			}
+			if err := copyFileReflink(src, dst); err != nil {
+				log.Printf("qemu: checkpoint %s: stage %s: %v", checkpointID, f, err)
+				archiveOk = false
+				break
+			}
+			stagedFiles = append(stagedFiles, f)
+		}
+		if archiveOk {
+			stagedRootfs := filepath.Join(archiveStaging, "rootfs.qcow2")
+			if fileExists(stagedRootfs) {
+				rebase := exec.Command("qemu-img", "rebase", "-b", "", stagedRootfs)
+				if out, err := rebase.CombinedOutput(); err != nil {
+					log.Printf("qemu: checkpoint %s: rootfs rebase failed: %v (%s)",
+						checkpointID, err, strings.TrimSpace(string(out)))
+					archiveOk = false
+				}
+			}
+		}
+		archivePath := filepath.Join(cacheDir, "checkpoint.tar.zst")
+		if archiveOk {
+			if err := createArchive(archivePath, archiveStaging, stagedFiles); err != nil {
+				log.Printf("qemu: checkpoint %s: archive failed: %v", checkpointID, err)
+			} else {
+				uploadCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				if _, uerr := checkpointStore.Upload(uploadCtx, rootfsKey, archivePath); uerr != nil {
+					log.Printf("qemu: checkpoint %s: S3 upload failed: %v", checkpointID, uerr)
+				} else {
+					log.Printf("qemu: checkpoint %s: S3 upload complete (%dms, files=%v, flattened=true)",
+						checkpointID, time.Since(t1).Milliseconds(), stagedFiles)
+				}
+				cancel()
+				os.Remove(archivePath)
+			}
+		}
+		os.RemoveAll(archiveStaging)
 	}
 
 	if onReady != nil {

--- a/internal/qemu/snapshot.go
+++ b/internal/qemu/snapshot.go
@@ -200,7 +200,24 @@ func (m *Manager) doHibernate(ctx context.Context, vm *VMInstance, checkpointSto
 			return nil, fmt.Errorf("copy %s for archive staging: %w", driveFile, err)
 		}
 	}
-	log.Printf("qemu: hibernate %s: archive staging ready (reflink copies)", sandboxID)
+	// Flatten rootfs before archiving: the cached rootfs.qcow2 is a thin overlay
+	// on top of /data/firecracker/images/default.ext4. That base file's byte
+	// content differs per worker (random ext4 UUID at build time), so if the
+	// archive is downloaded on another worker the overlay resolves unchanged
+	// clusters through a DIFFERENT base and the restored guest's ext4 metadata
+	// fails checksum verification → EBADMSG on every file read. `qemu-img rebase
+	// -b ""` merges the base into the overlay so the qcow2 is self-contained.
+	// Unlike `qemu-img convert`, rebase preserves internal savevm snapshots
+	// which loadvm on the destination needs to restore VM state.
+	stagedRootfs := filepath.Join(archiveDir, rootfsFile)
+	if fileExists(stagedRootfs) {
+		rebaseCmd := exec.Command("qemu-img", "rebase", "-b", "", stagedRootfs)
+		if out, err := rebaseCmd.CombinedOutput(); err != nil {
+			log.Printf("qemu: hibernate %s: rootfs rebase failed — archive may not be cross-worker portable: %v (%s)",
+				sandboxID, err, strings.TrimSpace(string(out)))
+		}
+	}
+	log.Printf("qemu: hibernate %s: archive staging ready (reflink + flatten)", sandboxID)
 
 	// Signal channel so destroyVM can wait for archive completion before deleting files.
 	archiveDone := make(chan struct{})


### PR DESCRIPTION
## Summary

After PR #128 merged, prod surfaced a residual cross-worker fork corruption: forks that land on a different worker from the one that created the checkpoint come up with EBADMSG on every file read. Same-worker forks work fine.

## Root cause

The cached `rootfs.qcow2` for each sandbox is a thin qcow2 overlay with backing file = `/data/firecracker/images/default.ext4`. The base ext4 image is rebuilt independently on each worker from the same Dockerfile, but:
- `mkfs.ext4` generates a random UUID per build.
- The ext4 inode table layout can vary between builds.

So byte content of `default.ext4` differs between workers even when logical filesystem content is identical. The qcow2 overlay only stores cluster deltas; unchanged clusters are resolved through the backing file. On a cross-worker download, the target worker resolves those unchanged clusters through ITS OWN `default.ext4` (different bytes), and the guest's restored ext4 metadata (captured in the memory snapshot at savevm time) fails checksum verification → EBADMSG.

Verified by inspection: md5 of `default.ext4` differs between `oc-worker-1` and `oc-worker-2`; the cross-worker forks that failed were the ones that had to download from S3 and resolve through a different backing.

## Fix

Before archiving, `qemu-img rebase -b "" <rootfs>` merges backing-file content into the overlay so the qcow2 is self-contained. Unlike `qemu-img convert`, `rebase` preserves internal savevm snapshots — critical because `loadvm` on the destination needs the `cp-<id>` snapshot intact.

Applied to both archival paths:
- `CreateCheckpoint` — reflink-stage to a temp archive dir, flatten rootfs there, tar+upload. Leaves the local-fork `cacheDir` copy as a thin overlay so same-worker forks stay fast.
- `doHibernate` — flatten in-place in `archiveDir` before tar.

Same approach as `autoscaling-etc` branch's `MigrateToS3Flatten` — that branch already solved this for live migration but the fix never made it to main.

## Tradeoff

Archive size grows from ~150MB to ~1.5GB because the base ext4 content is now embedded. Necessary for cross-worker correctness; size optimization can come later via deterministic `default.ext4` builds (fixed UUID + fixed `hash_seed`).

## Test plan

- [x] Verified root cause by comparing md5 of `default.ext4` across prod workers and inspecting the qcow2's `backing file` field.
- [ ] After merge + deploy, re-run `scripts/integration-tests/02-fork-no-corruption.ts` against prod — all 10 forks should pass regardless of which worker they land on.
- [ ] Re-run `sdks/typescript/examples/test-secret-store-fork.ts` against prod — should return to 27/27.