### PR TITLE
Add oc agent command group for managed agents

### DIFF
--- a/cmd/oc/internal/client/client.go
+++ b/cmd/oc/internal/client/client.go
@@ -13,6 +13,7 @@ import (
 )
 
 type contextKey struct{}
+type sessionsContextKey struct{}
 
 // Client is an HTTP client for the OpenComputer API.
 type Client struct {
@@ -53,6 +54,31 @@ func WithClient(ctx context.Context, c *Client) context.Context {
 // FromContext retrieves the client from the context.
 func FromContext(ctx context.Context) *Client {
 	return ctx.Value(contextKey{}).(*Client)
+}
+
+// WithSessionsClient stores the sessions-api client in the context.
+func WithSessionsClient(ctx context.Context, c *Client) context.Context {
+	return context.WithValue(ctx, sessionsContextKey{}, c)
+}
+
+// SessionsFromContext retrieves the sessions-api client from the context.
+func SessionsFromContext(ctx context.Context) *Client {
+	v := ctx.Value(sessionsContextKey{})
+	if v == nil {
+		return nil
+	}
+	return v.(*Client)
+}
+
+// NewSessionsAPI creates a client for the sessions-api service.
+// Uses X-API-Key auth but no /api prefix (sessions-api routes are /v1/...).
+func NewSessionsAPI(baseURL, apiKey string) *Client {
+	baseURL = strings.TrimRight(baseURL, "/")
+	return &Client{
+		baseURL:    baseURL,
+		apiKey:     apiKey,
+		httpClient: &http.Client{},
+	}
 }
 
 // NewWorker creates a client that authenticates with a Bearer token directly to a worker.

--- a/cmd/oc/internal/commands/agent.go
+++ b/cmd/oc/internal/commands/agent.go
@@ -1,0 +1,419 @@
+package commands
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/opensandbox/opensandbox/cmd/oc/internal/client"
+	"github.com/spf13/cobra"
+)
+
+// sessionsClient returns the sessions-api client from context, or errors if not configured.
+func sessionsClient(cmd *cobra.Command) (*client.Client, error) {
+	c := client.SessionsFromContext(cmd.Context())
+	if c == nil {
+		return nil, fmt.Errorf("sessions-api URL not configured. Set SESSIONS_API_URL or use --sessions-api-url")
+	}
+	return c, nil
+}
+
+// ── Types for sessions-api responses ──
+
+type agentResponse struct {
+	ID          string      `json:"id"`
+	DisplayName string      `json:"display_name"`
+	Core        *string     `json:"core"`
+	Channels    interface{} `json:"channels"`
+	Packages    interface{} `json:"packages"`
+	SecretStore *string     `json:"secret_store"`
+	Config      interface{} `json:"config"`
+	CreatedAt   string      `json:"created_at"`
+	UpdatedAt   string      `json:"updated_at"`
+}
+
+type agentListResponse struct {
+	Agents []agentResponse `json:"agents"`
+}
+
+type instanceResponse struct {
+	ID        string `json:"id"`
+	AgentID   string `json:"agent_id"`
+	Status    string `json:"status"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+type instanceListResponse struct {
+	Instances []instanceResponse `json:"instances"`
+}
+
+// ── Commands ──
+
+var agentCmd = &cobra.Command{
+	Use:   "agent",
+	Short: "Manage agents",
+	Long:  "Create and manage managed agents on OpenComputer.",
+}
+
+var agentCreateCmd = &cobra.Command{
+	Use:   "create <id>",
+	Short: "Create a new managed agent",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		id := args[0]
+		core, _ := cmd.Flags().GetString("core")
+		secretSlice, _ := cmd.Flags().GetStringSlice("secret")
+
+		body := map[string]interface{}{
+			"id": id,
+		}
+		if core != "" {
+			body["core"] = core
+		}
+
+		// Parse --secret KEY=VAL flags into secrets map
+		if len(secretSlice) > 0 {
+			secrets := make(map[string]string)
+			for _, s := range secretSlice {
+				parts := strings.SplitN(s, "=", 2)
+				if len(parts) == 2 {
+					secrets[parts[0]] = parts[1]
+				}
+			}
+			body["secrets"] = secrets
+		}
+
+		var agent agentResponse
+		if err := sc.Post(cmd.Context(), "/v1/agents", body, &agent); err != nil {
+			return err
+		}
+
+		printer.Print(agent, func() {
+			fmt.Printf("Created agent %s", agent.ID)
+			if agent.Core != nil {
+				fmt.Printf(" (core: %s)", *agent.Core)
+			}
+			fmt.Println()
+			if agent.Core != nil {
+				fmt.Println("Instance is booting...")
+			}
+		})
+		return nil
+	},
+}
+
+var agentListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List agents",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		var resp agentListResponse
+		if err := sc.Get(cmd.Context(), "/v1/agents", &resp); err != nil {
+			return err
+		}
+
+		printer.Print(resp.Agents, func() {
+			if len(resp.Agents) == 0 {
+				fmt.Println("No agents found.")
+				return
+			}
+			headers := []string{"ID", "CORE", "CHANNELS", "PACKAGES", "CREATED"}
+			var rows [][]string
+			for _, a := range resp.Agents {
+				coreStr := "-"
+				if a.Core != nil {
+					coreStr = *a.Core
+				}
+				channels := formatList(a.Channels)
+				packages := formatList(a.Packages)
+				created := formatAge(a.CreatedAt)
+				rows = append(rows, []string{a.ID, coreStr, channels, packages, created})
+			}
+			printer.Table(headers, rows)
+		})
+		return nil
+	},
+}
+
+var agentGetCmd = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Get agent details",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		var agent agentResponse
+		if err := sc.Get(cmd.Context(), "/v1/agents/"+args[0], &agent); err != nil {
+			return err
+		}
+
+		printer.Print(agent, func() {
+			fmt.Printf("ID:        %s\n", agent.ID)
+			fmt.Printf("Name:      %s\n", agent.DisplayName)
+			coreStr := "-"
+			if agent.Core != nil {
+				coreStr = *agent.Core
+			}
+			fmt.Printf("Core:      %s\n", coreStr)
+			fmt.Printf("Channels:  %s\n", formatList(agent.Channels))
+			fmt.Printf("Packages:  %s\n", formatList(agent.Packages))
+			fmt.Printf("Created:   %s\n", agent.CreatedAt)
+		})
+
+		// Show instance status
+		var instResp instanceListResponse
+		if err := sc.Get(cmd.Context(), "/v1/agents/"+args[0]+"/instances", &instResp); err == nil && len(instResp.Instances) > 0 {
+			inst := instResp.Instances[0]
+			fmt.Printf("Instance:  %s (%s)\n", inst.ID, inst.Status)
+		}
+
+		return nil
+	},
+}
+
+var agentDeleteCmd = &cobra.Command{
+	Use:   "delete <id>",
+	Short: "Delete an agent",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		if err := sc.Delete(cmd.Context(), "/v1/agents/"+args[0]); err != nil {
+			return err
+		}
+
+		fmt.Printf("Agent %s deleted.\n", args[0])
+		return nil
+	},
+}
+
+var agentConnectCmd = &cobra.Command{
+	Use:   "connect <id> <channel>",
+	Short: "Connect a channel to an agent",
+	Long:  "Connect a messaging channel (e.g. telegram) to a managed agent.",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		agentID := args[0]
+		channel := args[1]
+
+		body := map[string]interface{}{}
+
+		if channel == "telegram" {
+			fmt.Println("To connect Telegram:")
+			fmt.Println("  1. Open Telegram and message @BotFather")
+			fmt.Println("  2. Send /newbot, choose a name and username")
+			fmt.Println("  3. Copy the bot token")
+			fmt.Println()
+			fmt.Print("Paste bot token: ")
+
+			reader := bufio.NewReader(os.Stdin)
+			token, _ := reader.ReadString('\n')
+			token = strings.TrimSpace(token)
+			if token == "" {
+				return fmt.Errorf("bot token is required")
+			}
+			body["bot_token"] = token
+		}
+
+		var result map[string]interface{}
+		if err := sc.Post(cmd.Context(), "/v1/agents/"+agentID+"/channels/"+channel, body, &result); err != nil {
+			return err
+		}
+
+		fmt.Printf("Telegram connected to %s.\n", agentID)
+		if channel == "telegram" {
+			fmt.Println("Message your bot on Telegram to start chatting.")
+		}
+		return nil
+	},
+}
+
+var agentDisconnectCmd = &cobra.Command{
+	Use:   "disconnect <id> <channel>",
+	Short: "Disconnect a channel from an agent",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		if err := sc.Delete(cmd.Context(), "/v1/agents/"+args[0]+"/channels/"+args[1]); err != nil {
+			return err
+		}
+
+		fmt.Printf("Channel %s disconnected from %s.\n", args[1], args[0])
+		return nil
+	},
+}
+
+var agentChannelsCmd = &cobra.Command{
+	Use:   "channels <id>",
+	Short: "List channels connected to an agent",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		var resp map[string]interface{}
+		if err := sc.Get(cmd.Context(), "/v1/agents/"+args[0]+"/channels", &resp); err != nil {
+			return err
+		}
+
+		printer.Print(resp, func() {
+			channels := formatList(resp["channels"])
+			if channels == "-" {
+				fmt.Println("No channels connected.")
+			} else {
+				fmt.Printf("Channels: %s\n", channels)
+			}
+		})
+		return nil
+	},
+}
+
+var agentInstallCmd = &cobra.Command{
+	Use:   "install <id> <package>",
+	Short: "Install a package on an agent",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		agentID := args[0]
+		pkg := args[1]
+
+		var result map[string]interface{}
+		if err := sc.Post(cmd.Context(), "/v1/agents/"+agentID+"/packages/"+pkg, nil, &result); err != nil {
+			return err
+		}
+
+		fmt.Printf("Package %s installed on %s.\n", pkg, agentID)
+		return nil
+	},
+}
+
+var agentUninstallCmd = &cobra.Command{
+	Use:   "uninstall <id> <package>",
+	Short: "Uninstall a package from an agent",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		if err := sc.Delete(cmd.Context(), "/v1/agents/"+args[0]+"/packages/"+args[1]); err != nil {
+			return err
+		}
+
+		fmt.Printf("Package %s uninstalled from %s.\n", args[1], args[0])
+		return nil
+	},
+}
+
+var agentPackagesCmd = &cobra.Command{
+	Use:   "packages <id>",
+	Short: "List packages installed on an agent",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		var resp map[string]interface{}
+		if err := sc.Get(cmd.Context(), "/v1/agents/"+args[0]+"/packages", &resp); err != nil {
+			return err
+		}
+
+		printer.Print(resp, func() {
+			packages := formatList(resp["packages"])
+			if packages == "-" {
+				fmt.Println("No packages installed.")
+			} else {
+				fmt.Printf("Packages: %s\n", packages)
+			}
+		})
+		return nil
+	},
+}
+
+// ── Helpers ──
+
+func formatList(v interface{}) string {
+	if v == nil {
+		return "-"
+	}
+	switch items := v.(type) {
+	case []interface{}:
+		if len(items) == 0 {
+			return "-"
+		}
+		strs := make([]string, len(items))
+		for i, item := range items {
+			strs[i] = fmt.Sprintf("%v", item)
+		}
+		return strings.Join(strs, ", ")
+	case []string:
+		if len(items) == 0 {
+			return "-"
+		}
+		return strings.Join(items, ", ")
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func formatAge(isoTime string) string {
+	t, err := time.Parse(time.RFC3339Nano, isoTime)
+	if err != nil {
+		return isoTime
+	}
+	return time.Since(t).Truncate(time.Second).String()
+}
+
+func init() {
+	// agent create flags
+	agentCreateCmd.Flags().String("core", "", "Managed core (e.g. hermes)")
+	agentCreateCmd.Flags().StringSlice("secret", nil, "Secrets (KEY=VALUE)")
+
+	agentCmd.AddCommand(agentCreateCmd)
+	agentCmd.AddCommand(agentListCmd)
+	agentCmd.AddCommand(agentGetCmd)
+	agentCmd.AddCommand(agentDeleteCmd)
+	agentCmd.AddCommand(agentConnectCmd)
+	agentCmd.AddCommand(agentDisconnectCmd)
+	agentCmd.AddCommand(agentChannelsCmd)
+	agentCmd.AddCommand(agentInstallCmd)
+	agentCmd.AddCommand(agentUninstallCmd)
+	agentCmd.AddCommand(agentPackagesCmd)
+}

--- a/cmd/oc/internal/commands/root.go
+++ b/cmd/oc/internal/commands/root.go
@@ -29,7 +29,15 @@ var rootCmd = &cobra.Command{
 			fmt.Fprintln(os.Stderr, "Warning: no API key configured. Set OPENCOMPUTER_API_KEY or run 'oc config set api-key <key>'")
 		}
 		c := client.New(cfg.APIURL, cfg.APIKey)
-		cmd.SetContext(client.WithClient(cmd.Context(), c))
+		ctx := client.WithClient(cmd.Context(), c)
+
+		// Set up sessions-api client if configured
+		if cfg.SessionsAPIURL != "" {
+			sc := client.NewSessionsAPI(cfg.SessionsAPIURL, cfg.APIKey)
+			ctx = client.WithSessionsClient(ctx, sc)
+		}
+
+		cmd.SetContext(ctx)
 		printer = output.New(jsonOutput)
 		return nil
 	},
@@ -41,6 +49,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
 	rootCmd.PersistentFlags().String("api-key", "", "API key (overrides OPENCOMPUTER_API_KEY)")
 	rootCmd.PersistentFlags().String("api-url", "", "API URL (overrides OPENCOMPUTER_API_URL)")
+	rootCmd.PersistentFlags().String("sessions-api-url", "", "Sessions API URL (overrides SESSIONS_API_URL)")
 
 	// Register command groups
 	rootCmd.AddCommand(sandboxCmd)
@@ -52,6 +61,7 @@ func init() {
 	rootCmd.AddCommand(secretStoreCmd)
 	rootCmd.AddCommand(secretCmd)
 	rootCmd.AddCommand(configCmd)
+	rootCmd.AddCommand(agentCmd)
 
 	// Top-level shortcuts
 	rootCmd.AddCommand(createShortcut)

--- a/cmd/oc/internal/commands/shell.go
+++ b/cmd/oc/internal/commands/shell.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"regexp"
 	"syscall"
 
 	"github.com/gorilla/websocket"
@@ -13,6 +14,8 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
+
+var uuidPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
 var shellCmd = &cobra.Command{
 	Use:   "shell <sandbox-id>",
@@ -27,6 +30,21 @@ Examples:
 		c := client.FromContext(cmd.Context())
 		sandboxID := args[0]
 		shellPath, _ := cmd.Flags().GetString("shell")
+
+		// If the argument doesn't look like a UUID, try to resolve it as an
+		// agent name through sessions-api → agent → instance → sandbox_id.
+		if !uuidPattern.MatchString(sandboxID) {
+			sc := client.SessionsFromContext(cmd.Context())
+			if sc != nil {
+				resolved, err := resolveAgentSandbox(cmd, sc, sandboxID)
+				if err != nil {
+					return fmt.Errorf("failed to resolve agent %q: %w", sandboxID, err)
+				}
+				sandboxID = resolved
+			} else {
+				return fmt.Errorf("%q does not look like a sandbox ID. Set SESSIONS_API_URL to resolve agent names.", sandboxID)
+			}
+		}
 
 		// Get sandbox info to resolve connectURL for direct worker access
 		var sandbox struct {
@@ -130,6 +148,27 @@ Examples:
 
 		return nil
 	},
+}
+
+// resolveAgentSandbox looks up an agent by name through sessions-api and returns
+// the sandbox ID of its first running instance.
+func resolveAgentSandbox(cmd *cobra.Command, sc *client.Client, agentName string) (string, error) {
+	var instResp struct {
+		Instances []struct {
+			ID        string  `json:"id"`
+			Status    string  `json:"status"`
+			SandboxID *string `json:"sandbox_id"`
+		} `json:"instances"`
+	}
+	if err := sc.Get(cmd.Context(), "/v1/agents/"+agentName+"/instances", &instResp); err != nil {
+		return "", err
+	}
+	for _, inst := range instResp.Instances {
+		if inst.Status == "running" && inst.SandboxID != nil {
+			return *inst.SandboxID, nil
+		}
+	}
+	return "", fmt.Errorf("no running instance found for agent %q", agentName)
 }
 
 func init() {

--- a/cmd/oc/internal/config/config.go
+++ b/cmd/oc/internal/config/config.go
@@ -16,8 +16,9 @@ const (
 
 // Config holds the resolved CLI configuration.
 type Config struct {
-	APIURL string `json:"api_url,omitempty"`
-	APIKey string `json:"api_key,omitempty"`
+	APIURL         string `json:"api_url,omitempty"`
+	APIKey         string `json:"api_key,omitempty"`
+	SessionsAPIURL string `json:"sessions_api_url,omitempty"`
 }
 
 // Load resolves configuration from flags > env > config file > defaults.
@@ -36,6 +37,9 @@ func Load(cmd *cobra.Command) Config {
 	if v := os.Getenv("OPENCOMPUTER_API_KEY"); v != "" {
 		cfg.APIKey = v
 	}
+	if v := os.Getenv("SESSIONS_API_URL"); v != "" {
+		cfg.SessionsAPIURL = v
+	}
 
 	// Flags override env
 	if cmd != nil {
@@ -44,6 +48,9 @@ func Load(cmd *cobra.Command) Config {
 		}
 		if v, _ := cmd.Flags().GetString("api-key"); v != "" {
 			cfg.APIKey = v
+		}
+		if v, _ := cmd.Flags().GetString("sessions-api-url"); v != "" {
+			cfg.SessionsAPIURL = v
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Adds `oc agent` command group: create, list, get, delete, connect, disconnect, channels, install, uninstall, packages
- Adds sessions-api client (`NewSessionsAPI`) with `SESSIONS_API_URL` / `--sessions-api-url` config
- Extends `oc shell` to resolve agent names via sessions-api (not just sandbox UUIDs)

The CLI talks to sessions-api for agent management. The `X-API-Key` from the user's OC config is passed through to sessions-api, which forwards it to OC for sandbox operations.

### Commands

| Command | What it does |
|---------|-------------|
| `oc agent create <id> --core hermes` | Create a managed agent |
| `oc agent list` | List agents |
| `oc agent get <id>` | Show agent details + instance status |
| `oc agent delete <id>` | Delete an agent |
| `oc agent connect <id> telegram` | Connect Telegram (prompts for bot token) |
| `oc agent disconnect <id> telegram` | Disconnect a channel |
| `oc agent install <id> gbrain` | Install a package |
| `oc agent uninstall <id> gbrain` | Uninstall a package |
| `oc shell <agent-name>` | Shell into agent's sandbox (resolves name → sandbox ID) |

### Known issues

- `oc agent connect` defaults to interactive mode (prompts for bot token). Should default to `--bot-token` flag with `--interactive` opt-in.

## Test plan

- [ ] `oc agent create test --core hermes` — creates agent, instance boots
- [ ] `oc agent list` / `oc agent get test` — shows agent with status
- [ ] `oc agent connect test telegram` — registers webhook, wires config
- [ ] `oc shell test` — resolves agent name, opens shell
- [ ] `oc agent delete test` — cleans up

🤖 Generated with [Claude Code](https://claude.com/claude-code)