### PR TITLE
Default sessions-api URL to api.opencomputer.dev

### DIFF
--- a/cmd/oc/internal/commands/root.go
+++ b/cmd/oc/internal/commands/root.go
@@ -31,11 +31,9 @@ var rootCmd = &cobra.Command{
 		c := client.New(cfg.APIURL, cfg.APIKey)
 		ctx := client.WithClient(cmd.Context(), c)
 
-		// Set up sessions-api client if configured
-		if cfg.SessionsAPIURL != "" {
-			sc := client.NewSessionsAPI(cfg.SessionsAPIURL, cfg.APIKey)
-			ctx = client.WithSessionsClient(ctx, sc)
-		}
+		// Set up sessions-api client (defaults to api.opencomputer.dev)
+		sc := client.NewSessionsAPI(cfg.SessionsAPIURL, cfg.APIKey)
+		ctx = client.WithSessionsClient(ctx, sc)
 
 		cmd.SetContext(ctx)
 		printer = output.New(jsonOutput)

--- a/cmd/oc/internal/config/config.go
+++ b/cmd/oc/internal/config/config.go
@@ -9,9 +9,10 @@ import (
 )
 
 const (
-	DefaultAPIURL = "https://app.opencomputer.dev"
-	configDir     = ".oc"
-	configFile    = "config.json"
+	DefaultAPIURL         = "https://app.opencomputer.dev"
+	DefaultSessionsAPIURL = "https://api.opencomputer.dev"
+	configDir             = ".oc"
+	configFile            = "config.json"
 )
 
 // Config holds the resolved CLI configuration.
@@ -36,6 +37,9 @@ func Load(cmd *cobra.Command) Config {
 	}
 	if v := os.Getenv("OPENCOMPUTER_API_KEY"); v != "" {
 		cfg.APIKey = v
+	}
+	if cfg.SessionsAPIURL == "" {
+		cfg.SessionsAPIURL = DefaultSessionsAPIURL
 	}
 	if v := os.Getenv("SESSIONS_API_URL"); v != "" {
 		cfg.SessionsAPIURL = v


### PR DESCRIPTION
## Summary

- Adds `DefaultSessionsAPIURL` constant (`https://api.opencomputer.dev`)
- Sessions-api client is always initialized (no nil check needed)

Without this, `oc agent` commands fail unless the user manually sets `SESSIONS_API_URL`.

## Test plan

- [ ] `oc agent list` works without `SESSIONS_API_URL` set
- [ ] `SESSIONS_API_URL` env var still overrides the default
- [ ] `--sessions-api-url` flag still overrides both

🤖 Generated with [Claude Code](https://claude.com/claude-code)