### PR TITLE
Split CLI install into separate code blocks

### DIFF
--- a/docs/guides/create-hermes-agent.mdx
+++ b/docs/guides/create-hermes-agent.mdx
@@ -17,6 +17,9 @@ See [CLI installation](/cli/overview#installation) for all platforms, or quick-i
 
 ```bash
 curl -fsSL https://github.com/diggerhq/opencomputer/releases/latest/download/oc-darwin-arm64 -o /usr/local/bin/oc && chmod +x /usr/local/bin/oc
+```
+
+```bash
 oc config set api-key YOUR_API_KEY
 ```
 


### PR DESCRIPTION
Each command gets its own block so copy-paste works correctly.