### PR TITLE
Hermes guide: link to CLI install instead of inline commands

### DIFF
--- a/docs/guides/create-hermes-agent.mdx
+++ b/docs/guides/create-hermes-agent.mdx
@@ -13,11 +13,7 @@ This guide walks through creating a managed Hermes agent on OpenComputer, connec
 
 ### Install the CLI
 
-See [CLI installation](/cli/overview#installation) for all platforms, or quick-install on macOS:
-
-```bash
-curl -fsSL https://github.com/diggerhq/opencomputer/releases/latest/download/oc-darwin-arm64 -o /usr/local/bin/oc && chmod +x /usr/local/bin/oc
-```
+Install the `oc` binary from the [CLI installation guide](/cli/overview#installation).
 
 ```bash
 oc config set api-key YOUR_API_KEY


### PR DESCRIPTION
## Summary

- Removes inline curl/chmod install commands from the Hermes agent guide
- Links to the existing CLI installation page instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)