### PR TITLE
Add managed agents and gbrain docs

### DIFF
--- a/docs/agents-api/gbrain.mdx
+++ b/docs/agents-api/gbrain.mdx
@@ -1,0 +1,101 @@
+---
+title: "gbrain Package"
+description: "Install persistent memory on a managed agent with gbrain"
+---
+
+[gbrain](https://github.com/garrytan/gbrain) is a personal knowledge system that gives your agent persistent memory backed by Postgres with vector search. When installed on a managed agent, it's wired as an MCP server — the agent gets 34 tools for storing, searching, and organizing knowledge.
+
+## Install
+
+```bash
+oc agent install my-hermes gbrain
+```
+
+This runs through five phases:
+
+| Phase | What happens |
+|-------|-------------|
+| **Allocate** | Creates a managed Postgres database (with `pgvector` and `pg_trgm` extensions) for this agent |
+| **Provision** | Clones gbrain from GitHub into the sandbox and installs dependencies |
+| **Initialize** | Runs `gbrain init` against the managed database to create the schema |
+| **Wire** | Adds gbrain as an MCP server in the core's config and restarts the gateway |
+| **Verify** | Runs `gbrain doctor` to confirm the installation |
+
+Install is **idempotent** — re-running it after a partial failure is safe. The allocate phase skips if the database exists, provision skips if gbrain is already cloned, and so on.
+
+## What the agent gets
+
+After install, the agent has these tool groups available:
+
+| Group | Tools | What they do |
+|-------|-------|-------------|
+| **Pages** | `put_page`, `get_page`, `delete_page`, `list_pages` | Store and retrieve knowledge pages with Markdown content |
+| **Search** | `query` (vector + keyword hybrid), `search` (full-text) | Find pages by meaning or keywords |
+| **Versions** | `get_versions`, `revert_version` | Page version history |
+| **Graph** | `add_link`, `remove_link`, `get_links`, `get_backlinks`, `traverse_graph` | Link pages into a knowledge graph |
+| **Tags** | `add_tag`, `remove_tag`, `get_tags` | Categorize pages |
+| **Timeline** | `add_timeline_entry`, `get_timeline` | Chronological event log |
+| **Files** | `file_upload`, `file_list`, `file_url` | Attach files to the knowledge base |
+| **System** | `get_stats`, `get_health`, `sync_brain` | Health checks and maintenance |
+
+## Test it
+
+After installing, message your agent on Telegram:
+
+```
+You:   What new tools do you have?
+Agent: I now have gbrain tools — search, put_page, timeline...
+
+You:   Use gbrain to remember that our deployment target is Kubernetes on GCP
+Agent: Saved to knowledge base.
+
+You:   Use gbrain to search for deployment
+Agent: You deploy to Kubernetes on GCP.
+```
+
+## Managed database
+
+The database that backs gbrain is **managed by OpenComputer** — you don't need to provision or configure Postgres yourself. The database:
+
+- Lives outside the sandbox on a shared Postgres cluster
+- Survives instance restarts and sandbox recreation
+- Is preserved when you uninstall gbrain (your data isn't deleted)
+- Is restored when you reinstall gbrain on the same agent
+
+The connection URL is passed to gbrain via the MCP server's environment config, not as a sandbox-level secret.
+
+## Uninstall
+
+```bash
+oc agent uninstall my-hermes gbrain
+```
+
+This removes the MCP wiring from the core's config and restarts the gateway. The agent loses access to gbrain tools, but the **database is preserved**. Reinstalling gbrain on the same agent reconnects to the existing data.
+
+## Debugging
+
+Shell into the sandbox to inspect the installation:
+
+```bash
+oc shell my-hermes
+```
+
+```bash
+# Check if gbrain is cloned
+ls ~/.gbrain/src/cli.ts
+
+# Check the MCP config
+cat ~/.hermes/config.yaml
+
+# Check gateway logs for MCP connection status
+tail -20 ~/.hermes/logs/gateway.log
+
+# Run gbrain directly
+~/.bun/bin/bun run ~/.gbrain/src/cli.ts doctor
+```
+
+Common issues:
+
+- **"missing executable 'bun'"** in gateway logs — the MCP config needs absolute paths (e.g., `/home/sandbox/.bun/bin/bun`), not bare `bun`
+- **Embedding failures** — gbrain uses OpenAI for vector embeddings. If `OPENAI_API_KEY` is missing from the MCP env config, pages are stored but semantic search won't work
+- **Gateway didn't pick up MCP** — check if the gateway restarted after the wire phase. Run `hermes gateway run --replace` from the shell to force a restart

--- a/docs/agents-api/managed-agents.mdx
+++ b/docs/agents-api/managed-agents.mdx
@@ -1,0 +1,95 @@
+---
+title: "Managed Agents"
+description: "Cores, channels, and packages — the building blocks of a managed agent"
+---
+
+A managed agent is an agent with a **core** — a blessed runtime that OpenComputer knows how to configure, connect, and extend. Instead of managing snapshots and entrypoints yourself, you pick a core and build up from there.
+
+```
+ManagedAgent = Core + Channels + Packages + Secrets
+```
+
+## Cores
+
+A core is the AI runtime that powers your agent. When you create a managed agent with `--core`, OpenComputer boots a sandbox with that runtime pre-installed, an LLM key configured, and a gateway ready to accept channels.
+
+```bash
+oc agent create my-agent --core hermes
+```
+
+| Core | Runtime | What you get |
+|------|---------|-------------|
+| `hermes` | [Hermes Agent](https://github.com/NousResearch/hermes-agent) | Self-improving AI agent with skill creation, memory, multi-channel gateway, browser, code execution |
+
+Without `--core`, the agent uses the raw sandbox path — you provide your own `snapshot` and `entrypoint` via the API. Managed and raw agents coexist on the same platform.
+
+## Channels
+
+A channel is a messaging platform connected to your agent. You **connect** and **disconnect** channels.
+
+```bash
+oc agent connect my-agent telegram --bot-token <token>
+oc agent disconnect my-agent telegram
+```
+
+| Channel | How it works |
+|---------|-------------|
+| `telegram` | Registers a webhook with Telegram. Messages flow through the OpenComputer gateway to your agent's sandbox. The agent replies directly to Telegram. |
+
+Channels are stateless — disconnecting removes the webhook and config. Nothing to clean up.
+
+When you connect a channel, the platform:
+
+1. Stores the channel secret (bot token) in the agent's secret store
+2. Registers the webhook with the channel provider
+3. Configures the core for webhook mode
+4. Restarts the gateway
+
+## Packages
+
+A package extends what the agent can do beyond its core. You **install** and **uninstall** packages.
+
+```bash
+oc agent install my-agent gbrain
+oc agent uninstall my-agent gbrain
+```
+
+| Package | What it adds |
+|---------|-------------|
+| `gbrain` | Personal knowledge system — 34 MCP tools for pages, vector search, graph links, timeline, files. Backed by a managed Postgres database. |
+
+Packages can be **stateful**. When you install gbrain, OpenComputer creates a managed Postgres database for that agent. The database lives outside the sandbox and survives instance restarts, uninstall/reinstall cycles, and even agent recreation.
+
+Uninstalling a package removes the wiring (MCP config) but preserves the data by default.
+
+## Putting it together
+
+Three commands to a personal AI agent on Telegram with persistent memory:
+
+```bash
+# Boot a Hermes agent
+oc agent create my-hermes --core hermes
+
+# Connect Telegram (create a bot via @BotFather first)
+oc agent connect my-hermes telegram --bot-token <token>
+
+# Install persistent memory
+oc agent install my-hermes gbrain
+```
+
+See the [Create a Hermes Agent](/guides/create-hermes-agent) guide for a step-by-step walkthrough, and the [gbrain package](/agents-api/gbrain) page for details on persistent memory.
+
+## The manual path
+
+Managed agents are sugar over OpenComputer sandboxes. You can always drop to the sandbox level:
+
+```bash
+# Shell into any agent's sandbox
+oc shell my-hermes
+
+# From there: edit config, install software, debug, run native commands
+cat ~/.hermes/config.yaml
+hermes skill list
+```
+
+The managed path and the manual path coexist. Channels and packages that you wire manually (via `oc shell`) won't appear in the managed state, but they work fine.

--- a/docs/guides/create-hermes-agent.mdx
+++ b/docs/guides/create-hermes-agent.mdx
@@ -122,7 +122,7 @@ Disconnecting deregisters the Telegram webhook and removes the channel config fr
 
 ## What's next
 
-- **Install gbrain** for persistent memory: `oc agent install my-hermes gbrain` (coming soon)
+- **[Install gbrain](/agents-api/gbrain)** for persistent memory: `oc agent install my-hermes gbrain`
 - **Connect Slack** instead of Telegram (planned)
 - **Custom cores** — bring your own agent runtime with `oc shell` and the raw sandbox API
 - **Hermes docs** — see the full [Hermes documentation](https://hermes-agent.nousresearch.com/docs/) for skills, cron jobs, voice, browser tools, and more

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -78,6 +78,8 @@
       "group": "Agents API",
       "pages": [
         "agents-api/overview",
+        "agents-api/managed-agents",
+        "agents-api/gbrain",
         "agents-api/agents",
         "agents-api/instances",
         "agents-api/sessions"


### PR DESCRIPTION
## Summary

- New **Managed Agents** page (`agents-api/managed-agents`) — introduces cores, channels, and packages as the building blocks of a managed agent, with CLI examples for the full create → connect → install flow
- New **gbrain Package** page (`agents-api/gbrain`) — install guide, five-phase orchestration, tool inventory (34 MCP tools), managed database lifecycle, debugging tips
- Updated Hermes guide — gbrain link changed from "coming soon" to live reference
- Updated mint.json nav — new pages added to Agents API group

## Test plan

- [ ] Preview docs site renders both new pages
- [ ] Nav shows Managed Agents and gbrain under Agents API
- [ ] Links between pages work (Hermes guide → gbrain, managed-agents → gbrain, managed-agents → Hermes guide)
- [ ] Code blocks render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)