### PR TITLE
fix(billing): close open scale_events when session leaves running state

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -497,11 +497,30 @@ func (s *Store) UpdateSandboxSessionStatus(ctx context.Context, sandboxID, statu
 		query = `UPDATE sandbox_sessions SET status = $1 WHERE sandbox_id = $2 AND status = 'running'`
 		args = []interface{}{status, sandboxID}
 	}
-	_, err := s.pool.Exec(ctx, query, args...)
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	tag, err := tx.Exec(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("failed to update sandbox session: %w", err)
 	}
-	return nil
+
+	// Close any open scale_events when the session actually transitioned to a
+	// non-billable state. Tied to the same tx as the session update so the
+	// usage reporter can never observe a stopped/hibernated session with an
+	// ended_at IS NULL scale_event (which would keep billing the window).
+	if tag.RowsAffected() > 0 && (status == "stopped" || status == "hibernated" || status == "error") {
+		if _, err := tx.Exec(ctx,
+			`UPDATE sandbox_scale_events SET ended_at = now()
+			 WHERE sandbox_id = $1 AND ended_at IS NULL`, sandboxID); err != nil {
+			return fmt.Errorf("failed to close scale events: %w", err)
+		}
+	}
+	return tx.Commit(ctx)
 }
 
 // SetMigrating marks a sandbox as migrating to a target worker.
@@ -911,8 +930,14 @@ func (s *Store) UpdateSandboxSessionForWake(ctx context.Context, sandboxID, newW
 // Sessions without a checkpoint are set to "stopped" (VM is gone, no recovery possible).
 // Returns the count of sessions transitioned to each state.
 func (s *Store) ReconcileWorkerSessions(ctx context.Context, workerID string) (hibernated, stopped int, err error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
 	// First: mark sessions that have an active hibernation as "hibernated"
-	res1, err := s.pool.Exec(ctx,
+	res1, err := tx.Exec(ctx,
 		`UPDATE sandbox_sessions SET status = 'hibernated'
 		 WHERE worker_id = $1 AND status = 'running'
 		 AND sandbox_id IN (
@@ -924,7 +949,7 @@ func (s *Store) ReconcileWorkerSessions(ctx context.Context, workerID string) (h
 	}
 
 	// Second: mark remaining "running" sessions as "stopped"
-	res2, err := s.pool.Exec(ctx,
+	res2, err := tx.Exec(ctx,
 		`UPDATE sandbox_sessions SET status = 'stopped', stopped_at = now(),
 		 error_msg = 'worker restarted'
 		 WHERE worker_id = $1 AND status = 'running'`, workerID)
@@ -932,6 +957,21 @@ func (s *Store) ReconcileWorkerSessions(ctx context.Context, workerID string) (h
 		return int(res1.RowsAffected()), 0, fmt.Errorf("failed to reconcile stopped sessions: %w", err)
 	}
 
+	// Close any open scale_events for sessions we just transitioned off running
+	// on this worker, so billing stops at reconciliation time.
+	if _, err := tx.Exec(ctx,
+		`UPDATE sandbox_scale_events se SET ended_at = now()
+		 WHERE se.ended_at IS NULL
+		   AND se.sandbox_id IN (
+		       SELECT sandbox_id FROM sandbox_sessions
+		       WHERE worker_id = $1 AND status IN ('hibernated', 'stopped')
+		   )`, workerID); err != nil {
+		return int(res1.RowsAffected()), int(res2.RowsAffected()), fmt.Errorf("failed to close scale events: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, 0, fmt.Errorf("failed to commit reconcile tx: %w", err)
+	}
 	return int(res1.RowsAffected()), int(res2.RowsAffected()), nil
 }
 


### PR DESCRIPTION
## Summary
- Stop the billing leak where `sandbox_scale_events` stay open (`ended_at IS NULL`) after sessions transition to `stopped` / `hibernated` / `error`. The usage reporter was computing `SUM(COALESCE(ended_at, LEAST(now(), $to)) - GREATEST(started_at, $from))` (`internal/db/usage.go:175`), so each 5-min tick kept billing ~300 sec per orphan event across every open tier — forever.
- Fix applied at the DB layer so **all 14 call sites** are covered at once (worker auto-hibernate callbacks, shutdown HibernateAll, control-plane stop, API stop/hibernate, proxy error paths, image-builder cleanup, worker reconcile).

## Changes
- `internal/db/store.go` — `UpdateSandboxSessionStatus` wraps session update + `UPDATE sandbox_scale_events SET ended_at = now() WHERE sandbox_id = $1 AND ended_at IS NULL` in a single tx. Scale-event close only fires if the session UPDATE actually moved a row (so re-calls don't re-close) and the target status is terminal (`stopped`/`hibernated`/`error`). Atomicity guarantees the usage-reporter can't observe a non-running session with an open event.
- `internal/db/store.go` — `ReconcileWorkerSessions` (worker-restart path) wrapped in a tx, with a third statement that closes any still-open scale events for sandboxes on that worker now in `hibernated`/`stopped`.
- No changes to hot paths: `CreateSandbox`, wake, and migrate still legitimately open / keep events open.

## Observed incident
- 65 orphan open scale events across 11 orgs at the time of the fix. One org had events open since 2026-04-07 (~7 days). These have been manually closed in prod (separate op) to stop the bleeding; this PR prevents the class of bug from reopening.
- Credit note for the affected customer is a separate Stripe action and not in scope here.

## Test plan
- [ ] `go build ./...` (darwin subset) — green locally
- [ ] `go vet ./internal/db/... ./internal/billing/... ./cmd/server/... ./internal/api/... ./internal/controlplane/... ./internal/proxy/...` — green locally
- [ ] Manual: create a sandbox, stop it, verify `sandbox_scale_events.ended_at` is now set and `usage-reporter` log no longer reports that sandbox's tier in subsequent cycles
- [ ] Manual: hibernate a sandbox (both explicit RPC and auto-hibernate paths), verify `ended_at` set
- [ ] Manual: restart a worker with running sandboxes, verify `ReconcileWorkerSessions` closes orphan events for the now-stopped/hibernated sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)