### PR TITLE
billing: correct Stripe memory-tier Prices (60× under-bill fix)

### DIFF
--- a/internal/billing/pricing.go
+++ b/internal/billing/pricing.go
@@ -31,13 +31,22 @@ var TierMeterKey = map[int]string{
 // changes for that tier: Stripe Prices are immutable, so a new key forces
 // EnsureProducts to create a fresh Price at the new rate. Existing subscriptions
 // must then be migrated to the new Price via cmd/migrate-prices.
+//
+// The suffixes were bumped one step (1gb→_v2, 4gb→_v2, 8gb_v2→_v3, 16gb→_v2,
+// 32gb→_v2, 64gb→_v2) to force EnsureProducts to recreate every memory-tier
+// Stripe Price at the documented per-second rate. The previously-deployed
+// Prices were calibrated off a stale rate map and were under-billing
+// subscribers by 60× (per-minute economics instead of per-second). Run
+// `migrate-prices --tier=<X> --live` for every tier after deploy to move all
+// existing subscriptions onto the corrected Prices — this is a correction,
+// not a price change, so no grandfathering.
 var TierPriceKey = map[int]string{
-	1024:  "sandbox_1gb",
-	4096:  "sandbox_4gb",
-	8192:  "sandbox_8gb_v2",
-	16384: "sandbox_16gb",
-	32768: "sandbox_32gb",
-	65536: "sandbox_64gb",
+	1024:  "sandbox_1gb_v2",
+	4096:  "sandbox_4gb_v2",
+	8192:  "sandbox_8gb_v3",
+	16384: "sandbox_16gb_v2",
+	32768: "sandbox_32gb_v2",
+	65536: "sandbox_64gb_v2",
 }
 
 // Disk overage billing — every GB above DiskFreeAllowanceMB is metered for the


### PR DESCRIPTION
## Summary
Bumps every `TierPriceKey` suffix one step so `EnsureProducts` recreates all six memory-tier Stripe Prices at the documented per-second rate. The deployed Prices were calibrated off a stale rate map and have been under-billing subscribers by ~60× — per-minute economics when the meter emits per-second.

**No change to `TierPricePerSecond`** — the Go values are already correct. Only `TierPriceKey` suffixes change so Stripe drops the old (under-priced) Price IDs from active subscription items:

| Tier | Current `TierPriceKey` | New `TierPriceKey` | Rate (unchanged) |
|---|---|---|---|
| 1GB  | `sandbox_1gb`      | `sandbox_1gb_v2`  | \$0.000001080246914 / sec |
| 4GB  | `sandbox_4gb`      | `sandbox_4gb_v2`  | \$0.000005787037037 / sec |
| 8GB  | `sandbox_8gb_v2`   | `sandbox_8gb_v3`  | \$0.00001350308642 / sec |
| 16GB | `sandbox_16gb`     | `sandbox_16gb_v2` | \$0.00002700617284 / sec |
| 32GB | `sandbox_32gb`     | `sandbox_32gb_v2` | \$0.0001929012346 / sec |
| 64GB | `sandbox_64gb`     | `sandbox_64gb_v2` | \$0.0005401234568 / sec |

## Rollout
1. Merge + deploy this PR.
2. On next server boot, `EnsureProducts` creates six new Stripe Prices at the correct rates (same stable meters).
3. Run on the control plane:
   ```
   for TIER in 1024 4096 8192 16384 32768 65536; do
     DATABASE_URL="$OPENSANDBOX_DATABASE_URL" STRIPE_SECRET_KEY="$STRIPE_SECRET_KEY" \
       /tmp/migrate-prices --tier=$TIER --live
   done
   ```
   This moves **every** org at each tier onto the corrected Price. No `--force` needed — `price_locked` doesn't exist yet; that lands with #142.
4. Verify in Stripe that each tier's active subscription items reference the new `_v2`/`_v3` Price IDs.

## Impact
- **All six currently-paying orgs** will see ~60× higher invoices for usage accrued *after* the migration. Usage accrued this billing cycle stays on the old Price (per `ProrationBehavior: "none"`), so there's no retroactive billing spike.
- **New signups** after this deploys will subscribe to the corrected Prices via `CreateSubscription`.
- **Disk-overage Price** is not touched — it was created recently and is already at the documented \$0.0000001/GB-sec rate.

## Knock-on effects on other open PRs
- **[#142](https://github.com/diggerhq/opencomputer/pull/142)** (10× + grandfather): needs a rebase on top of this. `TierPriceKey` must bump again (to `_v3`/`_v4`) and `TierPricePerSecond` × 10. Migration 022 should run *after* this PR's migrate-prices sweep so `price_locked=TRUE` freezes orgs on the corrected (not the under-priced) Stripe Prices.
- **[#146](https://github.com/diggerhq/opencomputer/pull/146)** (hide dashboard cost): independent, can merge anytime.
- **[opencomputer-site-v1#19](https://github.com/diggerhq/opencomputer-site-v1/pull/19)** (site 10× display): no change — site already shows the correct per-second rates.

## Test plan
- [ ] After deploy, server logs show `billing: created price for sandbox_1gb_v2 (...)` through `sandbox_64gb_v2` plus `sandbox_8gb_v3`, all attached to the existing stable meters (`sandbox_compute_sandbox_1gb` etc. — meters unchanged).
- [ ] Dry-run one tier first: `migrate-prices --tier=1024 --dry-run` — confirm candidate count matches expected org count.
- [ ] Live migration for all six tiers; verify `migrated=N skipped=0 failed=0` for each.
- [ ] Open one of the six org's subscription in Stripe; confirm each of its six subscription items references the new `_v2`/`_v3` Price IDs.
- [ ] Verify disk-overage Price and meter untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)