### PR TITLE
docs: no-sudo CLI installer script

### DIFF
--- a/docs/guides/agent-skill.mdx
+++ b/docs/guides/agent-skill.mdx
@@ -18,7 +18,7 @@ This works with Claude Code, Codex, Cursor, and any agent that supports the [Age
 The `oc` CLI must be installed and configured:
 
 ```bash
-curl -fsSL https://github.com/diggerhq/opencomputer/releases/latest/download/oc-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') -o /usr/local/bin/oc && chmod +x /usr/local/bin/oc
+curl -fsSL https://raw.githubusercontent.com/diggerhq/opencomputer/main/scripts/install.sh | bash
 oc config set api-key YOUR_API_KEY
 ```
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -33,8 +33,8 @@ pip install opencomputer-sdk
 ```
 
 ```bash CLI
-# See cli/overview for platform-specific install
-curl -fsSL https://github.com/diggerhq/opencomputer/releases/latest/download/oc-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') -o /usr/local/bin/oc && chmod +x /usr/local/bin/oc
+# Installs to ~/.local/bin (no sudo). See cli/overview for manual install.
+curl -fsSL https://raw.githubusercontent.com/diggerhq/opencomputer/main/scripts/install.sh | bash
 ```
 
 </CodeGroup>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="diggerhq/opencomputer"
+BIN_NAME="oc"
+INSTALL_DIR="${OC_INSTALL_DIR:-$HOME/.local/bin}"
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+arch="$(uname -m)"
+case "$arch" in
+  x86_64|amd64) arch="amd64" ;;
+  aarch64|arm64) arch="arm64" ;;
+  *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
+esac
+
+case "$os" in
+  linux|darwin) ;;
+  *) echo "Unsupported OS: $os" >&2; exit 1 ;;
+esac
+
+url="https://github.com/${REPO}/releases/latest/download/${BIN_NAME}-${os}-${arch}"
+target="${INSTALL_DIR}/${BIN_NAME}"
+
+mkdir -p "$INSTALL_DIR"
+echo "Downloading $url"
+curl -fsSL "$url" -o "$target"
+chmod +x "$target"
+
+echo "Installed ${BIN_NAME} to ${target}"
+
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *)
+    echo
+    echo "warning: $INSTALL_DIR is not on your PATH."
+    echo "Add it by appending this line to your shell rc file (~/.bashrc, ~/.zshrc):"
+    echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Replace the fragile inline `curl ... -o /usr/local/bin/oc` one-liner (requires sudo, breaks when copy-pasted with escaped parens) with `scripts/install.sh` piped via `curl | bash`.
- Installer detects OS/arch, installs to `~/.local/bin` (overridable via `OC_INSTALL_DIR`), warns if that dir isn't on PATH.
- Updated `docs/introduction.mdx` and `docs/guides/agent-skill.mdx` to point at the new script.

## Test plan
- [ ] Run `bash scripts/install.sh` on macOS (arm64) and Linux (amd64); confirm `~/.local/bin/oc` is created and executable.
- [ ] Run with `OC_INSTALL_DIR=/tmp/oc-test bash scripts/install.sh`; confirm target dir is respected.
- [ ] Run on a shell where `~/.local/bin` is not on PATH; confirm the warning prints.
- [ ] Render the updated `introduction.mdx` and `guides/agent-skill.mdx` pages and verify the snippets display correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)