### PR TITLE
Add POST /api/auth/token — identity JWT endpoint

### DIFF
--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -2,14 +2,18 @@ package api
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/opensandbox/opensandbox/internal/auth"
 )
 
-// getMe returns the identity (org and optional user) associated with the
-// current API key. Downstream services use this to resolve key → owner.
-func (s *Server) getMe(c echo.Context) error {
+const identityTokenTTL = 10 * time.Minute
+
+// createAuthToken exchanges the current API key for a short-lived identity JWT.
+// Downstream services (sessions-api) use this to resolve key → owner without
+// calling back on every request.
+func (s *Server) createAuthToken(c echo.Context) error {
 	orgID, ok := auth.GetOrgID(c)
 	if !ok {
 		return c.JSON(http.StatusUnauthorized, map[string]string{
@@ -17,13 +21,28 @@ func (s *Server) getMe(c echo.Context) error {
 		})
 	}
 
-	resp := map[string]interface{}{
-		"org_id": orgID.String(),
+	if s.jwtIssuer == nil {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{
+			"error": "token issuance not configured",
+		})
 	}
 
+	orgStr := orgID.String()
+	var userStr *string
 	if userID := auth.GetUserID(c); userID != nil {
-		resp["user_id"] = userID.String()
+		s := userID.String()
+		userStr = &s
 	}
 
-	return c.JSON(http.StatusOK, resp)
+	token, err := s.jwtIssuer.IssueIdentityToken(orgStr, userStr, identityTokenTTL)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "failed to issue token",
+		})
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"token":      token,
+		"expires_in": int(identityTokenTTL.Seconds()),
+	})
 }

--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/opensandbox/opensandbox/internal/auth"
+)
+
+// getMe returns the identity (org and optional user) associated with the
+// current API key. Downstream services use this to resolve key → owner.
+func (s *Server) getMe(c echo.Context) error {
+	orgID, ok := auth.GetOrgID(c)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, map[string]string{
+			"error": "org context required",
+		})
+	}
+
+	resp := map[string]interface{}{
+		"org_id": orgID.String(),
+	}
+
+	if userID := auth.GetUserID(c); userID != nil {
+		resp["user_id"] = userID.String()
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -188,7 +188,7 @@ func NewServer(mgr sandbox.Manager, ptyMgr *sandbox.PTYManager, apiKey string, o
 	api.Use(auth.PGAPIKeyMiddleware(s.store, apiKey))
 
 	// Identity
-	api.GET("/me", s.getMe)
+	api.POST("/auth/token", s.createAuthToken)
 
 	// Sandbox lifecycle
 	api.POST("/sandboxes", s.createSandbox)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -187,6 +187,9 @@ func NewServer(mgr sandbox.Manager, ptyMgr *sandbox.PTYManager, apiKey string, o
 	api := e.Group("/api")
 	api.Use(auth.PGAPIKeyMiddleware(s.store, apiKey))
 
+	// Identity
+	api.GET("/me", s.getMe)
+
 	// Sandbox lifecycle
 	api.POST("/sandboxes", s.createSandbox)
 	api.GET("/sandboxes", s.listSandboxes)

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -45,6 +45,53 @@ func (j *JWTIssuer) IssueSandboxToken(orgID uuid.UUID, sandboxID, workerID strin
 	return token.SignedString(j.secret)
 }
 
+// IdentityClaims are the JWT claims for identity tokens issued to downstream
+// services (e.g. sessions-api). They carry the caller's org and user identity
+// so the downstream can authorize without calling back to the control plane.
+type IdentityClaims struct {
+	jwt.RegisteredClaims
+	OrgID  string  `json:"org_id"`
+	UserID *string `json:"user_id,omitempty"`
+}
+
+// IssueIdentityToken creates a short-lived JWT carrying the caller's identity.
+func (j *JWTIssuer) IssueIdentityToken(orgID string, userID *string, ttl time.Duration) (string, error) {
+	now := time.Now()
+	claims := IdentityClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   orgID,
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
+			Issuer:    "opensandbox",
+		},
+		OrgID:  orgID,
+		UserID: userID,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(j.secret)
+}
+
+// ValidateIdentityToken parses and validates an identity JWT.
+func (j *JWTIssuer) ValidateIdentityToken(tokenStr string) (*IdentityClaims, error) {
+	token, err := jwt.ParseWithClaims(tokenStr, &IdentityClaims{}, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return j.secret, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("invalid token: %w", err)
+	}
+
+	claims, ok := token.Claims.(*IdentityClaims)
+	if !ok || !token.Valid {
+		return nil, fmt.Errorf("invalid token claims")
+	}
+
+	return claims, nil
+}
+
 // SigningSecret returns the raw HMAC secret for use by other signing functions (e.g. signed URLs).
 func (j *JWTIssuer) SigningSecret() []byte { return j.secret }
 


### PR DESCRIPTION
## Summary

- Adds `POST /api/auth/token` on the API-key-authed route group
- Exchanges an API key for a short-lived identity JWT (HS256, 10min TTL)
- JWT carries `org_id` and optional `user_id` as claims
- Uses the existing `JWTIssuer` and `OPENSANDBOX_JWT_SECRET` shared secret
- Adds `IdentityClaims` type + `IssueIdentityToken` / `ValidateIdentityToken` alongside existing `SandboxClaims`

## Why

sessions-api needs to resolve API keys to stable user identities for per-user agent scoping. Rather than a raw JSON `/me` endpoint, a signed JWT lets downstream services verify identity locally without calling back to OC.

This follows the standard token exchange pattern (OAuth `POST /token`, AWS STS `GetSessionToken`). When a gateway (CF worker) is later extracted upstream, it mints the same JWT — downstream services don't change.

## What changed

| File | Change |
|------|--------|
| `internal/auth/jwt.go` | Add `IdentityClaims`, `IssueIdentityToken`, `ValidateIdentityToken` |
| `internal/api/identity.go` | `createAuthToken` handler — mints identity JWT from API key context |
| `internal/api/router.go` | Register `POST /api/auth/token` |

## Companion change

- diggerhq/sessions-api main — calls this endpoint, verifies JWT with shared secret, scopes agent queries per-user

## Test plan

- [ ] `curl -X POST -H "X-API-Key: $KEY" https://app.opencomputer.dev/api/auth/token` returns `{ token, expires_in }`
- [ ] Token decodes to `{ org_id, user_id, exp, iss: "opensandbox" }`
- [ ] Invalid key returns 401
- [ ] Missing `OPENSANDBOX_JWT_SECRET` returns 503


🤖 Generated with [Claude Code](https://claude.com/claude-code)