### PR TITLE
make sure that control planes can be discovered in workflow

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -78,6 +78,7 @@ jobs:
         run: |
           CPS=$(az vm list \
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
+            --show-details \
             --query "[?contains(name,'controlplane') && powerState=='VM running'].name" \
             -o tsv 2>/dev/null | tr '\n' ',' | sed 's/,$//')
           echo "Discovered CPs: $CPS"


### PR DESCRIPTION
Basically a small bug, by omitting show details it wont returning running

<img width="559" height="361" alt="Screenshot 2026-04-15 at 1 35 30 PM" src="https://github.com/user-attachments/assets/c3ea2744-79e5-4189-8893-9e821bd15bfe" />
