### PR TITLE
add signal to prepare for hibernate

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -35,7 +35,11 @@ func main() {
 	srv := agent.NewServer(Version)
 	// Only set ListenPort for vsock-based backends (Firecracker).
 	// For virtio-serial (QEMU), PTY I/O flows over gRPC PTYAttach instead.
-	if _, isVirtioSerial := lis.(*virtioSerialListener); !isVirtioSerial {
+	if vsl, isVirtioSerial := lis.(*virtioSerialListener); isVirtioSerial {
+		// Wire the PrepareHibernate RPC to reset the virtio-serial listener
+		// synchronously — replaces the old SIGUSR1 + sleep dance.
+		srv.OnPrepareHibernate = vsl.PrepareHibernate
+	} else {
 		srv.ListenPort = listenPortForPTY
 	}
 

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -59,6 +59,11 @@ type Server struct {
 	// gRPC server reference for hibernate GracefulStop
 	mu         sync.Mutex
 	grpcServer *grpc.Server
+
+	// OnPrepareHibernate is called during the PrepareHibernate RPC after
+	// filesystem sync completes. The host wires this to virtioSerialListener.PrepareHibernate
+	// so the listener is ready for a fresh Accept on wake/fork.
+	OnPrepareHibernate func()
 }
 
 // NewServer creates a new agent server.

--- a/internal/agent/stats.go
+++ b/internal/agent/stats.go
@@ -182,6 +182,34 @@ func (s *Server) SyncFS(ctx context.Context, req *pb.SyncFSRequest) (*pb.SyncFSR
 	return &pb.SyncFSResponse{}, nil
 }
 
+// PrepareHibernate does all the pre-hibernate work synchronously:
+// sync filesystems, flush block device buffers, and reset the virtio-serial
+// listener so a clean Accept happens on wake/fork. Returns only after all
+// work completes — the host does not need to sleep after this call.
+func (s *Server) PrepareHibernate(ctx context.Context, req *pb.PrepareHibernateRequest) (*pb.PrepareHibernateResponse, error) {
+	syscall.Sync()
+	flushBlockDevices("/dev/vda", "/dev/vdb")
+	syscall.Sync()
+	if s.OnPrepareHibernate != nil {
+		s.OnPrepareHibernate()
+	}
+	return &pb.PrepareHibernateResponse{}, nil
+}
+
+// flushBlockDevices issues BLKFLSBUF on each device (equivalent to `blockdev --flushbufs`).
+// Ignores errors — not all devices may be present (e.g., /dev/vdb).
+func flushBlockDevices(paths ...string) {
+	const BLKFLSBUF = 0x1261
+	for _, path := range paths {
+		f, err := os.OpenFile(path, os.O_RDONLY, 0)
+		if err != nil {
+			continue
+		}
+		_, _, _ = syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), uintptr(BLKFLSBUF), 0)
+		f.Close()
+	}
+}
+
 // syncFS calls sync(2) to flush all filesystem buffers.
 // This syncs ALL mounted filesystems (rootfs + workspace), ensuring dirty pages
 // are written to their backing ext4 images before snapshot/checkpoint.

--- a/internal/qemu/agent_client.go
+++ b/internal/qemu/agent_client.go
@@ -184,6 +184,13 @@ func (c *AgentClient) Exec(ctx context.Context, req *pb.ExecRequest) (*pb.ExecRe
 	return c.client.Exec(ctx, req)
 }
 
+// PrepareHibernate synchronously prepares the guest for hibernate/checkpoint.
+// Returns only after the guest has synced filesystems and reset the virtio-serial
+// listener, so no sleep is needed after this call.
+func (c *AgentClient) PrepareHibernate(ctx context.Context, req *pb.PrepareHibernateRequest) (*pb.PrepareHibernateResponse, error) {
+	return c.client.PrepareHibernate(ctx, req)
+}
+
 // ReadFile reads a file from the VM.
 func (c *AgentClient) ReadFile(ctx context.Context, path string) ([]byte, error) {
 	resp, err := c.client.ReadFile(ctx, &pb.ReadFileRequest{Path: path})

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -24,7 +24,39 @@ import (
 	"github.com/opensandbox/opensandbox/internal/storage"
 	"github.com/opensandbox/opensandbox/pkg/types"
 	pb "github.com/opensandbox/opensandbox/proto/agent"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// prepareAgentForHibernate synchronously syncs the guest filesystems and quiesces
+// the virtio-serial listener. Returns when the guest is fully prepared — no sleep
+// needed afterward.
+//
+// On agents that don't implement the PrepareHibernate RPC (older builds), falls
+// back to the legacy Exec("sync; kill -USR1 1") path with a 1s sleep.
+func prepareAgentForHibernate(ctx context.Context, agent *AgentClient) {
+	if agent == nil {
+		return
+	}
+	rpcCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	_, err := agent.PrepareHibernate(rpcCtx, &pb.PrepareHibernateRequest{})
+	if err == nil {
+		return
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.Unimplemented {
+		log.Printf("qemu: PrepareHibernate RPC failed: %v (falling back to legacy path)", err)
+	}
+	// Fallback for older agents: sync + SIGUSR1 + sleep.
+	execCtx, cancel2 := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel2()
+	_, _ = agent.Exec(execCtx, &pb.ExecRequest{
+		Command:   "/bin/sh",
+		Args:      []string{"-c", "sync; blockdev --flushbufs /dev/vda 2>/dev/null; blockdev --flushbufs /dev/vdb 2>/dev/null; sync; kill -USR1 1"},
+		RunAsRoot: true,
+	})
+	time.Sleep(1 * time.Second)
+}
 
 // Compile-time check that Manager implements sandbox.Manager.
 var _ sandbox.Manager = (*Manager)(nil)
@@ -2030,29 +2062,12 @@ func (m *Manager) CreateCheckpoint(ctx context.Context, sandboxID, checkpointID 
 		return "", "", fmt.Errorf("QMP connection not available for %s", sandboxID)
 	}
 
-	// Sync filesystem before snapshot. Flush dirty pages so the drives are
-	// consistent when we copy them while the VM is paused.
+	// Sync filesystem and quiesce virtio-serial before snapshot. The PrepareHibernate
+	// RPC returns only after the guest is fully prepared, so no sleep is needed.
 	if vm.agent != nil {
-		syncCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		_, syncErr := vm.agent.Exec(syncCtx, &pb.ExecRequest{
-			Command:   "/bin/sh",
-			Args:      []string{"-c", "sync; blockdev --flushbufs /dev/vda 2>/dev/null; blockdev --flushbufs /dev/vdb 2>/dev/null; sync; kill -USR1 1"},
-			RunAsRoot: true,
-		})
-		cancel()
-		if syncErr != nil {
-			log.Printf("qemu: CreateCheckpoint %s/%s: sync failed: %v", sandboxID, checkpointID, syncErr)
-		}
-		// Close the agent connection before pausing — the agent's SIGUSR1 handler
-		// resets the virtio-serial listener so forks start with a clean Accept state.
+		prepareAgentForHibernate(ctx, vm.agent)
 		vm.agent.Close()
 		vm.agent = nil
-		// Give the guest time to fully quiesce virtio-serial state. 500ms was
-		// observed to leave a small residual rate of "agent not ready" failures
-		// on fork after loadvm (post-loadvm virtio-serial comes up but Accept
-		// doesn't land cleanly). 1s should give the guest enough time without
-		// noticeably adding to checkpoint latency.
-		time.Sleep(1 * time.Second)
 	}
 
 	// Savevm-based checkpoint: pack memory + device state + disk deltas into

--- a/internal/qemu/snapshot.go
+++ b/internal/qemu/snapshot.go
@@ -64,19 +64,12 @@ func (m *Manager) doHibernate(ctx context.Context, vm *VMInstance, checkpointSto
 
 	// Step 1: Sync filesystems and quiesce agent.
 	// Don't unmount /workspace — open FDs prevent clean unmount and cause ext4 corruption.
-	// Just sync to flush dirty pages. savevm captures a consistent snapshot.
-	// SIGUSR1 resets the virtio-serial listener for instant reconnection on wake.
+	// PrepareHibernate syncs dirty pages and resets the virtio-serial listener
+	// synchronously, so no post-close sleep is needed.
 	if vm.agent != nil {
-		shutdownCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		_, _ = vm.agent.Exec(shutdownCtx, &pb.ExecRequest{
-			Command:   "/bin/sh",
-			Args:      []string{"-c", "sync; blockdev --flushbufs /dev/vda 2>/dev/null; blockdev --flushbufs /dev/vdb 2>/dev/null; sync; kill -USR1 1"},
-			RunAsRoot: true,
-		})
-		cancel()
+		prepareAgentForHibernate(ctx, vm.agent)
 		vm.agent.Close()
 		vm.agent = nil
-		time.Sleep(500 * time.Millisecond) // let guest process SIGUSR1
 	}
 	log.Printf("qemu: hibernate %s: guest sync + unmount done (%dms)", vm.ID, time.Since(t0).Milliseconds())
 

--- a/proto/agent/agent.pb.go
+++ b/proto/agent/agent.pb.go
@@ -2589,6 +2589,78 @@ func (*SyncFSResponse) Descriptor() ([]byte, []int) {
 	return file_proto_agent_agent_proto_rawDescGZIP(), []int{48}
 }
 
+type PrepareHibernateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PrepareHibernateRequest) Reset() {
+	*x = PrepareHibernateRequest{}
+	mi := &file_proto_agent_agent_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrepareHibernateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrepareHibernateRequest) ProtoMessage() {}
+
+func (x *PrepareHibernateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_agent_agent_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrepareHibernateRequest.ProtoReflect.Descriptor instead.
+func (*PrepareHibernateRequest) Descriptor() ([]byte, []int) {
+	return file_proto_agent_agent_proto_rawDescGZIP(), []int{49}
+}
+
+type PrepareHibernateResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PrepareHibernateResponse) Reset() {
+	*x = PrepareHibernateResponse{}
+	mi := &file_proto_agent_agent_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PrepareHibernateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PrepareHibernateResponse) ProtoMessage() {}
+
+func (x *PrepareHibernateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_agent_agent_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PrepareHibernateResponse.ProtoReflect.Descriptor instead.
+func (*PrepareHibernateResponse) Descriptor() ([]byte, []int) {
+	return file_proto_agent_agent_proto_rawDescGZIP(), []int{50}
+}
+
 type SetResourceLimitsRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	MaxPids        int32                  `protobuf:"varint,1,opt,name=max_pids,json=maxPids,proto3" json:"max_pids,omitempty"`                        // pids.max (0 = don't change)
@@ -2601,7 +2673,7 @@ type SetResourceLimitsRequest struct {
 
 func (x *SetResourceLimitsRequest) Reset() {
 	*x = SetResourceLimitsRequest{}
-	mi := &file_proto_agent_agent_proto_msgTypes[49]
+	mi := &file_proto_agent_agent_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2613,7 +2685,7 @@ func (x *SetResourceLimitsRequest) String() string {
 func (*SetResourceLimitsRequest) ProtoMessage() {}
 
 func (x *SetResourceLimitsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_agent_agent_proto_msgTypes[49]
+	mi := &file_proto_agent_agent_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2626,7 +2698,7 @@ func (x *SetResourceLimitsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetResourceLimitsRequest.ProtoReflect.Descriptor instead.
 func (*SetResourceLimitsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_agent_agent_proto_rawDescGZIP(), []int{49}
+	return file_proto_agent_agent_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *SetResourceLimitsRequest) GetMaxPids() int32 {
@@ -2665,7 +2737,7 @@ type SetResourceLimitsResponse struct {
 
 func (x *SetResourceLimitsResponse) Reset() {
 	*x = SetResourceLimitsResponse{}
-	mi := &file_proto_agent_agent_proto_msgTypes[50]
+	mi := &file_proto_agent_agent_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2677,7 +2749,7 @@ func (x *SetResourceLimitsResponse) String() string {
 func (*SetResourceLimitsResponse) ProtoMessage() {}
 
 func (x *SetResourceLimitsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_agent_agent_proto_msgTypes[50]
+	mi := &file_proto_agent_agent_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2690,7 +2762,7 @@ func (x *SetResourceLimitsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetResourceLimitsResponse.ProtoReflect.Descriptor instead.
 func (*SetResourceLimitsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_agent_agent_proto_rawDescGZIP(), []int{50}
+	return file_proto_agent_agent_proto_rawDescGZIP(), []int{52}
 }
 
 type GetVersionRequest struct {
@@ -2701,7 +2773,7 @@ type GetVersionRequest struct {
 
 func (x *GetVersionRequest) Reset() {
 	*x = GetVersionRequest{}
-	mi := &file_proto_agent_agent_proto_msgTypes[51]
+	mi := &file_proto_agent_agent_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2713,7 +2785,7 @@ func (x *GetVersionRequest) String() string {
 func (*GetVersionRequest) ProtoMessage() {}
 
 func (x *GetVersionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_agent_agent_proto_msgTypes[51]
+	mi := &file_proto_agent_agent_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2726,7 +2798,7 @@ func (x *GetVersionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVersionRequest.ProtoReflect.Descriptor instead.
 func (*GetVersionRequest) Descriptor() ([]byte, []int) {
-	return file_proto_agent_agent_proto_rawDescGZIP(), []int{51}
+	return file_proto_agent_agent_proto_rawDescGZIP(), []int{53}
 }
 
 type GetVersionResponse struct {
@@ -2738,7 +2810,7 @@ type GetVersionResponse struct {
 
 func (x *GetVersionResponse) Reset() {
 	*x = GetVersionResponse{}
-	mi := &file_proto_agent_agent_proto_msgTypes[52]
+	mi := &file_proto_agent_agent_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2750,7 +2822,7 @@ func (x *GetVersionResponse) String() string {
 func (*GetVersionResponse) ProtoMessage() {}
 
 func (x *GetVersionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_agent_agent_proto_msgTypes[52]
+	mi := &file_proto_agent_agent_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2763,7 +2835,7 @@ func (x *GetVersionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVersionResponse.ProtoReflect.Descriptor instead.
 func (*GetVersionResponse) Descriptor() ([]byte, []int) {
-	return file_proto_agent_agent_proto_rawDescGZIP(), []int{52}
+	return file_proto_agent_agent_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *GetVersionResponse) GetVersion() string {
@@ -2782,7 +2854,7 @@ type UpgradeRequest struct {
 
 func (x *UpgradeRequest) Reset() {
 	*x = UpgradeRequest{}
-	mi := &file_proto_agent_agent_proto_msgTypes[53]
+	mi := &file_proto_agent_agent_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2794,7 +2866,7 @@ func (x *UpgradeRequest) String() string {
 func (*UpgradeRequest) ProtoMessage() {}
 
 func (x *UpgradeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_agent_agent_proto_msgTypes[53]
+	mi := &file_proto_agent_agent_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2807,7 +2879,7 @@ func (x *UpgradeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpgradeRequest.ProtoReflect.Descriptor instead.
 func (*UpgradeRequest) Descriptor() ([]byte, []int) {
-	return file_proto_agent_agent_proto_rawDescGZIP(), []int{53}
+	return file_proto_agent_agent_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *UpgradeRequest) GetBinaryPath() string {
@@ -2826,7 +2898,7 @@ type UpgradeResponse struct {
 
 func (x *UpgradeResponse) Reset() {
 	*x = UpgradeResponse{}
-	mi := &file_proto_agent_agent_proto_msgTypes[54]
+	mi := &file_proto_agent_agent_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2838,7 +2910,7 @@ func (x *UpgradeResponse) String() string {
 func (*UpgradeResponse) ProtoMessage() {}
 
 func (x *UpgradeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_agent_agent_proto_msgTypes[54]
+	mi := &file_proto_agent_agent_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2851,7 +2923,7 @@ func (x *UpgradeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpgradeResponse.ProtoReflect.Descriptor instead.
 func (*UpgradeResponse) Descriptor() ([]byte, []int) {
-	return file_proto_agent_agent_proto_rawDescGZIP(), []int{54}
+	return file_proto_agent_agent_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *UpgradeResponse) GetOk() bool {
@@ -3035,7 +3107,9 @@ const file_proto_agent_agent_proto_rawDesc = "" +
 	"\x0fShutdownRequest\"\x12\n" +
 	"\x10ShutdownResponse\"\x0f\n" +
 	"\rSyncFSRequest\"\x10\n" +
-	"\x0eSyncFSResponse\"\xa9\x01\n" +
+	"\x0eSyncFSResponse\"\x19\n" +
+	"\x17PrepareHibernateRequest\"\x1a\n" +
+	"\x18PrepareHibernateResponse\"\xa9\x01\n" +
 	"\x18SetResourceLimitsRequest\x12\x19\n" +
 	"\bmax_pids\x18\x01 \x01(\x05R\amaxPids\x12(\n" +
 	"\x10max_memory_bytes\x18\x02 \x01(\x03R\x0emaxMemoryBytes\x12 \n" +
@@ -3050,7 +3124,7 @@ const file_proto_agent_agent_proto_rawDesc = "" +
 	"\vbinary_path\x18\x01 \x01(\tR\n" +
 	"binaryPath\"!\n" +
 	"\x0fUpgradeResponse\x12\x0e\n" +
-	"\x02ok\x18\x01 \x01(\bR\x02ok2\xc1\r\n" +
+	"\x02ok\x18\x01 \x01(\bR\x02ok2\x96\x0e\n" +
 	"\fSandboxAgent\x12/\n" +
 	"\x04Exec\x12\x12.agent.ExecRequest\x1a\x13.agent.ExecResponse\x12:\n" +
 	"\n" +
@@ -3076,7 +3150,8 @@ const file_proto_agent_agent_proto_rawDesc = "" +
 	"\x0fExecSessionKill\x12\x1d.agent.ExecSessionKillRequest\x1a\x1e.agent.ExecSessionKillResponse\x128\n" +
 	"\aSetEnvs\x12\x15.agent.SetEnvsRequest\x1a\x16.agent.SetEnvsResponse\x12;\n" +
 	"\bShutdown\x12\x16.agent.ShutdownRequest\x1a\x17.agent.ShutdownResponse\x125\n" +
-	"\x06SyncFS\x12\x14.agent.SyncFSRequest\x1a\x15.agent.SyncFSResponse\x12V\n" +
+	"\x06SyncFS\x12\x14.agent.SyncFSRequest\x1a\x15.agent.SyncFSResponse\x12S\n" +
+	"\x10PrepareHibernate\x12\x1e.agent.PrepareHibernateRequest\x1a\x1f.agent.PrepareHibernateResponse\x12V\n" +
 	"\x11SetResourceLimits\x12\x1f.agent.SetResourceLimitsRequest\x1a .agent.SetResourceLimitsResponse\x12A\n" +
 	"\n" +
 	"GetVersion\x12\x18.agent.GetVersionRequest\x1a\x19.agent.GetVersionResponse\x128\n" +
@@ -3095,7 +3170,7 @@ func file_proto_agent_agent_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_agent_agent_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_proto_agent_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 58)
+var file_proto_agent_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 60)
 var file_proto_agent_agent_proto_goTypes = []any{
 	(ExecOutputChunk_Stream)(0),       // 0: agent.ExecOutputChunk.Stream
 	(ExecSessionOutput_Type)(0),       // 1: agent.ExecSessionOutput.Type
@@ -3148,24 +3223,26 @@ var file_proto_agent_agent_proto_goTypes = []any{
 	(*ShutdownResponse)(nil),          // 48: agent.ShutdownResponse
 	(*SyncFSRequest)(nil),             // 49: agent.SyncFSRequest
 	(*SyncFSResponse)(nil),            // 50: agent.SyncFSResponse
-	(*SetResourceLimitsRequest)(nil),  // 51: agent.SetResourceLimitsRequest
-	(*SetResourceLimitsResponse)(nil), // 52: agent.SetResourceLimitsResponse
-	(*GetVersionRequest)(nil),         // 53: agent.GetVersionRequest
-	(*GetVersionResponse)(nil),        // 54: agent.GetVersionResponse
-	(*UpgradeRequest)(nil),            // 55: agent.UpgradeRequest
-	(*UpgradeResponse)(nil),           // 56: agent.UpgradeResponse
-	nil,                               // 57: agent.ExecRequest.EnvsEntry
-	nil,                               // 58: agent.ExecSessionCreateRequest.EnvsEntry
-	nil,                               // 59: agent.SetEnvsRequest.EnvsEntry
+	(*PrepareHibernateRequest)(nil),   // 51: agent.PrepareHibernateRequest
+	(*PrepareHibernateResponse)(nil),  // 52: agent.PrepareHibernateResponse
+	(*SetResourceLimitsRequest)(nil),  // 53: agent.SetResourceLimitsRequest
+	(*SetResourceLimitsResponse)(nil), // 54: agent.SetResourceLimitsResponse
+	(*GetVersionRequest)(nil),         // 55: agent.GetVersionRequest
+	(*GetVersionResponse)(nil),        // 56: agent.GetVersionResponse
+	(*UpgradeRequest)(nil),            // 57: agent.UpgradeRequest
+	(*UpgradeResponse)(nil),           // 58: agent.UpgradeResponse
+	nil,                               // 59: agent.ExecRequest.EnvsEntry
+	nil,                               // 60: agent.ExecSessionCreateRequest.EnvsEntry
+	nil,                               // 61: agent.SetEnvsRequest.EnvsEntry
 }
 var file_proto_agent_agent_proto_depIdxs = []int32{
-	57, // 0: agent.ExecRequest.envs:type_name -> agent.ExecRequest.EnvsEntry
+	59, // 0: agent.ExecRequest.envs:type_name -> agent.ExecRequest.EnvsEntry
 	0,  // 1: agent.ExecOutputChunk.stream:type_name -> agent.ExecOutputChunk.Stream
 	14, // 2: agent.ListDirResponse.entries:type_name -> agent.DirEntry
-	58, // 3: agent.ExecSessionCreateRequest.envs:type_name -> agent.ExecSessionCreateRequest.EnvsEntry
+	60, // 3: agent.ExecSessionCreateRequest.envs:type_name -> agent.ExecSessionCreateRequest.EnvsEntry
 	1,  // 4: agent.ExecSessionOutput.type:type_name -> agent.ExecSessionOutput.Type
 	42, // 5: agent.ExecSessionListResponse.sessions:type_name -> agent.ExecSessionInfo
-	59, // 6: agent.SetEnvsRequest.envs:type_name -> agent.SetEnvsRequest.EnvsEntry
+	61, // 6: agent.SetEnvsRequest.envs:type_name -> agent.SetEnvsRequest.EnvsEntry
 	2,  // 7: agent.SandboxAgent.Exec:input_type -> agent.ExecRequest
 	2,  // 8: agent.SandboxAgent.ExecStream:input_type -> agent.ExecRequest
 	5,  // 9: agent.SandboxAgent.ReadFile:input_type -> agent.ReadFileRequest
@@ -3190,38 +3267,40 @@ var file_proto_agent_agent_proto_depIdxs = []int32{
 	45, // 28: agent.SandboxAgent.SetEnvs:input_type -> agent.SetEnvsRequest
 	47, // 29: agent.SandboxAgent.Shutdown:input_type -> agent.ShutdownRequest
 	49, // 30: agent.SandboxAgent.SyncFS:input_type -> agent.SyncFSRequest
-	51, // 31: agent.SandboxAgent.SetResourceLimits:input_type -> agent.SetResourceLimitsRequest
-	53, // 32: agent.SandboxAgent.GetVersion:input_type -> agent.GetVersionRequest
-	55, // 33: agent.SandboxAgent.Upgrade:input_type -> agent.UpgradeRequest
-	3,  // 34: agent.SandboxAgent.Exec:output_type -> agent.ExecResponse
-	4,  // 35: agent.SandboxAgent.ExecStream:output_type -> agent.ExecOutputChunk
-	6,  // 36: agent.SandboxAgent.ReadFile:output_type -> agent.ReadFileResponse
-	8,  // 37: agent.SandboxAgent.WriteFile:output_type -> agent.WriteFileResponse
-	10, // 38: agent.SandboxAgent.ReadFileStream:output_type -> agent.FileChunk
-	12, // 39: agent.SandboxAgent.WriteFileStream:output_type -> agent.WriteFileStreamResponse
-	15, // 40: agent.SandboxAgent.ListDir:output_type -> agent.ListDirResponse
-	17, // 41: agent.SandboxAgent.MakeDir:output_type -> agent.MakeDirResponse
-	19, // 42: agent.SandboxAgent.Remove:output_type -> agent.RemoveResponse
-	21, // 43: agent.SandboxAgent.Exists:output_type -> agent.ExistsResponse
-	23, // 44: agent.SandboxAgent.Stat:output_type -> agent.StatResponse
-	25, // 45: agent.SandboxAgent.Stats:output_type -> agent.StatsResponse
-	27, // 46: agent.SandboxAgent.Ping:output_type -> agent.PingResponse
-	29, // 47: agent.SandboxAgent.PTYCreate:output_type -> agent.PTYCreateResponse
-	31, // 48: agent.SandboxAgent.PTYResize:output_type -> agent.PTYResizeResponse
-	33, // 49: agent.SandboxAgent.PTYKill:output_type -> agent.PTYKillResponse
-	35, // 50: agent.SandboxAgent.PTYAttach:output_type -> agent.PTYOutput
-	37, // 51: agent.SandboxAgent.ExecSessionCreate:output_type -> agent.ExecSessionCreateResponse
-	39, // 52: agent.SandboxAgent.ExecSessionAttach:output_type -> agent.ExecSessionOutput
-	41, // 53: agent.SandboxAgent.ExecSessionList:output_type -> agent.ExecSessionListResponse
-	44, // 54: agent.SandboxAgent.ExecSessionKill:output_type -> agent.ExecSessionKillResponse
-	46, // 55: agent.SandboxAgent.SetEnvs:output_type -> agent.SetEnvsResponse
-	48, // 56: agent.SandboxAgent.Shutdown:output_type -> agent.ShutdownResponse
-	50, // 57: agent.SandboxAgent.SyncFS:output_type -> agent.SyncFSResponse
-	52, // 58: agent.SandboxAgent.SetResourceLimits:output_type -> agent.SetResourceLimitsResponse
-	54, // 59: agent.SandboxAgent.GetVersion:output_type -> agent.GetVersionResponse
-	56, // 60: agent.SandboxAgent.Upgrade:output_type -> agent.UpgradeResponse
-	34, // [34:61] is the sub-list for method output_type
-	7,  // [7:34] is the sub-list for method input_type
+	51, // 31: agent.SandboxAgent.PrepareHibernate:input_type -> agent.PrepareHibernateRequest
+	53, // 32: agent.SandboxAgent.SetResourceLimits:input_type -> agent.SetResourceLimitsRequest
+	55, // 33: agent.SandboxAgent.GetVersion:input_type -> agent.GetVersionRequest
+	57, // 34: agent.SandboxAgent.Upgrade:input_type -> agent.UpgradeRequest
+	3,  // 35: agent.SandboxAgent.Exec:output_type -> agent.ExecResponse
+	4,  // 36: agent.SandboxAgent.ExecStream:output_type -> agent.ExecOutputChunk
+	6,  // 37: agent.SandboxAgent.ReadFile:output_type -> agent.ReadFileResponse
+	8,  // 38: agent.SandboxAgent.WriteFile:output_type -> agent.WriteFileResponse
+	10, // 39: agent.SandboxAgent.ReadFileStream:output_type -> agent.FileChunk
+	12, // 40: agent.SandboxAgent.WriteFileStream:output_type -> agent.WriteFileStreamResponse
+	15, // 41: agent.SandboxAgent.ListDir:output_type -> agent.ListDirResponse
+	17, // 42: agent.SandboxAgent.MakeDir:output_type -> agent.MakeDirResponse
+	19, // 43: agent.SandboxAgent.Remove:output_type -> agent.RemoveResponse
+	21, // 44: agent.SandboxAgent.Exists:output_type -> agent.ExistsResponse
+	23, // 45: agent.SandboxAgent.Stat:output_type -> agent.StatResponse
+	25, // 46: agent.SandboxAgent.Stats:output_type -> agent.StatsResponse
+	27, // 47: agent.SandboxAgent.Ping:output_type -> agent.PingResponse
+	29, // 48: agent.SandboxAgent.PTYCreate:output_type -> agent.PTYCreateResponse
+	31, // 49: agent.SandboxAgent.PTYResize:output_type -> agent.PTYResizeResponse
+	33, // 50: agent.SandboxAgent.PTYKill:output_type -> agent.PTYKillResponse
+	35, // 51: agent.SandboxAgent.PTYAttach:output_type -> agent.PTYOutput
+	37, // 52: agent.SandboxAgent.ExecSessionCreate:output_type -> agent.ExecSessionCreateResponse
+	39, // 53: agent.SandboxAgent.ExecSessionAttach:output_type -> agent.ExecSessionOutput
+	41, // 54: agent.SandboxAgent.ExecSessionList:output_type -> agent.ExecSessionListResponse
+	44, // 55: agent.SandboxAgent.ExecSessionKill:output_type -> agent.ExecSessionKillResponse
+	46, // 56: agent.SandboxAgent.SetEnvs:output_type -> agent.SetEnvsResponse
+	48, // 57: agent.SandboxAgent.Shutdown:output_type -> agent.ShutdownResponse
+	50, // 58: agent.SandboxAgent.SyncFS:output_type -> agent.SyncFSResponse
+	52, // 59: agent.SandboxAgent.PrepareHibernate:output_type -> agent.PrepareHibernateResponse
+	54, // 60: agent.SandboxAgent.SetResourceLimits:output_type -> agent.SetResourceLimitsResponse
+	56, // 61: agent.SandboxAgent.GetVersion:output_type -> agent.GetVersionResponse
+	58, // 62: agent.SandboxAgent.Upgrade:output_type -> agent.UpgradeResponse
+	35, // [35:63] is the sub-list for method output_type
+	7,  // [7:35] is the sub-list for method input_type
 	7,  // [7:7] is the sub-list for extension type_name
 	7,  // [7:7] is the sub-list for extension extendee
 	0,  // [0:7] is the sub-list for field type_name
@@ -3238,7 +3317,7 @@ func file_proto_agent_agent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_agent_agent_proto_rawDesc), len(file_proto_agent_agent_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   58,
+			NumMessages:   60,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/agent/agent.proto
+++ b/proto/agent/agent.proto
@@ -59,6 +59,12 @@ service SandboxAgent {
   // Used before snapshot to ensure disk state is consistent.
   rpc SyncFS(SyncFSRequest) returns (SyncFSResponse);
 
+  // PrepareHibernate synchronously prepares the guest for hibernate/checkpoint:
+  // syncs filesystems, flushes block device buffers, and quiesces the virtio-serial
+  // listener so a clean Accept happens on wake/fork. Returns only after all work
+  // completes — no sleep needed on the host side after this RPC.
+  rpc PrepareHibernate(PrepareHibernateRequest) returns (PrepareHibernateResponse);
+
   // SetResourceLimits adjusts sandbox cgroup limits at runtime.
   // Used for elastic scaling — raise/lower memory, CPU, pids without restart.
   rpc SetResourceLimits(SetResourceLimitsRequest) returns (SetResourceLimitsResponse);
@@ -321,6 +327,12 @@ message ShutdownResponse {}
 message SyncFSRequest {}
 
 message SyncFSResponse {}
+
+// --- PrepareHibernate ---
+
+message PrepareHibernateRequest {}
+
+message PrepareHibernateResponse {}
 
 // --- Resource Limits ---
 

--- a/proto/agent/agent_grpc.pb.go
+++ b/proto/agent/agent_grpc.pb.go
@@ -43,6 +43,7 @@ const (
 	SandboxAgent_SetEnvs_FullMethodName           = "/agent.SandboxAgent/SetEnvs"
 	SandboxAgent_Shutdown_FullMethodName          = "/agent.SandboxAgent/Shutdown"
 	SandboxAgent_SyncFS_FullMethodName            = "/agent.SandboxAgent/SyncFS"
+	SandboxAgent_PrepareHibernate_FullMethodName  = "/agent.SandboxAgent/PrepareHibernate"
 	SandboxAgent_SetResourceLimits_FullMethodName = "/agent.SandboxAgent/SetResourceLimits"
 	SandboxAgent_GetVersion_FullMethodName        = "/agent.SandboxAgent/GetVersion"
 	SandboxAgent_Upgrade_FullMethodName           = "/agent.SandboxAgent/Upgrade"
@@ -95,6 +96,11 @@ type SandboxAgentClient interface {
 	// SyncFS flushes all filesystem buffers without exiting.
 	// Used before snapshot to ensure disk state is consistent.
 	SyncFS(ctx context.Context, in *SyncFSRequest, opts ...grpc.CallOption) (*SyncFSResponse, error)
+	// PrepareHibernate synchronously prepares the guest for hibernate/checkpoint:
+	// syncs filesystems, flushes block device buffers, and quiesces the virtio-serial
+	// listener so a clean Accept happens on wake/fork. Returns only after all work
+	// completes — no sleep needed on the host side after this RPC.
+	PrepareHibernate(ctx context.Context, in *PrepareHibernateRequest, opts ...grpc.CallOption) (*PrepareHibernateResponse, error)
 	// SetResourceLimits adjusts sandbox cgroup limits at runtime.
 	// Used for elastic scaling — raise/lower memory, CPU, pids without restart.
 	SetResourceLimits(ctx context.Context, in *SetResourceLimitsRequest, opts ...grpc.CallOption) (*SetResourceLimitsResponse, error)
@@ -380,6 +386,16 @@ func (c *sandboxAgentClient) SyncFS(ctx context.Context, in *SyncFSRequest, opts
 	return out, nil
 }
 
+func (c *sandboxAgentClient) PrepareHibernate(ctx context.Context, in *PrepareHibernateRequest, opts ...grpc.CallOption) (*PrepareHibernateResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PrepareHibernateResponse)
+	err := c.cc.Invoke(ctx, SandboxAgent_PrepareHibernate_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *sandboxAgentClient) SetResourceLimits(ctx context.Context, in *SetResourceLimitsRequest, opts ...grpc.CallOption) (*SetResourceLimitsResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(SetResourceLimitsResponse)
@@ -457,6 +473,11 @@ type SandboxAgentServer interface {
 	// SyncFS flushes all filesystem buffers without exiting.
 	// Used before snapshot to ensure disk state is consistent.
 	SyncFS(context.Context, *SyncFSRequest) (*SyncFSResponse, error)
+	// PrepareHibernate synchronously prepares the guest for hibernate/checkpoint:
+	// syncs filesystems, flushes block device buffers, and quiesces the virtio-serial
+	// listener so a clean Accept happens on wake/fork. Returns only after all work
+	// completes — no sleep needed on the host side after this RPC.
+	PrepareHibernate(context.Context, *PrepareHibernateRequest) (*PrepareHibernateResponse, error)
 	// SetResourceLimits adjusts sandbox cgroup limits at runtime.
 	// Used for elastic scaling — raise/lower memory, CPU, pids without restart.
 	SetResourceLimits(context.Context, *SetResourceLimitsRequest) (*SetResourceLimitsResponse, error)
@@ -546,6 +567,9 @@ func (UnimplementedSandboxAgentServer) Shutdown(context.Context, *ShutdownReques
 }
 func (UnimplementedSandboxAgentServer) SyncFS(context.Context, *SyncFSRequest) (*SyncFSResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SyncFS not implemented")
+}
+func (UnimplementedSandboxAgentServer) PrepareHibernate(context.Context, *PrepareHibernateRequest) (*PrepareHibernateResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PrepareHibernate not implemented")
 }
 func (UnimplementedSandboxAgentServer) SetResourceLimits(context.Context, *SetResourceLimitsRequest) (*SetResourceLimitsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SetResourceLimits not implemented")
@@ -962,6 +986,24 @@ func _SandboxAgent_SyncFS_Handler(srv interface{}, ctx context.Context, dec func
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SandboxAgent_PrepareHibernate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PrepareHibernateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SandboxAgentServer).PrepareHibernate(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SandboxAgent_PrepareHibernate_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SandboxAgentServer).PrepareHibernate(ctx, req.(*PrepareHibernateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _SandboxAgent_SetResourceLimits_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(SetResourceLimitsRequest)
 	if err := dec(in); err != nil {
@@ -1098,6 +1140,10 @@ var SandboxAgent_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SyncFS",
 			Handler:    _SandboxAgent_SyncFS_Handler,
+		},
+		{
+			MethodName: "PrepareHibernate",
+			Handler:    _SandboxAgent_PrepareHibernate_Handler,
 		},
 		{
 			MethodName: "SetResourceLimits",


### PR DESCRIPTION
Adds rpc call for deterministic quiescence instead of 1s safety net (which is only needed .5% of the time at most). Tested on dev, 1000x. 


  Added: PrepareHibernate RPC to the sandbox agent. The host calls it before pausing the VM for checkpoint/hibernate. The agent synchronously syncs
  filesystems, flushes block device buffers, and resets the virtio-serial listener. Returns only when all that work completes.

  Removed: the Exec("sync; kill -USR1 1") + time.Sleep(1s) dance at two call sites (CreateCheckpoint and doHibernate). The 1s sleep was there to cover for the
  fact that SIGUSR1 delivery is async — the exec returned before the agent's signal handler had actually done anything. Now the RPC returning IS the signal.

  Result: deterministic — host knows exactly when guest is ready for savevm. Saves ~1 second per checkpoint and hibernate. No races on fork-after-loadvm.

  Fallback: if the agent returns Unimplemented (older builds still in existing golden snapshots), falls back to the old Exec+sleep path. So deployment is safe
  across versions.