### PR TITLE
docs: restructure Agents section with CLI/REST parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,9 @@ Managed-agent product behavior is mostly **not** implemented here:
 `git push --force-with-lease` are forbidden. No exceptions. Make a new commit
 instead.
 
+**NEVER push to main.** Always create a feature branch and open a pull request.
+Direct pushes to `main` are not allowed in this repo.
+
 ## Repo scope
 
 This repo owns the **sandbox platform**:

--- a/docs/agents-api/overview.mdx
+++ b/docs/agents-api/overview.mdx
@@ -1,37 +1,75 @@
 ---
-title: "Agents API"
+title: "Overview"
 description: "Define agents, run persistent instances or ephemeral sessions on OpenComputer sandboxes"
 ---
 
-The Agents API is a higher-level interface for running AI agents on OpenComputer. Instead of managing sandboxes directly, you define an **Agent** (configuration) and then create **Instances** (persistent) or **Sessions** (ephemeral) from it.
+Agents are a higher-level interface for running AI on OpenComputer. Instead of managing sandboxes directly, you define an **Agent** (configuration) and then create **Instances** (persistent) or **Sessions** (ephemeral) from it.
 
 | Concept | What it is | Lifecycle | Use case |
 |---------|-----------|-----------|----------|
-| **Agent** | Configuration — snapshot, entrypoint, secrets, elasticity | Indefinite | Define once, reuse |
-| **Instance** | Persistent sandbox, hibernates/wakes, multiplexes conversations | Long-lived | AI coworkers (Slack, Teams) |
+| **Agent** | Configuration — core, snapshot, entrypoint, secrets | Indefinite | Define once, reuse |
+| **Instance** | Persistent sandbox, hibernates/wakes, multiplexes conversations | Long-lived | AI coworkers (Slack, Teams, Telegram) |
 | **Session** | Ephemeral sandbox, runs to completion | Bounded | Batch jobs, webhook handlers |
 
-## Base URL
+## Managed vs raw agents
+
+A **managed agent** has a **core** — a blessed runtime that OpenComputer knows how to configure, connect, and extend:
 
 ```
-https://api.opencomputer.dev
+ManagedAgent = Core + Channels + Packages + Secrets
 ```
+
+| Core | Runtime | What you get |
+|------|---------|-------------|
+| [`hermes`](/agents/cores/hermes) | Hermes Agent | Self-improving agent with skill creation, memory, multi-channel gateway, browser, code execution |
+| [`openclaw`](/agents/cores/openclaw) | OpenClaw | Multi-channel AI gateway with plugin SDK, native MCP support, hot-reload config |
+
+A **raw agent** uses no core — you provide your own `snapshot` and `entrypoint` via the REST API. Managed and raw agents coexist on the same platform.
+
+## Three commands to a running agent
+
+```bash
+oc agent create my-agent --core hermes       # boot an agent
+oc agent connect my-agent telegram            # connect Telegram
+oc agent install my-agent gbrain              # add persistent memory
+```
+
+## Two ways to interact
+
+Everything you can do with the CLI you can do with the REST API, and vice versa.
+
+<CardGroup cols={2}>
+  <Card title="CLI" icon="terminal" href="/cli/agents">
+    `oc agent` commands — create, connect, install, inspect
+  </Card>
+  <Card title="REST API" icon="code" href="/agents/rest/agents">
+    HTTP endpoints for agents, instances, sessions
+  </Card>
+</CardGroup>
+
+## Building blocks
+
+<CardGroup cols={2}>
+  <Card title="Cores" icon="microchip" href="/agents/cores/hermes">
+    AI runtimes that power your agent
+  </Card>
+  <Card title="Channels" icon="comments" href="/agents/channels/telegram">
+    Messaging platforms connected to your agent
+  </Card>
+  <Card title="Packages" icon="puzzle-piece" href="/agents/packages/gbrain">
+    Stateful extensions beyond the core
+  </Card>
+  <Card title="Guides" icon="book" href="/guides/create-hermes-agent">
+    Step-by-step walkthroughs
+  </Card>
+</CardGroup>
 
 ## Authentication
 
-All requests require an OpenComputer API key via `X-API-Key`. The key is passed through to the OC SDK for sandbox operations.
+All requests require an OpenComputer API key via `X-API-Key` header or `--api-key` CLI flag.
 
 ```
 X-API-Key: osb_your_api_key
 ```
 
-## Errors
-
-```json
-{
-  "error": {
-    "type": "invalid_request | not_found | conflict | internal_error",
-    "message": "Human-readable description"
-  }
-}
-```
+Base URL for REST: `https://api.opencomputer.dev`

--- a/docs/agents/channels/telegram.mdx
+++ b/docs/agents/channels/telegram.mdx
@@ -1,0 +1,82 @@
+---
+title: "Telegram"
+description: "Connect your agent to Telegram via webhook"
+---
+
+The Telegram channel connects your agent to a Telegram bot. Messages flow through the OpenComputer gateway to your agent's sandbox, and the agent replies directly to Telegram.
+
+## Connect
+
+<CodeGroup>
+
+```bash CLI
+oc agent connect my-agent telegram --bot-token <token>
+```
+
+```bash REST API
+curl -X POST https://api.opencomputer.dev/v1/agents/my-agent/channels/telegram \
+  -H "X-API-Key: $OC_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"bot_token": "<token>"}'
+```
+
+</CodeGroup>
+
+If you omit `--bot-token`, the CLI prompts for it interactively.
+
+### What happens
+
+1. The bot token is stored in the agent's secret store
+2. A webhook is registered with Telegram pointing to `https://<gateway>/gw/agents/<id>/telegram`
+3. The core config is updated for webhook mode
+4. The gateway is restarted (Hermes) or hot-reloaded (OpenClaw)
+
+## Prerequisites
+
+Create a Telegram bot first:
+
+1. Open Telegram and message [@BotFather](https://t.me/BotFather)
+2. Send `/newbot`, choose a name and username
+3. Copy the bot token
+
+## Disconnect
+
+<CodeGroup>
+
+```bash CLI
+oc agent disconnect my-agent telegram
+```
+
+```bash REST API
+curl -X DELETE https://api.opencomputer.dev/v1/agents/my-agent/channels/telegram \
+  -H "X-API-Key: $OC_API_KEY"
+```
+
+</CodeGroup>
+
+Disconnecting removes the webhook registration and config entry. The bot token is removed from the secret store.
+
+## List channels
+
+<CodeGroup>
+
+```bash CLI
+oc agent channels my-agent
+```
+
+```bash REST API
+curl https://api.opencomputer.dev/v1/agents/my-agent/channels \
+  -H "X-API-Key: $OC_API_KEY"
+```
+
+</CodeGroup>
+
+## How it works
+
+```
+Telegram → webhook POST → OpenComputer gateway → agent sandbox → reply → Telegram
+```
+
+The gateway receives Telegram updates at `/gw/agents/:agentId/telegram` and enqueues them for the agent. The agent processes the message through its core runtime and sends a response back via the Telegram Bot API.
+
+Channels are **stateless** from the platform's perspective — disconnecting removes the webhook and config. Nothing to clean up inside the sandbox.

--- a/docs/agents/cores/hermes.mdx
+++ b/docs/agents/cores/hermes.mdx
@@ -1,0 +1,79 @@
+---
+title: "Hermes"
+description: "Self-improving AI agent with skill creation, memory, and multi-channel gateway"
+---
+
+[Hermes Agent](https://github.com/NousResearch/hermes-agent) is an AI runtime that gives your agent self-improvement capabilities, automatic skill creation, built-in memory, browser access, and code execution — all behind a multi-channel gateway.
+
+## What you get
+
+| Capability | Description |
+|-----------|-------------|
+| **Gateway** | HTTP gateway that accepts webhooks from connected channels and routes them to the agent |
+| **Skill creation** | Agent can create, edit, and invoke reusable skills to extend its own capabilities |
+| **Memory** | Built-in conversation memory with configurable retention |
+| **Browser** | Headless browser for web navigation and scraping |
+| **Code execution** | Sandboxed code execution for computation tasks |
+| **Multi-channel** | Single agent instance serves multiple channels simultaneously |
+
+## Create a Hermes agent
+
+<CodeGroup>
+
+```bash CLI
+oc agent create my-hermes --core hermes
+```
+
+```bash REST API
+curl -X POST https://api.opencomputer.dev/v1/agents \
+  -H "X-API-Key: $OC_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"id": "my-hermes", "core": "hermes"}'
+```
+
+</CodeGroup>
+
+This boots a sandbox with Hermes pre-installed, an LLM key configured, and the gateway running. An instance is created automatically.
+
+## Configuration
+
+Hermes uses YAML configuration at `~/.hermes/config.yaml` inside the sandbox. When you connect channels or install packages via `oc agent`, the platform updates this config and restarts the gateway.
+
+To inspect or edit manually:
+
+```bash
+oc shell my-hermes
+cat ~/.hermes/config.yaml
+```
+
+## Gateway
+
+The Hermes gateway listens for incoming webhooks and dispatches them to the agent. When you [connect a channel](/agents/channels/telegram), the platform:
+
+1. Registers the channel's webhook with the provider
+2. Adds the channel config to `~/.hermes/config.yaml`
+3. Restarts the gateway with `hermes gateway run --replace`
+
+Gateway logs are at `~/.hermes/logs/gateway.log`.
+
+## Skills
+
+Hermes can create skills — reusable functions it builds and invokes on its own. To see what skills an agent has created:
+
+```bash
+oc shell my-hermes
+hermes skill list
+```
+
+## Extending with packages
+
+Hermes supports [packages](/agents/packages/gbrain) that add capabilities via MCP servers. When a package is installed, the platform adds it to the Hermes MCP config and restarts the gateway.
+
+<CardGroup cols={2}>
+  <Card title="Create a Hermes Agent" icon="rocket" href="/guides/create-hermes-agent">
+    Step-by-step guide
+  </Card>
+  <Card title="oc agent CLI" icon="terminal" href="/cli/agents">
+    CLI commands for managing agents
+  </Card>
+</CardGroup>

--- a/docs/agents/cores/openclaw.mdx
+++ b/docs/agents/cores/openclaw.mdx
@@ -1,0 +1,69 @@
+---
+title: "OpenClaw"
+description: "Multi-channel AI gateway with plugin SDK, native MCP support, and hot-reload config"
+---
+
+[OpenClaw](https://openclaw.ai) is a multi-channel AI gateway with a rich plugin SDK, native MCP support, and hot-reload configuration. It comes with 6 built-in channels and 20+ plugin channels.
+
+## What you get
+
+| Capability | Description |
+|-----------|-------------|
+| **Multi-channel gateway** | Serves Telegram, Slack, Discord, and more from a single agent |
+| **Plugin SDK** | Extend the agent with custom plugins |
+| **Native MCP** | First-class Model Context Protocol support for tool servers |
+| **Hot-reload config** | Configuration changes take effect without gateway restart |
+| **Built-in channels** | 6 built-in channel types out of the box |
+| **Plugin channels** | 20+ additional channels via the plugin ecosystem |
+
+## Create an OpenClaw agent
+
+<CodeGroup>
+
+```bash CLI
+oc agent create my-claw --core openclaw
+```
+
+```bash REST API
+curl -X POST https://api.opencomputer.dev/v1/agents \
+  -H "X-API-Key: $OC_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"id": "my-claw", "core": "openclaw"}'
+```
+
+</CodeGroup>
+
+This boots a sandbox with OpenClaw pre-installed, an LLM key configured, and the gateway running. An instance is created automatically.
+
+## Configuration
+
+OpenClaw uses JSON5 configuration at `~/.openclaw/openclaw.json` inside the sandbox. Unlike Hermes, OpenClaw supports **hot-reload** — config changes take effect without restarting the gateway.
+
+To inspect or edit manually:
+
+```bash
+oc shell my-claw
+cat ~/.openclaw/openclaw.json
+```
+
+## MCP servers
+
+OpenClaw has native MCP support. When you [install a package](/agents/packages/gbrain) like gbrain, the platform adds it as an MCP server in the OpenClaw config. To see what MCP servers are configured:
+
+```bash
+oc shell my-claw
+openclaw mcp list
+```
+
+## Extending with packages
+
+OpenClaw supports [packages](/agents/packages/gbrain) that add capabilities via MCP servers. Because of hot-reload, package installation takes effect immediately without a gateway restart.
+
+<CardGroup cols={2}>
+  <Card title="Create an OpenClaw Agent" icon="rocket" href="/guides/create-openclaw-agent">
+    Step-by-step guide
+  </Card>
+  <Card title="oc agent CLI" icon="terminal" href="/cli/agents">
+    CLI commands for managing agents
+  </Card>
+</CardGroup>

--- a/docs/agents/packages/gbrain.mdx
+++ b/docs/agents/packages/gbrain.mdx
@@ -1,0 +1,122 @@
+---
+title: "gbrain Package"
+description: "Install persistent memory on a managed agent with gbrain"
+---
+
+[gbrain](https://github.com/garrytan/gbrain) is a personal knowledge system that gives your agent persistent memory backed by Postgres with vector search. When installed on a managed agent, it's wired as an MCP server — the agent gets 34 tools for storing, searching, and organizing knowledge.
+
+## Install
+
+<CodeGroup>
+
+```bash CLI
+oc agent install my-agent gbrain
+```
+
+```bash REST API
+curl -X POST https://api.opencomputer.dev/v1/agents/my-agent/packages/gbrain \
+  -H "X-API-Key: $OC_API_KEY"
+```
+
+</CodeGroup>
+
+This runs through five phases:
+
+| Phase | What happens |
+|-------|-------------|
+| **Allocate** | Creates a managed Postgres database (with `pgvector` and `pg_trgm` extensions) for this agent |
+| **Provision** | Clones gbrain from GitHub into the sandbox and installs dependencies |
+| **Initialize** | Runs `gbrain init` against the managed database to create the schema |
+| **Wire** | Adds gbrain as an MCP server in the core's config and restarts the gateway |
+| **Verify** | Runs `gbrain doctor` to confirm the installation |
+
+Install is **idempotent** — re-running it after a partial failure is safe. The allocate phase skips if the database exists, provision skips if gbrain is already cloned, and so on.
+
+## What the agent gets
+
+After install, the agent has these tool groups available:
+
+| Group | Tools | What they do |
+|-------|-------|-------------|
+| **Pages** | `put_page`, `get_page`, `delete_page`, `list_pages` | Store and retrieve knowledge pages with Markdown content |
+| **Search** | `query` (vector + keyword hybrid), `search` (full-text) | Find pages by meaning or keywords |
+| **Versions** | `get_versions`, `revert_version` | Page version history |
+| **Graph** | `add_link`, `remove_link`, `get_links`, `get_backlinks`, `traverse_graph` | Link pages into a knowledge graph |
+| **Tags** | `add_tag`, `remove_tag`, `get_tags` | Categorize pages |
+| **Timeline** | `add_timeline_entry`, `get_timeline` | Chronological event log |
+| **Files** | `file_upload`, `file_list`, `file_url` | Attach files to the knowledge base |
+| **System** | `get_stats`, `get_health`, `sync_brain` | Health checks and maintenance |
+
+## Test it
+
+After installing, message your agent on Telegram:
+
+```
+You:   What new tools do you have?
+Agent: I now have gbrain tools — search, put_page, timeline...
+
+You:   Use gbrain to remember that our deployment target is Kubernetes on GCP
+Agent: Saved to knowledge base.
+
+You:   Use gbrain to search for deployment
+Agent: You deploy to Kubernetes on GCP.
+```
+
+## Managed database
+
+The database that backs gbrain is **managed by OpenComputer** — you don't need to provision or configure Postgres yourself. The database:
+
+- Lives outside the sandbox on a shared Postgres cluster
+- Survives instance restarts and sandbox recreation
+- Is preserved when you uninstall gbrain (your data isn't deleted)
+- Is restored when you reinstall gbrain on the same agent
+
+The connection URL is passed to gbrain via the MCP server's environment config, not as a sandbox-level secret.
+
+## Uninstall
+
+<CodeGroup>
+
+```bash CLI
+oc agent uninstall my-agent gbrain
+```
+
+```bash REST API
+curl -X DELETE https://api.opencomputer.dev/v1/agents/my-agent/packages/gbrain \
+  -H "X-API-Key: $OC_API_KEY"
+```
+
+</CodeGroup>
+
+This removes the MCP wiring from the core's config and restarts the gateway. The agent loses access to gbrain tools, but the **database is preserved**. Reinstalling gbrain on the same agent reconnects to the existing data.
+
+## Debugging
+
+Shell into the sandbox to inspect the installation:
+
+```bash
+oc shell my-agent
+```
+
+```bash
+# Check if gbrain is cloned
+ls ~/.gbrain/src/cli.ts
+
+# Check the MCP config (Hermes)
+cat ~/.hermes/config.yaml
+
+# Check the MCP config (OpenClaw)
+cat ~/.openclaw/openclaw.json
+
+# Check gateway logs for MCP connection status
+tail -20 ~/.hermes/logs/gateway.log
+
+# Run gbrain directly
+~/.bun/bin/bun run ~/.gbrain/src/cli.ts doctor
+```
+
+Common issues:
+
+- **"missing executable 'bun'"** in gateway logs — the MCP config needs absolute paths (e.g., `/home/sandbox/.bun/bin/bun`), not bare `bun`
+- **Embedding failures** — gbrain uses OpenAI for vector embeddings. If `OPENAI_API_KEY` is missing from the MCP env config, pages are stored but semantic search won't work
+- **Gateway didn't pick up MCP** — check if the gateway restarted after the wire phase. Run `hermes gateway run --replace` from the shell to force a restart

--- a/docs/agents/rest/agents.mdx
+++ b/docs/agents/rest/agents.mdx
@@ -1,0 +1,144 @@
+---
+title: "Agents"
+description: "Create and manage agent definitions — snapshot, entrypoint, secrets, elasticity"
+---
+
+An Agent is configuration, not compute. It defines what core or snapshot to boot, what entrypoint to run, which secrets to inject, and how elasticity works. The same agent can back both Instances and Sessions.
+
+<Tip>
+  **Prefer the CLI?** All operations below have [`oc agent`](/cli/agents) equivalents.
+</Tip>
+
+## Create agent
+
+```
+POST /v1/agents
+```
+
+```json
+{
+  "id": "issue-resolver",
+  "display_name": "Issue Resolver",
+  "config": {
+    "snapshot": "agent-snapshot-v1",
+    "entrypoint": "node /workspace/agent/index.js",
+    "env": { "LOG_LEVEL": "info" },
+    "elasticity": { "baseline_mb": 1024, "max_mb": 8192 },
+    "idle_timeout_s": 600
+  }
+}
+```
+
+`id` must be DNS-safe (lowercase alphanumeric + hyphens). Returns `201` with the agent object.
+
+**Managed agents** — pass `core` instead of `config` to create a managed agent:
+
+```json
+{
+  "id": "my-hermes",
+  "core": "hermes"
+}
+```
+
+**CLI equivalent:** `oc agent create my-hermes --core hermes`
+
+**Entrypoint vs agent_config**: if `config.entrypoint` is set, the platform runs it via `sandbox.exec.start()`. If `config.agent_config` is set instead, the platform uses `sandbox.agent.start()` with the provided `system_prompt` and `allowed_tools`. They are mutually exclusive.
+
+## CRUD
+
+```
+GET    /v1/agents                  List all agents
+GET    /v1/agents/:agentId         Get agent
+PATCH  /v1/agents/:agentId         Update (accepts display_name, config)
+DELETE /v1/agents/:agentId         Delete (cascades to instances and sessions)
+```
+
+| Operation | CLI equivalent |
+|-----------|---------------|
+| List | `oc agent list` |
+| Get | `oc agent get <id>` |
+| Update | — (REST only) |
+| Delete | `oc agent delete <id>` |
+
+## Agent object
+
+```json
+{
+  "id": "issue-resolver",
+  "display_name": "Issue Resolver",
+  "secret_store": "agent:issue-resolver",
+  "config": { ... },
+  "created_at": "2026-04-09T...",
+  "updated_at": "2026-04-09T..."
+}
+```
+
+## Secrets
+
+Convenience wrapper over OpenComputer's [secret store](/sandboxes/secrets). Values are AES-256-GCM encrypted at rest, injected as sealed tokens at sandbox creation. Values are never returned via API.
+
+```
+PUT    /v1/agents/:agentId/secrets/:key     Set a secret
+GET    /v1/agents/:agentId/secrets          List keys (values never returned)
+DELETE /v1/agents/:agentId/secrets/:key     Remove a secret
+```
+
+**Set secret:**
+
+```json
+PUT /v1/agents/issue-resolver/secrets/ANTHROPIC_API_KEY
+{ "value": "sk-ant-...", "allowed_hosts": ["api.anthropic.com"] }
+```
+
+The first `PUT` auto-creates a backing OC secret store named `agent:{agentId}`. `allowed_hosts` is optional — restricts which outbound hosts can receive the decrypted value.
+
+**List secrets** returns keys and metadata only:
+
+```json
+{ "secrets": [{ "key": "ANTHROPIC_API_KEY", "allowed_hosts": ["api.anthropic.com"], "set_at": "..." }] }
+```
+
+**CLI note:** Secrets can be set at creation time with `oc agent create --secret KEY=VALUE`. There is no standalone `oc agent secret` command yet.
+
+## Channels
+
+```
+POST   /v1/agents/:agentId/channels/:channel    Connect a channel
+DELETE /v1/agents/:agentId/channels/:channel    Disconnect a channel
+GET    /v1/agents/:agentId/channels             List connected channels
+```
+
+| Operation | CLI equivalent |
+|-----------|---------------|
+| Connect | `oc agent connect <id> <channel>` |
+| Disconnect | `oc agent disconnect <id> <channel>` |
+| List | `oc agent channels <id>` |
+
+See [Telegram channel](/agents/channels/telegram) for details.
+
+## Packages
+
+```
+POST   /v1/agents/:agentId/packages/:pkg    Install a package
+DELETE /v1/agents/:agentId/packages/:pkg    Uninstall a package
+GET    /v1/agents/:agentId/packages         List installed packages
+```
+
+| Operation | CLI equivalent |
+|-----------|---------------|
+| Install | `oc agent install <id> <pkg>` |
+| Uninstall | `oc agent uninstall <id> <pkg>` |
+| List | `oc agent packages <id>` |
+
+See [gbrain package](/agents/packages/gbrain) for details.
+
+## Errors
+
+```json
+{
+  "error": {
+    "type": "invalid_request | not_found | conflict | internal_error",
+    "message": "Human-readable description"
+  }
+}
+```

--- a/docs/agents/rest/instances.mdx
+++ b/docs/agents/rest/instances.mdx
@@ -1,0 +1,67 @@
+---
+title: "Instances"
+description: "Persistent sandboxes that multiplex conversations, hibernate when idle, and wake on demand"
+---
+
+An Instance is a persistent sandbox bound to an Agent. It stays alive across conversations, accumulates state (filesystem, installed tools, running processes), and hibernates when idle. Multiple conversations are multiplexed onto one instance via `conversation_id`.
+
+**Typical mapping:** one Instance per user or team. The caller owns conversation identity (e.g., Slack thread timestamp).
+
+## Create instance
+
+```
+POST /v1/agents/:agentId/instances
+```
+
+```json
+{ "metadata": { "slack_user": "U123", "team": "engineering" } }
+```
+
+Returns `201` with `status: "creating"`. The platform provisions a sandbox from the agent's snapshot in the background. Status becomes `"running"` once ready.
+
+## List / Get / Delete
+
+```
+GET    /v1/agents/:agentId/instances        List instances for an agent
+GET    /v1/agents/:agentId/instances/:id    Get instance
+DELETE /v1/agents/:agentId/instances/:id    Destroy (kills sandbox)
+```
+
+## Instance object
+
+```json
+{
+  "id": "inst_98adcc7e...",
+  "agent_id": "slack-coworker",
+  "status": "creating | running | error",
+  "metadata": { "slack_user": "U123" },
+  "created_at": "2026-04-09T...",
+  "updated_at": "2026-04-09T..."
+}
+```
+
+## Send message
+
+```
+POST /v1/agents/:agentId/instances/:id/messages
+```
+
+```json
+{ "content": "analyze the auth service repo", "conversation_id": "1712345678.123456" }
+```
+
+Returns `200` with `Content-Type: text/event-stream`. If the instance is still `creating`, waits up to 30s for it to become ready.
+
+**SSE events:**
+
+```
+data: {"type":"text","content":"Cloning the repo now...","conversation_id":"1712345678.123456"}
+data: {"type":"text","content":"Found 3 issues...","conversation_id":"1712345678.123456"}
+data: {"type":"done"}
+```
+
+The stream closes after the agent completes one turn. The caller collects `text` events and concatenates their `content` for the full response.
+
+## Recovery
+
+If the caller process restarts, rebuild instance mappings from `GET /v1/agents/:agentId/instances` using `metadata` to match external identities (e.g., Slack user IDs) back to instance IDs.

--- a/docs/agents/rest/sessions.mdx
+++ b/docs/agents/rest/sessions.mdx
@@ -1,0 +1,74 @@
+---
+title: "Sessions"
+description: "Ephemeral sandboxes for fire-and-forget agent tasks with input/result"
+---
+
+A Session is an ephemeral sandbox bound to an Agent. One session = one task = one sandbox. The sandbox is created, the agent runs to completion, and the sandbox is destroyed. For process-mode agents that take input and produce a result.
+
+**Typical mapping:** one Session per webhook, API call, or batch job.
+
+## Create session
+
+```
+POST /v1/agents/:agentId/sessions
+```
+
+```json
+{
+  "input": {
+    "repo": "acme/backend",
+    "issue_number": 42,
+    "webhook_payload": { "..." }
+  },
+  "metadata": { "trigger": "github_webhook" }
+}
+```
+
+The platform creates a sandbox, writes `input` to `/tmp/agent_input.json`, sets `AGENT_INPUT_PATH` as an env var, and runs the agent's entrypoint. The agent reads input, does work, writes its result to `/tmp/agent_result.json`, and exits.
+
+Returns `201` with `status: "creating"`.
+
+## Get / Delete
+
+```
+GET    /v1/agents/:agentId/sessions/:id    Get session
+DELETE /v1/agents/:agentId/sessions/:id    End session (kills sandbox)
+```
+
+## Get result
+
+```
+GET /v1/agents/:agentId/sessions/:id/result
+```
+
+Returns the agent's output after completion. The platform reads `/tmp/agent_result.json` from the sandbox.
+
+```
+-- While running:         409 { "error": { "type": "conflict", "message": "Session still running" } }
+-- When complete:         200 { "data": { "pr_url": "https://..." }, "completed_at": "2026-04-09T..." }
+-- If no result written:  200 { "data": null, "completed_at": "2026-04-09T..." }
+```
+
+## Session object
+
+```json
+{
+  "id": "sess_98adcc7e...",
+  "agent_id": "issue-resolver",
+  "status": "creating | running | completed | failed",
+  "input": { "..." },
+  "result": null,
+  "preview_url": null,
+  "metadata": {},
+  "created_at": "2026-04-09T...",
+  "updated_at": "2026-04-09T..."
+}
+```
+
+## Lifecycle
+
+```
+creating → running → completed (exit 0) | failed (non-zero exit)
+```
+
+Terminal states are final. The sandbox is destroyed when the session ends.

--- a/docs/api-reference/agents/connect-channel.mdx
+++ b/docs/api-reference/agents/connect-channel.mdx
@@ -1,0 +1,29 @@
+---
+title: 'Connect Channel'
+api: 'POST /v1/agents/{agentId}/channels/{channel}'
+---
+
+Connect a messaging channel to an agent.
+
+**CLI equivalent:** `oc agent connect <id> <channel>`
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ParamField path="channel" type="string" required>
+  Channel type (e.g. `telegram`)
+</ParamField>
+
+<ParamField body="bot_token" type="string">
+  Bot token (required for Telegram)
+</ParamField>
+
+<ResponseExample>
+```json 200
+{
+  "channel": "telegram",
+  "status": "connected"
+}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/create-instance.mdx
+++ b/docs/api-reference/agents/create-instance.mdx
@@ -1,0 +1,27 @@
+---
+title: 'Create Instance'
+api: 'POST /v1/agents/{agentId}/instances'
+---
+
+Create a persistent instance for an agent. The platform provisions a sandbox from the agent's snapshot in the background.
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ParamField body="metadata" type="object">
+  Arbitrary metadata for matching instances to external identities (e.g. Slack user IDs)
+</ParamField>
+
+<ResponseExample>
+```json 201
+{
+  "id": "inst_98adcc7e",
+  "agent_id": "my-hermes",
+  "status": "creating",
+  "metadata": { "slack_user": "U123" },
+  "created_at": "2026-04-09T10:30:00Z",
+  "updated_at": "2026-04-09T10:30:00Z"
+}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/create-session.mdx
+++ b/docs/api-reference/agents/create-session.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Create Session'
+api: 'POST /v1/agents/{agentId}/sessions'
+---
+
+Create an ephemeral session. The platform creates a sandbox, writes `input` to `/tmp/agent_input.json`, sets `AGENT_INPUT_PATH`, and runs the agent's entrypoint.
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ParamField body="input" type="object">
+  Input data written to `/tmp/agent_input.json` in the sandbox
+</ParamField>
+
+<ParamField body="metadata" type="object">
+  Arbitrary metadata
+</ParamField>
+
+<ResponseExample>
+```json 201
+{
+  "id": "sess_98adcc7e",
+  "agent_id": "issue-resolver",
+  "status": "creating",
+  "input": { "repo": "acme/backend", "issue_number": 42 },
+  "result": null,
+  "preview_url": null,
+  "metadata": { "trigger": "github_webhook" },
+  "created_at": "2026-04-09T10:30:00Z",
+  "updated_at": "2026-04-09T10:30:00Z"
+}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/create.mdx
+++ b/docs/api-reference/agents/create.mdx
@@ -1,0 +1,68 @@
+---
+title: 'Create Agent'
+api: 'POST /v1/agents'
+---
+
+Create a new agent. For managed agents, pass `core` to get a pre-configured runtime. For raw agents, pass `config` with your own snapshot and entrypoint.
+
+**CLI equivalent:** `oc agent create <id> [--core <core>] [--secret KEY=VALUE]`
+
+<ParamField body="id" type="string" required>
+  Agent ID. Must be DNS-safe (lowercase alphanumeric + hyphens).
+</ParamField>
+
+<ParamField body="display_name" type="string">
+  Human-readable display name
+</ParamField>
+
+<ParamField body="core" type="string">
+  Managed core (`hermes` or `openclaw`). Mutually exclusive with `config`.
+</ParamField>
+
+<ParamField body="config" type="object">
+  Raw agent configuration. Mutually exclusive with `core`.
+</ParamField>
+
+<ParamField body="config.snapshot" type="string">
+  Snapshot to boot the sandbox from
+</ParamField>
+
+<ParamField body="config.entrypoint" type="string">
+  Command to run on sandbox start
+</ParamField>
+
+<ParamField body="config.agent_config" type="object">
+  Alternative to entrypoint — uses `sandbox.agent.start()` with `system_prompt` and `allowed_tools`
+</ParamField>
+
+<ParamField body="config.env" type="object">
+  Environment variables
+</ParamField>
+
+<ParamField body="config.elasticity" type="object">
+  Memory elasticity. `baseline_mb` and `max_mb`.
+</ParamField>
+
+<ParamField body="config.idle_timeout_s" type="integer">
+  Idle timeout in seconds
+</ParamField>
+
+<ParamField body="secrets" type="object">
+  Key-value map of secrets to set on creation
+</ParamField>
+
+<ResponseExample>
+```json 201
+{
+  "id": "my-hermes",
+  "display_name": "my-hermes",
+  "core": "hermes",
+  "channels": [],
+  "packages": [],
+  "secret_store": "agent:my-hermes",
+  "config": null,
+  "created_at": "2026-04-09T10:30:00Z",
+  "updated_at": "2026-04-09T10:30:00Z"
+}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/delete-instance.mdx
+++ b/docs/api-reference/agents/delete-instance.mdx
@@ -1,0 +1,20 @@
+---
+title: 'Delete Instance'
+api: 'DELETE /v1/agents/{agentId}/instances/{id}'
+---
+
+Delete an instance. Kills the backing sandbox.
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ParamField path="id" type="string" required>
+  Instance ID
+</ParamField>
+
+<ResponseExample>
+```json 200
+{}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/delete-secret.mdx
+++ b/docs/api-reference/agents/delete-secret.mdx
@@ -1,0 +1,20 @@
+---
+title: 'Delete Secret'
+api: 'DELETE /v1/agents/{agentId}/secrets/{key}'
+---
+
+Remove a secret from an agent.
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ParamField path="key" type="string" required>
+  Secret key name
+</ParamField>
+
+<ResponseExample>
+```json 200
+{}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/delete-session.mdx
+++ b/docs/api-reference/agents/delete-session.mdx
@@ -1,0 +1,20 @@
+---
+title: 'Delete Session'
+api: 'DELETE /v1/agents/{agentId}/sessions/{id}'
+---
+
+Delete a session. Kills the backing sandbox if still running.
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ParamField path="id" type="string" required>
+  Session ID
+</ParamField>
+
+<ResponseExample>
+```json 200
+{}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/delete.mdx
+++ b/docs/api-reference/agents/delete.mdx
@@ -1,0 +1,18 @@
+---
+title: 'Delete Agent'
+api: 'DELETE /v1/agents/{agentId}'
+---
+
+Delete an agent. Cascades to all instances and sessions — their sandboxes are destroyed.
+
+**CLI equivalent:** `oc agent delete <id>`
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ResponseExample>
+```json 200
+{}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/disconnect-channel.mdx
+++ b/docs/api-reference/agents/disconnect-channel.mdx
@@ -1,0 +1,22 @@
+---
+title: 'Disconnect Channel'
+api: 'DELETE /v1/agents/{agentId}/channels/{channel}'
+---
+
+Disconnect a channel from an agent. Removes webhook registration and config.
+
+**CLI equivalent:** `oc agent disconnect <id> <channel>`
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ParamField path="channel" type="string" required>
+  Channel type (e.g. `telegram`)
+</ParamField>
+
+<ResponseExample>
+```json 200
+{}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/get-instance.mdx
+++ b/docs/api-reference/agents/get-instance.mdx
@@ -1,0 +1,27 @@
+---
+title: 'Get Instance'
+api: 'GET /v1/agents/{agentId}/instances/{id}'
+---
+
+Get a specific instance.
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ParamField path="id" type="string" required>
+  Instance ID
+</ParamField>
+
+<ResponseExample>
+```json 200
+{
+  "id": "inst_98adcc7e",
+  "agent_id": "my-hermes",
+  "status": "running",
+  "metadata": { "slack_user": "U123" },
+  "created_at": "2026-04-09T10:30:00Z",
+  "updated_at": "2026-04-09T10:30:00Z"
+}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/get-session-result.mdx
+++ b/docs/api-reference/agents/get-session-result.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Get Session Result'
+api: 'GET /v1/agents/{agentId}/sessions/{id}/result'
+---
+
+Get the result of a completed session. The platform reads `/tmp/agent_result.json` from the sandbox.
+
+Returns `409` if the session is still running.
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ParamField path="id" type="string" required>
+  Session ID
+</ParamField>
+
+<ResponseExample>
+```json 200
+{
+  "data": { "pr_url": "https://github.com/acme/backend/pull/43" },
+  "completed_at": "2026-04-09T10:35:00Z"
+}
+```
+
+```json 409
+{
+  "error": {
+    "type": "conflict",
+    "message": "Session still running"
+  }
+}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/get-session.mdx
+++ b/docs/api-reference/agents/get-session.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Get Session'
+api: 'GET /v1/agents/{agentId}/sessions/{id}'
+---
+
+Get a specific session.
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ParamField path="id" type="string" required>
+  Session ID
+</ParamField>
+
+<ResponseExample>
+```json 200
+{
+  "id": "sess_98adcc7e",
+  "agent_id": "issue-resolver",
+  "status": "running",
+  "input": { "repo": "acme/backend", "issue_number": 42 },
+  "result": null,
+  "preview_url": null,
+  "metadata": { "trigger": "github_webhook" },
+  "created_at": "2026-04-09T10:30:00Z",
+  "updated_at": "2026-04-09T10:30:00Z"
+}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/get.mdx
+++ b/docs/api-reference/agents/get.mdx
@@ -1,0 +1,28 @@
+---
+title: 'Get Agent'
+api: 'GET /v1/agents/{agentId}'
+---
+
+Get details for a specific agent.
+
+**CLI equivalent:** `oc agent get <id>`
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ResponseExample>
+```json 200
+{
+  "id": "my-hermes",
+  "display_name": "my-hermes",
+  "core": "hermes",
+  "channels": ["telegram"],
+  "packages": ["gbrain"],
+  "secret_store": "agent:my-hermes",
+  "config": null,
+  "created_at": "2026-04-09T10:30:00Z",
+  "updated_at": "2026-04-09T10:30:00Z"
+}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/install-package.mdx
+++ b/docs/api-reference/agents/install-package.mdx
@@ -1,0 +1,25 @@
+---
+title: 'Install Package'
+api: 'POST /v1/agents/{agentId}/packages/{pkg}'
+---
+
+Install a package on an agent.
+
+**CLI equivalent:** `oc agent install <id> <package>`
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ParamField path="pkg" type="string" required>
+  Package name (e.g. `gbrain`)
+</ParamField>
+
+<ResponseExample>
+```json 200
+{
+  "package": "gbrain",
+  "status": "installed"
+}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/list-channels.mdx
+++ b/docs/api-reference/agents/list-channels.mdx
@@ -1,0 +1,20 @@
+---
+title: 'List Channels'
+api: 'GET /v1/agents/{agentId}/channels'
+---
+
+List channels connected to an agent.
+
+**CLI equivalent:** `oc agent channels <id>`
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ResponseExample>
+```json 200
+{
+  "channels": ["telegram"]
+}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/list-instances.mdx
+++ b/docs/api-reference/agents/list-instances.mdx
@@ -1,0 +1,27 @@
+---
+title: 'List Instances'
+api: 'GET /v1/agents/{agentId}/instances'
+---
+
+List all instances for an agent.
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ResponseExample>
+```json 200
+{
+  "instances": [
+    {
+      "id": "inst_98adcc7e",
+      "agent_id": "my-hermes",
+      "status": "running",
+      "metadata": { "slack_user": "U123" },
+      "created_at": "2026-04-09T10:30:00Z",
+      "updated_at": "2026-04-09T10:30:00Z"
+    }
+  ]
+}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/list-packages.mdx
+++ b/docs/api-reference/agents/list-packages.mdx
@@ -1,0 +1,20 @@
+---
+title: 'List Packages'
+api: 'GET /v1/agents/{agentId}/packages'
+---
+
+List packages installed on an agent.
+
+**CLI equivalent:** `oc agent packages <id>`
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ResponseExample>
+```json 200
+{
+  "packages": ["gbrain"]
+}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/list-secrets.mdx
+++ b/docs/api-reference/agents/list-secrets.mdx
@@ -1,0 +1,24 @@
+---
+title: 'List Secrets'
+api: 'GET /v1/agents/{agentId}/secrets'
+---
+
+List secret keys for an agent. Values are never returned.
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ResponseExample>
+```json 200
+{
+  "secrets": [
+    {
+      "key": "ANTHROPIC_API_KEY",
+      "allowed_hosts": ["api.anthropic.com"],
+      "set_at": "2026-04-09T10:30:00Z"
+    }
+  ]
+}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/list.mdx
+++ b/docs/api-reference/agents/list.mdx
@@ -1,0 +1,28 @@
+---
+title: 'List Agents'
+api: 'GET /v1/agents'
+---
+
+List all agents owned by the authenticated API key.
+
+**CLI equivalent:** `oc agent list`
+
+<ResponseExample>
+```json 200
+{
+  "agents": [
+    {
+      "id": "my-hermes",
+      "display_name": "my-hermes",
+      "core": "hermes",
+      "channels": ["telegram"],
+      "packages": ["gbrain"],
+      "secret_store": "agent:my-hermes",
+      "config": null,
+      "created_at": "2026-04-09T10:30:00Z",
+      "updated_at": "2026-04-09T10:30:00Z"
+    }
+  ]
+}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/send-message.mdx
+++ b/docs/api-reference/agents/send-message.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Send Message'
+api: 'POST /v1/agents/{agentId}/instances/{id}/messages'
+---
+
+Send a message to an agent instance. Returns a server-sent event stream with the agent's response.
+
+If the instance is still `creating`, waits up to 30s for it to become ready.
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ParamField path="id" type="string" required>
+  Instance ID
+</ParamField>
+
+<ParamField body="content" type="string" required>
+  Message content
+</ParamField>
+
+<ParamField body="conversation_id" type="string">
+  Conversation identifier for multiplexing. The caller owns this identity (e.g. Slack thread timestamp).
+</ParamField>
+
+<ResponseExample>
+```text 200
+Content-Type: text/event-stream
+
+data: {"type":"text","content":"Cloning the repo now...","conversation_id":"1712345678.123456"}
+data: {"type":"text","content":"Found 3 issues...","conversation_id":"1712345678.123456"}
+data: {"type":"done"}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/set-secret.mdx
+++ b/docs/api-reference/agents/set-secret.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Set Secret'
+api: 'PUT /v1/agents/{agentId}/secrets/{key}'
+---
+
+Set or update a secret on an agent. The first call auto-creates a backing secret store. Values are AES-256-GCM encrypted at rest and never returned via API.
+
+**CLI equivalent:** `oc agent create --secret KEY=VALUE` (at creation time only)
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ParamField path="key" type="string" required>
+  Secret key name
+</ParamField>
+
+<ParamField body="value" type="string" required>
+  Secret value
+</ParamField>
+
+<ParamField body="allowed_hosts" type="string[]">
+  Restrict which outbound hosts can receive the decrypted value
+</ParamField>
+
+<ResponseExample>
+```json 200
+{
+  "key": "ANTHROPIC_API_KEY",
+  "allowed_hosts": ["api.anthropic.com"],
+  "set_at": "2026-04-09T10:30:00Z"
+}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/uninstall-package.mdx
+++ b/docs/api-reference/agents/uninstall-package.mdx
@@ -1,0 +1,22 @@
+---
+title: 'Uninstall Package'
+api: 'DELETE /v1/agents/{agentId}/packages/{pkg}'
+---
+
+Uninstall a package from an agent. Data is preserved by default — reinstalling reconnects to existing data.
+
+**CLI equivalent:** `oc agent uninstall <id> <package>`
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ParamField path="pkg" type="string" required>
+  Package name (e.g. `gbrain`)
+</ParamField>
+
+<ResponseExample>
+```json 200
+{}
+```
+</ResponseExample>

--- a/docs/api-reference/agents/update.mdx
+++ b/docs/api-reference/agents/update.mdx
@@ -1,0 +1,36 @@
+---
+title: 'Update Agent'
+api: 'PATCH /v1/agents/{agentId}'
+---
+
+Update an agent's display name or configuration.
+
+**CLI equivalent:** none (REST only)
+
+<ParamField path="agentId" type="string" required>
+  Agent ID
+</ParamField>
+
+<ParamField body="display_name" type="string">
+  New display name
+</ParamField>
+
+<ParamField body="config" type="object">
+  Updated configuration (partial update)
+</ParamField>
+
+<ResponseExample>
+```json 200
+{
+  "id": "my-hermes",
+  "display_name": "My Hermes Agent",
+  "core": "hermes",
+  "channels": ["telegram"],
+  "packages": ["gbrain"],
+  "secret_store": "agent:my-hermes",
+  "config": null,
+  "created_at": "2026-04-09T10:30:00Z",
+  "updated_at": "2026-04-10T08:15:00Z"
+}
+```
+</ResponseExample>

--- a/docs/cli/agents.mdx
+++ b/docs/cli/agents.mdx
@@ -1,0 +1,98 @@
+---
+title: "Agent Management"
+description: "Create, inspect, and manage agents, channels, and packages from the CLI"
+---
+
+## Creating an Agent
+
+`oc agent create` provisions a managed agent with a core runtime:
+
+```bash
+oc agent create my-agent --core hermes
+oc agent create my-agent --core openclaw
+oc agent create my-agent --core hermes --secret OPENAI_API_KEY=sk-...
+```
+
+With `--core`, OpenComputer boots a sandbox with the runtime pre-installed and an instance running. Without `--core`, you get a raw agent — provide your own `snapshot` and `entrypoint` via the [REST API](/agents/rest/agents).
+
+## Listing & Inspecting
+
+```bash
+# List all agents
+oc agent ls
+
+# Detailed info for a specific agent
+oc agent get my-agent
+```
+
+`oc agent ls` shows a table with ID, core, channels, packages, and age. Add `--json` for machine-readable output.
+
+`oc agent get` also shows instance status if one exists.
+
+## Connecting Channels
+
+Connect messaging platforms to your agent. Currently supports Telegram.
+
+```bash
+# Connect (prompts for bot token interactively)
+oc agent connect my-agent telegram
+
+# Disconnect
+oc agent disconnect my-agent telegram
+
+# List connected channels
+oc agent channels my-agent
+```
+
+See [Telegram channel](/agents/channels/telegram) for setup details.
+
+## Installing Packages
+
+Extend what the agent can do with packages like [gbrain](/agents/packages/gbrain) for persistent memory.
+
+```bash
+# Install
+oc agent install my-agent gbrain
+
+# Uninstall (data preserved)
+oc agent uninstall my-agent gbrain
+
+# List installed packages
+oc agent packages my-agent
+```
+
+## Deleting an Agent
+
+```bash
+oc agent delete my-agent
+```
+
+Cascades to instances and sessions — the sandbox is destroyed.
+
+## Shell Access
+
+Any agent is also a sandbox. Drop into it for manual inspection and debugging:
+
+```bash
+oc shell my-agent
+```
+
+## Common Patterns
+
+### Create a full agent setup
+
+```bash
+oc agent create my-agent --core hermes
+oc agent connect my-agent telegram
+oc agent install my-agent gbrain
+```
+
+### Script with JSON output
+
+```bash
+oc agent ls --json | jq -r '.[].id'
+```
+
+<Tip>
+  Full flag reference: [CLI Reference](/reference/cli/agent). REST API equivalents: [Agents REST](/agents/rest/agents).
+</Tip>

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -126,6 +126,7 @@ oc exec $ID2 --wait -- ./test-b.sh
 
 | Command | Description |
 | --- | --- |
+| [`oc agent`](/cli/agents) | Create, manage, connect channels, install packages |
 | [`oc sandbox`](/cli/sandbox) | Create, list, kill, hibernate, wake |
 | [`oc exec`](/cli/exec) | Run commands, manage exec sessions |
 | [`oc shell`](/cli/shell) | Interactive PTY terminal |

--- a/docs/guides/create-hermes-agent.mdx
+++ b/docs/guides/create-hermes-agent.mdx
@@ -122,7 +122,7 @@ Disconnecting deregisters the Telegram webhook and removes the channel config fr
 
 ## What's next
 
-- **[Install gbrain](/agents-api/gbrain)** for persistent memory: `oc agent install my-hermes gbrain`
+- **[Install gbrain](/agents/packages/gbrain)** for persistent memory: `oc agent install my-hermes gbrain`
 - **Connect Slack** instead of Telegram (planned)
 - **[Create an OpenClaw Agent](/guides/create-openclaw-agent)** — same journey, different core: multi-channel gateway with plugin SDK and hot-reload config
 - **Custom cores** — bring your own agent runtime with `oc shell` and the raw sandbox API

--- a/docs/guides/create-openclaw-agent.mdx
+++ b/docs/guides/create-openclaw-agent.mdx
@@ -157,6 +157,6 @@ Choose Hermes for its self-improving skill loop and built-in memory. Choose Open
 
 ## What's next
 
-- **[Install gbrain](/agents-api/gbrain)** for persistent memory: `oc agent install my-claw gbrain`
+- **[Install gbrain](/agents/packages/gbrain)** for persistent memory: `oc agent install my-claw gbrain`
 - **[Create a Hermes Agent](/guides/create-hermes-agent)** -- try the other managed core
 - **Custom cores** -- bring your own agent runtime with `oc shell` and the raw sandbox API

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -75,20 +75,33 @@
       ]
     },
     {
-      "group": "Agents API",
+      "group": "Agents",
       "pages": [
         "agents-api/overview",
-        "agents-api/managed-agents",
-        "agents-api/gbrain",
-        "agents-api/agents",
-        "agents-api/instances",
-        "agents-api/sessions"
+        {
+          "group": "Cores",
+          "pages": ["agents/cores/hermes", "agents/cores/openclaw"]
+        },
+        {
+          "group": "Packages",
+          "pages": ["agents/packages/gbrain"]
+        },
+        {
+          "group": "Channels",
+          "pages": ["agents/channels/telegram"]
+        },
+        "cli/agents",
+        {
+          "group": "REST API",
+          "pages": ["agents/rest/agents", "agents/rest/instances", "agents/rest/sessions"]
+        }
       ]
     },
     {
       "group": "CLI",
       "pages": [
         "cli/overview",
+        "cli/agents",
         "cli/sandbox",
         "cli/exec",
         "cli/shell",
@@ -132,6 +145,7 @@
       "group": "CLI Reference",
       "pages": [
         "reference/cli/overview",
+        "reference/cli/agent",
         "reference/cli/sandbox",
         "reference/cli/exec",
         "reference/cli/shell",
@@ -145,6 +159,44 @@
       "group": "API Reference",
       "pages": [
         "api-reference/overview",
+        {
+          "group": "Agents",
+          "pages": [
+            "api-reference/agents/create",
+            "api-reference/agents/list",
+            "api-reference/agents/get",
+            "api-reference/agents/update",
+            "api-reference/agents/delete",
+            "api-reference/agents/set-secret",
+            "api-reference/agents/list-secrets",
+            "api-reference/agents/delete-secret",
+            "api-reference/agents/connect-channel",
+            "api-reference/agents/disconnect-channel",
+            "api-reference/agents/list-channels",
+            "api-reference/agents/install-package",
+            "api-reference/agents/uninstall-package",
+            "api-reference/agents/list-packages"
+          ]
+        },
+        {
+          "group": "Instances",
+          "pages": [
+            "api-reference/agents/create-instance",
+            "api-reference/agents/list-instances",
+            "api-reference/agents/get-instance",
+            "api-reference/agents/delete-instance",
+            "api-reference/agents/send-message"
+          ]
+        },
+        {
+          "group": "Sessions",
+          "pages": [
+            "api-reference/agents/create-session",
+            "api-reference/agents/get-session",
+            "api-reference/agents/delete-session",
+            "api-reference/agents/get-session-result"
+          ]
+        },
         {
           "group": "Sandboxes",
           "pages": [

--- a/docs/reference/cli/agent.mdx
+++ b/docs/reference/cli/agent.mdx
@@ -1,0 +1,125 @@
+---
+title: "oc agent"
+description: "Manage agents, channels, and packages"
+---
+
+## `oc agent create <id>`
+
+Create a new agent. [HTTP API →](/api-reference/agents/create)
+
+<ParamField query="--core" type="string">
+  Managed core to use (e.g. `hermes`, `openclaw`). Without this flag, creates a raw agent.
+</ParamField>
+
+<ParamField query="--secret" type="string">
+  Secret `KEY=VALUE` (repeatable). Secrets are stored encrypted and injected at sandbox creation.
+</ParamField>
+
+```bash
+oc agent create my-hermes --core hermes
+oc agent create my-hermes --core hermes --secret OPENAI_API_KEY=sk-...
+```
+
+---
+
+## `oc agent list`
+
+List all agents. **Alias:** `oc agent ls`
+
+[HTTP API →](/api-reference/agents/list)
+
+Output columns: `ID`, `CORE`, `CHANNELS`, `PACKAGES`, `CREATED`
+
+```bash
+oc agent ls
+oc agent ls --json
+```
+
+---
+
+## `oc agent get <id>`
+
+Show detailed information for an agent, including instance status. [HTTP API →](/api-reference/agents/get)
+
+Output: ID, Name, Core, Channels, Packages, Created, Instance (ID + status).
+
+```bash
+oc agent get my-hermes
+```
+
+---
+
+## `oc agent delete <id>`
+
+Delete an agent. Cascades to instances and sessions — the sandbox is destroyed. [HTTP API →](/api-reference/agents/delete)
+
+```bash
+oc agent delete my-hermes
+```
+
+---
+
+## `oc agent connect <id> <channel>`
+
+Connect a messaging channel to an agent. [HTTP API →](/api-reference/agents/connect-channel)
+
+For Telegram, prompts interactively for the bot token if `--bot-token` is not provided.
+
+<ParamField query="--bot-token" type="string">
+  Telegram bot token (Telegram channel only). If omitted, prompts interactively.
+</ParamField>
+
+```bash
+oc agent connect my-hermes telegram
+oc agent connect my-hermes telegram --bot-token 123:ABC
+```
+
+---
+
+## `oc agent disconnect <id> <channel>`
+
+Disconnect a channel from an agent. Removes webhook registration and config. [HTTP API →](/api-reference/agents/disconnect-channel)
+
+```bash
+oc agent disconnect my-hermes telegram
+```
+
+---
+
+## `oc agent channels <id>`
+
+List channels connected to an agent. [HTTP API →](/api-reference/agents/list-channels)
+
+```bash
+oc agent channels my-hermes
+```
+
+---
+
+## `oc agent install <id> <package>`
+
+Install a package on an agent. [HTTP API →](/api-reference/agents/install-package)
+
+```bash
+oc agent install my-hermes gbrain
+```
+
+---
+
+## `oc agent uninstall <id> <package>`
+
+Uninstall a package from an agent. Data is preserved by default. [HTTP API →](/api-reference/agents/uninstall-package)
+
+```bash
+oc agent uninstall my-hermes gbrain
+```
+
+---
+
+## `oc agent packages <id>`
+
+List packages installed on an agent. [HTTP API →](/api-reference/agents/list-packages)
+
+```bash
+oc agent packages my-hermes
+```

--- a/docs/reference/cli/overview.mdx
+++ b/docs/reference/cli/overview.mdx
@@ -22,6 +22,9 @@ These flags apply to all commands.
 ## Commands
 
 <CardGroup cols={2}>
+  <Card title="oc agent" icon="robot" href="/reference/cli/agent">
+    Manage agents, channels, and packages
+  </Card>
   <Card title="oc sandbox" icon="box" href="/reference/cli/sandbox">
     Manage sandbox lifecycle
   </Card>


### PR DESCRIPTION
## Summary

- Rename **"Agents API"** nav group to **"Agents"** and break the monolithic managed-agents page into dedicated sub-pages
- **Cores**: separate pages for Hermes and OpenClaw with config details, capabilities, and CLI+REST code groups
- **Packages**: gbrain moved to `agents/packages/` with proper nesting
- **Channels**: Telegram extracted into `agents/channels/` with connect/disconnect workflows
- **CLI**: new `cli/agents.mdx` documenting all 10 `oc agent` subcommands with workflow examples
- **REST API**: conceptual pages for agents, instances, sessions with CLI cross-reference tables
- **API Reference**: 23 new Mintlify endpoint reference pages for the full `/v1/agents` family (agents, secrets, instances, sessions, channels, packages)
- **CLI Reference**: new `reference/cli/agent.mdx` with ParamField flag docs for every subcommand
- Every CLI command cross-links to its REST equivalent and vice versa

Old `agents-api/*.mdx` files stay on disk but are removed from nav (no deletion, safe rollback).

## Test plan

- [ ] Run `mintlify dev` and verify all new pages render without broken links
- [ ] Verify sidebar navigation shows correct hierarchy: Agents > Cores/Packages/Channels/CLI/REST API
- [ ] Check that API Reference shows Agents/Instances/Sessions groups before Sandboxes
- [ ] Verify CLI Reference shows `oc agent` card
- [ ] Spot-check cross-links: CLI pages → REST equivalents, REST pages → CLI equivalents
- [ ] Verify guides still link correctly to gbrain package page

🤖 Generated with [Claude Code](https://claude.com/claude-code)