### PR TITLE
hotfix: register migration 023 in Migrate() slice

### DIFF
--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -109,6 +109,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 		{22, "migrations/020_scale_events_disk_mb.up.sql"},
 		{23, "migrations/021_migration_state.up.sql"},
 		{24, "migrations/022_orgs_price_locked.up.sql"},
+		{25, "migrations/023_checkpoints_public.up.sql"},
 	}
 
 	for _, m := range migrations {


### PR DESCRIPTION
## Summary

PR #161 added `023_checkpoints_public.up.sql` under `internal/db/migrations/` but I forgot to add the corresponding entry in the hardcoded `migrations` slice inside `Migrate()` in `internal/db/store.go`. The `//go:embed migrations/*.sql` picks up the file, but `Migrate()` only iterates what's in the slice — so at deploy, no migration ran, while the Go code now expects `is_public`.

Result: `GetCheckpoint` and `ListCheckpoints` 500'd `column "is_public" does not exist` across all callers for the ~35 minutes between PR #161 deploy and this fix landing.

## What this PR does

Adds `{25, "migrations/023_checkpoints_public.up.sql"}` to the slice.

## Prod state

Already unstuck via direct psql against the shared Postgres:

```sql
BEGIN;
ALTER TABLE sandbox_checkpoints ADD COLUMN is_public BOOLEAN NOT NULL DEFAULT false;
CREATE INDEX idx_checkpoints_public ON sandbox_checkpoints(is_public) WHERE is_public = true;
INSERT INTO schema_migrations (version) VALUES (25);
COMMIT;
```

Verified — API is healthy, column + partial index present, `schema_migrations.max = 25`.

Effect of merging this PR on the next prod deploy: `Migrate()` sees `currentVersion >= 25` and skips the new entry. No-op. Safe to merge and deploy any time.

Dev / preview / anyone-with-a-local-DB envs will apply the migration on their next boot as expected.

## Follow-up (not in this PR)

The embed + slice duplication is the foot-gun that caused this. Options:
- Auto-discover migrations from the embedded filenames (alphabetical order = apply order) and drop the slice
- Keep the slice, add a CI check that every `*.up.sql` under `migrations/` has a corresponding slice entry

Worth doing in a follow-up so this exact bug can't recur.

## Test plan

- [ ] On any env with `schema_migrations.max < 25`, next boot applies the migration
- [ ] On prod (already at 25), next boot is a no-op
- [ ] Nothing else touched; diff is one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)