### PR TITLE
agent CLI: error visibility — render last_error, poll create, events subcommand

### DIFF
--- a/cmd/oc/internal/commands/agent.go
+++ b/cmd/oc/internal/commands/agent.go
@@ -32,6 +32,12 @@ type agentResponse struct {
 	Config      interface{} `json:"config"`
 	CreatedAt   string      `json:"created_at"`
 	UpdatedAt   string      `json:"updated_at"`
+
+	// Populated by GET /v1/agents/:id (enriched response); omitted by
+	// POST /v1/agents and the list endpoint.
+	Status     *string    `json:"status,omitempty"`
+	InstanceID *string    `json:"instance_id,omitempty"`
+	LastError  *LastError `json:"last_error,omitempty"`
 }
 
 type agentListResponse struct {
@@ -71,6 +77,7 @@ var agentCreateCmd = &cobra.Command{
 		id := args[0]
 		core, _ := cmd.Flags().GetString("core")
 		secretSlice, _ := cmd.Flags().GetStringSlice("secret")
+		noWait, _ := cmd.Flags().GetBool("no-wait")
 
 		body := map[string]interface{}{
 			"id": id,
@@ -96,17 +103,31 @@ var agentCreateCmd = &cobra.Command{
 			return err
 		}
 
-		printer.Print(agent, func() {
-			fmt.Printf("Created agent %s", agent.ID)
+		// Text-mode preamble (suppressed in --json mode — scripts only want
+		// the final JSON object).
+		if !jsonOutput {
+			fmt.Fprintf(os.Stderr, "Creating agent %s", agent.ID)
 			if agent.Core != nil {
-				fmt.Printf(" (core: %s)", *agent.Core)
+				fmt.Fprintf(os.Stderr, " (core: %s)", *agent.Core)
 			}
-			fmt.Println()
-			if agent.Core != nil {
-				fmt.Println("Instance is booting...")
-			}
-		})
-		return nil
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "  ✓ Agent record created")
+		}
+
+		// No core means no instance to wait for — skip polling.
+		if agent.Core == nil {
+			printer.Print(agent, func() {})
+			return nil
+		}
+
+		// --no-wait short-circuits into Mode 3 (async fallback). Scripts
+		// that don't want to block use this path.
+		if noWait {
+			renderAsyncFallback(os.Stdout, jsonOutput, id, "Instance provisioning", "")
+			return nil
+		}
+
+		return pollUntilTerminal(cmd, sc, id, "instance")
 	},
 }
 
@@ -163,6 +184,8 @@ var agentGetCmd = &cobra.Command{
 			return err
 		}
 
+		// /v1/agents/:id now returns status + last_error inline, so we no
+		// longer fetch /instances separately.
 		printer.Print(agent, func() {
 			fmt.Printf("ID:        %s\n", agent.ID)
 			fmt.Printf("Name:      %s\n", agent.DisplayName)
@@ -171,17 +194,18 @@ var agentGetCmd = &cobra.Command{
 				coreStr = *agent.Core
 			}
 			fmt.Printf("Core:      %s\n", coreStr)
+			if agent.Status != nil {
+				fmt.Printf("Status:    %s\n", *agent.Status)
+			}
 			fmt.Printf("Channels:  %s\n", formatList(agent.Channels))
 			fmt.Printf("Packages:  %s\n", formatList(agent.Packages))
 			fmt.Printf("Created:   %s\n", agent.CreatedAt)
-		})
 
-		// Show instance status
-		var instResp instanceListResponse
-		if err := sc.Get(cmd.Context(), "/v1/agents/"+args[0]+"/instances", &instResp); err == nil && len(instResp.Instances) > 0 {
-			inst := instResp.Instances[0]
-			fmt.Printf("Instance:  %s (%s)\n", inst.ID, inst.Status)
-		}
+			if agent.LastError != nil {
+				fmt.Println()
+				RenderLastError(os.Stdout, agent.LastError)
+			}
+		})
 
 		return nil
 	},
@@ -310,14 +334,38 @@ var agentInstallCmd = &cobra.Command{
 
 		agentID := args[0]
 		pkg := args[1]
+		noWait, _ := cmd.Flags().GetBool("no-wait")
 
-		var result map[string]interface{}
-		if err := sc.Post(cmd.Context(), "/v1/agents/"+agentID+"/packages/"+pkg, nil, &result); err != nil {
-			return err
+		if !jsonOutput {
+			fmt.Fprintf(os.Stderr, "Installing %s on %s\n", pkg, agentID)
 		}
 
-		fmt.Printf("Package %s installed on %s.\n", pkg, agentID)
-		return nil
+		// sessions-api returns 500 when install orchestration fails
+		// synchronously. A successful 200 means the whole flow completed.
+		// The orchestrator writes per-phase events to agent_events; we
+		// surface them by polling and rendering last_error on error.
+		var result map[string]interface{}
+		postErr := sc.Post(cmd.Context(), "/v1/agents/"+agentID+"/packages/"+pkg, nil, &result)
+
+		if postErr == nil {
+			if !jsonOutput {
+				fmt.Fprintf(os.Stderr, "  ✓ %s installed\n", pkg)
+			}
+			if jsonOutput {
+				_ = result // suppress unused warning when we don't render below
+				printer.PrintJSON(result)
+			}
+			return nil
+		}
+
+		// 500 from the orchestrator — the event is already written. --no-wait
+		// callers get the async fallback because they opted out of waiting;
+		// otherwise fetch the latest state to render the error block.
+		if noWait {
+			renderAsyncFallback(os.Stdout, jsonOutput, agentID, "Package install", postErr.Error())
+			return nil
+		}
+		return renderAgentError(cmd, sc, agentID, "install")
 	},
 }
 
@@ -367,6 +415,132 @@ var agentPackagesCmd = &cobra.Command{
 	},
 }
 
+// ── Polling + error-state rendering ──
+
+// Poll cadence for async operations. 2s is fast enough that humans don't
+// notice, slow enough not to hammer the API. The 180s cap is a generous
+// bound on "it's almost certainly still working" before falling back to
+// the async message.
+const (
+	pollInterval = 2 * time.Second
+	pollTimeout  = 180 * time.Second
+)
+
+// pollUntilTerminal polls GET /v1/agents/:id until status reaches a terminal
+// state (running / error), the deadline hits, or a persistent network error
+// occurs. One of three Mode outcomes results:
+//   - Mode 1 (running):       success block, exit 0
+//   - Mode 2 (error):         error block, ExitError with class-based code
+//   - Mode 3 (timeout / err): async-fallback message, exit 0
+//
+// See ws-gstack/work/agent-error-visibility.md — "Three outcome modes".
+func pollUntilTerminal(cmd *cobra.Command, sc *client.Client, agentID, op string) error {
+	deadline := time.Now().Add(pollTimeout)
+
+	// Print phase progress only in text mode. JSON mode suppresses stderr
+	// progress so consumers get exactly one object on stdout.
+	printProgress := func(phase string) {
+		if !jsonOutput {
+			fmt.Fprintf(os.Stderr, "  ⋯ %s\n", phase)
+		}
+	}
+
+	lastPhase := ""
+	consecutiveErrors := 0
+	const errorThreshold = 3 // tolerate transient blips before declaring the poll dead
+
+	for time.Now().Before(deadline) {
+		time.Sleep(pollInterval)
+
+		var agent agentResponse
+		if err := sc.Get(cmd.Context(), "/v1/agents/"+agentID, &agent); err != nil {
+			consecutiveErrors++
+			if consecutiveErrors >= errorThreshold {
+				// Poll lost connection; Mode 3 fallback. Work may still be
+				// running in sessions-api — the user just can't observe it
+				// from here.
+				renderAsyncFallback(os.Stdout, jsonOutput, agentID, capitalize(op)+" still in progress", "")
+				return nil
+			}
+			continue
+		}
+		consecutiveErrors = 0
+
+		status := ""
+		if agent.Status != nil {
+			status = *agent.Status
+		}
+
+		switch status {
+		case "running":
+			// Mode 1 — success.
+			if !jsonOutput {
+				fmt.Fprintln(os.Stderr, "  ✓ Ready")
+			}
+			printer.Print(agent, func() {})
+			return nil
+
+		case "error":
+			// Mode 2 — failure. Render the error block and exit with the
+			// class-mapped code.
+			if !jsonOutput {
+				fmt.Fprintln(os.Stderr, "  ✗ "+capitalize(op)+" failed")
+				fmt.Fprintln(os.Stderr)
+				RenderLastError(os.Stderr, agent.LastError)
+			} else {
+				printer.Print(agent, func() {})
+			}
+			return &ExitError{Code: ExitCodeFor(agent.LastError)}
+
+		case "creating", "":
+			// Still working. Report phase progress from packageStatus /
+			// channelStatus in a future pass; for now the instance status
+			// alone is enough to reassure the user something's happening.
+			phase := "Provisioning instance"
+			if phase != lastPhase {
+				printProgress(phase)
+				lastPhase = phase
+			}
+		}
+	}
+
+	// Mode 3 — poll hit the cap. Work is likely still running.
+	renderAsyncFallback(os.Stdout, jsonOutput, agentID, capitalize(op)+" still in progress", "")
+	return nil
+}
+
+// renderAgentError fetches the current agent state and renders the last_error
+// block. Used by synchronous failure paths (install) where the POST returned
+// 500 and the orchestrator has already persisted an error event. If the fetch
+// itself fails we fall through to returning the original postErr so the user
+// sees something rather than nothing.
+func renderAgentError(cmd *cobra.Command, sc *client.Client, agentID, op string) error {
+	var agent agentResponse
+	if err := sc.Get(cmd.Context(), "/v1/agents/"+agentID, &agent); err != nil {
+		return fmt.Errorf("%s failed (unable to fetch agent state: %w)", op, err)
+	}
+	if agent.LastError == nil {
+		// 500 without an event row shouldn't happen post-migration, but guard
+		// against it so the user isn't told "everything's fine" after a 500.
+		return fmt.Errorf("%s failed (no error detail available — check server logs)", op)
+	}
+	if !jsonOutput {
+		fmt.Fprintln(os.Stderr, "  ✗ "+capitalize(op)+" failed")
+		fmt.Fprintln(os.Stderr)
+		RenderLastError(os.Stderr, agent.LastError)
+	} else {
+		printer.Print(agent, func() {})
+	}
+	return &ExitError{Code: ExitCodeFor(agent.LastError)}
+}
+
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
 // ── Helpers ──
 
 func formatList(v interface{}) string {
@@ -401,10 +575,100 @@ func formatAge(isoTime string) string {
 	return time.Since(t).Truncate(time.Second).String()
 }
 
+// agent events — show the time-ordered event history for an agent. Primarily
+// surfaces error events today; as Design 003 adds recovered / health check
+// events, they flow through the same table and command.
+var agentEventsCmd = &cobra.Command{
+	Use:   "events <id>",
+	Short: "Show an agent's event history (errors, recoveries, etc.)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		limit, _ := cmd.Flags().GetInt("limit")
+		before, _ := cmd.Flags().GetString("before")
+
+		path := "/v1/agents/" + args[0] + "/events"
+		q := []string{}
+		if limit > 0 {
+			q = append(q, fmt.Sprintf("limit=%d", limit))
+		}
+		if before != "" {
+			q = append(q, "before="+before)
+		}
+		if len(q) > 0 {
+			path += "?" + strings.Join(q, "&")
+		}
+
+		var resp agentEventsResponse
+		if err := sc.Get(cmd.Context(), path, &resp); err != nil {
+			return err
+		}
+
+		printer.Print(resp, func() {
+			if len(resp.Events) == 0 {
+				fmt.Println("No events.")
+				return
+			}
+			headers := []string{"TIMESTAMP", "TYPE", "PHASE", "MESSAGE"}
+			var rows [][]string
+			for _, e := range resp.Events {
+				rows = append(rows, []string{e.At, e.Type, valueOr(e.Phase, "-"), truncate(valueOr(e.Message, ""), 80)})
+			}
+			printer.Table(headers, rows)
+		})
+		return nil
+	},
+}
+
+type agentEventRow struct {
+	ID             int    `json:"id"`
+	InstanceID     string `json:"instance_id"`
+	Type           string `json:"type"`
+	Phase          string `json:"phase"`
+	Message        string `json:"message"`
+	Code           string `json:"code"`
+	UpstreamStatus int    `json:"upstream_status"`
+	At             string `json:"at"`
+}
+
+type agentEventsResponse struct {
+	Events     []agentEventRow `json:"events"`
+	NextBefore *string         `json:"next_before"`
+}
+
+func valueOr(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n < 1 {
+		return ""
+	}
+	return s[:n-1] + "…"
+}
+
 func init() {
 	// agent create flags
 	agentCreateCmd.Flags().String("core", "", "Managed core (e.g. hermes)")
 	agentCreateCmd.Flags().StringSlice("secret", nil, "Secrets (KEY=VALUE)")
+	agentCreateCmd.Flags().Bool("no-wait", false, "Don't wait for instance provisioning; exit after agent record is created")
+
+	// agent install flags
+	agentInstallCmd.Flags().Bool("no-wait", false, "Don't wait for install orchestration to finish")
+
+	// agent events flags
+	agentEventsCmd.Flags().Int("limit", 0, "Max events to return (1-200, default 50)")
+	agentEventsCmd.Flags().String("before", "", "Return events before this ISO timestamp (for pagination)")
 
 	agentCmd.AddCommand(agentCreateCmd)
 	agentCmd.AddCommand(agentListCmd)
@@ -416,4 +680,5 @@ func init() {
 	agentCmd.AddCommand(agentInstallCmd)
 	agentCmd.AddCommand(agentUninstallCmd)
 	agentCmd.AddCommand(agentPackagesCmd)
+	agentCmd.AddCommand(agentEventsCmd)
 }

--- a/cmd/oc/internal/commands/agent.go
+++ b/cmd/oc/internal/commands/agent.go
@@ -1,9 +1,15 @@
 package commands
 
+// This file holds the parent `oc agent` cobra command, init() for flag +
+// subcommand registration, shared response types used across multiple agent
+// subcommands, and small formatting helpers. Each subcommand lives in its
+// own file: agent_create.go, agent_get.go, agent_list.go, agent_delete.go,
+// agent_connect.go, agent_packages.go, agent_events.go. Error rendering
+// helpers (LastError, ExitError, codeCatalog, RenderLastError,
+// renderAsyncFallback) live in agent_errors.go.
+
 import (
-	"bufio"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -20,8 +26,12 @@ func sessionsClient(cmd *cobra.Command) (*client.Client, error) {
 	return c, nil
 }
 
-// ── Types for sessions-api responses ──
+// ── Shared response types ──
 
+// agentResponse is the shape returned by sessions-api for both GET /v1/agents
+// (list rows) and GET /v1/agents/:id (detail). The list endpoint only
+// populates the top half; the detail endpoint additionally populates Status,
+// InstanceID, and LastError.
 type agentResponse struct {
 	ID          string      `json:"id"`
 	DisplayName string      `json:"display_name"`
@@ -44,19 +54,7 @@ type agentListResponse struct {
 	Agents []agentResponse `json:"agents"`
 }
 
-type instanceResponse struct {
-	ID        string `json:"id"`
-	AgentID   string `json:"agent_id"`
-	Status    string `json:"status"`
-	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
-}
-
-type instanceListResponse struct {
-	Instances []instanceResponse `json:"instances"`
-}
-
-// ── Commands ──
+// ── Parent command ──
 
 var agentCmd = &cobra.Command{
 	Use:   "agent",
@@ -64,477 +62,7 @@ var agentCmd = &cobra.Command{
 	Long:  "Create and manage managed agents on OpenComputer.",
 }
 
-var agentCreateCmd = &cobra.Command{
-	Use:   "create <id>",
-	Short: "Create a new managed agent",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		sc, err := sessionsClient(cmd)
-		if err != nil {
-			return err
-		}
-
-		id := args[0]
-		core, _ := cmd.Flags().GetString("core")
-		secretSlice, _ := cmd.Flags().GetStringSlice("secret")
-		noWait, _ := cmd.Flags().GetBool("no-wait")
-
-		body := map[string]interface{}{
-			"id": id,
-		}
-		if core != "" {
-			body["core"] = core
-		}
-
-		// Parse --secret KEY=VAL flags into secrets map
-		if len(secretSlice) > 0 {
-			secrets := make(map[string]string)
-			for _, s := range secretSlice {
-				parts := strings.SplitN(s, "=", 2)
-				if len(parts) == 2 {
-					secrets[parts[0]] = parts[1]
-				}
-			}
-			body["secrets"] = secrets
-		}
-
-		var agent agentResponse
-		if err := sc.Post(cmd.Context(), "/v1/agents", body, &agent); err != nil {
-			return err
-		}
-
-		// Text-mode preamble (suppressed in --json mode — scripts only want
-		// the final JSON object).
-		if !jsonOutput {
-			fmt.Fprintf(os.Stderr, "Creating agent %s", agent.ID)
-			if agent.Core != nil {
-				fmt.Fprintf(os.Stderr, " (core: %s)", *agent.Core)
-			}
-			fmt.Fprintln(os.Stderr)
-			fmt.Fprintln(os.Stderr, "  ✓ Agent record created")
-		}
-
-		// No core means no instance to wait for — skip polling.
-		if agent.Core == nil {
-			printer.Print(agent, func() {})
-			return nil
-		}
-
-		// --no-wait short-circuits into Mode 3 (async fallback). Scripts
-		// that don't want to block use this path.
-		if noWait {
-			renderAsyncFallback(os.Stdout, jsonOutput, id, "Instance provisioning", "")
-			return nil
-		}
-
-		return pollUntilTerminal(cmd, sc, id, "Instance creation")
-	},
-}
-
-var agentListCmd = &cobra.Command{
-	Use:     "list",
-	Aliases: []string{"ls"},
-	Short:   "List agents",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		sc, err := sessionsClient(cmd)
-		if err != nil {
-			return err
-		}
-
-		var resp agentListResponse
-		if err := sc.Get(cmd.Context(), "/v1/agents", &resp); err != nil {
-			return err
-		}
-
-		printer.Print(resp.Agents, func() {
-			if len(resp.Agents) == 0 {
-				fmt.Println("No agents found.")
-				return
-			}
-			headers := []string{"ID", "CORE", "CHANNELS", "PACKAGES", "CREATED"}
-			var rows [][]string
-			for _, a := range resp.Agents {
-				coreStr := "-"
-				if a.Core != nil {
-					coreStr = *a.Core
-				}
-				channels := formatList(a.Channels)
-				packages := formatList(a.Packages)
-				created := formatAge(a.CreatedAt)
-				rows = append(rows, []string{a.ID, coreStr, channels, packages, created})
-			}
-			printer.Table(headers, rows)
-		})
-		return nil
-	},
-}
-
-var agentGetCmd = &cobra.Command{
-	Use:   "get <id>",
-	Short: "Get agent details",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		sc, err := sessionsClient(cmd)
-		if err != nil {
-			return err
-		}
-
-		var agent agentResponse
-		if err := sc.Get(cmd.Context(), "/v1/agents/"+args[0], &agent); err != nil {
-			return err
-		}
-
-		// /v1/agents/:id now returns status + last_error inline, so we no
-		// longer fetch /instances separately.
-		printer.Print(agent, func() {
-			fmt.Printf("ID:        %s\n", agent.ID)
-			fmt.Printf("Name:      %s\n", agent.DisplayName)
-			coreStr := "-"
-			if agent.Core != nil {
-				coreStr = *agent.Core
-			}
-			fmt.Printf("Core:      %s\n", coreStr)
-			if agent.Status != nil {
-				fmt.Printf("Status:    %s\n", *agent.Status)
-			}
-			fmt.Printf("Channels:  %s\n", formatList(agent.Channels))
-			fmt.Printf("Packages:  %s\n", formatList(agent.Packages))
-			fmt.Printf("Created:   %s\n", agent.CreatedAt)
-
-			if agent.LastError != nil {
-				fmt.Println()
-				RenderLastError(os.Stdout, agent.LastError)
-			}
-		})
-
-		return nil
-	},
-}
-
-var agentDeleteCmd = &cobra.Command{
-	Use:   "delete <id>",
-	Short: "Delete an agent",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		sc, err := sessionsClient(cmd)
-		if err != nil {
-			return err
-		}
-
-		if err := sc.Delete(cmd.Context(), "/v1/agents/"+args[0]); err != nil {
-			return err
-		}
-
-		fmt.Printf("Agent %s deleted.\n", args[0])
-		return nil
-	},
-}
-
-var agentConnectCmd = &cobra.Command{
-	Use:   "connect <id> <channel>",
-	Short: "Connect a channel to an agent",
-	Long:  "Connect a messaging channel (e.g. telegram) to a managed agent.",
-	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		sc, err := sessionsClient(cmd)
-		if err != nil {
-			return err
-		}
-
-		agentID := args[0]
-		channel := args[1]
-
-		body := map[string]interface{}{}
-
-		if channel == "telegram" {
-			fmt.Println("To connect Telegram:")
-			fmt.Println("  1. Open Telegram and message @BotFather")
-			fmt.Println("  2. Send /newbot, choose a name and username")
-			fmt.Println("  3. Copy the bot token")
-			fmt.Println()
-			fmt.Print("Paste bot token: ")
-
-			reader := bufio.NewReader(os.Stdin)
-			token, _ := reader.ReadString('\n')
-			token = strings.TrimSpace(token)
-			if token == "" {
-				return fmt.Errorf("bot token is required")
-			}
-			body["bot_token"] = token
-		}
-
-		var result map[string]interface{}
-		if err := sc.Post(cmd.Context(), "/v1/agents/"+agentID+"/channels/"+channel, body, &result); err != nil {
-			return err
-		}
-
-		fmt.Printf("Telegram connected to %s.\n", agentID)
-		if channel == "telegram" {
-			fmt.Println("Message your bot on Telegram to start chatting.")
-		}
-		return nil
-	},
-}
-
-var agentDisconnectCmd = &cobra.Command{
-	Use:   "disconnect <id> <channel>",
-	Short: "Disconnect a channel from an agent",
-	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		sc, err := sessionsClient(cmd)
-		if err != nil {
-			return err
-		}
-
-		if err := sc.Delete(cmd.Context(), "/v1/agents/"+args[0]+"/channels/"+args[1]); err != nil {
-			return err
-		}
-
-		fmt.Printf("Channel %s disconnected from %s.\n", args[1], args[0])
-		return nil
-	},
-}
-
-var agentChannelsCmd = &cobra.Command{
-	Use:   "channels <id>",
-	Short: "List channels connected to an agent",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		sc, err := sessionsClient(cmd)
-		if err != nil {
-			return err
-		}
-
-		var resp map[string]interface{}
-		if err := sc.Get(cmd.Context(), "/v1/agents/"+args[0]+"/channels", &resp); err != nil {
-			return err
-		}
-
-		printer.Print(resp, func() {
-			channels := formatList(resp["channels"])
-			if channels == "-" {
-				fmt.Println("No channels connected.")
-			} else {
-				fmt.Printf("Channels: %s\n", channels)
-			}
-		})
-		return nil
-	},
-}
-
-var agentInstallCmd = &cobra.Command{
-	Use:   "install <id> <package>",
-	Short: "Install a package on an agent",
-	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		sc, err := sessionsClient(cmd)
-		if err != nil {
-			return err
-		}
-
-		agentID := args[0]
-		pkg := args[1]
-		noWait, _ := cmd.Flags().GetBool("no-wait")
-
-		if !jsonOutput {
-			fmt.Fprintf(os.Stderr, "Installing %s on %s\n", pkg, agentID)
-		}
-
-		// sessions-api returns 500 when install orchestration fails
-		// synchronously. A successful 200 means the whole flow completed.
-		// The orchestrator writes per-phase events to agent_events; we
-		// surface them by polling and rendering last_error on error.
-		var result map[string]interface{}
-		postErr := sc.Post(cmd.Context(), "/v1/agents/"+agentID+"/packages/"+pkg, nil, &result)
-
-		if postErr == nil {
-			if !jsonOutput {
-				fmt.Fprintf(os.Stderr, "  ✓ %s installed\n", pkg)
-			}
-			if jsonOutput {
-				_ = result // suppress unused warning when we don't render below
-				printer.PrintJSON(result)
-			}
-			return nil
-		}
-
-		// 500 from the orchestrator — the event is already written. --no-wait
-		// callers get the async fallback because they opted out of waiting;
-		// otherwise fetch the latest state to render the error block.
-		if noWait {
-			renderAsyncFallback(os.Stdout, jsonOutput, agentID, "Package install", postErr.Error())
-			return nil
-		}
-		return renderAgentError(cmd, sc, agentID, "Install")
-	},
-}
-
-var agentUninstallCmd = &cobra.Command{
-	Use:   "uninstall <id> <package>",
-	Short: "Uninstall a package from an agent",
-	Args:  cobra.ExactArgs(2),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		sc, err := sessionsClient(cmd)
-		if err != nil {
-			return err
-		}
-
-		if err := sc.Delete(cmd.Context(), "/v1/agents/"+args[0]+"/packages/"+args[1]); err != nil {
-			return err
-		}
-
-		fmt.Printf("Package %s uninstalled from %s.\n", args[1], args[0])
-		return nil
-	},
-}
-
-var agentPackagesCmd = &cobra.Command{
-	Use:   "packages <id>",
-	Short: "List packages installed on an agent",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		sc, err := sessionsClient(cmd)
-		if err != nil {
-			return err
-		}
-
-		var resp map[string]interface{}
-		if err := sc.Get(cmd.Context(), "/v1/agents/"+args[0]+"/packages", &resp); err != nil {
-			return err
-		}
-
-		printer.Print(resp, func() {
-			packages := formatList(resp["packages"])
-			if packages == "-" {
-				fmt.Println("No packages installed.")
-			} else {
-				fmt.Printf("Packages: %s\n", packages)
-			}
-		})
-		return nil
-	},
-}
-
-// ── Polling + error-state rendering ──
-
-// Poll cadence for async operations. 2s is fast enough that humans don't
-// notice, slow enough not to hammer the API. The 180s cap is a generous
-// bound on "it's almost certainly still working" before falling back to
-// the async message.
-const (
-	pollInterval = 2 * time.Second
-	pollTimeout  = 180 * time.Second
-)
-
-// pollUntilTerminal polls GET /v1/agents/:id until status reaches a terminal
-// state (running / error), the deadline hits, or a persistent network error
-// occurs. One of three Mode outcomes results:
-//   - Mode 1 (running):       success block, exit 0
-//   - Mode 2 (error):         error block, ExitError with class-based code
-//   - Mode 3 (timeout / err): async-fallback message, exit 0
-//
-// See ws-gstack/work/agent-error-visibility.md — "Three outcome modes".
-func pollUntilTerminal(cmd *cobra.Command, sc *client.Client, agentID, op string) error {
-	deadline := time.Now().Add(pollTimeout)
-
-	// Print phase progress only in text mode. JSON mode suppresses stderr
-	// progress so consumers get exactly one object on stdout.
-	printProgress := func(phase string) {
-		if !jsonOutput {
-			fmt.Fprintf(os.Stderr, "  ⋯ %s\n", phase)
-		}
-	}
-
-	lastPhase := ""
-	consecutiveErrors := 0
-	const errorThreshold = 3 // tolerate transient blips before declaring the poll dead
-
-	for time.Now().Before(deadline) {
-		time.Sleep(pollInterval)
-
-		var agent agentResponse
-		if err := sc.Get(cmd.Context(), "/v1/agents/"+agentID, &agent); err != nil {
-			consecutiveErrors++
-			if consecutiveErrors >= errorThreshold {
-				// Poll lost connection; Mode 3 fallback. Work may still be
-				// running in sessions-api — the user just can't observe it
-				// from here.
-				renderAsyncFallback(os.Stdout, jsonOutput, agentID, op+" still in progress", "")
-				return nil
-			}
-			continue
-		}
-		consecutiveErrors = 0
-
-		status := ""
-		if agent.Status != nil {
-			status = *agent.Status
-		}
-
-		switch status {
-		case "running":
-			// Mode 1 — success.
-			if !jsonOutput {
-				fmt.Fprintln(os.Stderr, "  ✓ Ready")
-			}
-			printer.Print(agent, func() {})
-			return nil
-
-		case "error":
-			// Mode 2 — failure. Render the error block and exit with the
-			// class-mapped code.
-			if !jsonOutput {
-				fmt.Fprintln(os.Stderr, "  ✗ "+op+" failed")
-				fmt.Fprintln(os.Stderr)
-				RenderLastError(os.Stderr, agent.LastError)
-			} else {
-				printer.Print(agent, func() {})
-			}
-			return &ExitError{Code: ExitCodeFor(agent.LastError)}
-
-		case "creating", "":
-			// Still working. Report phase progress from packageStatus /
-			// channelStatus in a future pass; for now the instance status
-			// alone is enough to reassure the user something's happening.
-			phase := "Provisioning instance"
-			if phase != lastPhase {
-				printProgress(phase)
-				lastPhase = phase
-			}
-		}
-	}
-
-	// Mode 3 — poll hit the cap. Work is likely still running.
-	renderAsyncFallback(os.Stdout, jsonOutput, agentID, op+" still in progress", "")
-	return nil
-}
-
-// renderAgentError fetches the current agent state and renders the last_error
-// block. Used by synchronous failure paths (install) where the POST returned
-// 500 and the orchestrator has already persisted an error event. If the fetch
-// itself fails we fall through to returning the original postErr so the user
-// sees something rather than nothing.
-func renderAgentError(cmd *cobra.Command, sc *client.Client, agentID, op string) error {
-	var agent agentResponse
-	if err := sc.Get(cmd.Context(), "/v1/agents/"+agentID, &agent); err != nil {
-		return fmt.Errorf("%s failed (unable to fetch agent state: %w)", op, err)
-	}
-	if agent.LastError == nil {
-		// 500 without an event row shouldn't happen post-migration, but guard
-		// against it so the user isn't told "everything's fine" after a 500.
-		return fmt.Errorf("%s failed (no error detail available — check server logs)", op)
-	}
-	if !jsonOutput {
-		fmt.Fprintln(os.Stderr, "  ✗ "+op+" failed")
-		fmt.Fprintln(os.Stderr)
-		RenderLastError(os.Stderr, agent.LastError)
-	} else {
-		printer.Print(agent, func() {})
-	}
-	return &ExitError{Code: ExitCodeFor(agent.LastError)}
-}
-
-// ── Helpers ──
+// ── Formatting helpers ──
 
 func formatList(v interface{}) string {
 	if v == nil {
@@ -568,101 +96,20 @@ func formatAge(isoTime string) string {
 	return time.Since(t).Truncate(time.Second).String()
 }
 
-// agent events — show the time-ordered event history for an agent. Primarily
-// surfaces error events today; as Design 003 adds recovered / health check
-// events, they flow through the same table and command.
-var agentEventsCmd = &cobra.Command{
-	Use:   "events <id>",
-	Short: "Show an agent's event history (errors, recoveries, etc.)",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		sc, err := sessionsClient(cmd)
-		if err != nil {
-			return err
-		}
-
-		limit, _ := cmd.Flags().GetInt("limit")
-		before, _ := cmd.Flags().GetString("before")
-
-		path := "/v1/agents/" + args[0] + "/events"
-		q := []string{}
-		if limit > 0 {
-			q = append(q, fmt.Sprintf("limit=%d", limit))
-		}
-		if before != "" {
-			q = append(q, "before="+before)
-		}
-		if len(q) > 0 {
-			path += "?" + strings.Join(q, "&")
-		}
-
-		var resp agentEventsResponse
-		if err := sc.Get(cmd.Context(), path, &resp); err != nil {
-			return err
-		}
-
-		printer.Print(resp, func() {
-			if len(resp.Events) == 0 {
-				fmt.Println("No events.")
-				return
-			}
-			headers := []string{"TIMESTAMP", "TYPE", "PHASE", "MESSAGE"}
-			var rows [][]string
-			for _, e := range resp.Events {
-				rows = append(rows, []string{e.At, e.Type, valueOr(e.Phase, "-"), truncate(valueOr(e.Message, ""), 80)})
-			}
-			printer.Table(headers, rows)
-		})
-		return nil
-	},
-}
-
-type agentEventRow struct {
-	ID             int    `json:"id"`
-	InstanceID     string `json:"instance_id"`
-	Type           string `json:"type"`
-	Phase          string `json:"phase"`
-	Message        string `json:"message"`
-	Code           string `json:"code"`
-	UpstreamStatus int    `json:"upstream_status"`
-	At             string `json:"at"`
-}
-
-type agentEventsResponse struct {
-	Events     []agentEventRow `json:"events"`
-	NextBefore *string         `json:"next_before"`
-}
-
-func valueOr(s, fallback string) string {
-	if s == "" {
-		return fallback
-	}
-	return s
-}
-
-func truncate(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	if n < 1 {
-		return ""
-	}
-	return s[:n-1] + "…"
-}
+// ── Registration ──
 
 func init() {
-	// agent create flags
+	// Per-subcommand flags
 	agentCreateCmd.Flags().String("core", "", "Managed core (e.g. hermes)")
 	agentCreateCmd.Flags().StringSlice("secret", nil, "Secrets (KEY=VALUE)")
 	agentCreateCmd.Flags().Bool("no-wait", false, "Don't wait for instance provisioning; exit after agent record is created")
 
-	// agent install flags
 	agentInstallCmd.Flags().Bool("no-wait", false, "Don't wait for install orchestration to finish")
 
-	// agent events flags
 	agentEventsCmd.Flags().Int("limit", 0, "Max events to return (1-200, default 50)")
 	agentEventsCmd.Flags().String("before", "", "Return events before this ISO timestamp (for pagination)")
 
+	// Subcommand registration — each is defined in its own file in this package.
 	agentCmd.AddCommand(agentCreateCmd)
 	agentCmd.AddCommand(agentListCmd)
 	agentCmd.AddCommand(agentGetCmd)

--- a/cmd/oc/internal/commands/agent.go
+++ b/cmd/oc/internal/commands/agent.go
@@ -127,7 +127,7 @@ var agentCreateCmd = &cobra.Command{
 			return nil
 		}
 
-		return pollUntilTerminal(cmd, sc, id, "instance")
+		return pollUntilTerminal(cmd, sc, id, "Instance creation")
 	},
 }
 
@@ -365,7 +365,7 @@ var agentInstallCmd = &cobra.Command{
 			renderAsyncFallback(os.Stdout, jsonOutput, agentID, "Package install", postErr.Error())
 			return nil
 		}
-		return renderAgentError(cmd, sc, agentID, "install")
+		return renderAgentError(cmd, sc, agentID, "Install")
 	},
 }
 
@@ -459,7 +459,7 @@ func pollUntilTerminal(cmd *cobra.Command, sc *client.Client, agentID, op string
 				// Poll lost connection; Mode 3 fallback. Work may still be
 				// running in sessions-api — the user just can't observe it
 				// from here.
-				renderAsyncFallback(os.Stdout, jsonOutput, agentID, capitalize(op)+" still in progress", "")
+				renderAsyncFallback(os.Stdout, jsonOutput, agentID, op+" still in progress", "")
 				return nil
 			}
 			continue
@@ -484,7 +484,7 @@ func pollUntilTerminal(cmd *cobra.Command, sc *client.Client, agentID, op string
 			// Mode 2 — failure. Render the error block and exit with the
 			// class-mapped code.
 			if !jsonOutput {
-				fmt.Fprintln(os.Stderr, "  ✗ "+capitalize(op)+" failed")
+				fmt.Fprintln(os.Stderr, "  ✗ "+op+" failed")
 				fmt.Fprintln(os.Stderr)
 				RenderLastError(os.Stderr, agent.LastError)
 			} else {
@@ -505,7 +505,7 @@ func pollUntilTerminal(cmd *cobra.Command, sc *client.Client, agentID, op string
 	}
 
 	// Mode 3 — poll hit the cap. Work is likely still running.
-	renderAsyncFallback(os.Stdout, jsonOutput, agentID, capitalize(op)+" still in progress", "")
+	renderAsyncFallback(os.Stdout, jsonOutput, agentID, op+" still in progress", "")
 	return nil
 }
 
@@ -525,20 +525,13 @@ func renderAgentError(cmd *cobra.Command, sc *client.Client, agentID, op string)
 		return fmt.Errorf("%s failed (no error detail available — check server logs)", op)
 	}
 	if !jsonOutput {
-		fmt.Fprintln(os.Stderr, "  ✗ "+capitalize(op)+" failed")
+		fmt.Fprintln(os.Stderr, "  ✗ "+op+" failed")
 		fmt.Fprintln(os.Stderr)
 		RenderLastError(os.Stderr, agent.LastError)
 	} else {
 		printer.Print(agent, func() {})
 	}
 	return &ExitError{Code: ExitCodeFor(agent.LastError)}
-}
-
-func capitalize(s string) string {
-	if s == "" {
-		return s
-	}
-	return strings.ToUpper(s[:1]) + s[1:]
 }
 
 // ── Helpers ──

--- a/cmd/oc/internal/commands/agent_connect.go
+++ b/cmd/oc/internal/commands/agent_connect.go
@@ -1,0 +1,106 @@
+package commands
+
+// Channel lifecycle: connect, disconnect, list. The Telegram case prompts
+// interactively for a bot token since there's no --bot-token flag yet
+// (tracked as a launch-prep item).
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var agentConnectCmd = &cobra.Command{
+	Use:   "connect <id> <channel>",
+	Short: "Connect a channel to an agent",
+	Long:  "Connect a messaging channel (e.g. telegram) to a managed agent.",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		agentID := args[0]
+		channel := args[1]
+
+		body := map[string]interface{}{}
+
+		if channel == "telegram" {
+			fmt.Println("To connect Telegram:")
+			fmt.Println("  1. Open Telegram and message @BotFather")
+			fmt.Println("  2. Send /newbot, choose a name and username")
+			fmt.Println("  3. Copy the bot token")
+			fmt.Println()
+			fmt.Print("Paste bot token: ")
+
+			reader := bufio.NewReader(os.Stdin)
+			token, _ := reader.ReadString('\n')
+			token = strings.TrimSpace(token)
+			if token == "" {
+				return fmt.Errorf("bot token is required")
+			}
+			body["bot_token"] = token
+		}
+
+		var result map[string]interface{}
+		if err := sc.Post(cmd.Context(), "/v1/agents/"+agentID+"/channels/"+channel, body, &result); err != nil {
+			return err
+		}
+
+		fmt.Printf("Telegram connected to %s.\n", agentID)
+		if channel == "telegram" {
+			fmt.Println("Message your bot on Telegram to start chatting.")
+		}
+		return nil
+	},
+}
+
+var agentDisconnectCmd = &cobra.Command{
+	Use:   "disconnect <id> <channel>",
+	Short: "Disconnect a channel from an agent",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		if err := sc.Delete(cmd.Context(), "/v1/agents/"+args[0]+"/channels/"+args[1]); err != nil {
+			return err
+		}
+
+		fmt.Printf("Channel %s disconnected from %s.\n", args[1], args[0])
+		return nil
+	},
+}
+
+var agentChannelsCmd = &cobra.Command{
+	Use:   "channels <id>",
+	Short: "List channels connected to an agent",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		var resp map[string]interface{}
+		if err := sc.Get(cmd.Context(), "/v1/agents/"+args[0]+"/channels", &resp); err != nil {
+			return err
+		}
+
+		printer.Print(resp, func() {
+			channels := formatList(resp["channels"])
+			if channels == "-" {
+				fmt.Println("No channels connected.")
+			} else {
+				fmt.Printf("Channels: %s\n", channels)
+			}
+		})
+		return nil
+	},
+}

--- a/cmd/oc/internal/commands/agent_create.go
+++ b/cmd/oc/internal/commands/agent_create.go
@@ -1,0 +1,172 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/opensandbox/opensandbox/cmd/oc/internal/client"
+	"github.com/spf13/cobra"
+)
+
+var agentCreateCmd = &cobra.Command{
+	Use:   "create <id>",
+	Short: "Create a new managed agent",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		id := args[0]
+		core, _ := cmd.Flags().GetString("core")
+		secretSlice, _ := cmd.Flags().GetStringSlice("secret")
+		noWait, _ := cmd.Flags().GetBool("no-wait")
+
+		body := map[string]interface{}{
+			"id": id,
+		}
+		if core != "" {
+			body["core"] = core
+		}
+
+		// Parse --secret KEY=VAL flags into secrets map
+		if len(secretSlice) > 0 {
+			secrets := make(map[string]string)
+			for _, s := range secretSlice {
+				parts := strings.SplitN(s, "=", 2)
+				if len(parts) == 2 {
+					secrets[parts[0]] = parts[1]
+				}
+			}
+			body["secrets"] = secrets
+		}
+
+		var agent agentResponse
+		if err := sc.Post(cmd.Context(), "/v1/agents", body, &agent); err != nil {
+			return err
+		}
+
+		// Text-mode preamble (suppressed in --json mode — scripts only want
+		// the final JSON object).
+		if !jsonOutput {
+			fmt.Fprintf(os.Stderr, "Creating agent %s", agent.ID)
+			if agent.Core != nil {
+				fmt.Fprintf(os.Stderr, " (core: %s)", *agent.Core)
+			}
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "  ✓ Agent record created")
+		}
+
+		// No core means no instance to wait for — skip polling.
+		if agent.Core == nil {
+			printer.Print(agent, func() {})
+			return nil
+		}
+
+		// --no-wait short-circuits into Mode 3 (async fallback). Scripts
+		// that don't want to block use this path.
+		if noWait {
+			renderAsyncFallback(os.Stdout, jsonOutput, id, "Instance provisioning", "")
+			return nil
+		}
+
+		return pollUntilTerminal(cmd, sc, id, "Instance creation")
+	},
+}
+
+// ── Polling ──
+
+// Poll cadence for async operations. 2s is fast enough that humans don't
+// notice, slow enough not to hammer the API. The 180s cap is a generous
+// bound on "it's almost certainly still working" before falling back to
+// the async message.
+const (
+	pollInterval = 2 * time.Second
+	pollTimeout  = 180 * time.Second
+)
+
+// pollUntilTerminal polls GET /v1/agents/:id until status reaches a terminal
+// state (running / error), the deadline hits, or a persistent network error
+// occurs. One of three Mode outcomes results:
+//   - Mode 1 (running):       success block, exit 0
+//   - Mode 2 (error):         error block, ExitError with class-based code
+//   - Mode 3 (timeout / err): async-fallback message, exit 0
+//
+// See ws-gstack/work/agent-error-visibility.md — "Three outcome modes".
+func pollUntilTerminal(cmd *cobra.Command, sc *client.Client, agentID, op string) error {
+	deadline := time.Now().Add(pollTimeout)
+
+	// Print phase progress only in text mode. JSON mode suppresses stderr
+	// progress so consumers get exactly one object on stdout.
+	printProgress := func(phase string) {
+		if !jsonOutput {
+			fmt.Fprintf(os.Stderr, "  ⋯ %s\n", phase)
+		}
+	}
+
+	lastPhase := ""
+	consecutiveErrors := 0
+	const errorThreshold = 3 // tolerate transient blips before declaring the poll dead
+
+	for time.Now().Before(deadline) {
+		time.Sleep(pollInterval)
+
+		var agent agentResponse
+		if err := sc.Get(cmd.Context(), "/v1/agents/"+agentID, &agent); err != nil {
+			consecutiveErrors++
+			if consecutiveErrors >= errorThreshold {
+				// Poll lost connection; Mode 3 fallback. Work may still be
+				// running in sessions-api — the user just can't observe it
+				// from here.
+				renderAsyncFallback(os.Stdout, jsonOutput, agentID, op+" still in progress", "")
+				return nil
+			}
+			continue
+		}
+		consecutiveErrors = 0
+
+		status := ""
+		if agent.Status != nil {
+			status = *agent.Status
+		}
+
+		switch status {
+		case "running":
+			// Mode 1 — success.
+			if !jsonOutput {
+				fmt.Fprintln(os.Stderr, "  ✓ Ready")
+			}
+			printer.Print(agent, func() {})
+			return nil
+
+		case "error":
+			// Mode 2 — failure. Render the error block and exit with the
+			// class-mapped code.
+			if !jsonOutput {
+				fmt.Fprintln(os.Stderr, "  ✗ "+op+" failed")
+				fmt.Fprintln(os.Stderr)
+				RenderLastError(os.Stderr, agent.LastError)
+			} else {
+				printer.Print(agent, func() {})
+			}
+			return &ExitError{Code: ExitCodeFor(agent.LastError)}
+
+		case "creating", "":
+			// Still working. Report phase progress from packageStatus /
+			// channelStatus in a future pass; for now the instance status
+			// alone is enough to reassure the user something's happening.
+			phase := "Provisioning instance"
+			if phase != lastPhase {
+				printProgress(phase)
+				lastPhase = phase
+			}
+		}
+	}
+
+	// Mode 3 — poll hit the cap. Work is likely still running.
+	renderAsyncFallback(os.Stdout, jsonOutput, agentID, op+" still in progress", "")
+	return nil
+}

--- a/cmd/oc/internal/commands/agent_delete.go
+++ b/cmd/oc/internal/commands/agent_delete.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var agentDeleteCmd = &cobra.Command{
+	Use:   "delete <id>",
+	Short: "Delete an agent",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		if err := sc.Delete(cmd.Context(), "/v1/agents/"+args[0]); err != nil {
+			return err
+		}
+
+		fmt.Printf("Agent %s deleted.\n", args[0])
+		return nil
+	},
+}

--- a/cmd/oc/internal/commands/agent_errors.go
+++ b/cmd/oc/internal/commands/agent_errors.go
@@ -1,5 +1,13 @@
 package commands
 
+// Error-rendering helpers for agent commands: LastError / ExitError types,
+// the code→class catalog (mirrored from sessions-api/src/lib/error-codes.ts),
+// and the two renderers used by `agent get`, `agent create`, and
+// `agent install` (RenderLastError + renderAsyncFallback).
+//
+// Scope: agent commands only. If another command family ever needs to render
+// classified errors, lift this into a shared package.
+
 import (
 	"encoding/json"
 	"fmt"
@@ -130,11 +138,11 @@ func RenderLastError(w io.Writer, le *LastError) {
 // poll timeout, poll network error). Scripts branch on the `async` boolean
 // to decide whether to poll.
 type asyncFallback struct {
-	ID         string `json:"id"`
-	Status     string `json:"status"`
-	Async      bool   `json:"async"`
-	CheckWith  string `json:"check_with"`
-	Note       string `json:"note,omitempty"`
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	Async     bool   `json:"async"`
+	CheckWith string `json:"check_with"`
+	Note      string `json:"note,omitempty"`
 }
 
 // renderAsyncFallback prints the "work is continuing in background" message

--- a/cmd/oc/internal/commands/agent_events.go
+++ b/cmd/oc/internal/commands/agent_events.go
@@ -1,0 +1,91 @@
+package commands
+
+// `oc agent events <id>` — time-ordered event history for an agent.
+// Primarily surfaces error events today; as Design 003 adds recovered /
+// health_check_failed events, they flow through the same table and command.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var agentEventsCmd = &cobra.Command{
+	Use:   "events <id>",
+	Short: "Show an agent's event history (errors, recoveries, etc.)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		limit, _ := cmd.Flags().GetInt("limit")
+		before, _ := cmd.Flags().GetString("before")
+
+		path := "/v1/agents/" + args[0] + "/events"
+		q := []string{}
+		if limit > 0 {
+			q = append(q, fmt.Sprintf("limit=%d", limit))
+		}
+		if before != "" {
+			q = append(q, "before="+before)
+		}
+		if len(q) > 0 {
+			path += "?" + strings.Join(q, "&")
+		}
+
+		var resp agentEventsResponse
+		if err := sc.Get(cmd.Context(), path, &resp); err != nil {
+			return err
+		}
+
+		printer.Print(resp, func() {
+			if len(resp.Events) == 0 {
+				fmt.Println("No events.")
+				return
+			}
+			headers := []string{"TIMESTAMP", "TYPE", "PHASE", "MESSAGE"}
+			var rows [][]string
+			for _, e := range resp.Events {
+				rows = append(rows, []string{e.At, e.Type, valueOr(e.Phase, "-"), truncate(valueOr(e.Message, ""), 80)})
+			}
+			printer.Table(headers, rows)
+		})
+		return nil
+	},
+}
+
+type agentEventRow struct {
+	ID             int    `json:"id"`
+	InstanceID     string `json:"instance_id"`
+	Type           string `json:"type"`
+	Phase          string `json:"phase"`
+	Message        string `json:"message"`
+	Code           string `json:"code"`
+	UpstreamStatus int    `json:"upstream_status"`
+	At             string `json:"at"`
+}
+
+type agentEventsResponse struct {
+	Events     []agentEventRow `json:"events"`
+	NextBefore *string         `json:"next_before"`
+}
+
+func valueOr(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n < 1 {
+		return ""
+	}
+	return s[:n-1] + "…"
+}

--- a/cmd/oc/internal/commands/agent_get.go
+++ b/cmd/oc/internal/commands/agent_get.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var agentGetCmd = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Get agent details",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		var agent agentResponse
+		if err := sc.Get(cmd.Context(), "/v1/agents/"+args[0], &agent); err != nil {
+			return err
+		}
+
+		// /v1/agents/:id returns status + last_error inline so we no longer
+		// need a second call to /instances.
+		printer.Print(agent, func() {
+			fmt.Printf("ID:        %s\n", agent.ID)
+			fmt.Printf("Name:      %s\n", agent.DisplayName)
+			coreStr := "-"
+			if agent.Core != nil {
+				coreStr = *agent.Core
+			}
+			fmt.Printf("Core:      %s\n", coreStr)
+			if agent.Status != nil {
+				fmt.Printf("Status:    %s\n", *agent.Status)
+			}
+			fmt.Printf("Channels:  %s\n", formatList(agent.Channels))
+			fmt.Printf("Packages:  %s\n", formatList(agent.Packages))
+			fmt.Printf("Created:   %s\n", agent.CreatedAt)
+
+			if agent.LastError != nil {
+				fmt.Println()
+				RenderLastError(os.Stdout, agent.LastError)
+			}
+		})
+
+		return nil
+	},
+}

--- a/cmd/oc/internal/commands/agent_list.go
+++ b/cmd/oc/internal/commands/agent_list.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var agentListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List agents",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		var resp agentListResponse
+		if err := sc.Get(cmd.Context(), "/v1/agents", &resp); err != nil {
+			return err
+		}
+
+		printer.Print(resp.Agents, func() {
+			if len(resp.Agents) == 0 {
+				fmt.Println("No agents found.")
+				return
+			}
+			headers := []string{"ID", "CORE", "CHANNELS", "PACKAGES", "CREATED"}
+			var rows [][]string
+			for _, a := range resp.Agents {
+				coreStr := "-"
+				if a.Core != nil {
+					coreStr = *a.Core
+				}
+				channels := formatList(a.Channels)
+				packages := formatList(a.Packages)
+				created := formatAge(a.CreatedAt)
+				rows = append(rows, []string{a.ID, coreStr, channels, packages, created})
+			}
+			printer.Table(headers, rows)
+		})
+		return nil
+	},
+}

--- a/cmd/oc/internal/commands/agent_packages.go
+++ b/cmd/oc/internal/commands/agent_packages.go
@@ -1,0 +1,131 @@
+package commands
+
+// Package lifecycle: install, uninstall, list. Install is the only one that
+// goes through the error-visibility render path — orchestration runs
+// synchronously in sessions-api, so a 500 from the POST means we can fetch
+// the just-persisted last_error and render the block.
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/opensandbox/opensandbox/cmd/oc/internal/client"
+	"github.com/spf13/cobra"
+)
+
+var agentInstallCmd = &cobra.Command{
+	Use:   "install <id> <package>",
+	Short: "Install a package on an agent",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		agentID := args[0]
+		pkg := args[1]
+		noWait, _ := cmd.Flags().GetBool("no-wait")
+
+		if !jsonOutput {
+			fmt.Fprintf(os.Stderr, "Installing %s on %s\n", pkg, agentID)
+		}
+
+		// sessions-api returns 500 when install orchestration fails
+		// synchronously. A successful 200 means the whole flow completed.
+		// The orchestrator writes per-phase events to agent_events; we
+		// surface them by re-fetching and rendering last_error on error.
+		var result map[string]interface{}
+		postErr := sc.Post(cmd.Context(), "/v1/agents/"+agentID+"/packages/"+pkg, nil, &result)
+
+		if postErr == nil {
+			if !jsonOutput {
+				fmt.Fprintf(os.Stderr, "  ✓ %s installed\n", pkg)
+			}
+			if jsonOutput {
+				printer.PrintJSON(result)
+			}
+			return nil
+		}
+
+		// 500 from the orchestrator — the event is already written. --no-wait
+		// callers get the async fallback because they opted out of waiting;
+		// otherwise fetch the latest state to render the error block.
+		if noWait {
+			renderAsyncFallback(os.Stdout, jsonOutput, agentID, "Package install", postErr.Error())
+			return nil
+		}
+		return renderAgentError(cmd, sc, agentID, "Install")
+	},
+}
+
+var agentUninstallCmd = &cobra.Command{
+	Use:   "uninstall <id> <package>",
+	Short: "Uninstall a package from an agent",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		if err := sc.Delete(cmd.Context(), "/v1/agents/"+args[0]+"/packages/"+args[1]); err != nil {
+			return err
+		}
+
+		fmt.Printf("Package %s uninstalled from %s.\n", args[1], args[0])
+		return nil
+	},
+}
+
+var agentPackagesCmd = &cobra.Command{
+	Use:   "packages <id>",
+	Short: "List packages installed on an agent",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+
+		var resp map[string]interface{}
+		if err := sc.Get(cmd.Context(), "/v1/agents/"+args[0]+"/packages", &resp); err != nil {
+			return err
+		}
+
+		printer.Print(resp, func() {
+			packages := formatList(resp["packages"])
+			if packages == "-" {
+				fmt.Println("No packages installed.")
+			} else {
+				fmt.Printf("Packages: %s\n", packages)
+			}
+		})
+		return nil
+	},
+}
+
+// renderAgentError fetches the current agent state and renders the last_error
+// block. Used by synchronous failure paths (install) where the POST returned
+// 500 and the orchestrator has already persisted an error event. If the fetch
+// itself fails we return the original network error so the user sees
+// something rather than nothing.
+func renderAgentError(cmd *cobra.Command, sc *client.Client, agentID, op string) error {
+	var agent agentResponse
+	if err := sc.Get(cmd.Context(), "/v1/agents/"+agentID, &agent); err != nil {
+		return fmt.Errorf("%s failed (unable to fetch agent state: %w)", op, err)
+	}
+	if agent.LastError == nil {
+		// 500 without an event row shouldn't happen post-migration, but guard
+		// against it so the user isn't told "everything's fine" after a 500.
+		return fmt.Errorf("%s failed (no error detail available — check server logs)", op)
+	}
+	if !jsonOutput {
+		fmt.Fprintln(os.Stderr, "  ✗ "+op+" failed")
+		fmt.Fprintln(os.Stderr)
+		RenderLastError(os.Stderr, agent.LastError)
+	} else {
+		printer.Print(agent, func() {})
+	}
+	return &ExitError{Code: ExitCodeFor(agent.LastError)}
+}

--- a/cmd/oc/internal/commands/errors.go
+++ b/cmd/oc/internal/commands/errors.go
@@ -1,0 +1,154 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// LastError mirrors the JSON shape returned by sessions-api under
+// GET /v1/agents/:id when the backing instance is in an error state.
+// See ws-gstack/work/agent-error-visibility.md
+type LastError struct {
+	Phase          string `json:"phase"`
+	Message        string `json:"message"`
+	Code           string `json:"code"`
+	UpstreamStatus int    `json:"upstream_status,omitempty"`
+	At             string `json:"at"`
+}
+
+// errorClass determines the CLI exit code. Mirrors the `class` field of
+// sessions-api's error-codes catalog. Kept as a static mirror rather than
+// fetched from the API: the classification is UX policy, not data.
+type errorClass int
+
+const (
+	classGeneral     errorClass = 1
+	classUpstream4xx errorClass = 3
+	classConflict    errorClass = 4
+	classTransient   errorClass = 5
+)
+
+// codeCatalog maps error codes to a class + suggestion + optional docs URL.
+// Keep in sync with sessions-api/src/lib/error-codes.ts. The CLI ships its
+// own mirror so offline suggestions render even if the API doesn't return
+// them in the response (current API returns only code; suggestion/class
+// are client-side concerns).
+var codeCatalog = map[string]struct {
+	class      errorClass
+	suggestion string
+	docs       string
+}{
+	"checkpoint_org_mismatch": {
+		class: classUpstream4xx,
+		suggestion: "Your OC API key's org doesn't own this core's checkpoint.\n" +
+			"Contact an admin to share it, or use an API key from the owning org.",
+		docs: "https://docs.opencomputer.dev/errors/checkpoint-org",
+	},
+	"telegram_unauthorized": {
+		class:      classUpstream4xx,
+		suggestion: "Telegram rejected the bot token. Verify the token at https://t.me/BotFather.",
+	},
+	"sandbox_provision_timeout": {
+		class: classTransient,
+		suggestion: "Sandbox provisioning timed out. The OC worker may be unhealthy.\n" +
+			"Try `oc agent delete <id>` then recreate — you may land on a different worker.",
+	},
+	"git_clone_failed": {
+		class: classTransient,
+		suggestion: "Package clone failed. The sandbox worker may have no outbound internet.\n" +
+			"Delete and recreate the agent; you may land on a working worker.",
+	},
+}
+
+// ExitError signals the desired process exit code. main.go inspects this
+// to choose between 1 (general), 3 (upstream 4xx), 4 (conflict),
+// 5 (transient). The error message is expected to already be rendered
+// when ExitError is returned — main will not re-print it.
+type ExitError struct{ Code int }
+
+func (e *ExitError) Error() string { return "" }
+
+// ExitCodeFor classifies a LastError into an exit code. Falls back to
+// classGeneral (1) for unknown codes.
+func ExitCodeFor(le *LastError) int {
+	if le == nil {
+		return 0
+	}
+	if entry, ok := codeCatalog[le.Code]; ok {
+		return int(entry.class)
+	}
+	return int(classGeneral)
+}
+
+// RenderLastError writes the standard multi-line error block to w.
+// Used by both `agent get` (status block) and the poll loop in
+// create/install (failure case). One shared renderer keeps the CLI's
+// error voice consistent wherever errors appear.
+func RenderLastError(w io.Writer, le *LastError) {
+	if le == nil {
+		return
+	}
+
+	title := "Last error"
+	if t, err := time.Parse(time.RFC3339Nano, le.At); err == nil {
+		title = fmt.Sprintf("Last error (%s ago)", time.Since(t).Truncate(time.Second))
+	}
+
+	fmt.Fprintf(w, "%s:\n", title)
+	fmt.Fprintf(w, "  Phase:  %s\n", le.Phase)
+
+	reason := le.Message
+	if le.UpstreamStatus != 0 {
+		reason = fmt.Sprintf("%s (%d from upstream)", reason, le.UpstreamStatus)
+	}
+	fmt.Fprintf(w, "  Reason: %s\n", reason)
+
+	if entry, ok := codeCatalog[le.Code]; ok {
+		fmt.Fprintln(w)
+		for _, line := range strings.Split(entry.suggestion, "\n") {
+			fmt.Fprintf(w, "  %s\n", line)
+		}
+		if entry.docs != "" {
+			fmt.Fprintf(w, "  See: %s\n", entry.docs)
+		}
+	}
+}
+
+// asyncFallback is the JSON shape emitted for Mode 3 outcomes (--no-wait,
+// poll timeout, poll network error). Scripts branch on the `async` boolean
+// to decide whether to poll.
+type asyncFallback struct {
+	ID         string `json:"id"`
+	Status     string `json:"status"`
+	Async      bool   `json:"async"`
+	CheckWith  string `json:"check_with"`
+	Note       string `json:"note,omitempty"`
+}
+
+// renderAsyncFallback prints the "work is continuing in background" message
+// (Mode 3). Shared across --no-wait, poll timeout, and poll error so the
+// user sees the same next step regardless of trigger.
+func renderAsyncFallback(stdoutW io.Writer, jsonOut bool, id, op, note string) {
+	if jsonOut {
+		enc := json.NewEncoder(stdoutW)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(asyncFallback{
+			ID:        id,
+			Status:    "creating",
+			Async:     true,
+			CheckWith: "oc agent get " + id,
+			Note:      note,
+		})
+		return
+	}
+
+	fmt.Fprintf(stdoutW, "  ⋯ %s in background (typically 30-60s).\n", op)
+	if note != "" {
+		fmt.Fprintf(stdoutW, "    %s\n", note)
+	}
+	fmt.Fprintln(stdoutW)
+	fmt.Fprintf(stdoutW, "To check status:  oc agent get %s\n", id)
+}

--- a/cmd/oc/internal/commands/errors.go
+++ b/cmd/oc/internal/commands/errors.go
@@ -47,6 +47,12 @@ var codeCatalog = map[string]struct {
 			"Contact an admin to share it, or use an API key from the owning org.",
 		docs: "https://docs.opencomputer.dev/errors/checkpoint-org",
 	},
+	"checkpoint_not_found": {
+		class: classUpstream4xx,
+		suggestion: "The checkpoint configured for this core no longer exists on OC.\n" +
+			"It may have been deleted or replaced. Contact the operator to\n" +
+			"rebuild the checkpoint and update the sessions-api config.",
+	},
 	"telegram_unauthorized": {
 		class:      classUpstream4xx,
 		suggestion: "Telegram rejected the bot token. Verify the token at https://t.me/BotFather.",
@@ -100,7 +106,10 @@ func RenderLastError(w io.Writer, le *LastError) {
 	fmt.Fprintf(w, "%s:\n", title)
 	fmt.Fprintf(w, "  Phase:  %s\n", le.Phase)
 
-	reason := le.Message
+	// Upstream response bodies frequently carry trailing whitespace / newlines
+	// that survive the round-trip. Normalize before appending the upstream
+	// status so the block renders on one clean line.
+	reason := strings.TrimSpace(le.Message)
 	if le.UpstreamStatus != 0 {
 		reason = fmt.Sprintf("%s (%d from upstream)", reason, le.UpstreamStatus)
 	}

--- a/cmd/oc/main.go
+++ b/cmd/oc/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -9,6 +10,13 @@ import (
 
 func main() {
 	if err := commands.Execute(); err != nil {
+		// An ExitError means the command already rendered its output and
+		// just wants a specific exit code (e.g. 3 for user-fixable upstream
+		// errors, 5 for transient). Don't reprint the message.
+		var exit *commands.ExitError
+		if errors.As(err, &exit) {
+			os.Exit(exit.Code)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary

- Renders structured error blocks (phase / reason / suggestion) on `oc agent get`, `create`, and `install` failures instead of the previous opaque `Status: error`.
- Blocks by default on `agent create`/`install` with streamed phase progress; one shared async-fallback message covers `--no-wait`, poll timeout, and poll network error (all exit 0, with a concrete next command).
- Adds `oc agent events <id>` for the full time-ordered event history.
- Exit codes encode error class: 3 (upstream 4xx), 4 (conflict), 5 (transient), 1 (general) — driven by a catalog that mirrors sessions-api's `error-codes.ts`.

Paired sessions-api change already merged to main + deployed to Fly: https://github.com/diggerhq/sessions-api/commit/caf6301 (adds `agent_events` table, enriches `GET /v1/agents/:id` with `status` + `last_error`, adds `GET /v1/agents/:id/events`).

Design doc: [ws-gstack/work/agent-error-visibility.md](https://github.com/diggerhq/ws-gstack/blob/main/work/agent-error-visibility.md)

## Verified live against prod

- Mode 2 text: `oc agent create` → sandbox fails → full error block with `(404 from upstream)`, suggestion, exit 3.
- Mode 2 JSON (`--json`): single object with nested `last_error`, exit 3.
- Mode 3 `--no-wait --json`: `{"async": true, "check_with": "oc agent get X"}`, exit 0.
- `agent get` on errored agent: renders the same block inline.
- `agent events` and `agent events --json`: event rows persisted and returned, `code` populated by server-side classifier.

## Test plan

- [ ] Build: `make build-oc`
- [ ] `oc agent get <running-agent>` — should include `Status: running` line, no error block
- [ ] `oc agent get <broken-agent>` — should render error block with phase + suggestion
- [ ] `oc agent create <id> --core hermes` — blocks until terminal, streams progress to stderr, exit code reflects outcome
- [ ] `oc agent create <id> --core hermes --no-wait` — exits 0 immediately with async-fallback message
- [ ] `oc agent create <id> --core hermes --json` — emits one JSON object, no stderr progress
- [ ] `oc agent events <id>` — prints table (text) / array (`--json`)
- [ ] Exit codes: 0 success, 3 for `checkpoint_org_mismatch` / `checkpoint_not_found`, 5 for transient timeouts, 1 for unmatched errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)