### PR TITLE
oc agent: CLI must-fix pack (--core required, --bot-token, --yes, exit codes)

### DIFF
--- a/cmd/oc/internal/commands/agent.go
+++ b/cmd/oc/internal/commands/agent.go
@@ -93,7 +93,17 @@ type agentListResponse struct {
 var agentCmd = &cobra.Command{
 	Use:   "agent",
 	Short: "Manage agents",
-	Long:  "Create and manage managed agents on OpenComputer.",
+	Long: "Create and manage managed agents on OpenComputer.\n\n" +
+		"Exit codes:\n" +
+		"  0  Success\n" +
+		"  1  General error (unclassified failures, bad args/flags)\n" +
+		"  3  Upstream 4xx (not found, unauthorized, org mismatch)\n" +
+		"  4  Conflict (already exists, invalid state)\n" +
+		"  5  Transient error (timeout, retry-safe)\n\n" +
+		"Classes 3-5 are emitted by create/install/get when the failure\n" +
+		"carries a known code. Other commands exit 0 on success, 1 on\n" +
+		"failure. Agent callers can branch on the class to decide retry\n" +
+		"vs surface-to-user vs give-up.",
 }
 
 // ── Formatting helpers ──

--- a/cmd/oc/internal/commands/agent.go
+++ b/cmd/oc/internal/commands/agent.go
@@ -100,7 +100,8 @@ func formatAge(isoTime string) string {
 
 func init() {
 	// Per-subcommand flags
-	agentCreateCmd.Flags().String("core", "", "Managed core (e.g. hermes)")
+	agentCreateCmd.Flags().String("core", "", "Managed core (required, e.g. hermes|openclaw)")
+	_ = agentCreateCmd.MarkFlagRequired("core")
 	agentCreateCmd.Flags().StringSlice("secret", nil, "Secrets (KEY=VALUE)")
 	agentCreateCmd.Flags().Bool("no-wait", false, "Don't wait for instance provisioning; exit after agent record is created")
 

--- a/cmd/oc/internal/commands/agent.go
+++ b/cmd/oc/internal/commands/agent.go
@@ -9,6 +9,7 @@ package commands
 // renderAsyncFallback) live in agent_errors.go.
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strings"
@@ -27,6 +28,27 @@ func stdinIsTTY() bool {
 		return false
 	}
 	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+// confirmDestructive gates delete/disconnect/uninstall on explicit consent.
+// With --yes: proceed. Without --yes and a TTY: prompt. Without --yes and
+// no TTY: refuse — scripts and agents must pass --yes so accidental
+// invocation can't quietly destroy state.
+func confirmDestructive(cmd *cobra.Command, action string) error {
+	if yes, _ := cmd.Flags().GetBool("yes"); yes {
+		return nil
+	}
+	if !stdinIsTTY() {
+		return fmt.Errorf("refusing to %s without --yes (stdin is not a terminal)", action)
+	}
+	fmt.Fprintf(os.Stderr, "%s? [y/N] ", action)
+	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return nil
+	default:
+		return fmt.Errorf("aborted")
+	}
 }
 
 // sessionsClient returns the sessions-api client from context, or errors if not configured.
@@ -120,6 +142,11 @@ func init() {
 	agentConnectCmd.Flags().String("bot-token", "", "Telegram bot token (required for channel=telegram when stdin is not a TTY)")
 
 	agentInstallCmd.Flags().Bool("no-wait", false, "Don't wait for install orchestration to finish")
+
+	// Destructive ops — require explicit --yes in non-TTY callers.
+	agentDeleteCmd.Flags().Bool("yes", false, "Skip confirmation (required for non-interactive callers)")
+	agentDisconnectCmd.Flags().Bool("yes", false, "Skip confirmation (required for non-interactive callers)")
+	agentUninstallCmd.Flags().Bool("yes", false, "Skip confirmation (required for non-interactive callers)")
 
 	agentEventsCmd.Flags().Int("limit", 0, "Max events to return (1-200, default 50)")
 	agentEventsCmd.Flags().String("before", "", "Return events before this ISO timestamp (for pagination)")

--- a/cmd/oc/internal/commands/agent.go
+++ b/cmd/oc/internal/commands/agent.go
@@ -10,12 +10,24 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/opensandbox/opensandbox/cmd/oc/internal/client"
 	"github.com/spf13/cobra"
 )
+
+// stdinIsTTY reports whether stdin is attached to a terminal. Used to gate
+// interactive prompts: if stdin isn't a TTY we refuse to prompt, since the
+// caller is a script or agent that can't respond.
+func stdinIsTTY() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
 
 // sessionsClient returns the sessions-api client from context, or errors if not configured.
 func sessionsClient(cmd *cobra.Command) (*client.Client, error) {
@@ -104,6 +116,8 @@ func init() {
 	_ = agentCreateCmd.MarkFlagRequired("core")
 	agentCreateCmd.Flags().StringSlice("secret", nil, "Secrets (KEY=VALUE)")
 	agentCreateCmd.Flags().Bool("no-wait", false, "Don't wait for instance provisioning; exit after agent record is created")
+
+	agentConnectCmd.Flags().String("bot-token", "", "Telegram bot token (required for channel=telegram when stdin is not a TTY)")
 
 	agentInstallCmd.Flags().Bool("no-wait", false, "Don't wait for install orchestration to finish")
 

--- a/cmd/oc/internal/commands/agent_connect.go
+++ b/cmd/oc/internal/commands/agent_connect.go
@@ -1,8 +1,6 @@
 package commands
 
-// Channel lifecycle: connect, disconnect, list. The Telegram case prompts
-// interactively for a bot token since there's no --bot-token flag yet
-// (tracked as a launch-prep item).
+// Channel lifecycle: connect, disconnect, list.
 
 import (
 	"bufio"
@@ -16,8 +14,10 @@ import (
 var agentConnectCmd = &cobra.Command{
 	Use:   "connect <id> <channel>",
 	Short: "Connect a channel to an agent",
-	Long:  "Connect a messaging channel (e.g. telegram) to a managed agent.",
-	Args:  cobra.ExactArgs(2),
+	Long: "Connect a messaging channel to a managed agent.\n\n" +
+		"Supported channels:\n" +
+		"  telegram   requires --bot-token (or interactive prompt if TTY)",
+	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sc, err := sessionsClient(cmd)
 		if err != nil {
@@ -30,16 +30,25 @@ var agentConnectCmd = &cobra.Command{
 		body := map[string]interface{}{}
 
 		if channel == "telegram" {
-			fmt.Println("To connect Telegram:")
-			fmt.Println("  1. Open Telegram and message @BotFather")
-			fmt.Println("  2. Send /newbot, choose a name and username")
-			fmt.Println("  3. Copy the bot token")
-			fmt.Println()
-			fmt.Print("Paste bot token: ")
+			token, _ := cmd.Flags().GetString("bot-token")
+			if token == "" {
+				if !stdinIsTTY() {
+					return fmt.Errorf("--bot-token is required when stdin is not a terminal")
+				}
+				fmt.Println("To connect Telegram:")
+				fmt.Println("  1. Open Telegram and message @BotFather")
+				fmt.Println("  2. Send /newbot, choose a name and username")
+				fmt.Println("  3. Copy the bot token")
+				fmt.Println()
+				fmt.Print("Paste bot token: ")
 
-			reader := bufio.NewReader(os.Stdin)
-			token, _ := reader.ReadString('\n')
-			token = strings.TrimSpace(token)
+				reader := bufio.NewReader(os.Stdin)
+				line, err := reader.ReadString('\n')
+				if err != nil && line == "" {
+					return fmt.Errorf("reading bot token: %w", err)
+				}
+				token = strings.TrimSpace(line)
+			}
 			if token == "" {
 				return fmt.Errorf("bot token is required")
 			}
@@ -51,7 +60,7 @@ var agentConnectCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Printf("Telegram connected to %s.\n", agentID)
+		fmt.Printf("%s connected to %s.\n", channel, agentID)
 		if channel == "telegram" {
 			fmt.Println("Message your bot on Telegram to start chatting.")
 		}

--- a/cmd/oc/internal/commands/agent_connect.go
+++ b/cmd/oc/internal/commands/agent_connect.go
@@ -78,6 +78,10 @@ var agentDisconnectCmd = &cobra.Command{
 			return err
 		}
 
+		if err := confirmDestructive(cmd, fmt.Sprintf("Disconnect %s from %s", args[1], args[0])); err != nil {
+			return err
+		}
+
 		if err := sc.Delete(cmd.Context(), "/v1/agents/"+args[0]+"/channels/"+args[1]); err != nil {
 			return err
 		}

--- a/cmd/oc/internal/commands/agent_create.go
+++ b/cmd/oc/internal/commands/agent_create.go
@@ -13,7 +13,10 @@ import (
 var agentCreateCmd = &cobra.Command{
 	Use:   "create <id>",
 	Short: "Create a new managed agent",
-	Args:  cobra.ExactArgs(1),
+	Long: "Create a new managed agent. A core (e.g. --core hermes) is required:\n" +
+		"without one, the agent has no runtime and cannot connect channels\n" +
+		"or install packages.",
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sc, err := sessionsClient(cmd)
 		if err != nil {
@@ -26,10 +29,8 @@ var agentCreateCmd = &cobra.Command{
 		noWait, _ := cmd.Flags().GetBool("no-wait")
 
 		body := map[string]interface{}{
-			"id": id,
-		}
-		if core != "" {
-			body["core"] = core
+			"id":   id,
+			"core": core,
 		}
 
 		// Parse --secret KEY=VAL flags into secrets map
@@ -58,12 +59,6 @@ var agentCreateCmd = &cobra.Command{
 			}
 			fmt.Fprintln(os.Stderr)
 			fmt.Fprintln(os.Stderr, "  ✓ Agent record created")
-		}
-
-		// No core means no instance to wait for — skip polling.
-		if agent.Core == nil {
-			printer.Print(agent, func() {})
-			return nil
 		}
 
 		// --no-wait short-circuits into Mode 3 (async fallback). Scripts

--- a/cmd/oc/internal/commands/agent_delete.go
+++ b/cmd/oc/internal/commands/agent_delete.go
@@ -16,6 +16,10 @@ var agentDeleteCmd = &cobra.Command{
 			return err
 		}
 
+		if err := confirmDestructive(cmd, fmt.Sprintf("Delete agent %s", args[0])); err != nil {
+			return err
+		}
+
 		if err := sc.Delete(cmd.Context(), "/v1/agents/"+args[0]); err != nil {
 			return err
 		}

--- a/cmd/oc/internal/commands/agent_packages.go
+++ b/cmd/oc/internal/commands/agent_packages.go
@@ -69,6 +69,10 @@ var agentUninstallCmd = &cobra.Command{
 			return err
 		}
 
+		if err := confirmDestructive(cmd, fmt.Sprintf("Uninstall %s from %s", args[1], args[0])); err != nil {
+			return err
+		}
+
 		if err := sc.Delete(cmd.Context(), "/v1/agents/"+args[0]+"/packages/"+args[1]); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Four must-fix ergonomic issues from the `oc agent` CLI audit (see
[ws-gstack/work/oc-agent-ergonomics.md](https://github.com/diggerhq/ws-gstack/blob/main/work/oc-agent-ergonomics.md)).
One commit per item.

- **`agent create`**: `--core` is now required via cobra's `MarkFlagRequired`. Previously a core-less agent was created successfully, and every downstream command (`connect`, `install`) then failed with confusing errors. Dead code path that skipped polling on `core == nil` removed.
- **`agent connect`**: new `--bot-token` flag for Telegram. Interactive prompt is kept as the TTY fallback; non-TTY callers without the flag get a clear error instead of an EOF-read masked as `bot token is required`. Also fixed the hardcoded "Telegram connected to %s" to template on the channel arg.
- **`agent delete` / `disconnect` / `uninstall`**: new `--yes` flag plus shared `confirmDestructive` helper. TTY without `--yes` prompts; non-TTY without `--yes` refuses. Closes the footgun where a script or agent typo would silently destroy state.
- **`oc agent --help`**: documents the 1/3/4/5 exit code classes that already existed in `agent_errors.go` but were never surfaced. Agent callers can now branch on the class without reading source.

## Test plan

- [x] `oc agent create foo` (no `--core`) exits 1 with `required flag(s) "core" not set`
- [x] `echo | oc agent delete foo` exits 1 with `refusing to Delete agent foo without --yes (stdin is not a terminal)`
- [x] `oc agent connect my-agent telegram --bot-token 123:abc` uses the flag without prompting
- [x] `oc agent --help` shows the exit-code table
- [x] `oc agent create --help` / `connect --help` / `delete --help` show the new flags and their help text
- [ ] Manual: run the canonical happy path on a real agent once sessions-api is reachable — `create --core hermes` → `connect telegram --bot-token ...` → `install gbrain` → verify still works end-to-end
- [ ] Manual: verify TTY prompt still works for `connect` without `--bot-token` and for `delete` without `--yes`

## Out of scope (follow-up PRs)

"Should fix" audit items — raw API error bubble-up ("Instance has no sandbox"), JSON surface unevenness, `--wait` semantics across create/connect/install, silent malformed `--secret` drop. All touch shared plumbing and want a design discussion first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)