### PR TITLE
docs: sync oc agent CLI reference with must-fix behavior changes

### DIFF
--- a/docs/cli/agents.mdx
+++ b/docs/cli/agents.mdx
@@ -13,7 +13,7 @@ oc agent create my-agent --core openclaw
 oc agent create my-agent --core hermes --secret OPENAI_API_KEY=sk-...
 ```
 
-With `--core`, OpenComputer boots a sandbox with the runtime pre-installed and an instance running. Without `--core`, you get a raw agent — provide your own `snapshot` and `entrypoint` via the [REST API](/agents/rest/agents).
+`--core` is required. OpenComputer boots a sandbox with the runtime pre-installed and an instance running. To create a raw agent with your own `snapshot` and `entrypoint`, use the [REST API](/agents/rest/agents) directly.
 
 ## Listing & Inspecting
 
@@ -34,10 +34,11 @@ oc agent get my-agent
 Connect messaging platforms to your agent. Currently supports Telegram.
 
 ```bash
-# Connect (prompts for bot token interactively)
+# Connect — prompts for bot token on TTY, or pass via flag for scripts
 oc agent connect my-agent telegram
+oc agent connect my-agent telegram --bot-token 123:ABC
 
-# Disconnect
+# Disconnect (use --yes in scripts)
 oc agent disconnect my-agent telegram
 
 # List connected channels
@@ -64,10 +65,11 @@ oc agent packages my-agent
 ## Deleting an Agent
 
 ```bash
-oc agent delete my-agent
+oc agent delete my-agent          # prompts for confirmation
+oc agent delete my-agent --yes    # non-interactive (scripts, CI)
 ```
 
-Cascades to instances and sessions — the sandbox is destroyed.
+Cascades to instances and sessions — the sandbox is destroyed. The command refuses to delete without `--yes` when stdin is not a TTY, so a typo in a script can't silently destroy state.
 
 ## Shell Access
 

--- a/docs/reference/cli/agent.mdx
+++ b/docs/reference/cli/agent.mdx
@@ -7,12 +7,16 @@ description: "Manage agents, channels, and packages"
 
 Create a new agent. [HTTP API →](/api-reference/agents/create)
 
-<ParamField query="--core" type="string">
-  Managed core to use (e.g. `hermes`, `openclaw`). Without this flag, creates a raw agent.
+<ParamField query="--core" type="string" required>
+  Managed core to use (e.g. `hermes`, `openclaw`). Required — a core-less agent has no runtime and can't connect channels or install packages. To create a raw agent with your own snapshot, use the [REST API](/api-reference/agents/create) directly.
 </ParamField>
 
 <ParamField query="--secret" type="string">
   Secret `KEY=VALUE` (repeatable). Secrets are stored encrypted and injected at sandbox creation.
+</ParamField>
+
+<ParamField query="--no-wait" type="boolean">
+  Return immediately after the agent record is created, without polling for sandbox readiness. The `async` JSON field indicates the caller should re-check with `oc agent get`.
 </ParamField>
 
 ```bash
@@ -53,8 +57,13 @@ oc agent get my-hermes
 
 Delete an agent. Cascades to instances and sessions — the sandbox is destroyed. [HTTP API →](/api-reference/agents/delete)
 
+<ParamField query="--yes" type="boolean">
+  Skip the confirmation prompt. Required when stdin is not a TTY (e.g. running from a script) — the command otherwise refuses rather than destroying state silently on a typo.
+</ParamField>
+
 ```bash
-oc agent delete my-hermes
+oc agent delete my-hermes           # interactive: prompts "Delete agent my-hermes? [y/N]"
+oc agent delete my-hermes --yes     # script-safe: no prompt
 ```
 
 ---
@@ -63,15 +72,13 @@ oc agent delete my-hermes
 
 Connect a messaging channel to an agent. [HTTP API →](/api-reference/agents/connect-channel)
 
-For Telegram, prompts interactively for the bot token if `--bot-token` is not provided.
-
 <ParamField query="--bot-token" type="string">
-  Telegram bot token (Telegram channel only). If omitted, prompts interactively.
+  Telegram bot token (Telegram channel only). If omitted and stdin is a TTY, the CLI prompts interactively. If omitted and stdin is not a TTY (scripts, CI, agent callers), the command exits with an error — pass the flag explicitly.
 </ParamField>
 
 ```bash
-oc agent connect my-hermes telegram
-oc agent connect my-hermes telegram --bot-token 123:ABC
+oc agent connect my-hermes telegram                        # interactive prompt
+oc agent connect my-hermes telegram --bot-token 123:ABC    # script-safe
 ```
 
 ---
@@ -80,8 +87,13 @@ oc agent connect my-hermes telegram --bot-token 123:ABC
 
 Disconnect a channel from an agent. Removes webhook registration and config. [HTTP API →](/api-reference/agents/disconnect-channel)
 
+<ParamField query="--yes" type="boolean">
+  Skip the confirmation prompt. Required when stdin is not a TTY.
+</ParamField>
+
 ```bash
 oc agent disconnect my-hermes telegram
+oc agent disconnect my-hermes telegram --yes
 ```
 
 ---
@@ -110,8 +122,13 @@ oc agent install my-hermes gbrain
 
 Uninstall a package from an agent. Data is preserved by default. [HTTP API →](/api-reference/agents/uninstall-package)
 
+<ParamField query="--yes" type="boolean">
+  Skip the confirmation prompt. Required when stdin is not a TTY.
+</ParamField>
+
 ```bash
 oc agent uninstall my-hermes gbrain
+oc agent uninstall my-hermes gbrain --yes
 ```
 
 ---
@@ -123,3 +140,19 @@ List packages installed on an agent. [HTTP API →](/api-reference/agents/list-p
 ```bash
 oc agent packages my-hermes
 ```
+
+---
+
+## Exit codes
+
+`oc agent` commands use a class-based exit code scheme so scripts and agent callers can branch on failure type without parsing stderr.
+
+| Code | Class          | Meaning                                                      |
+|------|----------------|--------------------------------------------------------------|
+| 0    | Success        | Command completed successfully                               |
+| 1    | General error  | Unclassified failure, bad args/flags, aborted confirmation   |
+| 3    | Upstream 4xx   | Not found, unauthorized, org mismatch, bad request           |
+| 4    | Conflict       | Already exists, invalid state transition                     |
+| 5    | Transient      | Timeout, retry-safe — try again                              |
+
+Codes 3–5 are emitted by `create`, `install`, and `get` when the failure carries a known error code. Other subcommands exit 0 on success and 1 on any failure.


### PR DESCRIPTION
## Summary

Follow-up to #165. The CLI now enforces `--core`, ships `--bot-token` / `--yes` flags, and documents exit codes in help text — but the docs-site reference was still describing the old behavior. This PR brings them in sync.

**`docs/reference/cli/agent.mdx`**
- `--core`: marked required; dropped "Without this flag, creates a raw agent" (actively wrong now).
- `--bot-token`: documented the non-TTY requirement.
- `--yes`: new section on delete/disconnect/uninstall with no-TTY refusal behavior.
- `--no-wait`: documented on create (was shipped but undocumented).
- Exit codes: new table at the bottom (0/1/3/4/5 with scope note).

**`docs/cli/agents.mdx`**
- Dropped the stale "without --core, you get a raw agent" guidance.
- Surfaced `--bot-token` alongside the interactive prompt.
- Surfaced `--yes` on delete with the no-TTY behavior explained.

## Test plan

- [x] Cross-checked each claim against the CLI help text on `oc v0.5.0.49`
- [ ] Mintlify preview renders the new ParamField blocks and the exit-codes table cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)