### PR TITLE
20gb rootfs

### DIFF
--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -476,6 +476,26 @@ func (m *Manager) PrepareGoldenSnapshot() error {
 	}
 	log.Printf("qemu: golden: virtio_mem module loaded")
 
+	// Grow rootfs filesystem to fill the expanded virtual disk.
+	// The qcow2 overlay was resized to 20 GB but the ext4 filesystem still
+	// matches the smaller base image. resize2fs expands it in-place.
+	growCtx, growCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	growResp, growErr := agentClient.Exec(growCtx, &pb.ExecRequest{
+		Command:   "/bin/sh",
+		Args:      []string{"-c", "resize2fs /dev/vda"},
+		RunAsRoot: true,
+	})
+	growCancel()
+	if growErr != nil || (growResp != nil && growResp.ExitCode != 0) {
+		stderr := ""
+		if growResp != nil {
+			stderr = growResp.Stderr
+		}
+		log.Printf("qemu: golden: resize2fs /dev/vda failed (non-fatal): %v %s", growErr, stderr)
+	} else {
+		log.Printf("qemu: golden: rootfs expanded to 20GB")
+	}
+
 	// Unmount /home/sandbox and sync before snapshot — the golden migration state
 	// includes virtio-blk device state (ring buffers, pending I/O). If the data disk
 	// is mounted when we snapshot, those stale I/O ops will corrupt any fresh
@@ -1301,6 +1321,16 @@ func (m *Manager) Create(ctx context.Context, cfg types.SandboxConfig) (*types.S
 		return nil, fmt.Errorf("agent not ready: %w", err)
 	}
 	vm.agent = agentClient
+
+	// Grow rootfs filesystem if the disk is larger than the current ext4 fs.
+	// Golden-forked sandboxes already have the grown fs; this covers cold boot.
+	growCtx, growCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	agentClient.Exec(growCtx, &pb.ExecRequest{
+		Command:   "/bin/sh",
+		Args:      []string{"-c", "resize2fs /dev/vda 2>/dev/null"},
+		RunAsRoot: true,
+	})
+	growCancel()
 
 	envsToInject := m.sealSandboxEnvs(context.Background(), id, netCfg, agentClient, cfg)
 	if len(envsToInject) > 0 {

--- a/internal/qemu/rootfs.go
+++ b/internal/qemu/rootfs.go
@@ -32,6 +32,13 @@ func PrepareRootfs(baseImage, destPath string) error {
 		return fmt.Errorf("create qcow2 overlay: %w (%s)", err, strings.TrimSpace(string(out)))
 	}
 
+	// Expand the virtual size to 20 GB. The qcow2 is thin-provisioned so host
+	// disk usage stays proportional to actual writes, not virtual size.
+	resizeCmd := exec.Command("qemu-img", "resize", destPath, "20G")
+	if out, err := resizeCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("resize rootfs overlay: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
  - Expand rootfs virtual size from ~1.9 GB (base image size) to 20 GB
  - qcow2 overlay is thin-provisioned — host disk usage stays proportional to actual writes, not virtual size
  - Guest ext4 filesystem grown via resize2fs during golden snapshot creation (inherited by all forks) and cold boot fallback

  ## Why
  Agents installing packages via apt/pip into /usr or /tmp were hitting the 1.9 GB rootfs ceiling. The workspace disk (20 GB) is separate and mounted at
  /workspace, so system-level installs couldn't use it.

  ## What changed

  | File | Change |
  |------|--------|
  | `internal/qemu/rootfs.go` | `qemu-img resize` to 20 GB after creating qcow2 overlay |
  | `internal/qemu/manager.go` | `resize2fs /dev/vda` during golden boot + cold boot fallback |

  ## Impact on checkpoints
  Checkpoint archives remain small — only written blocks are captured. A sandbox that installs 500 MB of packages produces a ~500 MB overlay, not 20 GB.

  ## Tested
  - Deployed to `osb-worker-8f2c9b37` in prod (westus2)
  - Golden snapshot rebuilt successfully: `rootfs expanded to 20GB` (4.2s total)
  - Sandbox creation via golden fork working