### PR TITLE
fix(cli): oc shell accepts sb-* short sandbox IDs

### DIFF
--- a/cmd/oc/internal/commands/shell.go
+++ b/cmd/oc/internal/commands/shell.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
+	"strings"
 	"syscall"
 
 	"github.com/gorilla/websocket"
@@ -31,9 +32,10 @@ Examples:
 		sandboxID := args[0]
 		shellPath, _ := cmd.Flags().GetString("shell")
 
-		// If the argument doesn't look like a UUID, try to resolve it as an
-		// agent name through sessions-api → agent → instance → sandbox_id.
-		if !uuidPattern.MatchString(sandboxID) {
+		// If the argument doesn't look like a sandbox ID (full UUID or sb-* short form),
+		// try to resolve it as an agent name through sessions-api.
+		isSandboxID := uuidPattern.MatchString(sandboxID) || strings.HasPrefix(sandboxID, "sb-")
+		if !isSandboxID {
 			sc := client.SessionsFromContext(cmd.Context())
 			if sc != nil {
 				resolved, err := resolveAgentSandbox(cmd, sc, sandboxID)


### PR DESCRIPTION
## Summary

`oc shell sb-e78e2f8e` fails with `failed to resolve agent "sb-e78e2f8e": no running instance found` since the agent-resolution commit (38c4a3c) added a UUID-only regex check. Short sandbox IDs (`sb-*`) don't match the full UUID pattern and get routed to the agent-name resolver, which fails.

## Fix

Added `strings.HasPrefix(sandboxID, "sb-")` alongside the UUID check so both full UUIDs and `sb-*` short IDs are recognized as sandbox IDs and passed directly to the API.

## Test plan

- `oc shell sb-e78e2f8e` → connects to sandbox (previously: agent resolution error)
- `oc shell my-agent-name` → still resolves via sessions-api (unchanged)
- `oc shell 550e8400-e29b-41d4-a716-446655440000` → still works (UUID match, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)