### PR TITLE
agent: suggest next steps after create

### DIFF
--- a/cmd/oc/internal/commands/agent.go
+++ b/cmd/oc/internal/commands/agent.go
@@ -173,6 +173,25 @@ func formatList(v interface{}) string {
 	}
 }
 
+func listEntries(v interface{}) []string {
+	switch items := v.(type) {
+	case []interface{}:
+		out := make([]string, 0, len(items))
+		for _, item := range items {
+			out = append(out, fmt.Sprintf("%v", item))
+		}
+		return out
+	case []string:
+		return append([]string(nil), items...)
+	default:
+		return nil
+	}
+}
+
+func listIsEmpty(v interface{}) bool {
+	return len(listEntries(v)) == 0
+}
+
 func formatAge(isoTime string) string {
 	t, err := time.Parse(time.RFC3339Nano, isoTime)
 	if err != nil {

--- a/cmd/oc/internal/commands/agent_create.go
+++ b/cmd/oc/internal/commands/agent_create.go
@@ -82,7 +82,34 @@ var agentCreateCmd = &cobra.Command{
 			return nil
 		}
 
-		printer.Print(finalAgent, func() {})
+		printer.Print(finalAgent, func() {
+			fmt.Fprintln(os.Stdout, "Agent ready.")
+			renderCreateNextSteps(finalAgent)
+		})
 		return nil
 	},
+}
+
+func renderCreateNextSteps(agent *agentResponse) {
+	noChannels := listIsEmpty(agent.Channels)
+	noPackages := listIsEmpty(agent.Packages)
+	if !noChannels && !noPackages {
+		return
+	}
+
+	fmt.Fprintln(os.Stdout)
+	if noChannels {
+		fmt.Fprintln(os.Stdout, "No channels connected yet.")
+	}
+	if noPackages {
+		fmt.Fprintln(os.Stdout, "No packages installed yet.")
+	}
+
+	fmt.Fprintln(os.Stdout, "Next:")
+	if noChannels {
+		fmt.Fprintf(os.Stdout, "  oc agent connect %s telegram\n", agent.ID)
+	}
+	if noPackages {
+		fmt.Fprintf(os.Stdout, "  oc agent install %s gbrain\n", agent.ID)
+	}
 }


### PR DESCRIPTION
## Summary
- print concrete next-step guidance after a successful managed-agent create in text mode
- tell the user when no channels are connected and no packages are installed yet
- suggest the canonical follow-up commands: connect Telegram first, then install gbrain

## Verification
- go test ./cmd/oc/internal/commands/...
- go run ./cmd/oc agent create next-steps-smoke-190750 --core openclaw
- go run ./cmd/oc agent delete next-steps-smoke-190750 --yes
