### PR TITLE
fix(billing): enforce sandbox cap on free plan + show trial credits in UI

### DIFF
--- a/internal/api/dashboard_billing.go
+++ b/internal/api/dashboard_billing.go
@@ -80,10 +80,11 @@ func (s *Server) billingGet(c echo.Context) error {
 	// the Stripe Billing Portal instead of re-computing cost locally against a
 	// hardcoded rate table that would diverge for grandfathered orgs.
 	return c.JSON(http.StatusOK, map[string]interface{}{
-		"plan":                   org.Plan,
-		"stripeCreditCents":      stripeCreditCents,
-		"maxConcurrentSandboxes": org.MaxConcurrentSandboxes,
-		"hasPaymentMethod":       org.StripeCustomerID != nil,
+		"plan":                       org.Plan,
+		"stripeCreditCents":          stripeCreditCents,
+		"maxConcurrentSandboxes":     org.MaxConcurrentSandboxes,
+		"hasPaymentMethod":           org.StripeCustomerID != nil,
+		"freeCreditsRemainingCents":  org.FreeCreditsRemainingCents,
 	})
 }
 

--- a/internal/api/sandbox.go
+++ b/internal/api/sandbox.go
@@ -44,8 +44,15 @@ func (s *Server) createSandbox(c echo.Context) error {
 		var err error
 		org, err = s.store.GetOrg(ctx, orgID)
 		if err == nil {
-			// Free-tier: trial credits gate instead of a concurrent-sandbox cap.
-			// Pro (and any other non-free plan): concurrent limit still applies.
+			// Concurrent sandbox limit applies to all plans.
+			count, err := s.store.CountActiveSandboxes(ctx, orgID)
+			if err == nil && count >= org.MaxConcurrentSandboxes {
+				return c.JSON(http.StatusTooManyRequests, map[string]string{
+					"error": "concurrent sandbox limit reached",
+				})
+			}
+
+			// Free-tier: trial credits gate + machine-size restriction.
 			if org.Plan == "free" {
 				if org.FreeCreditsRemainingCents <= 0 {
 					return c.JSON(http.StatusPaymentRequired, map[string]string{
@@ -55,13 +62,6 @@ func (s *Server) createSandbox(c echo.Context) error {
 				if cfg.MemoryMB > 4096 || cfg.CpuCount > 1 {
 					return c.JSON(http.StatusPaymentRequired, map[string]string{
 						"error": "upgrade to pro for larger instances",
-					})
-				}
-			} else {
-				count, err := s.store.CountActiveSandboxes(ctx, orgID)
-				if err == nil && count >= org.MaxConcurrentSandboxes {
-					return c.JSON(http.StatusTooManyRequests, map[string]string{
-						"error": "concurrent sandbox limit reached",
 					})
 				}
 			}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -278,6 +278,7 @@ export interface BillingState {
   stripeCreditCents: number
   maxConcurrentSandboxes: number
   hasPaymentMethod: boolean
+  freeCreditsRemainingCents: number
 }
 
 export interface StripeInvoice {

--- a/web/src/pages/Billing.tsx
+++ b/web/src/pages/Billing.tsx
@@ -7,7 +7,7 @@ import {
 
 export default function Billing() {
   const queryClient = useQueryClient()
-  const { data: billing, isLoading } = useQuery({ queryKey: ['billing'], queryFn: getBilling })
+  const { data: billing, isLoading } = useQuery({ queryKey: ['billing'], queryFn: getBilling, refetchInterval: 30_000 })
   const { data: invoiceData } = useQuery({ queryKey: ['invoices'], queryFn: () => getBillingInvoices() })
 
   const [promoCode, setPromoCode] = useState('')
@@ -73,10 +73,29 @@ export default function Billing() {
               </div>
             )}
 
-            {!isPro && (
-              <div style={{ marginTop: 16 }}>
+            {!isPro && billing != null && (
+              <div style={{ marginTop: 12 }}>
+                {billing.freeCreditsRemainingCents > 0 ? (
+                  <div style={{
+                    fontSize: 14, fontWeight: 600, fontFamily: 'var(--font-mono)',
+                    color: 'var(--accent-emerald)', marginBottom: 12,
+                  }}>
+                    ${(billing.freeCreditsRemainingCents / 100).toFixed(2)} free trial credit remaining
+                  </div>
+                ) : (
+                  <div style={{
+                    fontSize: 13, color: 'var(--accent-rose)', marginBottom: 12,
+                    display: 'flex', alignItems: 'center', gap: 6,
+                  }}>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" />
+                    </svg>
+                    Free trial credits exhausted — upgrade to continue using sandboxes
+                  </div>
+                )}
+
                 <div style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: 10 }}>
-                  Unlock larger machine sizes and get $30 free credit
+                  Upgrade to Pro for an additional $30 free credit and larger machine sizes
                 </div>
                 <button
                   onClick={() => setupMutation.mutate()}


### PR DESCRIPTION
## Summary

- **Restore concurrent sandbox limit for free plan** — PR #156 removed the cap for free users, relying solely on credit deduction via the usage reporter. But if the reporter isn't running (no `STRIPE_SECRET_KEY`) or scale events aren't recorded (known race), credits never get deducted and there's no limit at all. The concurrent cap now applies to all plans again.
- **Surface free trial credits in billing API** — `billingGet` now returns `freeCreditsRemainingCents` so the frontend can display it.
- **Show credit balance on billing page** — Free users see their remaining trial credits (e.g. "$5.00 free trial credit remaining") in green, or a red exhausted warning when credits hit zero. CTA updated to "Upgrade to Pro for an additional $30 free credit and larger machine sizes". Polls every 30s to stay current.

## Test plan

- [ ] Free plan user sees credit balance on billing page
- [ ] Credit balance updates as usage reporter deducts
- [ ] Exhausted state shows red warning + upgrade CTA
- [ ] Free plan user hits 429 at concurrent sandbox limit (default 5)
- [ ] Free plan user hits 402 when credits exhausted
- [ ] Pro plan unaffected (concurrent cap still applies, no free credits shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)