### PR TITLE
identity: add email + workos_user_id to identity JWT

### DIFF
--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log"
 	"net/http"
 	"time"
 
@@ -12,7 +13,8 @@ const identityTokenTTL = 10 * time.Minute
 
 // createAuthToken exchanges the current API key for a short-lived identity JWT.
 // Downstream services (sessions-api) use this to resolve key → owner without
-// calling back on every request.
+// calling back on every request. The token carries email + workos_user_id so
+// downstreams can emit analytics events consistently with opencomputer.
 func (s *Server) createAuthToken(c echo.Context) error {
 	orgID, ok := auth.GetOrgID(c)
 	if !ok {
@@ -27,14 +29,31 @@ func (s *Server) createAuthToken(c echo.Context) error {
 		})
 	}
 
-	orgStr := orgID.String()
-	var userStr *string
+	in := auth.IdentityTokenInput{OrgID: orgID.String()}
 	if userID := auth.GetUserID(c); userID != nil {
-		s := userID.String()
-		userStr = &s
+		userStr := userID.String()
+		in.UserID = &userStr
+
+		// Look up email + workos_user_id for downstream analytics identity.
+		// Soft failure: if the lookup fails, still issue a token (without
+		// those fields) rather than block the caller.
+		if s.store != nil {
+			user, err := s.store.GetUserByID(c.Request().Context(), *userID)
+			if err != nil {
+				log.Printf("identity: failed to load user %s: %v", userStr, err)
+			} else {
+				if user.Email != "" {
+					email := user.Email
+					in.Email = &email
+				}
+				if user.WorkOSUserID != nil && *user.WorkOSUserID != "" {
+					in.WorkOSUserID = user.WorkOSUserID
+				}
+			}
+		}
 	}
 
-	token, err := s.jwtIssuer.IssueIdentityToken(orgStr, userStr, identityTokenTTL)
+	token, err := s.jwtIssuer.IssueIdentityToken(in, identityTokenTTL)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "failed to issue token",

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -47,25 +47,39 @@ func (j *JWTIssuer) IssueSandboxToken(orgID uuid.UUID, sandboxID, workerID strin
 
 // IdentityClaims are the JWT claims for identity tokens issued to downstream
 // services (e.g. sessions-api). They carry the caller's org and user identity
-// so the downstream can authorize without calling back to the control plane.
+// so the downstream can authorize and attribute analytics events without
+// calling back to the control plane.
 type IdentityClaims struct {
 	jwt.RegisteredClaims
-	OrgID  string  `json:"org_id"`
-	UserID *string `json:"user_id,omitempty"`
+	OrgID        string  `json:"org_id"`
+	UserID       *string `json:"user_id,omitempty"`
+	Email        *string `json:"email,omitempty"`
+	WorkOSUserID *string `json:"workos_user_id,omitempty"`
+}
+
+// IdentityTokenInput bundles the identity fields embedded in an identity JWT.
+// Nil pointers are omitted from the resulting token.
+type IdentityTokenInput struct {
+	OrgID        string
+	UserID       *string
+	Email        *string
+	WorkOSUserID *string
 }
 
 // IssueIdentityToken creates a short-lived JWT carrying the caller's identity.
-func (j *JWTIssuer) IssueIdentityToken(orgID string, userID *string, ttl time.Duration) (string, error) {
+func (j *JWTIssuer) IssueIdentityToken(in IdentityTokenInput, ttl time.Duration) (string, error) {
 	now := time.Now()
 	claims := IdentityClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
-			Subject:   orgID,
+			Subject:   in.OrgID,
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
 			Issuer:    "opensandbox",
 		},
-		OrgID:  orgID,
-		UserID: userID,
+		OrgID:        in.OrgID,
+		UserID:       in.UserID,
+		Email:        in.Email,
+		WorkOSUserID: in.WorkOSUserID,
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -372,6 +372,16 @@ func (s *Store) GetUserByEmail(ctx context.Context, email string) (*User, error)
 	return user, nil
 }
 
+func (s *Store) GetUserByID(ctx context.Context, userID uuid.UUID) (*User, error) {
+	user, err := scanUser(s.pool.QueryRow(ctx,
+		`SELECT `+userColumns+` FROM users WHERE id = $1`, userID,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("user not found: %w", err)
+	}
+	return user, nil
+}
+
 // --- API Key operations ---
 
 type APIKey struct {


### PR DESCRIPTION
## Summary
- Extend the identity JWT issued by `POST /api/auth/token` with optional `email` and `workos_user_id` claims.
- Downstream services (sessions-api) need these to emit Segment analytics events keyed by the same identity opencomputer already uses in `internal/analytics/segment.go` (`TrackGBSeconds` uses email as Segment userId). Without this, the same user shows up as two different Segment identities across the billing event and the managed-agent funnel events.
- Claims are optional (`omitempty`) — old consumers that only read `org_id` / `user_id` keep working.
- Lookup is soft-failure: if `GetUserByID` returns an error, the token still issues without the extra claims rather than blocking the caller.

## Changes
- `internal/db/store.go` — new `GetUserByID(ctx, uuid)` helper, mirrors existing `GetUserByEmail` / `GetUserByWorkOSID`.
- `internal/auth/jwt.go` — `IdentityClaims` gains `Email`, `WorkOSUserID`. `IssueIdentityToken` takes a struct input (`IdentityTokenInput`) so future fields don't churn the signature.
- `internal/api/identity.go` — `createAuthToken` looks up the user row when `user_id` is present and populates email + workos_user_id.

## Test plan
- [x] `go build ./internal/auth/... ./internal/api/... ./internal/db/...` — clean
- [x] `go test ./internal/auth/... ./internal/api/...` — pass
- [ ] Once deployed: sessions-api will consume the new claims in a follow-up PR and emit Segment events with email as userId

🤖 Generated with [Claude Code](https://claude.com/claude-code)