### PR TITLE
Register sentry DSN in key vault secret mapping

### DIFF
--- a/internal/config/keyvault.go
+++ b/internal/config/keyvault.go
@@ -43,6 +43,7 @@ var secretMapping = map[string]string{
 	"server-cf-zone-id":             "OPENSANDBOX_CF_ZONE_ID",
 	"server-stripe-secret-key":      "STRIPE_SECRET_KEY",
 	"server-stripe-webhook-secret":  "STRIPE_WEBHOOK_SECRET",
+	"server-sentry-dsn":             "OPENSANDBOX_SENTRY_DSN",
 
 	// Worker secrets
 	"worker-jwt-secret":    "OPENSANDBOX_JWT_SECRET",
@@ -50,6 +51,7 @@ var secretMapping = map[string]string{
 	"worker-redis-url":     "OPENSANDBOX_REDIS_URL",
 	"worker-s3-access-key": "OPENSANDBOX_S3_ACCESS_KEY_ID",
 	"worker-s3-secret-key": "OPENSANDBOX_S3_SECRET_ACCESS_KEY",
+	"worker-sentry-dsn":    "OPENSANDBOX_SENTRY_DSN",
 
 	// Shared
 	"pg-password": "OPENSANDBOX_PG_PASSWORD",


### PR DESCRIPTION
## Summary

Follow-up to #179. Without this, `LoadSecretsFromKeyVault` silently ignores `server-sentry-dsn` and `worker-sentry-dsn` (only names in the hardcoded `secretMapping` whitelist are loaded), so `OPENSANDBOX_SENTRY_DSN` stays empty and Sentry init no-ops even after setting the secrets in the vault.

## Test plan

- [ ] Set `server-sentry-dsn` and `worker-sentry-dsn` in the vault (already done)
- [ ] Redeploy control plane — confirm `keyvault: loaded N secrets` log line includes one more than before, and `sentry: enabled (service=control-plane, ...)` appears at startup
- [ ] Redeploy worker — same check, `service=worker`
- [ ] Trigger a test panic (or `sentry.CaptureMessage`) and confirm the event lands in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)