### PR TITLE
 gate exec on virtio-mem hotplug completion

### DIFF
--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -91,6 +91,7 @@ type VMInstance struct {
 	restoring     chan struct{}
 	opMu          sync.Mutex   // serializes destructive VM ops (checkpoint, restore, hibernate)
 	archiveDone   chan struct{} // closed when async hibernate archive completes (nil if no archive in flight)
+	memoryReady   chan struct{} // closed once virtio-mem hotplug has committed enough memory for user workloads (nil = pre-existing hotplug, treat as ready)
 	baseMemoryMB         int    // initial memory passed to -m (before virtio-mem)
 	virtioMemRequestedMB int    // additional memory via virtio-mem (beyond base)
 	goldenVersion        string // golden version this sandbox was created from (empty if cold-booted)
@@ -1839,14 +1840,74 @@ func (m *Manager) SetResourceLimits(ctx context.Context, sandboxID string, maxPi
 				log.Printf("qemu: virtio-mem %s: set %dMB failed: %v — returning insufficient capacity error", sandboxID, additionalMB, err)
 				return fmt.Errorf("insufficient_capacity: cannot hotplug %dMB on this worker: %w", additionalMB, err)
 			} else {
+				prevRequestedMB := vm.virtioMemRequestedMB
 				vm.virtioMemRequestedMB = additionalMB
 				vm.MemoryMB = vm.baseMemoryMB + additionalMB
 				log.Printf("qemu: virtio-mem %s: %dMB additional (total %dMB)", sandboxID, additionalMB, vm.MemoryMB)
+
+				// Scaling UP? Gate exec/write until enough memory is plugged in so
+				// user workloads (git clone, npm install, etc.) don't race the
+				// hotplug and crash trying to use memory that's allocated-but-not-backed.
+				// Remaining hotplug continues in the background after the gate opens.
+				if additionalMB > prevRequestedMB {
+					vm.memoryReady = make(chan struct{})
+					go m.watchMemoryHotplug(vm, additionalMB)
+				}
 			}
 		}
 	}
 
 	return vm.agent.SetResourceLimits(ctx, maxPids, maxMemoryBytes, cpuMaxUsec, cpuPeriodUsec)
+}
+
+// watchMemoryHotplug polls the guest's /proc/meminfo until at least 1GB of
+// virtio-mem memory has been onlined (or target if smaller), then closes
+// vm.memoryReady to unblock getReadyVM. Bounded by a 10s timeout so the
+// channel always closes even if hotplug stalls.
+func (m *Manager) watchMemoryHotplug(vm *VMInstance, targetAdditionalMB int) {
+	defer func() {
+		if vm.memoryReady != nil {
+			select {
+			case <-vm.memoryReady:
+			default:
+				close(vm.memoryReady)
+			}
+		}
+	}()
+
+	// We only need ~1GB plugged for most workloads to have breathing room.
+	// The rest hotplugs in the background and is usually done within seconds.
+	readyThresholdMB := 1024
+	if targetAdditionalMB < readyThresholdMB {
+		readyThresholdMB = targetAdditionalMB
+	}
+	requiredTotalMB := vm.baseMemoryMB + readyThresholdMB
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if vm.agent == nil {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		resp, err := vm.agent.Exec(ctx, &pb.ExecRequest{
+			Command:        "/bin/sh",
+			Args:           []string{"-c", "awk '/MemTotal/ {print $2}' /proc/meminfo"},
+			TimeoutSeconds: 2,
+		})
+		cancel()
+		if err == nil && resp != nil {
+			// MemTotal is in kB
+			var kB int
+			fmt.Sscanf(string(resp.Stdout), "%d", &kB)
+			if kB/1024 >= requiredTotalMB {
+				log.Printf("qemu: virtio-mem %s: hotplug gate opened (%dMB onlined, needed %dMB)",
+					vm.ID, kB/1024, requiredTotalMB)
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	log.Printf("qemu: virtio-mem %s: hotplug gate timed out after 10s, unblocking anyway", vm.ID)
 }
 
 // TotalCommittedMemoryMB returns the sum of MemoryMB (base + virtio-mem) across all running VMs.
@@ -2860,6 +2921,21 @@ func (m *Manager) getReadyVM(ctx context.Context, id string) (*VMInstance, error
 			}
 		case <-ctx.Done():
 			return nil, fmt.Errorf("sandbox %s: timed out waiting for restore", id)
+		}
+	}
+
+	// Block until virtio-mem has plugged in enough memory for user workloads.
+	// Sandbox is marked "running" as soon as QEMU boots, but the scaler's
+	// SetResourceLimits kicks off hotplug async — user code (e.g. git clone)
+	// running immediately can hit memory that's allocated-but-not-backed.
+	// Bounded wait so we never hang if hotplug stalls.
+	if vm.memoryReady != nil {
+		select {
+		case <-vm.memoryReady:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(5 * time.Second):
+			log.Printf("qemu: sandbox %s: memory hotplug wait exceeded 5s, proceeding anyway", id)
 		}
 	}
 


### PR DESCRIPTION
 # Gate exec on virtio-mem hotplug completion

  ## The race

  When a sandbox is scaled up (`POST /api/sandboxes/:id/scale`), the worker calls `vm.qmp.SetVirtioMemSize()` to ask QEMU to hotplug additional memory. That call
  returns immediately — QEMU acknowledges the request, but the guest kernel onlines the new pages asynchronously over the next several hundred ms to seconds
  depending on host pressure.

  Between the moment the API returns and the moment the guest kernel finishes onlining, **`/proc/meminfo` reports memory that the guest can't actually back yet**.
  Any user workload that races the hotplug — `git clone`, `npm install`, `cargo build`, even just a malloc-heavy program — can crash on memory the kernel has
  accounted for but isn't yet committed. We've seen this fail intermittently in customer sandboxes immediately after scale-ups.

  ## The fix

  Add a per-VM `memoryReady chan` that gates `getReadyVM` (every exec / file-op path) until the guest has onlined enough memory for typical workloads.

  - When `SetResourceLimits` triggers a scale-up (`additionalMB > prevRequestedMB`), open a fresh `memoryReady` channel and spawn `watchMemoryHotplug`.
  - The goroutine polls `awk '/MemTotal/ {print $2}' /proc/meminfo` inside the guest every 100 ms via the agent.
  - Once the guest reports `MemTotal ≥ baseMemoryMB + readyThresholdMB` (where `readyThresholdMB = min(1024, additionalMB)`), close the channel and let waiters
  through.
  - Hard-cap the wait at 10 s in the watcher and 5 s in `getReadyVM` so a stalled hotplug never wedges callers — they fall through with a log line.

  Created a fresh 1 CPU / 1024 MB sandbox on `dev.opensandbox.ai`, then fired a `POST /scale` to 4096 MB and an `exec` 50 ms later, racing the hotplug.

  ```
  exec 1 (before scale, baseline) →    6.4 ms latency, MemTotal: 917 MB
  exec 2 (raced, gated)            →   58.4 ms latency  ← held by gate
  exec 3 (after scale)             →    6.9 ms latency, MemTotal: 3.97 GB
  ```

  Worker log captures the gate firing:
  ```
  qemu: virtio-mem sb-a7e355b3: 3072MB additional (total 4096MB)
  qemu: virtio-mem sb-a7e355b3: hotplug gate opened (3968MB onlined, needed 2048MB)
  ```

  Threshold math on `requiredTotalMB`:
  ```
  readyThresholdMB = min(1024, 3072) = 1024
  requiredTotalMB  = baseMemoryMB + readyThresholdMB = 1024 + 1024 = 2048   ← matches log
  ```

  `exec 2`'s latency was ~10× normal because the gate held it while virtio-mem committed 3968 MB. Once enough was online, the channel closed and the exec ran — and
   saw `MemTotal: 3.97 GB`, i.e. real backed memory, not allocated-but-unbacked.

  The host on dev had fast NVMe + warm page cache, so hotplug completed in ~58 ms and the gate barely held. On a contended host where virtio-mem actually has to
  commit pages slowly, the gate would hold proportionally longer — which is exactly when the original race manifests, and exactly when this fix matters.

  ## Files changed
  - `internal/qemu/manager.go` — `memoryReady` channel on `VMInstance`, `watchMemoryHotplug` goroutine, gate in `getReadyVM`

  ## Notes
  - Pre-existing memory hotplugs are treated as "already ready" (`memoryReady = nil`), so this is backward-compatible with running sandboxes.
  - The watcher's `defer` block protects against double-close on already-closed channels.
  - Both timeouts (10 s in watcher, 5 s in `getReadyVM`) emit log lines so we'll see in production if hotplug stalls become a real pattern rather than a tail
  event.