### PR TITLE
oc exec: stream by default, implement `oc exec attach`

### DIFF
--- a/cmd/oc/internal/commands/exec.go
+++ b/cmd/oc/internal/commands/exec.go
@@ -1,13 +1,27 @@
 package commands
 
 import (
+	"context"
+	"encoding/binary"
 	"fmt"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
+	"github.com/gorilla/websocket"
 	"github.com/opensandbox/opensandbox/cmd/oc/internal/client"
 	"github.com/opensandbox/opensandbox/pkg/types"
 	"github.com/spf13/cobra"
+)
+
+// Exec WebSocket binary protocol stream IDs.
+const (
+	execStreamStdin         = 0x00
+	execStreamStdout        = 0x01
+	execStreamStderr        = 0x02
+	execStreamExit          = 0x03
+	execStreamScrollbackEnd = 0x04
 )
 
 var execCmd = &cobra.Command{
@@ -15,17 +29,25 @@ var execCmd = &cobra.Command{
 	Short: "Execute a command in a sandbox",
 	Long: `Execute a command in a running sandbox using session-based exec.
 
-Creates an exec session, attaches via WebSocket, and streams output.
-Use --wait to wait for completion and exit with the process exit code.
+By default, creates a session, attaches to it over WebSocket, and streams
+stdout/stderr live to your terminal. The CLI exits with the command's
+exit code. Stdin is forwarded to the process (Ctrl-C sends SIGINT; press
+Ctrl-C twice to force-detach).
+
+Modes:
+  (default)   create, stream live, exit with the command's exit code
+  --detach    create and print the session id, don't wait
+  --wait      run synchronously via /exec/run (buffered, no streaming)
 
 Examples:
   oc exec abc123 -- echo hello
-  oc exec abc123 --wait -- npm install
+  oc exec abc123 -- npm install           # streams output live
+  oc exec abc123 --detach -- long-job     # fire and forget
   oc exec abc123 --cwd /app -- ls -la
 
 Subcommands:
   oc exec list <sandbox-id>                   List active exec sessions
-  oc exec attach <sandbox-id> <session-id>    Reconnect to a session
+  oc exec attach <sandbox-id> <session-id>    Reconnect + stream
   oc exec kill <sandbox-id> <session-id>      Kill a session`,
 	Args:               cobra.MinimumNArgs(1),
 	DisableFlagParsing: false,
@@ -44,9 +66,14 @@ Subcommands:
 		timeout, _ := cmd.Flags().GetInt("timeout")
 		envSlice, _ := cmd.Flags().GetStringSlice("env")
 		wait, _ := cmd.Flags().GetBool("wait")
+		detach, _ := cmd.Flags().GetBool("detach")
+
+		if wait && detach {
+			return fmt.Errorf("--wait and --detach are mutually exclusive")
+		}
 
 		if wait {
-			// Wait mode: use exec/run endpoint for synchronous execution
+			// Buffered mode: POST /exec/run, print everything at the end.
 			req := types.ProcessConfig{
 				Command: command,
 				Args:    cmdArgs,
@@ -76,7 +103,7 @@ Subcommands:
 			return nil
 		}
 
-		// Non-wait mode: create exec session
+		// Create an exec session.
 		req := types.ExecSessionCreateRequest{
 			Command: command,
 			Args:    cmdArgs,
@@ -90,11 +117,23 @@ Subcommands:
 			return err
 		}
 
-		if jsonOutput {
-			printer.PrintJSON(sessionInfo)
-		} else {
-			fmt.Printf("Session %s created (command: %s)\n", sessionInfo.SessionID, sessionInfo.Command)
-			fmt.Printf("Attach with: oc exec attach %s %s\n", sandboxID, sessionInfo.SessionID)
+		if detach {
+			if jsonOutput {
+				printer.PrintJSON(sessionInfo)
+			} else {
+				fmt.Printf("Session %s created (command: %s)\n", sessionInfo.SessionID, sessionInfo.Command)
+				fmt.Printf("Attach with: oc exec attach %s %s\n", sandboxID, sessionInfo.SessionID)
+			}
+			return nil
+		}
+
+		// Default: attach + stream.
+		code, err := streamExecSession(cmd.Context(), c, sandboxID, sessionInfo.SessionID, true)
+		if err != nil {
+			return err
+		}
+		if code != 0 {
+			os.Exit(code)
 		}
 		return nil
 	},
@@ -142,13 +181,23 @@ var execListCmd = &cobra.Command{
 
 var execAttachCmd = &cobra.Command{
 	Use:   "attach <sandbox-id> <session-id>",
-	Short: "Reconnect to an exec session",
-	Args:  cobra.ExactArgs(2),
+	Short: "Reconnect to an exec session and stream its output",
+	Long: `Open a WebSocket to an existing exec session. The server replays the
+scrollback buffer (historical output), then switches to live streaming.
+Stdin is forwarded to the process; Ctrl-C sends SIGINT.`,
+	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		c := client.FromContext(cmd.Context())
 		sandboxID := args[0]
 		sessionID := args[1]
-		fmt.Fprintf(os.Stderr, "Attach to session %s on sandbox %s via WebSocket (not yet implemented in CLI)\n", sessionID, sandboxID)
-		fmt.Fprintf(os.Stderr, "Use the SDK or websocat to connect to: /sandboxes/%s/exec/%s\n", sandboxID, sessionID)
+
+		code, err := streamExecSession(cmd.Context(), c, sandboxID, sessionID, true)
+		if err != nil {
+			return err
+		}
+		if code != 0 {
+			os.Exit(code)
+		}
 		return nil
 	},
 }
@@ -175,11 +224,104 @@ var execKillCmd = &cobra.Command{
 	},
 }
 
+// streamExecSession attaches to an exec session's WebSocket, pipes
+// stdout/stderr to the terminal, forwards stdin when requested, and
+// returns when the session ends. Returns the process exit code, or -1
+// if the WS closed without an exit frame.
+//
+// First SIGINT sends SIGINT to the process via the HTTP kill endpoint;
+// a second SIGINT aborts the CLI without waiting.
+func streamExecSession(ctx context.Context, c *client.Client, sandboxID, sessionID string, forwardStdin bool) (int, error) {
+	wsPath := fmt.Sprintf("/sandboxes/%s/exec/%s", sandboxID, sessionID)
+	conn, err := c.DialWebSocket(ctx, wsPath)
+	if err != nil {
+		return -1, fmt.Errorf("attach failed: %w", err)
+	}
+	defer conn.Close()
+
+	// Graceful Ctrl-C: forward SIGINT to the process. Second Ctrl-C bails.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	interrupts := 0
+	go func() {
+		for range sigCh {
+			interrupts++
+			if interrupts >= 2 {
+				conn.Close()
+				return
+			}
+			body := map[string]int{"signal": int(syscall.SIGINT)}
+			_ = c.Post(ctx, fmt.Sprintf("/sandboxes/%s/exec/%s/kill", sandboxID, sessionID), body, nil)
+			fmt.Fprintln(os.Stderr, "\n^C sent SIGINT (press again to force-detach)")
+		}
+	}()
+
+	// Stdin → WS (stream 0x00). Runs until EOF/error.
+	if forwardStdin {
+		go func() {
+			buf := make([]byte, 4096)
+			for {
+				n, err := os.Stdin.Read(buf)
+				if n > 0 {
+					msg := make([]byte, 1+n)
+					msg[0] = execStreamStdin
+					copy(msg[1:], buf[:n])
+					if werr := conn.WriteMessage(websocket.BinaryMessage, msg); werr != nil {
+						return
+					}
+				}
+				if err != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	// WS → stdout/stderr. Exit frame terminates.
+	exitCode := -1
+	gotExit := false
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		if len(msg) < 1 {
+			continue
+		}
+		switch msg[0] {
+		case execStreamStdout:
+			_, _ = os.Stdout.Write(msg[1:])
+		case execStreamStderr:
+			_, _ = os.Stderr.Write(msg[1:])
+		case execStreamExit:
+			gotExit = true
+			if len(msg) >= 5 {
+				exitCode = int(int32(binary.BigEndian.Uint32(msg[1:5])))
+			} else {
+				exitCode = 0
+			}
+		case execStreamScrollbackEnd:
+			// Marks the boundary between replayed history and live output.
+			// Nothing to do for the CLI — we stream both the same way.
+		}
+	}
+
+	if !gotExit {
+		// WS closed without an exit frame — either the user force-detached
+		// (second Ctrl-C) or the network dropped. Return -1 so the caller
+		// can decide what to do.
+		return -1, nil
+	}
+	return exitCode, nil
+}
+
 func init() {
 	execCmd.Flags().String("cwd", "", "Working directory")
 	execCmd.Flags().Int("timeout", 0, "Timeout in seconds (0 = no timeout)")
 	execCmd.Flags().StringSlice("env", nil, "Environment variables (KEY=VALUE)")
-	execCmd.Flags().Bool("wait", false, "Wait for command to exit and print result")
+	execCmd.Flags().Bool("wait", false, "Run synchronously via /exec/run (buffered, no streaming)")
+	execCmd.Flags().Bool("detach", false, "Create the session and print its id; don't stream")
 
 	execKillCmd.Flags().Int("signal", 9, "Signal to send (default SIGKILL=9)")
 


### PR DESCRIPTION
## Summary

Fix two CLI UX holes:

1. **`oc exec <sb> -- cmd`** (default, no flags) now creates a session, **attaches over WebSocket, and streams stdout/stderr live** to the user's terminal while forwarding stdin. The CLI exits with the command's exit code. Previously this path just POSTed to `/exec` and printed "Session X created / attach with ..." — a dead-end for anyone who actually wanted output.

2. **`oc exec attach <sb> <sid>`** was a stub that printed "not yet implemented in CLI — use the SDK or websocat." It now works: replays scrollback, streams live, forwards stdin, exits with the process exit code.

Both use the same binary WS protocol the SDKs speak (`0x00` stdin, `0x01` stdout, `0x02` stderr, `0x03` exit (big-endian int32), `0x04` scrollback-end). No backend changes — all the server-side plumbing for this has existed since exec sessions shipped.

## Flag changes

| Flag | Behavior |
| --- | --- |
| *(no flag)* | **New default:** create session + stream + exit with process exit code |
| `--detach` | **New:** create session, print id + hint, don't wait (preserves old no-flag behavior for fire-and-forget scripts) |
| `--wait` | Unchanged: buffered `/exec/run` POST, no streaming, prints result at the end (mutually exclusive with `--detach`) |

## Ctrl-C handling

First Ctrl-C sends SIGINT to the remote process via `/exec/:sid/kill` and keeps streaming — the process decides whether to handle it. Second Ctrl-C force-closes the WS and exits the CLI locally (the remote process keeps running; use `oc exec kill` to terminate it).

## Test plan

- [ ] `oc exec <sb> -- echo hello` — streams \"hello\", exits 0
- [ ] `oc exec <sb> -- sh -c 'echo out; echo err >&2; exit 7'` — stdout and stderr visibly separated, CLI exits 7
- [ ] `oc exec <sb> -- sleep 5` with Ctrl-C — first Ctrl-C interrupts, prints `^C sent SIGINT`; CLI exits when sleep is killed
- [ ] `oc exec <sb> -- cat` with piped stdin (`echo foo | oc exec ...`) — `foo` echoed back
- [ ] `oc exec <sb> --detach -- long-job` — prints session id, exits immediately
- [ ] `oc exec attach <sb> <sid>` against a detached session — scrollback replayed, live streaming continues
- [ ] `oc exec <sb> --wait -- cmd` — unchanged behavior, buffered result
- [ ] `oc exec <sb> --wait --detach -- cmd` — rejected with clear error

## Follow-ups (not in this PR)

- Fix typical Ctrl-C-from-pty issue: when stdin isn't a tty we rely on OS signal delivery; terminal raw-mode for richer key forwarding could come later.
- Consider making `--wait` delegate to the streaming path too (streaming is a strict superset). Not done here to avoid breaking scripts that parse the final buffered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)