### PR TITLE
set max limit 4096, zombie reaper

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -43,6 +43,14 @@ func main() {
 		srv.ListenPort = listenPortForPTY
 	}
 
+	// SIGCHLD reaper: when osb-agent runs as PID 1, every orphaned process
+	// in the VM is re-parented to it. If we don't wait4() them they stay as
+	// zombies, occupying a slot in the sandbox cgroup's pids.max budget.
+	// Within hours of a build/test loop the customer hits "fork failed:
+	// resource temporarily unavailable" even though they have nothing
+	// running. Drain on each SIGCHLD; signals coalesce so we loop.
+	startReaper()
+
 	// Signal handling:
 	// SIGTERM/SIGINT: clean shutdown (exit)
 	// SIGUSR1: hibernate prep — reset virtio-serial listener so Accept

--- a/cmd/agent/reaper_linux.go
+++ b/cmd/agent/reaper_linux.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
+)
+
+// startReaper spawns a goroutine that waits on SIGCHLD and reaps any
+// available zombie children. This is mandatory when osb-agent runs as PID 1
+// (always true inside the sandbox VM) — Linux re-parents orphaned processes
+// to PID 1, which is then responsible for calling wait() on them. If we
+// don't, zombies accumulate in the sandbox cgroup's pids.max budget and
+// eventually every fork() returns EAGAIN.
+//
+// Also calls prctl(PR_SET_CHILD_SUBREAPER) defensively so reaping still
+// works even if some future setup parents us to PID > 1.
+func startReaper() {
+	// Best-effort: PR_SET_CHILD_SUBREAPER (option 36). If running as PID 1
+	// this is a no-op; if not, it makes us inherit orphans of our subtree.
+	const PR_SET_CHILD_SUBREAPER = 36
+	_, _, _ = syscall.Syscall(syscall.SYS_PRCTL, PR_SET_CHILD_SUBREAPER, 1, 0)
+
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGCHLD)
+	go func() {
+		for range ch {
+			drainZombies()
+		}
+	}()
+}
+
+var reapedTotal atomic.Int64
+
+// drainZombies repeatedly waits for any child in non-blocking mode until
+// none are available. Multiple SIGCHLDs that arrive while we're already
+// reaping coalesce into one delivery, so each notification must drain all.
+func drainZombies() {
+	for {
+		var ws syscall.WaitStatus
+		pid, err := syscall.Wait4(-1, &ws, syscall.WNOHANG, nil)
+		if pid <= 0 {
+			// 0 = children exist but none ready; ECHILD = no children.
+			if err != nil && err != syscall.ECHILD {
+				log.Printf("agent: reaper: wait4 error: %v", err)
+			}
+			return
+		}
+		n := reapedTotal.Add(1)
+		// Log first few + every 100th so the journal stays readable.
+		if n <= 5 || n%100 == 0 {
+			log.Printf("agent: reaped pid=%d (status=%d, total=%d)", pid, ws.ExitStatus(), n)
+		}
+	}
+}

--- a/cmd/agent/reaper_other.go
+++ b/cmd/agent/reaper_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package main
+
+// startReaper is a no-op on non-Linux platforms. The agent only runs as
+// PID 1 inside the sandbox VM (Linux); local Darwin/Windows builds are
+// for testing and don't need to reap children.
+func startReaper() {}

--- a/deploy/ec2/build-rootfs-docker.sh
+++ b/deploy/ec2/build-rootfs-docker.sh
@@ -164,10 +164,15 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
     echo "+cpu +memory +pids" > /sys/fs/cgroup/cgroup.subtree_control 2>/dev/null
     # Create sandbox cgroup
     mkdir -p /sys/fs/cgroup/sandbox
-    # Defaults: 256 pids, 90% of total memory, 90% of CPUs
+    # Defaults: 4096 pids, 90% of total memory, 90% of CPUs.
+    # 4096 is enough headroom for typical dev tooling (npm install, go test,
+    # multi-process build systems) while still bounding fork-bomb damage.
+    # The previous default of 128 was below an interactive shell + LSP +
+    # build agent working set, and customers hit "fork failed: resource
+    # temporarily unavailable" inside otherwise-idle sandboxes.
     # CPU limit reserves 10% for the agent (PID 1) so it stays responsive
     # even under fork bomb / CPU exhaustion attacks.
-    echo 128 > /sys/fs/cgroup/sandbox/pids.max
+    echo 4096 > /sys/fs/cgroup/sandbox/pids.max
     SANDBOX_MEM=$(awk '/MemTotal/{printf "%.0f", $2 * 1024 * 0.9}' /proc/meminfo)
     echo "$SANDBOX_MEM" > /sys/fs/cgroup/sandbox/memory.max 2>/dev/null
     # cpu.max: limit user processes to 80% of available CPUs.
@@ -178,7 +183,7 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
     echo "$CPU_MAX 100000" > /sys/fs/cgroup/sandbox/cpu.max 2>/dev/null
     # cpu.weight: lower priority than agent
     echo 50 > /sys/fs/cgroup/sandbox/cpu.weight 2>/dev/null
-    echo "init: cgroup sandbox ready (pids=128, mem=${SANDBOX_MEM}, cpu=${CPU_MAX}/100000)"
+    echo "init: cgroup sandbox ready (pids=4096, mem=${SANDBOX_MEM}, cpu=${CPU_MAX}/100000)"
 else
     echo "init: warning: cgroup v2 not available"
 fi


### PR DESCRIPTION
# Sandbox PID exhaustion: reap zombies + raise pids.max

  Customer report: long-running sandboxes hit `fork failed: resource temporarily unavailable` on every shell command, dashboard shows 100+ "processes" the
  user didn't create, and `kill` doesn't help because the processes are zombies parented to PID 1.

  Two independent bugs combine to produce this. Fixing both.

  ## Bug 1 — `osb-agent` (PID 1) doesn't reap zombie children

  Inside the sandbox VM, `osb-agent` runs as PID 1. Linux re-parents every orphaned process in the system to PID 1, which is then expected to call `wait()` on
   them to free their kernel `task_struct` and PID slot.

  The agent only handled `SIGTERM`/`SIGINT`/`SIGUSR1`. **No SIGCHLD handler. No `wait4` loop.** Every orphan re-parented to PID 1 became a permanent zombie,
  holding its slot in `pids.current` forever. Within hours of normal `npm install` / `cargo build` / shell-pipeline activity, `pids.current` drifts up
  monotonically until it hits `pids.max` and every `fork()` returns `EAGAIN`.

  **Fix** (`cmd/agent/reaper_linux.go`): goroutine waits on SIGCHLD, drains all available children with `syscall.Wait4(-1, &ws, WNOHANG, nil)` in a loop until
   0/ECHILD on each notification (POSIX signals coalesce — a single SIGCHLD can mean N dead children). Also calls `prctl(PR_SET_CHILD_SUBREAPER)` defensively
  so the reaper still works if some future setup ends up parenting us to PID > 1.

  Non-Linux build stub so local Darwin development still compiles.

  ## Bug 2 — `pids.max=128` is hardcoded and far too low

  `deploy/ec2/build-rootfs-docker.sh:170` set the sandbox cgroup to `pids.max=128` (the comment said 256 but the code set 128). Even with proper zombie
  reaping, 128 doesn't fit modern dev tooling: an interactive shell + LSP + a single `go test ./...` or `npm install` legitimately spikes well past it.

  **Fix**: bump default to `4096`. Headroom for typical dev workloads while still bounding fork-bomb damage. Updated the log line to match.

  ## Impact on existing customers

  This change flips the rootfs `INPUT_HASH` (new agent binary + modified rootfs build script), so it triggers a new `goldenVersion` and a fresh AMI rollout.

  For the specific customer who reported this: shell-in is currently impossible because forks fail. The only paths forward for **their existing sandbox** are
  recreate or remote `SetResourceLimits` bump. New sandboxes after this rolls will be fine.