### PR TITLE
ensure theres no inbetween state

### DIFF
--- a/internal/controlplane/scaler.go
+++ b/internal/controlplane/scaler.go
@@ -867,6 +867,19 @@ func (s *Scaler) drainWorker(workerID, machineID, region string) {
 		}
 		if len(running) == 0 {
 			log.Printf("scaler: drain: worker %s fully drained", workerID)
+			// Terminal sweep: a post-QMP migration failure may leave DB rows
+			// pointing at this worker even though ListSandboxes returns 0.
+			// Reconcile any leftover running/migrating rows here so the row
+			// reflects reality before the worker gets destroyed.
+			if s.store != nil {
+				sweepCtx, sweepCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				if n, err := s.store.MarkOrphanedOnWorker(sweepCtx, workerID, "drain completed; worker reported no sandboxes"); err != nil {
+					log.Printf("scaler: drain: orphan sweep on %s failed: %v", workerID, err)
+				} else if n > 0 {
+					log.Printf("scaler: drain: orphan sweep on %s reconciled %d phantom row(s)", workerID, n)
+				}
+				sweepCancel()
+			}
 			return
 		}
 
@@ -1240,13 +1253,29 @@ func (s *Scaler) liveMigrateSandbox(ctx context.Context, sandboxID, sourceWorker
 	// Must happen after target selection because the DB row records the
 	// destination worker.
 	migrationCompleted := false
+	qmpSucceeded := false
 	if s.store != nil {
 		if err := s.store.SetMigrating(ctx, sandboxID, targetWorkerID); err != nil {
 			log.Printf("scaler: failed to set migrating state for %s: %v", sandboxID, err)
 		}
 		defer func() {
-			if !migrationCompleted && s.store != nil {
-				s.store.FailMigration(ctx, sandboxID)
+			if migrationCompleted || s.store == nil {
+				return
+			}
+			// Recovery path depends on which phase failed:
+			//   - Pre-QMP: source still has the VM. Revert to running on source.
+			//   - Post-QMP: source's QEMU has shut down (state migrated). Reverting to
+			//     running on source produces a phantom — DB says running, source has
+			//     no QEMU, drain's ListSandboxes returns 0 and exits cleanly leaving
+			//     the row stuck. Mark error instead so the sandbox is visibly broken.
+			if qmpSucceeded {
+				if err := s.store.FailMigrationPostQMP(ctx, sandboxID, "migration failed after QMP transfer; source VM gone, target failed to complete"); err != nil {
+					log.Printf("scaler: migrate %s: FailMigrationPostQMP failed: %v", sandboxID, err)
+				}
+			} else {
+				if err := s.store.FailMigration(ctx, sandboxID); err != nil {
+					log.Printf("scaler: migrate %s: FailMigration failed: %v", sandboxID, err)
+				}
 			}
 		}()
 	}
@@ -1285,6 +1314,10 @@ func (s *Scaler) liveMigrateSandbox(ctx context.Context, sandboxID, sourceWorker
 	if err != nil {
 		return fmt.Errorf("live migrate: %w", err)
 	}
+	// QMP transfer done — source has shut down its VM. Any failure from here
+	// must mark the sandbox as error rather than reverting to "running on source"
+	// (the source's QEMU is gone; reverting would produce a phantom).
+	qmpSucceeded = true
 
 	log.Printf("scaler: migrate %s: QMP migration complete (%dms)", sandboxID, time.Since(t0).Milliseconds())
 

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -597,12 +597,42 @@ func (s *Store) CompleteMigration(ctx context.Context, sandboxID, newWorkerID st
 }
 
 // FailMigration reverts a sandbox to running on its original worker after a failed migration.
+// Only safe before QMP transfer succeeds — after QMP, the source has lost the VM and reverting
+// to "running on source" produces a phantom (DB says running, source has no QEMU). Use
+// FailMigrationPostQMP in that case.
 func (s *Store) FailMigration(ctx context.Context, sandboxID string) error {
 	_, err := s.pool.Exec(ctx,
 		`UPDATE sandbox_sessions SET status = 'running', migrating_to_worker = ''
 		 WHERE sandbox_id = $1 AND status = 'migrating'`,
 		sandboxID)
 	return err
+}
+
+// FailMigrationPostQMP marks a sandbox as error after QMP transfer succeeded but the migration
+// failed to complete (typically agent-connect on target). After QMP, the source has shut down
+// its QEMU, so neither side has a healthy VM. Marking error (rather than reverting to running)
+// stops drainWorker from believing the sandbox is still alive on the source.
+func (s *Store) FailMigrationPostQMP(ctx context.Context, sandboxID, errorMsg string) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE sandbox_sessions SET status = 'error', migrating_to_worker = '', stopped_at = now(), error_msg = $2
+		 WHERE sandbox_id = $1 AND status = 'migrating'`,
+		sandboxID, errorMsg)
+	return err
+}
+
+// MarkOrphanedOnWorker marks any still-running/migrating sandboxes pointing at the given worker
+// as error. Called when drain finishes to sweep up rows the per-sandbox migration failure paths
+// missed — e.g. a sandbox that vanished from the worker (failed migration cleanup) but whose DB
+// row still references the worker.
+func (s *Store) MarkOrphanedOnWorker(ctx context.Context, workerID, errorMsg string) (int, error) {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE sandbox_sessions SET status = 'error', migrating_to_worker = '', stopped_at = now(), error_msg = $2
+		 WHERE worker_id = $1 AND status IN ('running', 'migrating')`,
+		workerID, errorMsg)
+	if err != nil {
+		return 0, err
+	}
+	return int(tag.RowsAffected()), nil
 }
 
 // RecoverStaleMigrations resets any sandbox stuck in 'migrating' status for more than the given duration.


### PR DESCRIPTION
If theres a failed transfer (like due to our PID exhaustion bug) we want to make sure they are properly marked