### PR TITLE
fix(capacity-test): anchor list-cursor pgfixture window around now

### DIFF
--- a/internal/db/capacity_pgfixture_test.go
+++ b/internal/db/capacity_pgfixture_test.go
@@ -257,8 +257,12 @@ func TestListReservations_cursor_pgfixture(t *testing.T) {
 		time.Sleep(2 * time.Millisecond)
 	}
 
-	from := time.Date(2029, 1, 1, 0, 0, 0, 0, time.UTC)
-	to := time.Date(2031, 1, 1, 0, 0, 0, 0, time.UTC)
+	// from/to filter on the reservation's createdAt, not the bucket time.
+	// CreateReservation uses time.Now().UTC() for createdAt, so anchor the
+	// window around wall-clock now.
+	now := time.Now().UTC()
+	from := now.Add(-1 * time.Hour)
+	to := now.Add(1 * time.Hour)
 
 	first, next, err := store.ListReservations(ctx, ListReservationsRequest{
 		OrgID: orgID, From: from, To: to, Limit: 2,


### PR DESCRIPTION
One-line test fix surfaced during post-merge smoke testing of phase-1 reserved capacity (PR #187).

`TestListReservations_cursor_pgfixture` used a fixed 2029–2031 window, but the audit-list endpoint filters by `created_at` (set to `time.Now().UTC()` at write time). Result: the test queried for rows 4 years in the future and got none.

Fix: anchor the window at `time.Now() ± 1 hour`. Other four capacity pgfixture tests don't filter by `created_at` and were unaffected.

Verified locally:
\`\`\`
TEST_DATABASE_URL=postgres://... go test -tags=pgfixture ./internal/db/ \
  -run 'TestCapacity|TestCreateReservation|TestListReservations' -v
\`\`\`
All 5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)