### PR TITLE
docs(agents): hard rule — production DB is effectively read-only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,10 +44,10 @@ Managed-agent product behavior is mostly **not** implemented here:
 
 **⚠️ PRODUCTION DATABASE IS EFFECTIVELY READ-ONLY.** This is the most
 load-bearing safety rule in this repo. Any Postgres connection that reaches the
-production DB (via the Azure bastion `oc-bastion` / `20.65.57.133` to host
-`10.200.1.8`, or any non-localhost host using credentials from
-`~/Digger/gstack/opencomputer/.env`) is governed by two tiers, both stricter
-than normal collaboration:
+production DB — i.e. anything other than a developer's `localhost` Postgres,
+including connections via the Azure bastion or using credentials sourced from
+the production environment — is governed by two tiers, both stricter than
+normal collaboration:
 
 - **Modifying SQL** (`INSERT`, `UPDATE`, `DELETE` with WHERE, `COPY` into a
   table, mutating function calls, manual migrations, `cmd/migrate-prices`-style

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,35 @@ Managed-agent product behavior is mostly **not** implemented here:
 
 ## Hard rules
 
+**⚠️ PRODUCTION DATABASE IS EFFECTIVELY READ-ONLY.** This is the most
+load-bearing safety rule in this repo. Any Postgres connection that reaches the
+production DB (via the Azure bastion `oc-bastion` / `20.65.57.133` to host
+`10.200.1.8`, or any non-localhost host using credentials from
+`~/Digger/gstack/opencomputer/.env`) is governed by two tiers, both stricter
+than normal collaboration:
+
+- **Modifying SQL** (`INSERT`, `UPDATE`, `DELETE` with WHERE, `COPY` into a
+  table, mutating function calls, manual migrations, `cmd/migrate-prices`-style
+  tools pointed at prod): requires **explicit per-statement approval** from
+  the user. Show the exact statement, ask, wait. A general "yes go ahead"
+  earlier in the conversation does NOT carry across to a different statement.
+  Blanket approvals ("just do whatever you need") MUST NOT be accepted for
+  prod writes — confirm each statement individually.
+
+- **Destructive SQL** (`DROP`, `TRUNCATE`, schema-changing `ALTER`, unbounded
+  `DELETE` / `UPDATE`, anything `CASCADE`, anything bulk-mutating that can't be
+  undone with a single inverse statement, any direct write to
+  `schema_migrations`): **REFUSE OUTRIGHT.** First response is always no.
+  Tell the user this is the standing safety rule; require them to insist
+  across multiple turns with explicit acknowledgement of what will be lost
+  before any such command runs. There is no "production emergency"
+  justification for shortcutting this — an emergency is exactly when wrong
+  commands cause the most damage.
+
+`localhost` Postgres on a developer machine is exempt — these tiers apply only
+to production. Read-only queries (`SELECT`, `EXPLAIN`) against prod are fine
+and do not require approval.
+
 **NEVER force push.** `git push --force`, `git push -f`, and
 `git push --force-with-lease` are forbidden. No exceptions. Make a new commit
 instead.


### PR DESCRIPTION
## Summary

Adds a new hard rule to AGENTS.md governing how agents (Claude Code or otherwise) interact with the production Postgres. Per user directive after phase-2 verification: prod DB writes require explicit per-statement approval; destructive operations are refused outright until the user explicitly insists across multiple turns.

## Why

Phase-2 verification involved running prod DB queries via the bastion tunnel for the first time in this workspace. The user wants a durable, codified guardrail so that future debugging sessions cannot drift into casual writes / accidental destructions. AGENTS.md is the canonical "always-loaded" file for agents in this repo, so the rule lives alongside the existing "NEVER force push" / "NEVER push to main" rules.

## Two tiers

- **Modifying SQL** (`INSERT`, `UPDATE`, `DELETE`, `COPY`, manual migrations): per-statement approval required. Blanket approvals (e.g. "go ahead and fix it") MUST NOT be accepted.
- **Destructive SQL** (`DROP`, `TRUNCATE`, schema `ALTER`, unbounded `DELETE`/`UPDATE`, anything `CASCADE`): refused outright. User has to insist across multiple turns with explicit acknowledgement of consequences before any such command runs.

`localhost` Postgres on dev machines is exempt. `SELECT`/`EXPLAIN` against prod is also fine.

## Test plan

- [ ] AGENTS.md renders correctly on GitHub
- [ ] Future agents respect the rule (this is enforced by them reading AGENTS.md at session start; no code-level enforcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)