### PR TITLE
fix(proxy): raise preview URL response header timeout to 60s

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -252,7 +252,7 @@ func (p *SandboxProxy) doHTTP(c echo.Context, sandboxID, addr string, hostPort i
 			DialContext: (&net.Dialer{
 				Timeout: 2 * time.Second,
 			}).DialContext,
-			ResponseHeaderTimeout: 10 * time.Second,
+			ResponseHeaderTimeout: 60 * time.Second,
 		}
 
 		var proxyErr error


### PR DESCRIPTION
## Summary
- Bump `ResponseHeaderTimeout` on the preview-URL reverse proxy from 10s → 60s in `internal/proxy/proxy.go`.
- 10s was too tight for cold-starting dev servers commonly run behind preview URLs (Next.js first compile, Vite SSR, Rails boot, slow Python startup).
- 60s leaves enough headroom for cold starts without holding connections open indefinitely on truly stuck upstreams. The 2s `DialContext` and 5s WebSocket-dial timeouts are unchanged.

## Test plan
- [ ] Hit a freshly-started preview URL backed by a cold Next.js / Vite dev server and confirm the first request no longer 502s on header timeout.
- [ ] Confirm normal/warm preview-URL traffic is unaffected.
- [ ] Confirm a genuinely unresponsive upstream still fails (just at 60s instead of 10s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)