### PR TITLE
docs(reserved-capacity): mark live + fix code/doc drift

### DIFF
--- a/docs/api-reference/capacity/create-reservations.mdx
+++ b/docs/api-reference/capacity/create-reservations.mdx
@@ -3,11 +3,6 @@ title: 'Create Reservation'
 api: 'POST /api/capacity/reservations'
 ---
 
-<Info>
-  **Coming soon.** Reserved capacity is not yet available. See the
-  [Reserved Capacity overview](/reserved-capacity/overview).
-</Info>
-
 Commit capacity across one or more 15-minute UTC intervals in a single
 atomic write. The result is one reservation event with a server-generated
 `reservationId` covering all intervals in the request. See

--- a/docs/api-reference/capacity/get-calendar.mdx
+++ b/docs/api-reference/capacity/get-calendar.mdx
@@ -19,11 +19,9 @@ per-org `reservationLimitGb`. See
 <ResponseExample>
 ```json 200
 {
-  "generatedAt": "2026-04-28T18:00:00Z",
-  "staleAt":     "2026-04-28T18:00:10Z",
-  "intervalDuration": "PT15M",
-  "timezone": "UTC",
-  "earliestReservableStart": "2026-04-28T18:30:00Z",
+  "from":      "2026-04-29T02:00:00Z",
+  "to":        "2026-04-29T04:00:00Z",
+  "resource":  "memory_gb",
   "intervals": [
     {
       "startsAt": "2026-04-29T02:00:00Z",

--- a/docs/api-reference/capacity/get-calendar.mdx
+++ b/docs/api-reference/capacity/get-calendar.mdx
@@ -3,11 +3,6 @@ title: 'Get Calendar'
 api: 'GET /api/capacity/calendar'
 ---
 
-<Info>
-  **Coming soon.** Reserved capacity is not yet available. See the
-  [Reserved Capacity overview](/reserved-capacity/overview).
-</Info>
-
 Return a planning snapshot of 15-minute UTC intervals in the requested window.
 One row per interval with current `reservedGb`, `reservableGb`, and the
 per-org `reservationLimitGb`. See

--- a/docs/api-reference/capacity/list-reservations.mdx
+++ b/docs/api-reference/capacity/list-reservations.mdx
@@ -8,11 +8,11 @@ reverse-chronological order by `createdAt`. Each reservation row includes
 all the intervals it committed to. Useful for end-of-month reconciliation
 and audit.
 
-<ParamField query="from" type="string">
+<ParamField query="from" type="string" required>
   Return reservations whose `createdAt >= from`. RFC 3339, UTC.
 </ParamField>
 
-<ParamField query="to" type="string">
+<ParamField query="to" type="string" required>
   Return reservations whose `createdAt < to`. RFC 3339, UTC.
 </ParamField>
 
@@ -27,6 +27,8 @@ and audit.
 <ResponseExample>
 ```json 200
 {
+  "from": "2026-04-01T00:00:00Z",
+  "to":   "2026-05-01T00:00:00Z",
   "reservations": [
     {
       "reservationId": "9f67b8f7-7b91-4d2d-b1cb-19d0d0a14562",

--- a/docs/api-reference/capacity/list-reservations.mdx
+++ b/docs/api-reference/capacity/list-reservations.mdx
@@ -3,11 +3,6 @@ title: 'List Reservations'
 api: 'GET /api/capacity/reservations'
 ---
 
-<Info>
-  **Coming soon.** Reserved capacity is not yet available. See the
-  [Reserved Capacity overview](/reserved-capacity/overview).
-</Info>
-
 Return reservation events made by the authenticated org, in
 reverse-chronological order by `createdAt`. Each reservation row includes
 all the intervals it committed to. Useful for end-of-month reconciliation

--- a/docs/reserved-capacity/calendar.mdx
+++ b/docs/reserved-capacity/calendar.mdx
@@ -3,11 +3,6 @@ title: "Reading the Calendar"
 description: "Preview reservable capacity and existing commitments per 15-minute interval"
 ---
 
-<Info>
-  **Coming soon.** Reserved capacity is not yet available. The contract below
-  may change before launch.
-</Info>
-
 The calendar is how you plan. It answers, per 15-minute interval:
 
 1. How much GB can I still reserve here?

--- a/docs/reserved-capacity/calendar.mdx
+++ b/docs/reserved-capacity/calendar.mdx
@@ -28,11 +28,9 @@ curl "https://app.opencomputer.dev/api/capacity/calendar?from=2026-04-29T02:00:0
 
 ```json
 {
-  "generatedAt": "2026-04-28T18:00:00Z",
-  "staleAt":     "2026-04-28T18:00:10Z",
-  "intervalDuration": "PT15M",
-  "timezone": "UTC",
-  "earliestReservableStart": "2026-04-28T18:30:00Z",
+  "from":      "2026-04-29T02:00:00Z",
+  "to":        "2026-04-29T04:00:00Z",
+  "resource":  "memory_gb",
   "intervals": [
     {
       "startsAt": "2026-04-29T02:00:00Z",
@@ -49,11 +47,9 @@ curl "https://app.opencomputer.dev/api/capacity/calendar?from=2026-04-29T02:00:0
 
 | Field | Meaning |
 | --- | --- |
-| `generatedAt` | When the server computed this snapshot. |
-| `staleAt` | After this, refresh before using the snapshot for planning. |
-| `intervalDuration` | Always `PT15M` in v1. |
-| `timezone` | Always `UTC` in v1. |
-| `earliestReservableStart` | First interval currently eligible for new reservations. The server enforces a minimum lead time between `now` and a bookable `startsAt`. |
+| `from`, `to` | The query window, echoed back. |
+| `resource` | Always `memory_gb` in v1. |
+| `intervals` | One row per 15-minute interval in the window. |
 
 ### Per-interval fields
 
@@ -63,6 +59,11 @@ curl "https://app.opencomputer.dev/api/capacity/calendar?from=2026-04-29T02:00:0
 | `reservationLimitGb` | Maximum GB this org may commit in this interval (your `max_memory_gb`). |
 | `reservedGb` | Total GB this org already has reserved in this interval. |
 | `reservableGb` | Additional GB the server would currently accept. **This is the number to plan against.** |
+
+The server enforces a **30-minute minimum lead time** between `now`
+and a reservation's `startsAt`. Intervals starting sooner are returned
+in the calendar (so you can see your existing commitments) but the
+write endpoint rejects new reservations against them.
 
 ## `reservableGb` is the planning field
 
@@ -75,11 +76,11 @@ Everything you need to decide "can I reserve 50 GB at 02:00?" is in
 - `reservedGb` lets you confirm what you already hold without a separate
   call to `GET /api/capacity/reservations`.
 
-## `staleAt` is a freshness marker, not a hold
+## The calendar is a snapshot, not a hold
 
-The calendar snapshot is cheap and immediate. `staleAt` tells you when to
-refresh, but capacity can change at any moment — another tenant (or you,
-in another tab) may reserve between `generatedAt` and your write.
+The calendar reflects state at the moment the request was served.
+Capacity can change between read and write — another tenant (or you,
+in another tab) may reserve in the meantime.
 
 This is fine. Writes are atomic and validation is authoritative: if
 capacity moved, the write returns `capacity_not_available` and you read

--- a/docs/reserved-capacity/concepts.mdx
+++ b/docs/reserved-capacity/concepts.mdx
@@ -91,20 +91,13 @@ See [Reading the calendar](/reserved-capacity/calendar) for the full shape.
 
 ## Per-org capacity cap
 
-Your org has a single configured ceiling: `max_memory_gb`. It applies in
-two places:
+Your org has a configured ceiling: `max_memory_gb`. It limits how
+much capacity you can hold in any single 15-minute interval — your
+`reservedGb` for an interval cannot exceed it. The cap appears as
+`reservationLimitGb` in calendar interval rows.
 
-| Where | What it limits |
-| --- | --- |
-| Reservations | Across any single interval, your `reservedGb` cannot exceed `max_memory_gb`. |
-| Runtime | Your concurrent running memory across all sandboxes cannot exceed `max_memory_gb` either. |
-
-Same number, two enforcement points. The mental model: "I can have up to
-N GB of memory in flight at once, whether reserved or running." If you
-need to reserve more than your current limit allows, ask to have the
-limit raised.
-
-This appears as `reservationLimitGb` in calendar interval rows.
+If you need to reserve more than your current limit allows, ask to
+have the limit raised.
 
 ## Usage and overage
 

--- a/docs/reserved-capacity/concepts.mdx
+++ b/docs/reserved-capacity/concepts.mdx
@@ -3,11 +3,6 @@ title: "Concepts"
 description: "Intervals, reservations, the reservation log, and the per-org cap"
 ---
 
-<Info>
-  **Coming soon.** Reserved capacity is not yet available. The contract below
-  may change before launch.
-</Info>
-
 A small vocabulary. Learn these and the rest of the API reads itself.
 
 ## Interval

--- a/docs/reserved-capacity/overview.mdx
+++ b/docs/reserved-capacity/overview.mdx
@@ -78,9 +78,9 @@ that interval falls back to on-demand rates.
 
 ## Why reserve instead of running on-demand?
 
-| | On-demand | Reserved |
+| | On-demand (instant) | Reserved (pre-booked) |
 | --- | --- | --- |
-| Cost per GB-second | Higher (includes reserve-margin premium) | Lower |
+| Rate | $0.060/GB-hour | $0.012/GB-hour |
 | Commitment | None | Full — you pay regardless of usage |
 | Availability | Subject to platform headroom | Guaranteed for the interval you booked |
 | Best for | Unpredictable or bursty workloads | Nightly batch jobs, scheduled runs, known traffic patterns |

--- a/docs/reserved-capacity/overview.mdx
+++ b/docs/reserved-capacity/overview.mdx
@@ -3,13 +3,6 @@ title: "Reserved Capacity"
 description: "Commit memory capacity to future 15-minute intervals at a discounted rate"
 ---
 
-<Info>
-  **Coming soon.** Reserved capacity is not yet available. These pages describe
-  the forthcoming v1 API. The contract may change before launch. [Book a
-  call](https://cal.com/team/digger/opencomputer-founder-chat) to be notified
-  when it ships or to influence the design.
-</Info>
-
 Reserved capacity lets you pre-commit to memory you'll use later. OpenComputer
 plans for it instead of holding margin against uncertain demand; you get a
 lower effective rate on the committed usage. Pure on-demand still works for
@@ -121,8 +114,9 @@ window.
 </Tip>
 
 <Note>
-  **Pricing is intentionally out of scope here.** This API manages capacity
-  rights only. Reserved usage is billed at a discounted rate, overage at the
-  on-demand rate. Specific dollar amounts will be announced separately before
-  launch.
+  **Pricing.** Pre-booked capacity bills at **$0.012/GB-hour**; instant
+  (overage) bills at **$0.060/GB-hour** — a 5× ratio that's the price of
+  optionality for capacity you didn't pre-commit. Both rates are flat
+  across sandbox sizes. Disk above the 20 GB allowance is billed
+  separately at the disk-overage rate (unchanged).
 </Note>

--- a/docs/reserved-capacity/reserving.mdx
+++ b/docs/reserved-capacity/reserving.mdx
@@ -3,11 +3,6 @@ title: "Reserving Capacity"
 description: "Write flow, idempotency, atomicity, and the audit list"
 ---
 
-<Info>
-  **Coming soon.** Reserved capacity is not yet available. The contract below
-  may change before launch.
-</Info>
-
 There are two write-side endpoints: `POST` to commit, `GET` to audit. Both
 work in terms of intervals and integer GB; there are no individual blocks
 or unit IDs.

--- a/docs/reserved-capacity/reserving.mdx
+++ b/docs/reserved-capacity/reserving.mdx
@@ -46,16 +46,22 @@ Response (success):
 
 ### Validation
 
-| Rule | Behavior |
-| --- | --- |
-| `startsAt` and `endsAt` UTC and 15-minute aligned | Reject misaligned. |
-| `endsAt == startsAt + 15 minutes` | Reject longer spans; enumerate intervals. |
-| `capacityGb` is a positive multiple of 4 | Reject anything else. The grain is 1 GB-hour (= 4 GB × 15 min). |
-| `startsAt >= earliestReservableStart` | Reject intervals too soon. |
-| Requested capacity fits current `reservableGb` | Reject instead of overbooking. |
-| `Idempotency-Key` stable on retry | Replaying same key + body returns original result. |
+The server rejects malformed requests with `400 Bad Request` and a
+plain text error message:
 
-### Rejected write
+| Rule | Failure |
+| --- | --- |
+| `startsAt` / `endsAt` UTC and 15-minute aligned | Misaligned values rejected. |
+| `endsAt == startsAt + 15 minutes` | Multi-interval spans rejected — enumerate intervals instead. |
+| `capacityGb` is a positive multiple of 4 | Other values rejected. The grain is 1 GB-hour (= 4 GB × 15 min). |
+| `startsAt >= now + 30 minutes` | Lead-time violation rejected. |
+
+### Capacity shortfall (409)
+
+When the request is well-formed but doesn't fit available capacity,
+the server returns `409 capacity_not_available` with a list of every
+problematic interval, so the client can retry with adjusted numbers in
+a single round-trip:
 
 ```json
 {
@@ -71,16 +77,12 @@ Response (success):
 }
 ```
 
-The response lists every problematic interval, so the client can retry
-with adjusted numbers in a single round-trip.
+`reason` is one of:
 
 | `reason` | Meaning |
 | --- | --- |
-| `insufficient_capacity` | Request exceeds current `reservableGb` (platform-side). |
-| `reservation_limit_exceeded` | Would exceed your org's `max_memory_gb` for the interval. |
-| `too_soon` | `startsAt` is before `earliestReservableStart`. |
-| `misaligned` | `startsAt`/`endsAt` not on the 15-minute grid. |
-| `capacity_grain` | `capacityGb` is not a positive multiple of 4. |
+| `insufficient_capacity` | Request exceeds current `reservableGb` for the interval (either the platform-side limit or your org's `max_memory_gb`). |
+| `concurrent_write` | Another reservation for the same interval committed first; retry with the updated `reservableGb`. |
 
 ## Idempotency
 
@@ -120,6 +122,8 @@ Response:
 
 ```json
 {
+  "from": "2026-04-01T00:00:00Z",
+  "to":   "2026-05-01T00:00:00Z",
   "reservations": [
     {
       "reservationId": "9f67b8f7-7b91-4d2d-b1cb-19d0d0a14562",
@@ -134,12 +138,12 @@ Response:
 }
 ```
 
-| Query param | Meaning |
-| --- | --- |
-| `from` | Return reservations whose `createdAt >= from`. |
-| `to` | Return reservations whose `createdAt < to`. |
-| `cursor` | Pagination cursor from a previous response. |
-| `limit` | Max reservations per page. |
+| Query param | Required | Meaning |
+| --- | --- | --- |
+| `from` | yes | Return reservations whose `createdAt >= from`. |
+| `to` | yes | Return reservations whose `createdAt < to`. |
+| `cursor` | no | Pagination cursor from a previous response's `nextCursor`. |
+| `limit` | no | Max reservations per page. Server applies a ceiling. |
 
 For end-of-month reconciliation, list reservations and group totals by
 interval. The calendar gives you the current per-interval state; the list

--- a/docs/reserved-capacity/usage-and-overage.mdx
+++ b/docs/reserved-capacity/usage-and-overage.mdx
@@ -115,7 +115,7 @@ reserve a higher amount.
 | You hold a reservation in one interval but run in another | No carryover. Allocation is per interval. |
 | Multiple sandboxes' memory sums above the ceiling | Concurrent memory is summed before the ceiling is applied. No per-sandbox attribution. |
 | A sandbox crashes mid-interval | Memory drops as soon as the scale event closes; subsequent seconds see the lower number. |
-| You try to reserve for an interval you're already in | Rejected — reservations require lead time (`earliestReservableStart`). |
+| You try to reserve for an interval you're already in | Rejected — reservations require a 30-minute minimum lead time. |
 
 ## Why per-second
 

--- a/docs/reserved-capacity/usage-and-overage.mdx
+++ b/docs/reserved-capacity/usage-and-overage.mdx
@@ -3,11 +3,6 @@ title: "Usage and Overage"
 description: "How reserved capacity is consumed and how overage is calculated"
 ---
 
-<Info>
-  **Coming soon.** Reserved capacity is not yet available. The contract below
-  may change before launch.
-</Info>
-
 ## Every second is its own settlement
 
 Reserved capacity is billed and settled per second. Not per minute, not per


### PR DESCRIPTION
## Summary

Customer-facing reserved-capacity docs now describe what's actually shipped and match the API contract. Two commits:

**Commit 1 — Mark live:**
- Remove "Coming soon. Reserved capacity is not yet available" `<Info>` from all 5 `reserved-capacity/` guide pages and all 3 `api-reference/capacity/` reference pages.
- Replace the bottom-of-overview "Pricing intentionally out of scope" `<Note>` with the real rates: \$0.012/GB-hour pre-booked, \$0.060/GB-hour instant (5× ratio, flat across sandbox sizes).

**Commit 2 — Code/doc drift audit (5 accuracy fixes + 2 conciseness):**

1. **Calendar response top-level shape** — doc claimed `generatedAt` / `staleAt` / `intervalDuration` / `timezone` / `earliestReservableStart`. Actual response is `from` / `to` / `resource` / `intervals`. Doc updated.
2. **Concepts page runtime-admission claim** — doc said `max_memory_gb` is enforced at runtime as well as reservations. False today (phase 4 deferred). Claim removed.
3. **Reserving error-reasons table** — listed 5 fictional `reason` values. Actual structured 409 only ever contains `insufficient_capacity` or `concurrent_write`. Validation failures (alignment, lead-time, grain) are plain 400s, now separated into their own table.
4. **`earliestReservableStart`** was referenced in 3 places but doesn't exist in any response. Replaced with prose "30-minute minimum lead time."
5. **List reservations** — `from` / `to` marked required to match handler; response example now includes the `from` / `to` echo the API actually returns.
6. overview.mdx hand-wavy "Cost per GB-second" row replaced with actual rates.
7. calendar.mdx section about `staleAt` shortened — concept (calendar is a snapshot) preserved without the nonexistent field.

## Why now

Reserved capacity is fully shipped (PRs #187, #199, #201) and verified end-to-end. New orgs auto-flow through the unified pipeline at the new rates. Docs now match production behavior, not aspirational design.

## Known limitation, intentionally not surfaced in docs

Pro orgs created before the phase-3 deploy are on `billing_mode='legacy'`. If they make a reservation, the row inserts but the discount mechanism only fires for `'unified'` orgs. Internal plumbing — runbook in `ws-pricing/work/001-reserved-capacity-impl.md` "Phase 3 shipped" section. Customer-facing docs describe the product, not the migration gap.

## Test plan

- [ ] Mintlify preview renders cleanly on all 8 changed pages
- [ ] Calendar JSON example matches what `curl` actually returns from prod
- [ ] List-reservations JSON example matches what `curl` actually returns from prod
- [ ] No remaining "coming soon" / "earliestReservableStart" / "staleAt" / "generatedAt" markers under `docs/reserved-capacity/` or `docs/api-reference/capacity/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)