### PR TITLE
fix(controlplane): default networkEnabled to true when caller omits it

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -99,11 +99,19 @@ func (s *Server) createSandbox(c echo.Context) error {
 		MemoryMB   int               `json:"memoryMB"`
 		CpuCount   int               `json:"cpuCount"`
 		Metadata   map[string]string `json:"metadata"`
-		NetworkEnabled bool          `json:"networkEnabled"`
+		NetworkEnabled *bool         `json:"networkEnabled"`
 		SecretStore    string        `json:"secretStore"` // secret store name — resolves secrets + egress config
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid request: " + err.Error()})
+	}
+
+	// Default networkEnabled to true when caller omits the field. The worker
+	// currently sets up networking unconditionally, so a missing field that
+	// marshaled to false caused the UI to mislabel sandboxes as "Disabled".
+	if req.NetworkEnabled == nil {
+		t := true
+		req.NetworkEnabled = &t
 	}
 
 	orgID, ok := auth.GetOrgID(c)
@@ -194,7 +202,7 @@ func (s *Server) createSandbox(c echo.Context) error {
 		Envs:               req.Envs,
 		MemoryMb:           int32(req.MemoryMB),
 		CpuCount:           int32(req.CpuCount),
-		NetworkEnabled:     req.NetworkEnabled,
+		NetworkEnabled:     *req.NetworkEnabled,
 		EgressAllowlist:    egressAllowlist,
 		SecretAllowedHosts: secretAllowedHosts,
 	})


### PR DESCRIPTION
## Summary
- `createSandbox` accepted `networkEnabled` as a plain `bool`, so a missing field in the request body deserialized to `false`.
- The worker actually sets up networking unconditionally (`internal/qemu/manager.go`), so the only observable effect was the dashboard rendering sandboxes as **Network: Disabled** even though network connectivity worked fine inside the VM.
- This switches the field to `*bool` so we can tell "absent" from "explicit false", defaults absent to `true`, and persists the resolved value into the stored session config so `SessionDetail.tsx` reflects reality.

## Notes
- Existing rows where `config.networkEnabled` is missing/false will continue to render as "Disabled" until separately backfilled.
- Callers that explicitly send `networkEnabled: false` keep that semantic — no behavior change for opt-out (modulo the worker not enforcing it today).

## Test plan
- [ ] Create a sandbox without `networkEnabled` in the body — verify stored config has `"networkEnabled": true` and dashboard shows "Enabled".
- [ ] Create a sandbox with `networkEnabled: false` — verify stored config retains `false` and dashboard shows "Disabled".
- [ ] Create a sandbox with `networkEnabled: true` — verify behavior matches current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)