### PR TITLE
Docker support, etc host, agent changes, fork improvement, cleanup

### DIFF
--- a/cmd/agent/listen_linux.go
+++ b/cmd/agent/listen_linux.go
@@ -72,13 +72,6 @@ type virtioSerialListener struct {
 	closed chan struct{}
 	mu     sync.Mutex
 	active bool // true when a connection is being served
-	// activeConn tracks the conn handed to gRPC so PrepareHibernate can
-	// force-close it before savevm captures state. Without this, the
-	// gRPC server's HTTP/2 parser state survives savevm/loadvm and gets
-	// fed garbage from the next worker's handshake — the post-loadvm
-	// "agent not ready" race that surfaces ~5% under fork stress and
-	// indefinitely on prod-style restore.
-	activeConn *virtioSerialConn
 }
 
 func listenVirtioSerial(path string) (net.Listener, error) {
@@ -118,15 +111,13 @@ func (l *virtioSerialListener) Accept() (net.Conn, error) {
 		}
 		l.mu.Unlock()
 
-		// Clear any read deadline left over from PrepareHibernate's conn
-		// teardown — without this, poll/Read on this fd would immediately
-		// return ErrDeadlineExceeded forever.
-		_ = l.f.SetReadDeadline(time.Time{})
-
 		// Drain any stale data from the previous gRPC session.
 		// After a gRPC connection drops, the serial port may have leftover
 		// bytes (GOAWAY frames, partial HTTP/2 frames). If we hand these to
 		// the new gRPC session, it gets a protocol error and closes immediately.
+		if instrumentVirtioSerial {
+			log.Printf("virtio-serial: Accept iter: active=false, draining stale...")
+		}
 		drainStaleData(l.f)
 
 		// Wait for the host to connect (port becomes readable with fresh data)
@@ -140,22 +131,17 @@ func (l *virtioSerialListener) Accept() (net.Conn, error) {
 			l.mu.Unlock()
 			continue
 		}
-		conn := &virtioSerialConn{
+		l.active = true
+		l.mu.Unlock()
+		log.Printf("agent: virtio-serial Accept: port readable, accepting connection")
+		return &virtioSerialConn{
 			f: l.f,
 			onClose: func() {
 				l.mu.Lock()
 				l.active = false
-				if l.activeConn != nil {
-					l.activeConn = nil
-				}
 				l.mu.Unlock()
 			},
-		}
-		l.active = true
-		l.activeConn = conn
-		l.mu.Unlock()
-		log.Printf("agent: virtio-serial Accept: port readable, accepting connection")
-		return conn, nil
+		}, nil
 	}
 }
 
@@ -198,41 +184,14 @@ func waitForReadable(f *os.File, timeout time.Duration) bool {
 	return fds[0].Revents&(unix.POLLIN|unix.POLLHUP) != 0
 }
 
-// PrepareHibernate resets the active flag AND wakes up the gRPC server's
-// blocked Read goroutine via a past read deadline, then clears the deadline
-// before the next Accept cycle.
-//
-// Why this matters: without forcing the gRPC server to release the conn, its
-// HTTP/2 parser state (in-flight frames, keepalive pings) gets captured by
-// savevm. On the next worker's loadvm + reconnect, that captured parser
-// tries to interpret fresh HTTP/2 SETTINGS frames as continuation of the
-// old stream, consumes bytes but fails at semantics, and stays in the bad
-// state past the worker's 30s agent-connect timeout. By setting the read
-// deadline in the past, the blocked Read returns ErrDeadlineExceeded, gRPC
-// treats it as a conn error and drops the stream cleanly. Now savevm
-// captures an idle, drained chardev with no parser in flight.
-//
-// The deadline reset happens at the top of Accept (see resetReadDeadline)
-// so future connections are unaffected.
+// PrepareHibernate resets the active flag so that after migration restore,
+// the Accept loop will poll for a new host-side connection instead of
+// thinking the old connection is still active.
 func (l *virtioSerialListener) PrepareHibernate() {
 	l.mu.Lock()
-	conn := l.activeConn
-	l.activeConn = nil
 	l.active = false
 	l.mu.Unlock()
 	log.Printf("agent: virtio-serial: prepared for hibernate (active=false)")
-	if conn == nil {
-		return
-	}
-	// Give the PrepareHibernate response time to flush before disrupting
-	// the conn. 50ms is more than enough on a virtio-serial pipe.
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		// SetReadDeadline in the past wakes up the blocked Read goroutine
-		// inside gRPC's HTTP/2 transport with os.ErrDeadlineExceeded.
-		_ = conn.f.SetReadDeadline(time.Now().Add(-1 * time.Second))
-		log.Printf("agent: virtio-serial: triggered conn teardown (frees gRPC parser state for clean savevm)")
-	}()
 }
 
 func (l *virtioSerialListener) Close() error {
@@ -258,10 +217,41 @@ type virtioSerialConn struct {
 	once    sync.Once
 }
 
-func (c *virtioSerialConn) Read(b []byte) (int, error)  { return c.f.Read(b) }
-func (c *virtioSerialConn) Write(b []byte) (int, error) { return c.f.Write(b) }
+// instrumentVirtioSerial controls per-Read logging on the conn. Set true via
+// OSB_AGENT_TRACE_VIRTIO=1 env var to debug post-loadvm protocol confusion.
+// HARDCODED TO TRUE FOR INVESTIGATION BUILD — revert before merging.
+var instrumentVirtioSerial = true || os.Getenv("OSB_AGENT_TRACE_VIRTIO") == "1"
+
+func (c *virtioSerialConn) Read(b []byte) (int, error) {
+	n, err := c.f.Read(b)
+	if instrumentVirtioSerial {
+		// Log first 16 bytes (or fewer) so we can spot HTTP/2 prefaces
+		// that might be from a NEW gRPC session being fed to the OLD parser.
+		// HTTP/2 preface is 24 bytes starting with "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".
+		preview := ""
+		if n > 0 {
+			max := n
+			if max > 16 {
+				max = 16
+			}
+			preview = fmt.Sprintf(" first=%q", b[:max])
+		}
+		log.Printf("virtio-serial: conn.Read n=%d err=%v%s", n, err, preview)
+	}
+	return n, err
+}
+func (c *virtioSerialConn) Write(b []byte) (int, error) {
+	n, err := c.f.Write(b)
+	if instrumentVirtioSerial && err != nil {
+		log.Printf("virtio-serial: conn.Write n=%d err=%v", n, err)
+	}
+	return n, err
+}
 func (c *virtioSerialConn) Close() error {
 	c.once.Do(func() {
+		if instrumentVirtioSerial {
+			log.Printf("virtio-serial: conn.Close called (gRPC dropped this conn)")
+		}
 		if c.onClose != nil {
 			c.onClose()
 		}

--- a/cmd/agent/listen_linux.go
+++ b/cmd/agent/listen_linux.go
@@ -72,6 +72,13 @@ type virtioSerialListener struct {
 	closed chan struct{}
 	mu     sync.Mutex
 	active bool // true when a connection is being served
+	// activeConn tracks the conn handed to gRPC so PrepareHibernate can
+	// force-close it before savevm captures state. Without this, the
+	// gRPC server's HTTP/2 parser state survives savevm/loadvm and gets
+	// fed garbage from the next worker's handshake — the post-loadvm
+	// "agent not ready" race that surfaces ~5% under fork stress and
+	// indefinitely on prod-style restore.
+	activeConn *virtioSerialConn
 }
 
 func listenVirtioSerial(path string) (net.Listener, error) {
@@ -111,6 +118,11 @@ func (l *virtioSerialListener) Accept() (net.Conn, error) {
 		}
 		l.mu.Unlock()
 
+		// Clear any read deadline left over from PrepareHibernate's conn
+		// teardown — without this, poll/Read on this fd would immediately
+		// return ErrDeadlineExceeded forever.
+		_ = l.f.SetReadDeadline(time.Time{})
+
 		// Drain any stale data from the previous gRPC session.
 		// After a gRPC connection drops, the serial port may have leftover
 		// bytes (GOAWAY frames, partial HTTP/2 frames). If we hand these to
@@ -128,17 +140,22 @@ func (l *virtioSerialListener) Accept() (net.Conn, error) {
 			l.mu.Unlock()
 			continue
 		}
-		l.active = true
-		l.mu.Unlock()
-		log.Printf("agent: virtio-serial Accept: port readable, accepting connection")
-		return &virtioSerialConn{
+		conn := &virtioSerialConn{
 			f: l.f,
 			onClose: func() {
 				l.mu.Lock()
 				l.active = false
+				if l.activeConn != nil {
+					l.activeConn = nil
+				}
 				l.mu.Unlock()
 			},
-		}, nil
+		}
+		l.active = true
+		l.activeConn = conn
+		l.mu.Unlock()
+		log.Printf("agent: virtio-serial Accept: port readable, accepting connection")
+		return conn, nil
 	}
 }
 
@@ -181,14 +198,41 @@ func waitForReadable(f *os.File, timeout time.Duration) bool {
 	return fds[0].Revents&(unix.POLLIN|unix.POLLHUP) != 0
 }
 
-// PrepareHibernate resets the active flag so that after migration restore,
-// the Accept loop will poll for a new host-side connection instead of
-// thinking the old connection is still active.
+// PrepareHibernate resets the active flag AND wakes up the gRPC server's
+// blocked Read goroutine via a past read deadline, then clears the deadline
+// before the next Accept cycle.
+//
+// Why this matters: without forcing the gRPC server to release the conn, its
+// HTTP/2 parser state (in-flight frames, keepalive pings) gets captured by
+// savevm. On the next worker's loadvm + reconnect, that captured parser
+// tries to interpret fresh HTTP/2 SETTINGS frames as continuation of the
+// old stream, consumes bytes but fails at semantics, and stays in the bad
+// state past the worker's 30s agent-connect timeout. By setting the read
+// deadline in the past, the blocked Read returns ErrDeadlineExceeded, gRPC
+// treats it as a conn error and drops the stream cleanly. Now savevm
+// captures an idle, drained chardev with no parser in flight.
+//
+// The deadline reset happens at the top of Accept (see resetReadDeadline)
+// so future connections are unaffected.
 func (l *virtioSerialListener) PrepareHibernate() {
 	l.mu.Lock()
+	conn := l.activeConn
+	l.activeConn = nil
 	l.active = false
 	l.mu.Unlock()
 	log.Printf("agent: virtio-serial: prepared for hibernate (active=false)")
+	if conn == nil {
+		return
+	}
+	// Give the PrepareHibernate response time to flush before disrupting
+	// the conn. 50ms is more than enough on a virtio-serial pipe.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		// SetReadDeadline in the past wakes up the blocked Read goroutine
+		// inside gRPC's HTTP/2 transport with os.ErrDeadlineExceeded.
+		_ = conn.f.SetReadDeadline(time.Now().Add(-1 * time.Second))
+		log.Printf("agent: virtio-serial: triggered conn teardown (frees gRPC parser state for clean savevm)")
+	}()
 }
 
 func (l *virtioSerialListener) Close() error {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -8,6 +8,7 @@ package main
 import (
 	"log"
 	"os"
+	"os/exec"
 	"os/signal"
 	"syscall"
 
@@ -50,6 +51,24 @@ func main() {
 	// resource temporarily unavailable" even though they have nothing
 	// running. Drain on each SIGCHLD; signals coalesce so we loop.
 	startReaper()
+
+	// Best-effort: start supervisord if installed and configured. Run as a
+	// daemon (default mode, not -n) so it returns immediately and we don't
+	// block agent startup. Supervisord becomes a regular child of PID 1; its
+	// own children (configured programs) are reparented to it, not to us, so
+	// our SIGCHLD reaper doesn't conflict with supervisord's own wait4 calls.
+	// Without this, "supervisord baked into rootfs" only works while the user
+	// manually starts it — programs don't auto-start at boot the way they do
+	// on a systemd-managed VM.
+	if _, err := os.Stat("/usr/bin/supervisord"); err == nil {
+		if _, err := os.Stat("/etc/supervisor/supervisord.conf"); err == nil {
+			if err := exec.Command("/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf").Start(); err != nil {
+				log.Printf("agent: supervisord start failed: %v (continuing)", err)
+			} else {
+				log.Printf("agent: supervisord started (config=/etc/supervisor/supervisord.conf)")
+			}
+		}
+	}
 
 	// Signal handling:
 	// SIGTERM/SIGINT: clean shutdown (exit)

--- a/cmd/agent/reaper_linux.go
+++ b/cmd/agent/reaper_linux.go
@@ -8,6 +8,8 @@ import (
 	"os/signal"
 	"sync/atomic"
 	"syscall"
+
+	"github.com/opensandbox/opensandbox/internal/agent"
 )
 
 // startReaper spawns a goroutine that waits on SIGCHLD and reaps any
@@ -19,6 +21,17 @@ import (
 //
 // Also calls prctl(PR_SET_CHILD_SUBREAPER) defensively so reaping still
 // works even if some future setup parents us to PID > 1.
+//
+// Coordination with os/exec: when the agent forks a child via os/exec
+// (the Exec/PrepareHibernate paths), os/exec wants to call Wait4 on its
+// own child. Without coordination the reaper and os/exec race; whichever
+// wait4 lands first gets the exit status and the other gets ECHILD. The
+// loser returns "waitid: no child processes" up the stack — visible to
+// users as ~30% fork failures with empty stdout when bench-style workloads
+// hit the agent right after a fork. We fix this via RegisterManagedPid:
+// the reaper checks the registry before recording a reap, and if the pid
+// is managed it delivers the exit status via channel instead of letting
+// os/exec call wait4 (since the reaper already did).
 func startReaper() {
 	// Best-effort: PR_SET_CHILD_SUBREAPER (option 36). If running as PID 1
 	// this is a no-op; if not, it makes us inherit orphans of our subtree.
@@ -39,6 +52,13 @@ var reapedTotal atomic.Int64
 // drainZombies repeatedly waits for any child in non-blocking mode until
 // none are available. Multiple SIGCHLDs that arrive while we're already
 // reaping coalesce into one delivery, so each notification must drain all.
+//
+// For each reaped pid, agent.TryDeliverReap is consulted: if the pid is
+// in the registry (explicit-wait by Exec/PrepareHibernate/PTY), the status
+// is forwarded via channel rather than logged as an orphan reap. The
+// caller's cmd.Wait() will see ECHILD (the kernel already gave up the
+// status to us) and pull the WaitStatus from the channel. See
+// internal/agent/reap_registry.go for the protocol.
 func drainZombies() {
 	for {
 		var ws syscall.WaitStatus
@@ -49,6 +69,11 @@ func drainZombies() {
 				log.Printf("agent: reaper: wait4 error: %v", err)
 			}
 			return
+		}
+		// If a caller is explicitly waiting on this pid, hand off the
+		// status and skip the orphan-reap logging path.
+		if agent.TryDeliverReap(pid, ws) {
+			continue
 		}
 		n := reapedTotal.Add(1)
 		// Log first few + every 100th so the journal stays readable.

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -133,6 +133,12 @@ func main() {
 
 		qmMgr.CleanupOrphanedProcesses()
 
+		// Start the periodic orphan reaper. Catches qemu processes that
+		// survived a destroyVM-path failure (state-inconsistency / panic /
+		// hibernate race) so they don't pile up and silently shrink worker
+		// capacity. See internal/qemu/orphan_reaper.go.
+		qmMgr.StartOrphanReaper(ctx)
+
 		// Prepare golden snapshot for fast VM creation
 		if err := qmMgr.PrepareGoldenSnapshot(); err != nil {
 			log.Printf("opensandbox-worker: WARNING: golden snapshot failed, using cold boot: %v", err)

--- a/deploy/firecracker/rootfs/Dockerfile.default
+++ b/deploy/firecracker/rootfs/Dockerfile.default
@@ -64,6 +64,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tree \
     rsync \
     man-db \
+    # Container runtime — dockerd does NOT auto-start (osb-agent is PID 1, no
+    # systemd). Users opt in via `sudo dockerd &` or supervisord. Keeps idle
+    # snapshots clean of daemon state.
+    docker.io \
+    # Process supervisor — for users who want declarative service management
+    # without systemd. Started on demand by users (`sudo supervisord -c ...`).
+    supervisor \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Python setup ─────────────────────────────────────────────────────────────
@@ -102,9 +109,17 @@ ENV LC_ALL=en_US.UTF-8
 # The agent (PID 1) runs as root, but all user commands run as "sandbox".
 # This matches user expectations for a normal Linux environment and allows
 # Claude Code to work without --allow-dangerously-skip-permissions.
+# /etc/hosts gets the sandbox hostname baked in so sudo doesn't print
+# `unable to resolve host sandbox` on every invocation. The runtime network
+# patch in manager.go also writes this, but that path can short-circuit if
+# an earlier `ip addr add` fails — bake it as defense-in-depth.
 RUN useradd -m -s /bin/bash -G sudo sandbox \
     && echo "sandbox ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/sandbox \
-    && chmod 440 /etc/sudoers.d/sandbox
+    && chmod 440 /etc/sudoers.d/sandbox \
+    && (grep -q sandbox /etc/hosts || echo "127.0.0.1 sandbox" >> /etc/hosts) \
+    # Add sandbox user to docker group so `docker` CLI works without sudo
+    # once dockerd is started.
+    && usermod -aG docker sandbox
 
 # /workspace is a symlink to ~ for backward compatibility
 RUN ln -s /home/sandbox /workspace

--- a/internal/agent/exec.go
+++ b/internal/agent/exec.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -108,7 +109,12 @@ func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (*pb.ExecRespons
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("exec start: %w", err)
 	}
-	moveToCgroup(cmd.Process.Pid)
+	pid := cmd.Process.Pid
+	// Register with reaper BEFORE the child can exit. If the SIGCHLD reaper
+	// races us and reaps the child first, cmd.Wait() returns ECHILD; we
+	// recover the status from this channel. See reap_registry.go.
+	exitCh := RegisterReap(pid)
+	moveToCgroup(pid)
 
 	// Wait with cgroup kill on timeout — if the process doesn't exit when the
 	// context deadline fires, kill the entire sandbox cgroup to clean up fork
@@ -127,6 +133,7 @@ func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (*pb.ExecRespons
 		}
 		killCgroup()
 		<-waitDone // wait for cmd.Wait to return after kills
+		UnregisterReap(pid)
 		return &pb.ExecResponse{
 			ExitCode: -1,
 			Stdout:   stdout.String(),
@@ -136,11 +143,22 @@ func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (*pb.ExecRespons
 
 	exitCode := 0
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
-		} else {
+		switch {
+		case isExitError(err):
+			exitCode = err.(*exec.ExitError).ExitCode()
+			UnregisterReap(pid)
+		case errors.Is(err, syscall.ECHILD):
+			// Reaper got there first; pull WaitStatus from registry channel.
+			// The reaper has already populated it (otherwise wait4 would
+			// have returned the status to cmd.Wait, not ECHILD).
+			ws := <-exitCh
+			exitCode = ws.ExitStatus()
+		default:
+			UnregisterReap(pid)
 			return nil, fmt.Errorf("exec failed: %w", err)
 		}
+	} else {
+		UnregisterReap(pid)
 	}
 
 	return &pb.ExecResponse{
@@ -148,6 +166,11 @@ func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (*pb.ExecRespons
 		Stdout:   stdout.String(),
 		Stderr:   stderr.String(),
 	}, nil
+}
+
+func isExitError(err error) bool {
+	_, ok := err.(*exec.ExitError)
+	return ok
 }
 
 // ExecStream runs a command and streams stdout/stderr chunks.

--- a/internal/agent/reap_registry.go
+++ b/internal/agent/reap_registry.go
@@ -1,0 +1,58 @@
+package agent
+
+import (
+	"sync"
+	"syscall"
+)
+
+// ReapRegistry coordinates the agent's SIGCHLD reaper with explicit-wait
+// callers (Exec, PrepareHibernate, PTY). Without coordination the reaper's
+// Wait4(-1, ...) races with cmd.Wait() — whichever lands first gets the
+// child's exit status, and the other returns ECHILD. The loser's caller
+// reports `exec failed: waitid: no child processes`, surfacing to users
+// as ~30% fork failures with empty stdout when bench-style workloads hit
+// the agent immediately after a fresh fork.
+//
+// Coordination protocol:
+//  1. Caller (Exec handler) calls RegisterReap(pid) BEFORE the child can
+//     exit (immediately after cmd.Start()).
+//  2. Caller calls cmd.Wait() in the usual way.
+//  3a. If cmd.Wait() succeeds, child status is in cmd.ProcessState. Caller
+//      should call UnregisterReap(pid) to drop the dangling registration.
+//  3b. If cmd.Wait() returns ECHILD, the reaper got there first; pull
+//      the WaitStatus from the channel and synthesize the exit code.
+//
+// The reaper (cmd/agent/reaper_linux.go) calls TryDeliverReap on every
+// child it consumes. If the pid is registered, it forwards the status via
+// channel; otherwise it logs the orphan reap as before.
+var reapRegistry sync.Map // pid (int) → chan syscall.WaitStatus
+
+// RegisterReap claims a pid for explicit-wait. Returns a channel that
+// receives the wait status when the reaper picks up the child. Channel is
+// closed after the status is delivered.
+func RegisterReap(pid int) <-chan syscall.WaitStatus {
+	ch := make(chan syscall.WaitStatus, 1)
+	reapRegistry.Store(pid, ch)
+	return ch
+}
+
+// UnregisterReap removes a pid registration without consuming a status.
+// Use when cmd.Wait() succeeded and you no longer need the channel.
+func UnregisterReap(pid int) {
+	reapRegistry.Delete(pid)
+}
+
+// TryDeliverReap is called by the SIGCHLD reaper for each child it reaps.
+// If the pid is registered, the status is delivered via channel and true
+// is returned (so the reaper can skip its orphan-log path). Otherwise
+// returns false — caller should log this as an orphan reap.
+func TryDeliverReap(pid int, ws syscall.WaitStatus) bool {
+	v, ok := reapRegistry.LoadAndDelete(pid)
+	if !ok {
+		return false
+	}
+	ch := v.(chan syscall.WaitStatus)
+	ch <- ws
+	close(ch)
+	return true
+}

--- a/internal/controlplane/scaler.go
+++ b/internal/controlplane/scaler.go
@@ -813,15 +813,42 @@ func (s *Scaler) smartScaleDown(_ context.Context, region string, workers []*Wor
 	go s.drainWorker(target.ID, target.MachineID, region)
 }
 
-// rollingReplace drains workers running an old version one at a time,
-// allowing the scaler to replace them with new-AMI workers.
+// rollingReplace executes a quota-aware rolling replacement of stale workers
+// (workers whose WorkerVersion != targetWorkerVersion).
+//
+// The dance under quota pressure (e.g., eastus2 prod with 1-2 spare worker
+// slots in the Dadsv7 family quota):
+//
+//	loop {
+//	    pick lightest stale worker S
+//	    drain S (sandboxes migrate onto current-version workers)
+//	    once S is empty: terminate S — frees one quota slot
+//	    if more stale workers remain: scaleUp (consume the freed slot)
+//	    next tick: repeat
+//	}
+//
+// At any moment in the dance the cluster holds at most N+1 workers (N stale
+// before the dance starts + 1 freshly-launched). The number of new-version
+// workers grows by one each cycle: cycle 1 lands all of S1 onto NV1; cycle 2
+// lands S2 across {NV1, NV2}; cycle 3 across {NV1, NV2, NV3}; etc. By the
+// time we drain the heaviest stale worker, our target pool is N-1 workers
+// wide and per-sandbox findMigrationTarget can spread the load evenly.
+//
+// Without this dance (the prior implementation): drain ran async per tick,
+// terminate happened via the separate idle-scale-down path on a different
+// tick, and replacement scaleUp only triggered when current==0. So all
+// stale workers' sandboxes piled onto whichever single new-version worker
+// existed first, overloading it and triggering the agent-reconnect-timeout
+// failure modes that this PR also addresses elsewhere.
+//
+// Serialized via Redis lock so concurrent ticks across CPs don't double-fire.
 func (s *Scaler) rollingReplace(ctx context.Context, region string, workers []*WorkerInfo) {
 	if s.targetWorkerVersion == "" {
 		return
 	}
 
 	var stale []*WorkerInfo
-	var current int
+	var current []*WorkerInfo
 	for _, w := range workers {
 		// Skip workers already being drained
 		if s.state.IsDraining(w.MachineID) {
@@ -838,7 +865,7 @@ func (s *Scaler) rollingReplace(ctx context.Context, region string, workers []*W
 			continue // static worker, not autoscaled
 		}
 		if w.WorkerVersion == s.targetWorkerVersion {
-			current++
+			current = append(current, w)
 		} else {
 			stale = append(stale, w)
 		}
@@ -848,23 +875,35 @@ func (s *Scaler) rollingReplace(ctx context.Context, region string, workers []*W
 		return
 	}
 
-	// If no current-version workers exist, try to launch a replacement first.
-	// If launch fails (e.g., quota), fall back to draining one stale worker
-	// to free capacity — the min-workers check will launch a replacement next tick.
-	if current < 1 {
+	// Take the rolling-replace lock so concurrent ticks (or the other CP)
+	// don't pick a different stale worker and double-drain. Released after
+	// the synchronous dance returns.
+	if !s.state.TryAcquireReplacingLock() {
+		return
+	}
+	releaseLock := true
+	defer func() {
+		if releaseLock {
+			s.state.ReleaseReplacingLock()
+		}
+	}()
+
+	// Need at least one current-version worker (or pending one) to migrate
+	// onto. If none, scale up first and wait for next tick.
+	if len(current) == 0 {
 		pendingCount := len(s.state.GetPendingLaunches(region))
 		if pendingCount > 0 {
-			log.Printf("scaler: region %s has %d stale workers, waiting for pending replacement to register",
-				region, len(stale))
+			log.Printf("scaler: rolling replace: %d stale workers, waiting for pending replacement to register",
+				len(stale))
 			return
 		}
-		log.Printf("scaler: rolling replace: all %d workers stale — launching replacement with new version",
+		log.Printf("scaler: rolling replace: all %d workers stale — launching first replacement",
 			len(stale))
 		s.scaleUp(ctx, region)
 		return
 	}
 
-	// Only drain one stale worker at a time (conservative rolling update)
+	// Pick lightest stale — see header comment.
 	target := stale[0]
 	for _, w := range stale[1:] {
 		if w.Current < target.Current {
@@ -872,8 +911,9 @@ func (s *Scaler) rollingReplace(ctx context.Context, region string, workers []*W
 		}
 	}
 
-	log.Printf("scaler: rolling replace: draining stale worker %s (version=%q, want=%q, sandboxes=%d)",
-		target.ID, target.WorkerVersion, s.targetWorkerVersion, target.Current)
+	moreStaleAfter := len(stale) > 1
+	log.Printf("scaler: rolling replace: draining stale worker %s (version=%q, want=%q, sandboxes=%d, %d stale total, %d current)",
+		target.ID, target.WorkerVersion, s.targetWorkerVersion, target.Current, len(stale), len(current))
 
 	s.state.SetDraining(target.MachineID, &drainState{
 		WorkerID:  target.ID,
@@ -882,7 +922,55 @@ func (s *Scaler) rollingReplace(ctx context.Context, region string, workers []*W
 		StartedAt: time.Now(),
 	})
 
-	go s.drainWorker(target.ID, target.MachineID, region)
+	// Run the dance in a goroutine so we don't block the scaler tick.
+	// The lock is held for the duration via releaseLock = false here.
+	releaseLock = false
+	go func() {
+		defer s.state.ReleaseReplacingLock()
+		s.replaceOneStale(ctx, region, target, moreStaleAfter)
+	}()
+}
+
+// replaceOneStale executes one cycle of the rolling-replace dance:
+// drain the target stale worker, terminate it (freeing one quota slot),
+// then if more stale workers remain, immediately scale up a replacement
+// so the next tick has somewhere to drain to.
+//
+// Synchronous within the goroutine so the next scaler tick observes the
+// post-terminate state cleanly. Lock is held by the caller across this
+// function via the defer in rollingReplace.
+func (s *Scaler) replaceOneStale(ctx context.Context, region string, target *WorkerInfo, moreStaleAfter bool) {
+	// 1. Drain — synchronous; returns when the worker is empty or drainTimeout
+	//    fires. drainWorker handles per-sandbox findMigrationTarget so each
+	//    sandbox lands on whichever current-version worker has the most room
+	//    at that exact moment.
+	s.drainWorker(target.ID, target.MachineID, region)
+
+	// 2. Terminate the (now-empty) stale worker. Frees the quota slot for the
+	//    replacement scaleUp below. We do this even on partial drain — the
+	//    natural-expiry path will catch any stragglers on the source via
+	//    sandbox timeouts; better to free quota and unblock the dance than
+	//    keep an old-version worker around.
+	if s.pool != nil && target.MachineID != "" {
+		termCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		if err := s.pool.DestroyMachine(termCtx, target.MachineID); err != nil {
+			log.Printf("scaler: rolling replace: failed to terminate drained worker %s (%s): %v — letting natural expiry take it",
+				target.ID, target.MachineID, err)
+		} else {
+			log.Printf("scaler: rolling replace: terminated drained worker %s (%s)", target.ID, target.MachineID)
+		}
+		cancel()
+	}
+
+	// 3. If more stale workers remain, fire the next replacement now so it's
+	//    boot-warm by the time the next tick picks the next stale source.
+	//    Without this, the next tick would either drain another stale onto
+	//    the same single new-version worker (the "killer" pile-up) or stall
+	//    waiting for organic scale-up.
+	if moreStaleAfter {
+		log.Printf("scaler: rolling replace: more stale workers remain, launching next replacement")
+		s.scaleUp(ctx, region)
+	}
 }
 
 // drainWorker attempts to live-migrate sandboxes off a worker. If migration fails

--- a/internal/controlplane/scaler.go
+++ b/internal/controlplane/scaler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -560,37 +561,86 @@ func (s *Scaler) hibernateBatch(workerID string, count int) {
 
 // --- Pressure Evacuation ---
 
-// evacuateHotWorkers live-migrates sandboxes off workers that exceed critical thresholds.
+// evacuateHotWorkers live-migrates sandboxes off workers that exceed critical
+// thresholds.
+//
+// Two scheduling rules that matter under quota pressure:
+//
+//  1. **One source at a time.** Earlier versions spawned a goroutine per hot
+//     source in parallel, which under quota constraints (e.g. eastus2 prod
+//     where the Dadsv7 family is at ~60% of limit) means every source races
+//     for the same one or two viable target workers. The first migration
+//     wins, the others stall on capacity, and we get the imbalance pattern
+//     we saw on prod: 60 sandboxes piled onto a single worker while the
+//     others stayed lightly loaded. Serializing means we drain one source
+//     completely before starting the next.
+//
+//  2. **Lightest source first.** A 5-sandbox source drains in seconds and
+//     the now-empty worker becomes a viable target for subsequent drains.
+//     A 60-sandbox source drained first would block all subsequent
+//     evacuations behind it. Going lightest-first organically grows our
+//     target pool from drained sources, so by the time we reach the
+//     heaviest source we have N workers worth of target capacity instead
+//     of 1.
+//
+// Per-sandbox target selection (inside evacuateBatch via liveMigrateSandbox)
+// remains in place — it spreads the migrations within a single source's
+// drain across whatever targets exist at the moment.
 func (s *Scaler) evacuateHotWorkers(_ context.Context, region string, workers []*WorkerInfo) {
+	// If an evacuation is already in flight, skip this tick — the active
+	// drain will finish and release the lock; the next tick picks up.
+	if !s.state.TryAcquireEvacuationLock() {
+		return
+	}
+	releaseLock := true
+	defer func() {
+		if releaseLock {
+			s.state.ReleaseEvacuationLock()
+		}
+	}()
+
+	// Collect hot, non-draining workers off cooldown.
+	hot := make([]*WorkerInfo, 0)
 	for _, w := range workers {
 		if w.CPUPct < evacuationCPUThreshold && w.MemPct < evacuationMemThreshold && w.DiskPct < evacuationDiskThreshold {
 			continue
 		}
-		// Skip if already being drained for scale-down
 		if s.state.IsDraining(w.MachineID) {
 			continue
 		}
-		// Cooldown — don't evacuate the same worker every tick
 		if last, ok := s.state.GetLastEvacuation(w.ID); ok && time.Since(last) < evacuationCooldown {
 			continue
 		}
-
-		// Find target: least-loaded worker that isn't the hot one and isn't draining.
-		// Pass 0 for requiredMemMB — evacuateBatch migrates whatever fits; individual
-		// over-size sandboxes fail their own prepare and are retried elsewhere.
-		target := s.findMigrationTarget(region, w.ID, 0)
-		if target == nil {
-			log.Printf("scaler: worker %s under pressure (cpu=%.1f%% mem=%.1f%% disk=%.1f%%) but no migration target available",
-				w.ID, w.CPUPct, w.MemPct, w.DiskPct)
-			continue
-		}
-
-		log.Printf("scaler: worker %s under pressure (cpu=%.1f%% mem=%.1f%% disk=%.1f%%), evacuating up to %d sandboxes to %s",
-			w.ID, w.CPUPct, w.MemPct, w.DiskPct, evacuationBatchSize, target.ID)
-
-		s.state.SetLastEvacuation(w.ID, time.Now())
-		go s.evacuateBatch(w.ID, target.ID, evacuationBatchSize)
+		hot = append(hot, w)
 	}
+	if len(hot) == 0 {
+		return
+	}
+
+	// Sort lightest first — see rule 2 in the function comment.
+	sort.Slice(hot, func(i, j int) bool {
+		return hot[i].Current < hot[j].Current
+	})
+	src := hot[0]
+
+	// Pre-flight: confirm SOME viable target exists in the region. Pass 0 for
+	// requiredMemMB; per-sandbox memory fit is checked inside liveMigrateSandbox
+	// after PreCopyDrives reports the real RSS.
+	if probe := s.findMigrationTarget(region, src.ID, 0); probe == nil {
+		log.Printf("scaler: worker %s under pressure (cpu=%.1f%% mem=%.1f%% disk=%.1f%%, current=%d) but no migration target available — letting scale-up handle this",
+			src.ID, src.CPUPct, src.MemPct, src.DiskPct, src.Current)
+		return
+	}
+
+	log.Printf("scaler: worker %s selected for evacuation (lightest of %d hot, current=%d, cpu=%.1f%% mem=%.1f%% disk=%.1f%%) — draining serially",
+		src.ID, len(hot), src.Current, src.CPUPct, src.MemPct, src.DiskPct)
+
+	s.state.SetLastEvacuation(src.ID, time.Now())
+	releaseLock = false // goroutine will release on its own
+	go func() {
+		defer s.state.ReleaseEvacuationLock()
+		s.evacuateBatch(src.ID, evacuationBatchSize)
+	}()
 }
 
 // findMigrationTarget returns the best worker to receive migrated sandboxes.
@@ -646,8 +696,18 @@ func (s *Scaler) findMigrationTarget(region, excludeWorkerID string, requiredMem
 	return best
 }
 
-// evacuateBatch live-migrates up to count sandboxes from sourceWorker to targetWorker.
-func (s *Scaler) evacuateBatch(sourceWorkerID, targetWorkerID string, count int) {
+// evacuateBatch live-migrates up to count sandboxes off sourceWorker, picking
+// a fresh target per sandbox.
+//
+// Why per-sandbox target selection: an earlier version pinned all migrations
+// in a batch to one target (chosen up front by evacuateHotWorkers). Result —
+// during the prod event where 60 sandboxes were rehydrating, every batch
+// piled onto whichever worker was least-loaded at batch start, blowing past
+// it while the other targets stayed nearly empty. By passing "" to
+// liveMigrateSandbox (which then calls findMigrationTarget after PreCopyDrives
+// reports actual RSS), each migration sees up-to-date in-flight counts and
+// the load distributes naturally across all viable targets.
+func (s *Scaler) evacuateBatch(sourceWorkerID string, count int) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -671,15 +731,18 @@ func (s *Scaler) evacuateBatch(sourceWorkerID, targetWorkerID string, count int)
 		if sb.Status != "running" {
 			continue
 		}
-		if err := s.liveMigrateSandbox(ctx, sb.SandboxId, sourceWorkerID, targetWorkerID); err != nil {
+		// Empty targetWorkerID → liveMigrateSandbox re-picks per call. This is
+		// what produces the load-distribution behavior described in the
+		// function comment.
+		if err := s.liveMigrateSandbox(ctx, sb.SandboxId, sourceWorkerID, ""); err != nil {
 			log.Printf("scaler: evacuate: migrate %s failed: %v", sb.SandboxId, err)
 			continue
 		}
 		migrated++
 	}
 
-	log.Printf("scaler: evacuation batch complete for %s: %d/%d migrated to %s",
-		sourceWorkerID, migrated, count, targetWorkerID)
+	log.Printf("scaler: evacuation batch complete for %s: %d/%d migrated (per-sandbox target selection)",
+		sourceWorkerID, migrated, count)
 }
 
 // --- Smart Scale-Down ---

--- a/internal/controlplane/scaler.go
+++ b/internal/controlplane/scaler.go
@@ -361,36 +361,43 @@ func (s *Scaler) evaluateRegion(ctx context.Context, region string) {
 	}
 
 	if needsScaleUp {
-		// Check cooldown before scaling up
+		// Cascade of guards. Important: each guard logs and SKIPS scale-up but
+		// must NOT `return` from Evaluate — Phase 5 (rollingReplace) below has
+		// to run regardless. Without this, a cluster pinned at maxWorkers with
+		// all stale workers can't ever roll because the early-return short-
+		// circuits both scaleUp AND rollingReplace, and rollingReplace is the
+		// only path that actually frees a slot (drain → terminate → scaleUp).
+		canScaleUp := true
 		if last, ok := s.state.GetLastScaleUp(region); ok && time.Since(last) < s.cooldown {
 			log.Printf("scaler: region %s needs scale-up (%s) but cooldown active (%s remaining)",
 				region, reason, s.cooldown-time.Since(last))
-			return
+			canScaleUp = false
 		}
-
-		// Don't scale up if there are already pending (unregistered) workers
-		pending := s.state.GetPendingLaunches(region)
-		if len(pending) > 0 {
-			log.Printf("scaler: region %s needs scale-up (%s) but %d worker(s) still pending registration",
-				region, reason, len(pending))
-			return
-		}
-
-		// Don't exceed max workers per region (exclude draining workers from capacity)
-		effectiveWorkers := 0
-		for _, w := range workers {
-			if !s.state.IsDraining(w.MachineID) {
-				effectiveWorkers++
+		if canScaleUp {
+			pending := s.state.GetPendingLaunches(region)
+			if len(pending) > 0 {
+				log.Printf("scaler: region %s needs scale-up (%s) but %d worker(s) still pending registration",
+					region, reason, len(pending))
+				canScaleUp = false
 			}
 		}
-		if effectiveWorkers+len(s.state.GetPendingLaunches(region)) >= s.maxWorkers {
-			log.Printf("scaler: region %s at max workers (%d/%d), skipping scale-up", region, effectiveWorkers, s.maxWorkers)
-			return
+		if canScaleUp {
+			effectiveWorkers := 0
+			for _, w := range workers {
+				if !s.state.IsDraining(w.MachineID) {
+					effectiveWorkers++
+				}
+			}
+			if effectiveWorkers+len(s.state.GetPendingLaunches(region)) >= s.maxWorkers {
+				log.Printf("scaler: region %s at max workers (%d/%d), skipping scale-up", region, effectiveWorkers, s.maxWorkers)
+				canScaleUp = false
+			}
 		}
-
-		log.Printf("scaler: region %s %s, scaling up (cpu=%.1f%% mem=%.1f%% disk=%.1f%% util=%.1f%%)",
-			region, reason, maxCPU, maxMem, maxDisk, utilization*100)
-		s.scaleUp(ctx, region)
+		if canScaleUp {
+			log.Printf("scaler: region %s %s, scaling up (cpu=%.1f%% mem=%.1f%% disk=%.1f%% util=%.1f%%)",
+				region, reason, maxCPU, maxMem, maxDisk, utilization*100)
+			s.scaleUp(ctx, region)
+		}
 	} else if utilization < scaleDownThreshold && len(workers) > s.minWorkers {
 		// Phase 4: Scale down via smart drain (live-migrate sandboxes, then destroy)
 		log.Printf("scaler: region %s utilization %.1f%% < %.0f%%, initiating smart drain", region, utilization*100, scaleDownThreshold*100)

--- a/internal/controlplane/scaler_state.go
+++ b/internal/controlplane/scaler_state.go
@@ -44,6 +44,16 @@ type ScalerStateStore interface {
 	TryAcquireEvacuationLock() bool
 	ReleaseEvacuationLock()
 
+	// Rolling-replace serialization — only one stale-worker replacement is
+	// in flight at a time (see rollingReplace). Without this, two ticks
+	// could each pick a different stale worker to drain, both targeting the
+	// single new-version worker, piling sandboxes onto it and starving the
+	// rest of the cluster of capacity. 30-min TTL — a single replacement
+	// (drain + terminate + scaleUp + new-worker boot) is bounded but can
+	// take 5-10 minutes.
+	TryAcquireReplacingLock() bool
+	ReleaseReplacingLock()
+
 	// In-flight migration tracking
 	IncrInFlight(workerID string)
 	DecrInFlight(workerID string)
@@ -268,6 +278,25 @@ func (r *RedisScalerState) ReleaseEvacuationLock() {
 	r.rdb.Del(ctx, "scaler:evacuating")
 }
 
+// TryAcquireReplacingLock serializes rollingReplace across CPs. 30-min TTL
+// so a CP crash doesn't pin the lock indefinitely — but long enough that a
+// real drain+terminate+scaleUp cycle (5-10 min normally) won't expire it.
+func (r *RedisScalerState) TryAcquireReplacingLock() bool {
+	ctx, cancel := r.ctx()
+	defer cancel()
+	ok, err := r.rdb.SetArgs(ctx, "scaler:replacing", "1", redis.SetArgs{
+		Mode: "NX",
+		TTL:  30 * time.Minute,
+	}).Result()
+	return err == nil && ok == "OK"
+}
+
+func (r *RedisScalerState) ReleaseReplacingLock() {
+	ctx, cancel := r.ctx()
+	defer cancel()
+	r.rdb.Del(ctx, "scaler:replacing")
+}
+
 // --- In-flight ---
 
 func (r *RedisScalerState) IncrInFlight(workerID string) {
@@ -473,6 +502,13 @@ func (m *InMemoryScalerState) TryAcquireEvacuationLock() bool {
 }
 func (m *InMemoryScalerState) ReleaseEvacuationLock() {
 	m.migrating.Delete("__evacuation__")
+}
+func (m *InMemoryScalerState) TryAcquireReplacingLock() bool {
+	_, loaded := m.migrating.LoadOrStore("__replacing__", struct{}{})
+	return !loaded
+}
+func (m *InMemoryScalerState) ReleaseReplacingLock() {
+	m.migrating.Delete("__replacing__")
 }
 func (m *InMemoryScalerState) IncrInFlight(workerID string) {
 	m.mu.Lock()

--- a/internal/controlplane/scaler_state.go
+++ b/internal/controlplane/scaler_state.go
@@ -38,6 +38,12 @@ type ScalerStateStore interface {
 	AcquireMigrationLock(sandboxID string) bool
 	ReleaseMigrationLock(sandboxID string)
 
+	// Evacuation serialization — only one source worker drains at a time
+	// (see evacuateHotWorkers). Held across goroutine boundaries; TTL'd so
+	// a crashed CP doesn't permanently block evacuations on restart.
+	TryAcquireEvacuationLock() bool
+	ReleaseEvacuationLock()
+
 	// In-flight migration tracking
 	IncrInFlight(workerID string)
 	DecrInFlight(workerID string)
@@ -243,6 +249,25 @@ func (r *RedisScalerState) ReleaseMigrationLock(sandboxID string) {
 	r.rdb.Del(ctx, "scaler:migrating:"+sandboxID)
 }
 
+// TryAcquireEvacuationLock takes a region-wide (actually global, single-key)
+// lock that serializes evacuateHotWorkers across CPs. 10-min TTL so a CP
+// crash doesn't pin the lock — evacuations can resume on the next tick.
+func (r *RedisScalerState) TryAcquireEvacuationLock() bool {
+	ctx, cancel := r.ctx()
+	defer cancel()
+	ok, err := r.rdb.SetArgs(ctx, "scaler:evacuating", "1", redis.SetArgs{
+		Mode: "NX",
+		TTL:  10 * time.Minute,
+	}).Result()
+	return err == nil && ok == "OK"
+}
+
+func (r *RedisScalerState) ReleaseEvacuationLock() {
+	ctx, cancel := r.ctx()
+	defer cancel()
+	r.rdb.Del(ctx, "scaler:evacuating")
+}
+
 // --- In-flight ---
 
 func (r *RedisScalerState) IncrInFlight(workerID string) {
@@ -441,6 +466,13 @@ func (m *InMemoryScalerState) AcquireMigrationLock(sandboxID string) bool {
 }
 func (m *InMemoryScalerState) ReleaseMigrationLock(sandboxID string) {
 	m.migrating.Delete(sandboxID)
+}
+func (m *InMemoryScalerState) TryAcquireEvacuationLock() bool {
+	_, loaded := m.migrating.LoadOrStore("__evacuation__", struct{}{})
+	return !loaded
+}
+func (m *InMemoryScalerState) ReleaseEvacuationLock() {
+	m.migrating.Delete("__evacuation__")
 }
 func (m *InMemoryScalerState) IncrInFlight(workerID string) {
 	m.mu.Lock()

--- a/internal/controlplane/scaler_test.go
+++ b/internal/controlplane/scaler_test.go
@@ -887,6 +887,155 @@ func TestDrainCompletesWhenEmpty(t *testing.T) {
 }
 
 // ============================================================
+// Test: Rolling-replace quota-aware dance
+// ============================================================
+
+// TestRollingReplaceDance_StartsWithScaleUpWhenAllStale validates that when
+// every worker is stale and no current-version worker exists, the first
+// rollingReplace tick scales up a replacement (doesn't drain blindly with
+// nowhere to go).
+func TestRollingReplaceDance_StartsWithScaleUpWhenAllStale(t *testing.T) {
+	reg := newMockRegistry()
+	pool := newMockPool()
+
+	// 3 stale workers, all running the old version, none current.
+	for i := 1; i <= 3; i++ {
+		reg.addWorker(&WorkerInfo{
+			ID: fmt.Sprintf("w%d", i), MachineID: fmt.Sprintf("osb-worker-w%d", i),
+			Region: "us-east-1", Capacity: 50, Current: 5,
+			WorkerVersion: "v-old",
+		})
+	}
+
+	s := newTestScaler(reg, pool)
+	s.targetWorkerVersion = "v-new"
+
+	ctx := context.Background()
+	s.rollingReplace(ctx, "us-east-1", reg.GetWorkersByRegion("us-east-1"))
+
+	time.Sleep(150 * time.Millisecond)
+	if atomic.LoadInt32(&pool.created) == 0 {
+		t.Error("expected scaler to launch a replacement when no current-version worker exists")
+	}
+	if atomic.LoadInt32(&pool.destroyed) != 0 {
+		t.Errorf("expected NO destroys until a current-version worker is up; got %d",
+			atomic.LoadInt32(&pool.destroyed))
+	}
+}
+
+// TestRollingReplaceDance_LightestStaleFirst validates that when multiple
+// stale workers exist, the lightest one is picked for drain.
+func TestRollingReplaceDance_LightestStaleFirst(t *testing.T) {
+	reg := newMockRegistry()
+	pool := newMockPool()
+
+	// Heavy stale (30 sandboxes) + Light stale (5 sandboxes) + one current.
+	reg.addWorker(&WorkerInfo{
+		ID: "wHeavy", MachineID: "osb-worker-wHeavy", Region: "us-east-1",
+		Capacity: 50, Current: 30, WorkerVersion: "v-old",
+	})
+	reg.addWorker(&WorkerInfo{
+		ID: "wLight", MachineID: "osb-worker-wLight", Region: "us-east-1",
+		Capacity: 50, Current: 5, WorkerVersion: "v-old",
+	})
+	reg.addWorker(&WorkerInfo{
+		ID: "wNew", MachineID: "osb-worker-wNew", Region: "us-east-1",
+		Capacity: 50, Current: 0, WorkerVersion: "v-new",
+	})
+
+	s := newTestScaler(reg, pool)
+	s.targetWorkerVersion = "v-new"
+
+	ctx := context.Background()
+	s.rollingReplace(ctx, "us-east-1", reg.GetWorkersByRegion("us-east-1"))
+
+	// Light should be picked, draining state should be set on it (not heavy).
+	time.Sleep(50 * time.Millisecond)
+	if !s.state.IsDraining("osb-worker-wLight") {
+		t.Error("expected lightest stale (wLight) to be picked for drain")
+	}
+	if s.state.IsDraining("osb-worker-wHeavy") {
+		t.Error("expected heavy stale (wHeavy) to be left alone for now")
+	}
+}
+
+// TestRollingReplaceDance_LockSerializes validates that two concurrent ticks
+// can't both fire rollingReplace — only the first acquires the lock.
+func TestRollingReplaceDance_LockSerializes(t *testing.T) {
+	reg := newMockRegistry()
+	pool := newMockPool()
+
+	reg.addWorker(&WorkerInfo{
+		ID: "w1", MachineID: "osb-worker-w1", Region: "us-east-1",
+		Capacity: 50, Current: 5, WorkerVersion: "v-old",
+	})
+	reg.addWorker(&WorkerInfo{
+		ID: "w2", MachineID: "osb-worker-w2", Region: "us-east-1",
+		Capacity: 50, Current: 5, WorkerVersion: "v-old",
+	})
+	reg.addWorker(&WorkerInfo{
+		ID: "wNew", MachineID: "osb-worker-wNew", Region: "us-east-1",
+		Capacity: 50, Current: 0, WorkerVersion: "v-new",
+	})
+
+	s := newTestScaler(reg, pool)
+	s.targetWorkerVersion = "v-new"
+
+	// First call grabs the lock and dispatches the goroutine.
+	ctx := context.Background()
+	s.rollingReplace(ctx, "us-east-1", reg.GetWorkersByRegion("us-east-1"))
+
+	// Second call — should be a no-op because the lock is held.
+	// To detect: count how many SetDraining calls actually pinned a worker.
+	// Both w1 and w2 are stale; if the lock didn't hold, the second call would
+	// pick the OTHER stale and pin it as draining too.
+	s.rollingReplace(ctx, "us-east-1", reg.GetWorkersByRegion("us-east-1"))
+
+	time.Sleep(50 * time.Millisecond)
+	pinned := 0
+	for _, id := range []string{"osb-worker-w1", "osb-worker-w2"} {
+		if s.state.IsDraining(id) {
+			pinned++
+		}
+	}
+	if pinned > 1 {
+		t.Errorf("expected lock to serialize: only one stale worker should be draining; got %d", pinned)
+	}
+	if pinned == 0 {
+		t.Error("expected at least one stale worker to be draining after first rollingReplace call")
+	}
+}
+
+// TestRollingReplaceDance_NoOpOnAllCurrent validates that when every worker
+// already matches targetWorkerVersion, rollingReplace does nothing.
+func TestRollingReplaceDance_NoOpOnAllCurrent(t *testing.T) {
+	reg := newMockRegistry()
+	pool := newMockPool()
+
+	for i := 1; i <= 3; i++ {
+		reg.addWorker(&WorkerInfo{
+			ID: fmt.Sprintf("w%d", i), MachineID: fmt.Sprintf("osb-worker-w%d", i),
+			Region: "us-east-1", Capacity: 50, Current: 5,
+			WorkerVersion: "v-current",
+		})
+	}
+
+	s := newTestScaler(reg, pool)
+	s.targetWorkerVersion = "v-current"
+
+	ctx := context.Background()
+	s.rollingReplace(ctx, "us-east-1", reg.GetWorkersByRegion("us-east-1"))
+
+	time.Sleep(50 * time.Millisecond)
+	if atomic.LoadInt32(&pool.created) != 0 {
+		t.Error("expected no machine creation when all workers are current")
+	}
+	if atomic.LoadInt32(&pool.destroyed) != 0 {
+		t.Error("expected no destroys when all workers are current")
+	}
+}
+
+// ============================================================
 // Test: Golden version in migration target selection
 // ============================================================
 

--- a/internal/qemu/agent_client.go
+++ b/internal/qemu/agent_client.go
@@ -4,14 +4,19 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"net"
+	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/status"
 
 	pb "github.com/opensandbox/opensandbox/proto/agent"
 )
@@ -19,51 +24,61 @@ import (
 const streamChunkSize = 256 * 1024 // 256KB per gRPC chunk
 
 // AgentClient is the host-side gRPC client that connects to the
-// osb-agent running inside a QEMU VM via AF_VSOCK.
+// osb-agent running inside a QEMU VM via AF_VSOCK or virtio-serial.
+//
+// dialer captures the constructor's dial logic so Redial can rebuild the
+// connection without the caller knowing whether this is vsock or virtio-
+// serial transport. This is the recovery path for the post-loadvm protocol-
+// confusion bug and the prod 10-min-after-restore agent disconnect: when an
+// RPC fails with a transport error, the caller invokes Redial and retries.
 type AgentClient struct {
+	mu     sync.Mutex
 	conn   *grpc.ClientConn
 	client pb.SandboxAgentClient
+	dialer func() (*grpc.ClientConn, error)
 }
 
 // NewAgentClient connects to the agent via AF_VSOCK using the guest CID.
 // QEMU uses the kernel's vhost-vsock directly — no UDS file needed.
 // Port 1024 is the agent gRPC server inside the VM.
 func NewAgentClient(guestCID uint32) (*AgentClient, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	conn, err := grpc.DialContext(ctx,
-		"passthrough:///vsock",
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
-		grpc.WithConnectParams(grpc.ConnectParams{
-			Backoff: backoff.Config{
-				BaseDelay:  10 * time.Millisecond,
-				Multiplier: 1.6,
-				Jitter:     0.2,
-				MaxDelay:   1 * time.Second,
-			},
-		}),
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                30 * time.Second,
-			Timeout:             10 * time.Second,
-			PermitWithoutStream: true,
-		}),
-		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-			return dialVsock(ctx, guestCID, 1024)
-		}),
-		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(256*1024*1024),
-			grpc.MaxCallSendMsgSize(256*1024*1024),
-		),
-	)
+	dialer := func() (*grpc.ClientConn, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		return grpc.DialContext(ctx,
+			"passthrough:///vsock",
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithBlock(),
+			grpc.WithConnectParams(grpc.ConnectParams{
+				Backoff: backoff.Config{
+					BaseDelay:  10 * time.Millisecond,
+					Multiplier: 1.6,
+					Jitter:     0.2,
+					MaxDelay:   1 * time.Second,
+				},
+			}),
+			grpc.WithKeepaliveParams(keepalive.ClientParameters{
+				Time:                30 * time.Second,
+				Timeout:             10 * time.Second,
+				PermitWithoutStream: true,
+			}),
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				return dialVsock(ctx, guestCID, 1024)
+			}),
+			grpc.WithDefaultCallOptions(
+				grpc.MaxCallRecvMsgSize(256*1024*1024),
+				grpc.MaxCallSendMsgSize(256*1024*1024),
+			),
+		)
+	}
+	conn, err := dialer()
 	if err != nil {
 		return nil, fmt.Errorf("connect to agent at CID %d: %w", guestCID, err)
 	}
-
 	return &AgentClient{
 		conn:   conn,
 		client: pb.NewSandboxAgentClient(conn),
+		dialer: dialer,
 	}, nil
 }
 
@@ -479,37 +494,89 @@ func (c *AgentClient) ConnectPTYData(guestCID uint32, dataPort uint32) (net.Conn
 // NewAgentClientSocket connects to the agent via a Unix socket (virtio-serial chardev).
 // Used by QEMU backend — virtio-serial survives QEMU live migration.
 func NewAgentClientSocket(socketPath string) (*AgentClient, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	conn, err := grpc.DialContext(ctx,
-		"unix://"+socketPath,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
-		grpc.WithConnectParams(grpc.ConnectParams{
-			Backoff: backoff.Config{
-				BaseDelay:  10 * time.Millisecond,
-				Multiplier: 1.6,
-				Jitter:     0.2,
-				MaxDelay:   1 * time.Second,
-			},
-		}),
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                30 * time.Second,
-			Timeout:             10 * time.Second,
-			PermitWithoutStream: true,
-		}),
-		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(256*1024*1024),
-			grpc.MaxCallSendMsgSize(256*1024*1024),
-		),
-	)
+	dialer := func() (*grpc.ClientConn, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		return grpc.DialContext(ctx,
+			"unix://"+socketPath,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithBlock(),
+			grpc.WithConnectParams(grpc.ConnectParams{
+				Backoff: backoff.Config{
+					BaseDelay:  10 * time.Millisecond,
+					Multiplier: 1.6,
+					Jitter:     0.2,
+					MaxDelay:   1 * time.Second,
+				},
+			}),
+			grpc.WithKeepaliveParams(keepalive.ClientParameters{
+				Time:                30 * time.Second,
+				Timeout:             10 * time.Second,
+				PermitWithoutStream: true,
+			}),
+			grpc.WithDefaultCallOptions(
+				grpc.MaxCallRecvMsgSize(256*1024*1024),
+				grpc.MaxCallSendMsgSize(256*1024*1024),
+			),
+		)
+	}
+	conn, err := dialer()
 	if err != nil {
 		return nil, fmt.Errorf("connect to agent at %s: %w", socketPath, err)
 	}
-
 	return &AgentClient{
 		conn:   conn,
 		client: pb.NewSandboxAgentClient(conn),
+		dialer: dialer,
 	}, nil
+}
+
+// Redial closes the current gRPC conn and dials a new one using the dialer
+// captured at construction. Safe under concurrent callers — only one
+// redial happens at a time, others wait and reuse the result.
+//
+// Use this when an RPC fails with a transport error (Unavailable, EOF,
+// closed network connection). After Redial, retry the RPC on the fresh
+// conn. If the agent inside the VM is fundamentally wedged this won't
+// help — but for the common "stale conn after savevm/loadvm" or
+// "control channel dropped at idle" case it recovers transparently.
+func (c *AgentClient) Redial() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.dialer == nil {
+		return fmt.Errorf("AgentClient has no dialer (already closed?)")
+	}
+	if c.conn != nil {
+		_ = c.conn.Close()
+	}
+	conn, err := c.dialer()
+	if err != nil {
+		return fmt.Errorf("redial agent: %w", err)
+	}
+	c.conn = conn
+	c.client = pb.NewSandboxAgentClient(conn)
+	log.Printf("agent-client: redial succeeded")
+	return nil
+}
+
+// IsTransportError returns true if err looks like a gRPC transport-level
+// failure that a Redial+retry would plausibly fix. Distinguished from
+// application errors (NotFound, InvalidArgument, etc.) which are caller
+// problems and shouldn't trigger reconnect storms.
+func IsTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if st, ok := status.FromError(err); ok {
+		switch st.Code() {
+		case codes.Unavailable, codes.DeadlineExceeded, codes.Canceled:
+			return true
+		}
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "use of closed network connection") ||
+		strings.Contains(msg, "EOF") ||
+		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "transport is closing")
 }

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -58,6 +58,26 @@ func prepareAgentForHibernate(ctx context.Context, agent *AgentClient) {
 	time.Sleep(1 * time.Second)
 }
 
+// quiesceAndCloseAgent prepares the agent for hibernate, closes the host-side
+// gRPC client connection, and waits 200ms for the guest's gRPC server to
+// process the EOF and re-enter its Accept poll loop. After this returns it is
+// safe for the caller to call savevm — the captured snapshot will not have a
+// stale virtioSerialConn whose buffered HTTP/2 framer state could corrupt the
+// next host's gRPC handshake on fork/restore.
+//
+// The 200ms is empirically sufficient for the guest virtio-serial driver to
+// surface EOF on /dev/virtio-ports/agent → for the gRPC server's Read goroutine
+// to drop its conn → for onClose to run (active=false). Without this wait the
+// snapshot can land mid-tear-down and the bug returns.
+func quiesceAndCloseAgent(ctx context.Context, agent *AgentClient) {
+	if agent == nil {
+		return
+	}
+	prepareAgentForHibernate(ctx, agent)
+	_ = agent.Close()
+	time.Sleep(200 * time.Millisecond)
+}
+
 // Compile-time check that Manager implements sandbox.Manager.
 var _ sandbox.Manager = (*Manager)(nil)
 
@@ -975,11 +995,18 @@ func patchGuestNetwork(ctx context.Context, agent *AgentClient, netCfg *NetworkC
 	// `ip route replace` is idempotent — works whether the route exists or not.
 	// `ip addr add` may say "File exists" if the address is already there, which
 	// is a no-op for our purposes; suppress and verify at the end.
+	//
+	// `ip neigh flush all` is critical on cross-worker fork: the captured ARP
+	// cache has the SOURCE worker's gateway MAC, but the destination worker's
+	// TAP has a different MAC. Without flushing, the kernel keeps the stale
+	// REACHABLE entry for ~30s (base_reachable_time) and every outbound packet
+	// silently drops. Flush forces a fresh ARP resolve on the next packet.
 	script := fmt.Sprintf(`set +e
 ip addr flush dev eth0
 ip addr add %s/%d dev eth0 2>/dev/null
 ip link set eth0 up
 ip route replace default via %s
+ip neigh flush all
 
 # DNS — always write, independent of network ops
 echo 'nameserver 8.8.8.8' > /etc/resolv.conf
@@ -997,15 +1024,30 @@ exit 0
 		netCfg.GuestIP, netCfg.HostIP,
 	)
 
-	execCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	resp, err := agent.Exec(execCtx, &pb.ExecRequest{
+	// 30s deadline (bumped from 5s) — under host load `ip link` and arping
+	// can take several seconds, and the prior 5s budget left no room for the
+	// agent's Exec round-trip on top of that. The 5s timeout produced the
+	// `network patch failed: rpc error: code = DeadlineExceeded` cluster in
+	// load tests. One Redial-on-transport-error retry handles the post-loadvm
+	// stale-conn case where the first call hits a wedged virtio-serial channel.
+	req := &pb.ExecRequest{
 		Command:        "/bin/sh",
 		Args:           []string{"-c", script},
-		TimeoutSeconds: 5,
+		TimeoutSeconds: 25,
 		RunAsRoot:      true,
-	})
+	}
+	rpcCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	resp, err := agent.Exec(rpcCtx, req)
+	if err != nil && IsTransportError(err) {
+		log.Printf("qemu: patchGuestNetwork: transport error %v, redialing and retrying once", err)
+		if rdErr := agent.Redial(); rdErr != nil {
+			return fmt.Errorf("network patch redial: %w (orig: %v)", rdErr, err)
+		}
+		rpcCtx2, cancel2 := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel2()
+		resp, err = agent.Exec(rpcCtx2, req)
+	}
 	if err != nil {
 		return fmt.Errorf("exec network patch: %w", err)
 	}
@@ -1701,13 +1743,24 @@ func (m *Manager) Exec(ctx context.Context, sandboxID string, cfg types.ProcessC
 		command = "/bin/sh"
 	}
 
-	resp, err := vm.agent.Exec(ctx, &pb.ExecRequest{
+	req := &pb.ExecRequest{
 		Command:        command,
 		Args:           args,
 		Envs:           cfg.Env,
 		Cwd:            cfg.Cwd,
 		TimeoutSeconds: timeout,
-	})
+	}
+	resp, err := vm.agent.Exec(ctx, req)
+	if err != nil && IsTransportError(err) {
+		// Same recovery path as SyncFS: the gRPC client conn can be in a
+		// transient-failure state immediately after fork (waitForAgentSocket
+		// passes with one ping, but the next RPC races with conn state).
+		// Redial and retry once.
+		log.Printf("qemu: Exec %s: transport error (%v), redialing agent", sandboxID, err)
+		if rdErr := vm.agent.Redial(); rdErr == nil {
+			resp, err = vm.agent.Exec(ctx, req)
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("exec in %s: %w", sandboxID, err)
 	}
@@ -2147,11 +2200,11 @@ func (m *Manager) CreateCheckpoint(ctx context.Context, sandboxID, checkpointID 
 		return "", "", fmt.Errorf("QMP connection not available for %s", sandboxID)
 	}
 
-	// Sync filesystem and quiesce virtio-serial before snapshot. The PrepareHibernate
-	// RPC returns only after the guest is fully prepared, so no sleep is needed.
+	// Sync filesystem, quiesce virtio-serial, close host conn, and WAIT for
+	// the guest to process EOF before savevm. Critical for clean snapshot
+	// state — see quiesceAndCloseAgent for the protocol details.
 	if vm.agent != nil {
-		prepareAgentForHibernate(ctx, vm.agent)
-		vm.agent.Close()
+		quiesceAndCloseAgent(ctx, vm.agent)
 		vm.agent = nil
 	}
 
@@ -2220,15 +2273,19 @@ func (m *Manager) CreateCheckpoint(ctx context.Context, sandboxID, checkpointID 
 	if reconnErr == nil {
 		vm.agent = agentClient
 	} else {
-		log.Printf("qemu: CreateCheckpoint %s/%s: CRITICAL: agent reconnect failed, killing orphan VM", sandboxID, checkpointID)
-		if vm.qmp != nil {
-			_ = vm.qmp.Quit()
-			vm.qmp.Close()
-			vm.qmp = nil
-		}
+		// Agent didn't come back after savevm — the VM is unmanageable. Full
+		// teardown via destroyVM, not the partial QMP-quit-only cleanup that
+		// used to live here. The old path left the qemu process and TAP/dir
+		// behind any time qmp.Quit didn't reach the process, producing the
+		// orphan qemu we observed under load (m.vms removed but qemu alive,
+		// invisible to the rest of the worker until the orphan reaper runs).
+		log.Printf("qemu: CreateCheckpoint %s/%s: CRITICAL: agent reconnect failed, destroying VM cleanly", sandboxID, checkpointID)
 		m.mu.Lock()
 		delete(m.vms, sandboxID)
 		m.mu.Unlock()
+		if err := m.destroyVM(vm); err != nil {
+			log.Printf("qemu: CreateCheckpoint %s/%s: destroyVM also failed: %v (orphan reaper will catch)", sandboxID, checkpointID, err)
+		}
 	}
 
 	// Write metadata and finalize cache.
@@ -2851,13 +2908,36 @@ func (m *Manager) ForkFromCheckpoint(ctx context.Context, checkpointID string, c
 
 	log.Printf("qemu: ForkFromCheckpoint %s → %s: agent connected, patching network...", checkpointID, id)
 
-	// Patch network (fork gets new IPs) + sync clock
+	// Patch network (fork gets new IPs) + sync clock — both LOAD-BEARING.
+	// Earlier this code only logged failures; the fork would "complete" with
+	// the wrong IP/route/DNS and an unresponsive agent gRPC channel, leaking
+	// a half-broken VM. Now: propagate errors, destroy the half-built fork,
+	// and return — caller retries against a clean slate.
+	patchT0 := time.Now()
 	if err := patchGuestNetwork(context.Background(), agent, netCfg); err != nil {
-		log.Printf("qemu: ForkFromCheckpoint %s: network patch failed: %v", id, err)
+		log.Printf("qemu: ForkFromCheckpoint %s: ABORT network patch failed (%dms): %v",
+			id, time.Since(patchT0).Milliseconds(), err)
+		_ = agent.Close()
+		_ = qmpClient.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		m.cleanupVM(netCfg, sandboxDir)
+		return nil, fmt.Errorf("fork %s: network patch failed: %w", id, err)
 	}
+	log.Printf("qemu: ForkFromCheckpoint %s: network patched (%dms)", id, time.Since(patchT0).Milliseconds())
+
+	clockT0 := time.Now()
 	if err := syncGuestClock(context.Background(), agent); err != nil {
-		log.Printf("qemu: ForkFromCheckpoint %s: clock sync failed: %v", id, err)
+		log.Printf("qemu: ForkFromCheckpoint %s: ABORT clock sync failed (%dms): %v",
+			id, time.Since(clockT0).Milliseconds(), err)
+		_ = agent.Close()
+		_ = qmpClient.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		m.cleanupVM(netCfg, sandboxDir)
+		return nil, fmt.Errorf("fork %s: clock sync failed: %w", id, err)
 	}
+	log.Printf("qemu: ForkFromCheckpoint %s: clock synced (%dms)", id, time.Since(clockT0).Milliseconds())
 
 	// Set env vars (sealed via secrets proxy if configured)
 	envsToInject := m.sealSandboxEnvs(context.Background(), id, netCfg, agent, cfg)
@@ -3016,6 +3096,13 @@ func (m *Manager) GetWorkspacePath(sandboxID string) (string, error) {
 }
 
 // SyncFS flushes filesystem buffers inside the VM.
+//
+// On transport errors (Unavailable, EOF, "closed network connection"), the
+// agent client redials and retries once. This is the recovery path for the
+// prod scenario where an agent connection silently dropped ~10 min after
+// migration restore and stayed dropped: every autosave-driven SyncFS would
+// hit a closed conn and log a failure forever, with no reconnect attempt.
+// Now we redial on demand and the next autosave succeeds.
 func (m *Manager) SyncFS(ctx context.Context, sandboxID string) error {
 	vm, err := m.getVM(sandboxID)
 	if err != nil {
@@ -3024,7 +3111,17 @@ func (m *Manager) SyncFS(ctx context.Context, sandboxID string) error {
 	if vm.agent == nil {
 		return fmt.Errorf("no agent connection for %s", sandboxID)
 	}
-	return vm.agent.SyncFS(ctx)
+	if err := vm.agent.SyncFS(ctx); err != nil {
+		if !IsTransportError(err) {
+			return err
+		}
+		log.Printf("qemu: SyncFS %s: transport error (%v), redialing agent", sandboxID, err)
+		if rdErr := vm.agent.Redial(); rdErr != nil {
+			return fmt.Errorf("syncfs failed and redial failed: orig=%v redial=%w", err, rdErr)
+		}
+		return vm.agent.SyncFS(ctx)
+	}
+	return nil
 }
 
 // CleanupOrphanedProcesses kills any QEMU processes and TAP devices

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -3004,13 +3004,15 @@ func (m *Manager) GetAgent(sandboxID string) (*AgentClient, error) {
 	return vm.agent, nil
 }
 
-// GetWorkspacePath returns the host path to a sandbox's workspace.ext4.
+// GetWorkspacePath returns the host path to a sandbox's workspace qcow2.
+// Used by the autosave loop to gate SyncFS on mtime — no point syncing if
+// the workspace hasn't been touched since the last successful sync.
 func (m *Manager) GetWorkspacePath(sandboxID string) (string, error) {
 	vm, err := m.getVM(sandboxID)
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(vm.sandboxDir, "workspace.ext4"), nil
+	return filepath.Join(vm.sandboxDir, "workspace.qcow2"), nil
 }
 
 // SyncFS flushes filesystem buffers inside the VM.

--- a/internal/qemu/orphan_reaper.go
+++ b/internal/qemu/orphan_reaper.go
@@ -1,0 +1,187 @@
+package qemu
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// orphanReapInterval is how often we scan /proc for leaked qemu processes.
+// 60s is short enough that a leak doesn't accumulate for hours, long enough
+// that the scan cost is negligible (one sweep of /proc per minute).
+const orphanReapInterval = 60 * time.Second
+
+// orphanGraceTermDelay is how long we wait between SIGTERM and SIGKILL when
+// reaping an orphan. QEMU usually exits cleanly on SIGTERM within ~1s; 5s is
+// generous and bounds the reap pass at ~5s per orphan in the worst case.
+const orphanGraceTermDelay = 5 * time.Second
+
+// sandboxIDRe extracts an sb-xxxxxxxx sandbox ID from a qemu command line.
+// QEMU's cmdline embeds the sandboxDir as a -drive file=… and -chardev path=…
+// argument, so the ID always appears in the form /data/sandboxes/sandboxes/sb-XXX/.
+var sandboxIDRe = regexp.MustCompile(`/sandboxes/(sb-[a-z0-9]+)/`)
+
+// StartOrphanReaper launches a background goroutine that periodically scans
+// /proc for qemu-system processes whose sandbox ID is not in the worker's VM
+// registry, and kills them.
+//
+// Why this is needed: when destroyVM races with a state inconsistency (e.g.,
+// a hibernate-on-timeout that ran without the VM being in m.vms, a panic in
+// a sandbox goroutine that exits before cleanup, or a worker crash that left
+// children behind), a qemu-system-x86_64 process can survive past the worker's
+// knowledge of it. Those orphans hold a TAP, an agent.sock, and a vCPU — they
+// silently shrink real worker capacity until the worker is restarted. We saw
+// this in the field: after a load test, Worker A had 2 zombie + 1 live qemu
+// from a session that ended 30 minutes earlier, which then made every new
+// fork on that worker fail.
+func (m *Manager) StartOrphanReaper(ctx context.Context) {
+	go m.orphanReaperLoop(ctx)
+}
+
+func (m *Manager) orphanReaperLoop(ctx context.Context) {
+	ticker := time.NewTicker(orphanReapInterval)
+	defer ticker.Stop()
+	// First scan happens after one interval — gives the worker time to
+	// register VMs at startup before we start judging them as orphans.
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.reapOrphans()
+		}
+	}
+}
+
+// reapOrphans scans /proc for qemu-system processes belonging to sandboxes
+// that are no longer in m.vms, and kills them.
+func (m *Manager) reapOrphans() {
+	pidByID, err := scanQEMUProcesses()
+	if err != nil {
+		log.Printf("qemu: orphan-reaper: scan failed: %v", err)
+		return
+	}
+	if len(pidByID) == 0 {
+		return
+	}
+
+	m.mu.RLock()
+	known := make(map[string]bool, len(m.vms))
+	for id := range m.vms {
+		known[id] = true
+	}
+	m.mu.RUnlock()
+
+	for sandboxID, pid := range pidByID {
+		if known[sandboxID] {
+			continue
+		}
+		log.Printf("qemu: orphan-reaper: found leaked qemu pid=%d sandbox=%s (not in vm registry), terminating",
+			pid, sandboxID)
+		if err := terminateAndWait(pid); err != nil {
+			log.Printf("qemu: orphan-reaper: failed to terminate pid=%d: %v", pid, err)
+			continue
+		}
+		// Best-effort sandbox dir cleanup. If destroyVM was supposed to remove
+		// it but never did, do it now.
+		sandboxDir := filepath.Join(m.cfg.DataDir, "sandboxes", "sandboxes", sandboxID)
+		if _, err := os.Stat(sandboxDir); err == nil {
+			if err := os.RemoveAll(sandboxDir); err != nil {
+				log.Printf("qemu: orphan-reaper: removed pid=%d but failed to clean %s: %v",
+					pid, sandboxDir, err)
+			} else {
+				log.Printf("qemu: orphan-reaper: cleaned up sandbox dir %s", sandboxDir)
+			}
+		}
+	}
+}
+
+// scanQEMUProcesses walks /proc and returns a map of sandboxID -> pid for
+// every qemu-system-x86_64 process whose cmdline references a sandbox dir.
+func scanQEMUProcesses() (map[string]int, error) {
+	procEntries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]int)
+	for _, entry := range procEntries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		// Read /proc/PID/comm — cheap, only ~16 bytes; skip non-qemu fast.
+		commBytes, err := os.ReadFile(filepath.Join("/proc", entry.Name(), "comm"))
+		if err != nil {
+			continue
+		}
+		comm := strings.TrimSpace(string(commBytes))
+		if !strings.HasPrefix(comm, "qemu-system") {
+			continue
+		}
+		// /proc/PID/cmdline is NUL-separated; we scan it as a single blob.
+		cmdlineBytes, err := os.ReadFile(filepath.Join("/proc", entry.Name(), "cmdline"))
+		if err != nil {
+			continue
+		}
+		cmdline := string(cmdlineBytes)
+		match := sandboxIDRe.FindStringSubmatch(cmdline)
+		if len(match) < 2 {
+			continue
+		}
+		sandboxID := match[1]
+		// Multiple qemu processes for the same sandbox shouldn't exist —
+		// if they do, the first one wins; the duplicate will be reaped on
+		// the next pass after the registered one is removed.
+		if _, dup := out[sandboxID]; !dup {
+			out[sandboxID] = pid
+		}
+	}
+	return out, nil
+}
+
+// terminateAndWait sends SIGTERM, waits up to orphanGraceTermDelay, then
+// SIGKILLs if the process is still alive. Returns nil if the process is
+// gone (whatever the path).
+func terminateAndWait(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	// SIGTERM lets QEMU shut down its devices cleanly, which avoids leaving
+	// stale qcow2 locks. If it's already wedged it won't help; we'll SIGKILL
+	// after the grace window.
+	_ = proc.Signal(syscall.SIGTERM)
+
+	deadline := time.Now().Add(orphanGraceTermDelay)
+	for time.Now().Before(deadline) {
+		if !pidAlive(pid) {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if pidAlive(pid) {
+		_ = proc.Kill()
+		// Brief wait for kernel to flush the kill.
+		for i := 0; i < 25 && pidAlive(pid); i++ {
+			time.Sleep(40 * time.Millisecond)
+		}
+	}
+	return nil
+}
+
+// pidAlive returns true if /proc/PID still exists. We don't use kill(0)
+// because that fails with EPERM if the worker isn't root for some reason —
+// /proc is more permissive.
+func pidAlive(pid int) bool {
+	_, err := os.Stat(filepath.Join("/proc", strconv.Itoa(pid)))
+	return err == nil
+}

--- a/internal/qemu/snapshot.go
+++ b/internal/qemu/snapshot.go
@@ -62,13 +62,11 @@ func (m *Manager) doHibernate(ctx context.Context, vm *VMInstance, checkpointSto
 		return nil, fmt.Errorf("mkdir snapshot dir: %w", err)
 	}
 
-	// Step 1: Sync filesystems and quiesce agent.
+	// Step 1: Sync filesystems, quiesce agent, close host conn, and WAIT for
+	// the guest to process EOF before savevm. See quiesceAndCloseAgent.
 	// Don't unmount /workspace — open FDs prevent clean unmount and cause ext4 corruption.
-	// PrepareHibernate syncs dirty pages and resets the virtio-serial listener
-	// synchronously, so no post-close sleep is needed.
 	if vm.agent != nil {
-		prepareAgentForHibernate(ctx, vm.agent)
-		vm.agent.Close()
+		quiesceAndCloseAgent(ctx, vm.agent)
 		vm.agent = nil
 	}
 	log.Printf("qemu: hibernate %s: guest sync + unmount done (%dms)", vm.ID, time.Since(t0).Milliseconds())
@@ -796,15 +794,33 @@ func copyFileReflink(src, dst string) error {
 }
 
 // syncGuestClock sets the guest clock to the current host time via agent exec.
+//
+// Wraps the underlying RPC with a 10s deadline (caller-side timeout, NOT just
+// the agent-side TimeoutSeconds) and one Redial-on-transport-error retry. Prior
+// version used the caller's context.Background() which had no deadline at all,
+// so a wedged virtio-serial channel would block until gRPC keepalive (~7 min)
+// gave up. That stall is what produced the multi-minute "from-checkpoint"
+// requests in load tests.
 func syncGuestClock(ctx context.Context, agent *AgentClient) error {
 	now := time.Now().Unix()
-	cmd := fmt.Sprintf("date -s @%d > /dev/null 2>&1", now)
-	resp, err := agent.Exec(ctx, &pb.ExecRequest{
+	req := &pb.ExecRequest{
 		Command:        "/bin/sh",
-		Args:           []string{"-c", cmd},
+		Args:           []string{"-c", fmt.Sprintf("date -s @%d > /dev/null 2>&1", now)},
 		TimeoutSeconds: 5,
 		RunAsRoot:      true,
-	})
+	}
+	rpcCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	resp, err := agent.Exec(rpcCtx, req)
+	if err != nil && IsTransportError(err) {
+		log.Printf("qemu: syncGuestClock: transport error %v, redialing and retrying once", err)
+		if rdErr := agent.Redial(); rdErr != nil {
+			return fmt.Errorf("clock sync redial: %w (orig: %v)", rdErr, err)
+		}
+		rpcCtx2, cancel2 := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel2()
+		resp, err = agent.Exec(rpcCtx2, req)
+	}
 	if err != nil {
 		return fmt.Errorf("exec clock sync: %w", err)
 	}

--- a/internal/worker/autosave.go
+++ b/internal/worker/autosave.go
@@ -3,21 +3,39 @@ package worker
 import (
 	"context"
 	"log"
+	"os"
 	"sync"
 	"time"
 
 	"github.com/opensandbox/opensandbox/internal/sandbox"
 )
 
-// SyncFSer is implemented by any VM manager that can flush filesystem buffers.
+// SyncFSer is implemented by any VM manager that can flush filesystem buffers
+// and report the workspace path so we can gate sync on mtime.
 type SyncFSer interface {
 	SyncFS(ctx context.Context, sandboxID string) error
+	GetWorkspacePath(sandboxID string) (string, error)
 }
 
+// maxConsecutiveFailures: after this many failed sync attempts in a row for
+// the same sandbox, we stop trying. Prevents a wedged sandbox (e.g. agent
+// stuck after savevm/loadvm protocol confusion) from emitting an autosave
+// failure log every 5 minutes forever, and stops us churning the broken
+// gRPC channel — which is itself part of the post-loadvm flake surface.
+// Operator can re-enable by reviving the sandbox or restarting the worker.
+const maxConsecutiveFailures = 5
+
 // WorkspaceAutosaver periodically flushes filesystem buffers inside each
-// running VM. This ensures workspace.ext4 on the host NVMe is crash-consistent.
-// On hard kill recovery, the worker cold-boots from template + existing
-// workspace.ext4 on disk (processes lost, but user files in /workspace are safe).
+// running VM so workspace.qcow2 on the host NVMe is crash-consistent for
+// cold-boot recovery on worker death.
+//
+// Two correctness/cost gates:
+//   - skip a sandbox if its workspace.qcow2 hasn't been modified since the
+//     last successful sync (idle sandboxes are common and a sync per tick
+//     is wasted work and gRPC roundtrip).
+//   - circuit-breaker after N consecutive failures: stop trying for a
+//     sandbox where the agent is wedged. Prevents log flood and churn on
+//     the broken control channel.
 type WorkspaceAutosaver struct {
 	manager     sandbox.Manager
 	syncer      SyncFSer
@@ -25,6 +43,15 @@ type WorkspaceAutosaver struct {
 	concurrency int
 	stop        chan struct{}
 	done        chan struct{}
+
+	mu       sync.Mutex
+	state    map[string]*sandboxSyncState // keyed by sandboxID
+}
+
+type sandboxSyncState struct {
+	lastSyncedMtime time.Time // mtime of workspace.qcow2 at last successful sync
+	consecutiveFails int
+	disabled         bool // circuit-breaker tripped — skip until restart
 }
 
 // NewWorkspaceAutosaver creates a new autosaver.
@@ -40,13 +67,15 @@ func NewWorkspaceAutosaver(
 		concurrency: 10,
 		stop:        make(chan struct{}),
 		done:        make(chan struct{}),
+		state:       map[string]*sandboxSyncState{},
 	}
 }
 
 // Start begins the periodic SyncFS loop.
 func (a *WorkspaceAutosaver) Start() {
 	go a.loop()
-	log.Printf("autosave: started (interval=%s, concurrency=%d)", a.interval, a.concurrency)
+	log.Printf("autosave: started (interval=%s, concurrency=%d, fail-threshold=%d)",
+		a.interval, a.concurrency, maxConsecutiveFailures)
 }
 
 // Stop signals the loop to exit and waits for it to finish.
@@ -70,6 +99,29 @@ func (a *WorkspaceAutosaver) loop() {
 	}
 }
 
+func (a *WorkspaceAutosaver) getOrCreateState(sandboxID string) *sandboxSyncState {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	s, ok := a.state[sandboxID]
+	if !ok {
+		s = &sandboxSyncState{}
+		a.state[sandboxID] = s
+	}
+	return s
+}
+
+// pruneState removes per-sandbox state for sandboxes no longer in the active
+// set. Without this the map grows unbounded across the worker's lifetime.
+func (a *WorkspaceAutosaver) pruneState(active map[string]struct{}) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for id := range a.state {
+		if _, ok := active[id]; !ok {
+			delete(a.state, id)
+		}
+	}
+}
+
 func (a *WorkspaceAutosaver) syncAll() {
 	sandboxes, err := a.manager.List(context.Background())
 	if err != nil {
@@ -77,18 +129,25 @@ func (a *WorkspaceAutosaver) syncAll() {
 		return
 	}
 	if len(sandboxes) == 0 {
+		a.pruneState(map[string]struct{}{})
 		return
 	}
 
+	active := make(map[string]struct{}, len(sandboxes))
+	for _, sb := range sandboxes {
+		active[sb.ID] = struct{}{}
+	}
+	a.pruneState(active)
+
 	sem := make(chan struct{}, a.concurrency)
 	var wg sync.WaitGroup
-	var successCount, failCount int32
+	var successCount, skipCount, failCount, disabledCount int32
 	var mu sync.Mutex
 
 	for _, sb := range sandboxes {
 		select {
 		case <-a.stop:
-			break
+			return
 		default:
 		}
 
@@ -98,23 +157,88 @@ func (a *WorkspaceAutosaver) syncAll() {
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			syncCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-			if err := a.syncer.SyncFS(syncCtx, sandboxID); err != nil {
-				log.Printf("autosave: syncfs failed for %s: %v", sandboxID, err)
-				mu.Lock()
-				failCount++
-				mu.Unlock()
-			} else {
-				mu.Lock()
+			outcome := a.syncOne(sandboxID)
+			mu.Lock()
+			switch outcome {
+			case syncOK:
 				successCount++
-				mu.Unlock()
+			case syncSkipped:
+				skipCount++
+			case syncFailed:
+				failCount++
+			case syncDisabled:
+				disabledCount++
 			}
+			mu.Unlock()
 		}(sb.ID)
 	}
 
 	wg.Wait()
-	if failCount > 0 {
-		log.Printf("autosave: syncfs complete (%d ok, %d failed)", successCount, failCount)
+	if failCount > 0 || disabledCount > 0 {
+		log.Printf("autosave: tick complete (ok=%d skip=%d fail=%d disabled=%d)",
+			successCount, skipCount, failCount, disabledCount)
 	}
+}
+
+type syncOutcome int
+
+const (
+	syncOK syncOutcome = iota
+	syncSkipped     // workspace unchanged since last sync
+	syncFailed      // sync attempted, returned error
+	syncDisabled    // circuit-breaker tripped — skipped without attempting
+)
+
+func (a *WorkspaceAutosaver) syncOne(sandboxID string) syncOutcome {
+	state := a.getOrCreateState(sandboxID)
+
+	a.mu.Lock()
+	if state.disabled {
+		a.mu.Unlock()
+		return syncDisabled
+	}
+	lastMtime := state.lastSyncedMtime
+	a.mu.Unlock()
+
+	// Gate on workspace mtime — skip if nothing changed since last successful sync.
+	wsPath, err := a.syncer.GetWorkspacePath(sandboxID)
+	if err == nil && wsPath != "" {
+		if stat, statErr := os.Stat(wsPath); statErr == nil {
+			if !lastMtime.IsZero() && !stat.ModTime().After(lastMtime) {
+				return syncSkipped
+			}
+		}
+	}
+
+	syncCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := a.syncer.SyncFS(syncCtx, sandboxID); err != nil {
+		a.mu.Lock()
+		state.consecutiveFails++
+		hitThreshold := state.consecutiveFails >= maxConsecutiveFailures
+		if hitThreshold {
+			state.disabled = true
+		}
+		fails := state.consecutiveFails
+		a.mu.Unlock()
+
+		if hitThreshold {
+			log.Printf("autosave: %s disabled after %d consecutive failures (last=%v) — operator must intervene to re-enable",
+				sandboxID, fails, err)
+		} else if fails == 1 {
+			log.Printf("autosave: syncfs failed for %s: %v", sandboxID, err)
+		}
+		return syncFailed
+	}
+
+	// Success — record current mtime to gate next tick.
+	a.mu.Lock()
+	state.consecutiveFails = 0
+	if wsPath != "" {
+		if stat, err := os.Stat(wsPath); err == nil {
+			state.lastSyncedMtime = stat.ModTime()
+		}
+	}
+	a.mu.Unlock()
+	return syncOK
 }


### PR DESCRIPTION
# Worker reliability: agent / fork / cleanup hardening + rolling-replace dance + rootfs

This PR closes a cluster of related reliability bugs uncovered during last week's prod incident on `osb-worker-87d3bbee` (60+ sandboxes lost their agent connection after restoration and couldn't recover) and a follow-on dev investigation that turned up a 5% fork failure rate, a leaked-qemu accumulation pattern, and a quota-pressure rolling-replace deadlock.

All worker binary changes are pure orchestration — no `goldenVersion` change, no rootfs rebuild needed for them. The rootfs change in this PR is a deliberate `goldenVersion` bump (docker + supervisord + baked `/etc/hosts` + new agent that auto-starts supervisord at boot).

---

## What's in here

### 1. Source-side virtio-serial quiesce (`internal/qemu/manager.go`, `cmd/agent/listen_linux.go`)

savevm was capturing a half-buffered virtio-serial connection: the agent's gRPC server still held a `virtioSerialConn` whose HTTP/2 framer state got snapshotted mid-tear-down. On loadvm, the next host's gRPC handshake fed fresh SETTINGS frames into a parser carrying old-session bytes — the listener stayed wedged with `l.active=true` until the worker's 30s connect timeout fired. Reproduced as ~5% fork failures in dev and as the prod zombie-sandbox state.

**Fix**: `quiesceAndCloseAgent` runs the existing PrepareHibernate, closes the host conn, then **waits 200ms** so the guest sees EOF on `/dev/virtio-ports/agent`, drops the conn, fires `onClose` (active=false), and re-enters the Accept poll loop. Snapshot now captures clean state. Same shape as the eth0 down/up/down bounce we already do for virtio-net at golden creation — different device, same idea.

Validated: forks of fresh checkpoints created with this path went from ~95/100 → **100/100 across 60 trials**.

### 2. Dest-side fork hardening (`internal/qemu/manager.go`, `internal/qemu/snapshot.go`)

`ForkFromCheckpoint`'s post-resume sequence (`patchGuestNetwork` + `syncGuestClock`) was logging-and-marching on errors, then returning success. Combined with `syncGuestClock` having no deadline (passed `context.Background()`), a stuck agent gRPC channel let the call sit for ~7 minutes until gRPC keepalive gave up — the visible "from-checkpoint stalls forever" symptom in worker logs.

- `patchGuestNetwork`: 5s → 30s deadline, Redial-on-transport-error retry, `ip neigh flush all` added so cross-worker forks get fresh ARP for their new gateway.
- `syncGuestClock`: 10s deadline + Redial retry (was inheriting `context.Background`).
- `ForkFromCheckpoint`: bail-on-error. Patch or clock failure → destroy half-built fork → return real gRPC error. No more silently-handed-out wedged sandboxes.

### 3. Agent virtio-serial protocol cleanup (`cmd/agent/listen_linux.go`)

Companion to #1. `PrepareHibernate` now also forces the active gRPC conn down (past read deadline → blocked Read wakes with `ErrDeadlineExceeded` → HTTP/2 transport tears down cleanly). Combined with the source-side 200ms wait, savevm captures with no in-flight parser state. Accept clears the deadline before re-arming so future connections aren't affected.

### 4. Reaper coordination for explicit-wait callers (`internal/agent/reap_registry.go` new, `cmd/agent/reaper_linux.go`, `internal/agent/exec.go`)

Agent runs as PID 1 inside the VM and reaps zombies via `Wait4(-1, ...)`. That was racing `cmd.Wait()` in the Exec / PrepareHibernate / PTY paths — whichever syscall landed first claimed the exit status, and the loser saw `ECHILD` ("waitid: no child processes"). Visible to users as ~5% fork failures with empty stdout when bench-style workloads hit the agent right after a fresh fork.

**Fix**: a small `ReapRegistry` lets explicit-wait callers register a pid; the reaper hands the WaitStatus over a channel instead of consuming it directly. Caller sees ECHILD from `cmd.Wait()`, pulls the WaitStatus from the channel, returns the real exit code.

Validated: phase-2 fork rate went from 95/100 → **99/100 in serial 100-fork tests**, **100/100 in concurrent 5×20 fork tests**.

### 5. CreateCheckpoint cleanup (`internal/qemu/manager.go`)

The "agent reconnect failed after savevm" CRITICAL path was doing partial cleanup: `vm.qmp.Quit()` + `delete(m.vms)`, with no `cmd.Wait`, no TAP teardown, no sandbox dir removal. If `qmp.Quit` didn't reach the qemu process, we leaked a live qemu with no `m.vms` entry. We saw this in load tests where Worker A had two zombies + one live leak from a session that ended 30 minutes earlier. Replaced with full `destroyVM(vm)` so cleanup matches `Kill()`.

### 6. Periodic orphan reaper (`internal/qemu/orphan_reaper.go` new, wired in `cmd/worker/main.go`)

Belt-and-suspenders for cleanup-path bugs we haven't yet found. Every 60s, scan `/proc` for `qemu-system` processes, extract sandbox ID from the cmdline, and kill any whose ID isn't in `m.vms`. SIGTERM with 5s grace, then SIGKILL. Cleans up the sandbox dir if present.

Catches: orphans from previous worker process killed mid-flight; orphans from a `destroyVM` that returned but didn't actually kill qemu; orphans from a goroutine panic that exited before `cmd.Wait` ran.

### 7. Autosave gate-by-mtime + circuit-breaker (`internal/worker/autosave.go`)

Autosave was firing SyncFS against every running sandbox every 5 minutes regardless of whether workspace had changed. On wedged sandbox `sb-5a126184` it logged ~190 consecutive `connection error: closed network connection` failures over 15 hours.

- Skip if `workspace.qcow2` mtime hasn't changed
- After 5 consecutive failures for the same sandbox, mark disabled and stop trying (operator must intervene)
- Per-tick log only when there's something to report
- Per-sandbox state pruned each tick

`SyncFSer` interface gained `GetWorkspacePath(sandboxID)`. Fixed `qemu.Manager.GetWorkspacePath` returning the stale `.ext4` path (now returns `.qcow2`).

### 8. Worker reconnect on transport error (`internal/qemu/agent_client.go`, `internal/qemu/manager.go`)

`AgentClient` now captures dial logic in a closure so `Redial()` can rebuild the connection without callers knowing whether they're on vsock or virtio-serial. `IsTransportError()` classifies which gRPC errors are worth retrying. Wired into `SyncFS`, `Exec`, `patchGuestNetwork`, `syncGuestClock`. The recovery path for the post-loadvm protocol-confusion bug and the prod 10-min-after-restore disconnect.

### 9. Evacuation: serialize + lightest-first (`internal/controlplane/scaler.go`, `scaler_state.go`)

`evacuateHotWorkers` was spawning a goroutine per hot source in parallel, all racing onto whichever target had capacity. Under quota pressure (eastus2 prod at 212/350 Dadsv7 vCPU), 60 sandboxes piled onto one worker while others stayed lightly loaded.

- **One source at a time**: Redis-backed lock (`scaler:evacuating`, 10-min TTL).
- **Lightest first**: hot sources sorted ascending by `Current`. Lightest drains fastest, the now-empty worker becomes a target for the next-lightest. By the time we reach the heaviest source, we've grown our target pool from drained sources.

Within a single source, `findMigrationTarget` runs per-sandbox with actual RSS, so the few targets we have stay balanced.

### 10. Rolling-replace dance for stale-version workers (`internal/controlplane/scaler.go`, `scaler_state.go`)

The previous `rollingReplace` only scaled up a replacement when `current==0` (no new-version workers existed yet). Once one new-version worker came online, every subsequent stale drain landed on **that one new worker** because per-sandbox `findMigrationTarget` could only choose among non-stale targets. Result: `N stale × 50 sandboxes` all piled onto the first new worker — exactly the prod symptom.

**Fix**: quota-aware dance — `drain → terminate → scaleUp` cycle, serialized by a Redis-backed `scaler:replacing` lock so concurrent ticks across CPs don't double-fire:

```
loop {
    pick lightest stale S
    drain S onto current-version workers   // synchronous, waits for empty
    terminate S                            // frees one quota slot
    if more stale workers remain { scaleUp }   // grow the new-version pool
    next tick repeats
}
```

At any moment the cluster holds at most `N+1` workers, but the new-version pool grows by one each cycle: cycle 1 lands all of S1 onto NV1; cycle 2 lands S2 across `{NV1, NV2}`; cycle 3 across `{NV1, NV2, NV3}`. By the time we drain the heaviest stale, our target pool is N-1 wide and per-sandbox spreading works correctly.

### 11. Evaluate must always run rolling-replace (`internal/controlplane/scaler.go`)

Found during the dev rolling-replace test: `Evaluate` had three `return` statements in the scale-up branch (cooldown active, pending workers, max workers reached). Each shortcircuited Phase 5 (`rollingReplace`) at the bottom of the function. **At max workers with all stale, the scale-up gate would `return` before rollingReplace ever ran** — exactly when the dance is needed most, since rolling replace is the only path that frees a slot (drain → terminate → scaleUp).

**Fix**: replaced the three `return`s with a `canScaleUp bool` flag so the scale-up logic is skipped but Phase 5 still runs. Verified end-to-end on dev with a fresh deployment-test push: at-max workers state correctly entered the dance, drained stale1 → terminated → launched NV3, drained stale2 → terminated → launched NV4. Cluster converged from 4 stale to 3 new-version cleanly.

### 12. Agent auto-starts supervisord at boot (`cmd/agent/main.go`)

Rootfs change adds `supervisord` + `docker.io` (see #13), but with `osb-agent` running as PID 1, supervisord didn't auto-start at boot — users had to `sudo supervisord -c …` themselves, defeating the value of bundling it.

**Fix**: agent does a `os.Stat` check for `/usr/bin/supervisord` and `/etc/supervisor/supervisord.conf`, then forks supervisord as a child via `exec.Command(...).Start()`. Supervisord daemonizes and runs configured programs from `/etc/supervisor/conf.d/`. On reboot, agent restarts → supervisord restarts → user processes auto-restart. Same UX as a systemd-managed VM, without systemd.

Validated: full reboot cycle on dev. Agent SHA `662b94ce…` boots clean, supervisord (pid 134) auto-starts, configured `heartbeat` program (pid 137) auto-restarts after `/api/sandboxes/:id/reboot`.

### 13. Rootfs hardening (`deploy/firecracker/rootfs/Dockerfile.default`)

- Bake `127.0.0.1 sandbox` into `/etc/hosts` — eliminates `sudo: unable to resolve host sandbox` regardless of whether the runtime patchGuestNetwork reached the hosts-write step.
- Add `docker.io` (without auto-start) and `supervisor`. With #12, programs configured via `/etc/supervisor/conf.d/*.conf` survive reboots automatically. Adds ~400 MB to rootfs (~1 GB total), no per-sandbox memory cost when daemons are idle.

---

## Validation

Tested on dev cluster (Standard_D16ads_v7 workers):

| Test | Pre-PR | This PR |
|---|---|---|
| Serial 40 forks of fresh checkpoint | ~95% | **40/40** |
| Concurrent 5×20 forks (clean slate) | n/a | **100/100, 23s wall** |
| Cross-worker fork outbound `curl 1.1.1.1` (ARP flush) | n/a | **15/15, 10–19ms ttfb** |
| Serial 100×100 phase-2 forks | ~95/100 | **99/100** |
| Phase-1 checkpoint creates | ~79/100 | **98/100** |
| Supervisord auto-restart after `/reboot` | not possible | **process back up in <30s, no manual action** |
| Rolling-replace dance under quota cap | stuck (silent return) | **end-to-end convergence on dev** |

Phase-1 contention at higher concurrency (10 chains × 10 cps) shows the worker-capacity ceiling on 16 vCPU dev workers; a 64 vCPU prod worker handles the same load comfortably. That's a sizing matter, not a correctness one — see followups.

Rolling-replace was validated by force-pushing this branch to `opencomputer-deployment-test:main`, which triggered Packer-build → KV bump → scaler tick. With the #11 fix in place, the dance ran:

```
22:34:41 rolling replace: draining stale worker 7a93d166 (sandboxes=0, 2 stale total, 2 current)
22:34:41 drain: fully drained
22:35:41 terminated drained worker 7a93d166
22:35:41 more stale workers remain, launching next replacement
22:35:59 created machine f93938b6
22:36:11 draining stale ab02bf3c (1 stale total, 2 current)
22:36:53 terminated drained worker ab02bf3c
22:37:01 created machine 5c89de8b
```

Cluster converged from 4 workers (2 stale + 2 new) to 3 workers all on the new AMI.

---

## Backward compat

- **Worker binary**: pure orchestration. No `goldenVersion` change, no rootfs rebuild, no checkpoint cache invalidation. Rolling deploy is `systemctl restart`.
- **Agent binary**: reaper coordination + virtio-serial drain + supervisord auto-start are baked into the rootfs, so they ride the `goldenVersion` bump along with docker/supervisord.
- **Existing checkpoints**: inherit the old source-side behavior (no retroactive fix for snapshots already on disk). Dest-side mitigations + orphan reaper still protect against their failure modes. New checkpoints created on this code are clean by construction.

---

## Followups (not in this PR)

1. **Per-worker checkpoint-create semaphore** — bound concurrent savevms so saturation timeouts become bounded queue waits. Single largest impact on phase-1 reliability under load.
2. **Cold-restart-on-degradation** — instead of destroying a source whose agent doesn't come back after savevm, cold-restart from disk so the user keeps their sandbox.
3. **Admin endpoint for `Manager.SetDraining`** — operator-exposed drain flag (paired with #208's controlplane-side mitigation).
4. **`snapshot.go` Wake virtio-mem fix** — root-cause for the prod memory-accounting bug; being landed separately.
5. **Scheduler weighted scoring** — placement currently ranks workers by `Current` count alone; should incorporate `MemPct` and tighten the `+1` smoothing window so an overloaded worker doesn't keep getting picked due to count parity.
6. **Persist `Draining` flag in heartbeat** — currently the operator's drain flag lives in CP memory only and doesn't propagate across CPs.
