### PR TITLE
feat(admin): POST /admin/workers/:id/drain to toggle worker draining

### DIFF
--- a/internal/api/admin_workers.go
+++ b/internal/api/admin_workers.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// adminSetWorkerDraining toggles the in-memory `Draining` flag on a worker so
+// the placement filter (RedisWorkerRegistry.GetLeastLoadedWorker and
+// findScaleMigrationTargets) stops routing new sandboxes to it. Existing
+// sandboxes on the worker are unaffected.
+//
+// POST /admin/workers/:id/drain          — mark draining (default)
+// POST /admin/workers/:id/drain?drain=false — clear draining
+//
+// The flag is per-controlplane-instance memory: call this on every active
+// control plane to drain consistently across replicas. Heartbeats do not
+// overwrite the flag.
+func (s *Server) adminSetWorkerDraining(c echo.Context) error {
+	if s.workerRegistry == nil {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{
+			"error": "worker registry not configured (combined/worker mode)",
+		})
+	}
+
+	workerID := c.Param("id")
+	if workerID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "worker id required"})
+	}
+
+	drain := c.QueryParam("drain") != "false"
+
+	known := false
+	for _, w := range s.workerRegistry.GetAllWorkers() {
+		if w.ID == workerID {
+			known = true
+			break
+		}
+	}
+	if !known {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "worker not registered"})
+	}
+
+	s.workerRegistry.SetDraining(workerID, drain)
+
+	return c.JSON(http.StatusOK, map[string]any{
+		"workerID": workerID,
+		"draining": drain,
+	})
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -179,6 +179,7 @@ func NewServer(mgr sandbox.Manager, ptyMgr *sandbox.PTYManager, apiKey string, o
 	admin.GET("/events/history", s.adminEventsHistory)
 	admin.GET("/report", s.adminReport)
 	admin.POST("/events/clear", s.adminClearEvents)
+	admin.POST("/workers/:id/drain", s.adminSetWorkerDraining)
 	admin.GET("/demo/migration", s.demoPingPongPage)
 	admin.GET("/demo/chaos", s.demoChaosPage)
 


### PR DESCRIPTION
## Summary
- Adds `POST /admin/workers/:id/drain` to flip `RedisWorkerRegistry.Draining` from outside the autoscaler.
- Optional `?drain=false` to undrain.
- Returns `404` if the worker isn't registered, `503` if the controlplane is not in server mode.

## Why now
We hit a case (worker `w-azure-osb-worker-87d3bbee` / `10.200.1.100`) where every `SetSandboxLimits` call rejects with `insufficient_capacity` because the worker's in-memory `committed=486400MB` exceeds host capacity (root cause: `internal/qemu/snapshot.go` Wake path sets `vm.MemoryMB = meta.MemoryMB` from a checkpoint whose meta has the pre-hibernate ballooned size, but never re-plugs virtio-mem — so accounting inflates without backing memory).

We want to stop new sandboxes from landing on the affected worker while we ship the snapshot.go fix and rotate workers. The placement filter (`internal/api/sandbox.go:1306`, `internal/controlplane/redis_registry.go:335`) already skips workers with `Draining=true`, but `SetDraining()` was only callable from inside the scaler.

## Behavior
- Per-controlplane in-memory toggle (matches existing `SetDraining` callers).
- Heartbeats do **not** clobber the flag (`handleHeartbeat` doesn't touch `Draining`).
- Multi-CP setups: call on each active CP. A follow-up could persist via Redis if we want it to be cluster-wide.

## Usage
```
curl -X POST -H "X-API-Key: $ADMIN_KEY" \
  https://app.opencomputer.dev/admin/workers/w-azure-osb-worker-87d3bbee/drain
# → {"workerID":"w-...","draining":true}

# Undrain:
curl -X POST -H "X-API-Key: $ADMIN_KEY" \
  "https://app.opencomputer.dev/admin/workers/w-azure-osb-worker-87d3bbee/drain?drain=false"
```

## Test plan
- [x] `go build ./...` (cmd/server, all platforms; pre-existing firecracker/agent build errors are unrelated)
- [x] `go test ./internal/api/...` passes
- [ ] Smoke test in staging: drain a worker, confirm new `oc sandbox create` calls skip it; undrain, confirm it returns to rotation.
- [ ] Verify on prod after deploy: call against each CP and confirm via `/admin/status` that Current count stops growing on the drained worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)