### PR TITLE
docs: mark templates as alpha/experimental

### DIFF
--- a/docs/sandboxes/templates.mdx
+++ b/docs/sandboxes/templates.mdx
@@ -3,6 +3,8 @@ title: "Templates"
 description: "Define sandbox environments programmatically with the Image builder and Snapshots"
 ---
 
+<Warning>Templates are an alpha, experimental feature. APIs, behavior, and manifest formats may change without notice.</Warning>
+
 Templates provide a code-first approach to defining sandbox environments. Instead of configuring images manually, you define them programmatically using the SDK.
 
 The system supports two workflows:


### PR DESCRIPTION
Add a Warning callout to the Templates docs page noting that the
feature is in alpha and APIs/behavior may change without notice,
matching the convention used by the Sessions API docs.