### PR TITLE
Secret Store Migration

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -213,6 +213,7 @@ func main() {
 					"OPENSANDBOX_S3_FORCE_PATH_STYLE=%v\n"+
 					"OPENSANDBOX_SANDBOX_DOMAIN=%s\n"+
 					"OPENSANDBOX_DEFAULT_SANDBOX_DISK_MB=%d\n"+
+					"OPENSANDBOX_AZURE_KEY_VAULT_NAME=%s\n"+
 					"SEGMENT_WRITE_KEY=%s\n",
 				cfg.JWTSecret,
 				cfg.Region,
@@ -229,20 +230,22 @@ func main() {
 				cfg.S3ForcePathStyle,
 				cfg.SandboxDomain,
 				cfg.DefaultSandboxDiskMB,
+				cfg.AzureKeyVaultName,
 				cfg.SegmentWriteKey,
 			)
 			workerEnvB64 := base64.StdEncoding.EncodeToString([]byte(workerEnv))
 
 			azPool, err := compute.NewAzurePool(compute.AzurePoolConfig{
-				SubscriptionID:  cfg.AzureSubscriptionID,
-				ResourceGroup:   cfg.AzureResourceGroup,
-				Region:          cfg.Region,
-				VMSize:          cfg.AzureVMSize,
-				ImageID:         cfg.AzureImageID,
-				SubnetID:        cfg.AzureSubnetID,
-				SSHPublicKey:    cfg.AzureSSHPublicKey,
-				KeyVaultName:    cfg.AzureKeyVaultName,
-				WorkerEnvBase64: workerEnvB64,
+				SubscriptionID:   cfg.AzureSubscriptionID,
+				ResourceGroup:    cfg.AzureResourceGroup,
+				Region:           cfg.Region,
+				VMSize:           cfg.AzureVMSize,
+				ImageID:          cfg.AzureImageID,
+				SubnetID:         cfg.AzureSubnetID,
+				SSHPublicKey:     cfg.AzureSSHPublicKey,
+				KeyVaultName:     cfg.AzureKeyVaultName,
+				WorkerIdentityID: cfg.AzureWorkerIdentityID,
+				WorkerEnvBase64:  workerEnvB64,
 			})
 			if err != nil {
 				log.Fatalf("opensandbox: failed to create Azure pool: %v", err)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -91,7 +91,32 @@ func main() {
 
 	// Initialize secrets proxy for MITM token substitution.
 	// Runs on :3128 — VMs route HTTPS through this to keep real secrets off-VM.
-	secretsCA, err := secretsproxy.LoadOrCreateCA(filepath.Join(cfg.DataDir, "proxy-ca"))
+	//
+	// CA must be region-scoped (shared across all workers in the same KV)
+	// so live migration of a sandbox doesn't break TLS substitution. The
+	// guest's trust store has the source worker's CA cert baked in; if the
+	// destination presents certs signed by a different CA, every outbound
+	// HTTPS call after migration fails with "authority and subject key
+	// identifier mismatch". With KV-backed shared CA, every worker in the
+	// region presents the same cert and migration is transparent.
+	//
+	// Falls back to per-worker CA when no KV is configured (dev / EC2
+	// without SSM bridging) — single-worker setups still work, but live
+	// migration of secrets-using sandboxes will fail TLS until a shared
+	// store is wired.
+	caDir := filepath.Join(cfg.DataDir, "proxy-ca")
+	var kvStore secretsproxy.KVStore
+	if cfg.AzureKeyVaultName != "" {
+		if kv, kvErr := secretsproxy.NewAzureKVStore(cfg.AzureKeyVaultName); kvErr != nil {
+			log.Printf("opensandbox-worker: shared CA: KV client failed (%v) — falling back to per-worker CA", kvErr)
+		} else {
+			kvStore = kv
+			log.Printf("opensandbox-worker: shared CA: using Azure Key Vault %s", cfg.AzureKeyVaultName)
+		}
+	}
+	caCtx, caCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	secretsCA, err := secretsproxy.LoadOrCreateSharedCA(caCtx, kvStore, "proxy-ca-cert", "proxy-ca-key", caDir)
+	caCancel()
 	if err != nil {
 		log.Printf("opensandbox-worker: secrets proxy CA failed: %v (secrets proxy disabled)", err)
 	}

--- a/deploy/azure/bootstrap-worker-identity.sh
+++ b/deploy/azure/bootstrap-worker-identity.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# bootstrap-worker-identity.sh — one-time per-region setup for the worker
+# UserAssigned managed identity. Workers use this identity to fetch the
+# shared secrets-proxy CA from Azure Key Vault. Without this, freshly-
+# launched workers generate per-worker CAs and live migration of any
+# sandbox using a secret store will fail TLS substitution.
+#
+# Run ONCE per region. Idempotent — re-running is safe (skips work that's
+# already done). The output is the resource ID of the identity; set it as
+# OPENSANDBOX_AZURE_WORKER_IDENTITY_ID in the control plane's server.env.
+#
+# Usage:
+#   bash bootstrap-worker-identity.sh <resource-group> <key-vault-name> [identity-name]
+#
+# Example:
+#   bash bootstrap-worker-identity.sh opensandbox-prod opensandbox-dev-kv
+#
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <resource-group> <key-vault-name> [identity-name]" >&2
+  exit 1
+fi
+
+RG="$1"
+KV="$2"
+NAME="${3:-osb-worker-identity}"
+
+LOCATION=$(az group show --name "$RG" --query location -o tsv)
+echo "==> resource-group: $RG (location=$LOCATION)"
+echo "==> key-vault: $KV"
+echo "==> identity name: $NAME"
+
+# 1. Create UserAssigned identity (idempotent — show first, create if missing).
+if EXISTING=$(az identity show --resource-group "$RG" --name "$NAME" --query id -o tsv 2>/dev/null); then
+  echo "==> identity already exists: $EXISTING"
+  IDENTITY_ID="$EXISTING"
+else
+  echo "==> creating identity..."
+  IDENTITY_ID=$(az identity create --resource-group "$RG" --name "$NAME" --location "$LOCATION" --query id -o tsv)
+  echo "==> created: $IDENTITY_ID"
+  # Wait for the identity's principalId to be queryable (eventual consistency).
+  sleep 5
+fi
+
+PRINCIPAL_ID=$(az identity show --resource-group "$RG" --name "$NAME" --query principalId -o tsv)
+echo "==> principalId: $PRINCIPAL_ID"
+
+# 2. Grant "Key Vault Secrets Officer" on the regional KV (RBAC mode).
+KV_ID=$(az keyvault show --name "$KV" --query id -o tsv)
+echo "==> granting Key Vault Secrets Officer on $KV_ID..."
+# az role assignment create is idempotent: returns an error if it already
+# exists, but the role is granted either way. Grep the error to ignore it.
+if ! az role assignment create \
+    --assignee-object-id "$PRINCIPAL_ID" \
+    --assignee-principal-type ServicePrincipal \
+    --role "Key Vault Secrets Officer" \
+    --scope "$KV_ID" \
+    -o none 2>&1 | tee /tmp/_role_out; then
+  if grep -q "RoleAssignmentExists" /tmp/_role_out; then
+    echo "==> role already assigned (idempotent OK)"
+  else
+    echo "ERROR: role assignment failed" >&2
+    cat /tmp/_role_out >&2
+    exit 1
+  fi
+fi
+
+echo ""
+echo "===================================================================="
+echo "Done. Set this in the control plane's /etc/opensandbox/server.env:"
+echo ""
+echo "OPENSANDBOX_AZURE_WORKER_IDENTITY_ID=$IDENTITY_ID"
+echo ""
+echo "Then restart opensandbox-server. New worker VMs will attach this"
+echo "identity automatically. Existing workers need a manual roll to pick"
+echo "it up (terminate, scaler relaunches with identity attached)."
+echo "===================================================================="

--- a/internal/api/sandbox.go
+++ b/internal/api/sandbox.go
@@ -958,12 +958,19 @@ func (s *Server) migrateSandbox(c echo.Context) error {
 		WorkspaceS3Key:      preCopyResp.WorkspaceKey,
 		OverlayMode:         true,
 		SourceGoldenVersion: preCopyResp.GoldenVersion,
+		// Carry the secrets-proxy session from source → target. Without
+		// this the destination has no substitution map and outbound HTTPS
+		// from the migrated VM would leak `osb_sealed_xxx` env vars
+		// verbatim to upstream services. Empty when no secret store.
+		SealedTokens:    preCopyResp.SealedTokens,
+		EgressAllowlist: preCopyResp.EgressAllowlist,
+		TokenHosts:      preCopyResp.TokenHosts,
 	})
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "prepare target: " + err.Error()})
 	}
 
-	log.Printf("migrate %s: target prepared at %s (host port %d)", id, prepResp.IncomingAddr, prepResp.HostPort)
+	log.Printf("migrate %s: target prepared at %s (host port %d, secrets=%d)", id, prepResp.IncomingAddr, prepResp.HostPort, len(preCopyResp.SealedTokens))
 
 	// Step 3: Live migrate from source to target
 	migrateCtx, migrateCancel := context.WithTimeout(ctx, 5*time.Minute)
@@ -1387,6 +1394,10 @@ func (s *Server) migrateForScale(ctx context.Context, sandboxID string, session 
 		OverlayMode:         true,
 		SourceGoldenVersion: preCopyResp.GoldenVersion,
 		TargetMemoryMb:      int32(memoryMB),
+		// Carry secrets-proxy session from source to target (see PreCopyDrives).
+		SealedTokens:    preCopyResp.SealedTokens,
+		EgressAllowlist: preCopyResp.EgressAllowlist,
+		TokenHosts:      preCopyResp.TokenHosts,
 	})
 	if err != nil {
 		log.Printf("scale-migrate %s: prepare target failed: %v", sandboxID, err)

--- a/internal/compute/azure.go
+++ b/internal/compute/azure.go
@@ -36,6 +36,16 @@ type AzurePoolConfig struct {
 	DataDiskSizeGB     int    // data disk size (default: 256)
 	WorkerEnvBase64 string // base64-encoded worker.env content (injected via cloud-init)
 	KeyVaultName    string // Azure Key Vault name for dynamic image ID refresh (e.g. "opensandbox-prod")
+	// WorkerIdentityID is the full resource ID of a UserAssigned managed
+	// identity to attach to every worker VM. Bootstrap once per region
+	// (see deploy/azure/bootstrap-worker-identity.sh): create the identity,
+	// grant "Key Vault Secrets Officer" on the regional KV, then set this
+	// to the identity's resource ID. Required for live migration of
+	// secrets-using sandboxes — workers fetch the shared MITM CA from KV
+	// using this identity. Empty string = no identity attached (workers
+	// can't fetch shared CA; live migration of secrets sandboxes will TLS-
+	// fail across worker boundaries — see secretsproxy.LoadOrCreateSharedCA).
+	WorkerIdentityID string
 }
 
 // AzurePool implements compute.Pool using Azure VMs.
@@ -145,14 +155,28 @@ func (p *AzurePool) CreateMachine(ctx context.Context, opts MachineOpts) (*Machi
 	imageID := p.cfg.ImageID
 	p.mu.RUnlock()
 
-	// Create VM
-	log.Printf("azure: creating VM %s (size=%s, image=%s)", vmName, vmSize, imageID)
+	// Create VM. Identity is attached when WorkerIdentityID is configured —
+	// the worker uses this identity to fetch the shared secrets-proxy CA
+	// from Key Vault. Without it, freshly-launched workers generate per-
+	// worker CAs and live migration of secrets-using sandboxes fails TLS.
+	var identity *armcompute.VirtualMachineIdentity
+	if p.cfg.WorkerIdentityID != "" {
+		identity = &armcompute.VirtualMachineIdentity{
+			Type: to.Ptr(armcompute.ResourceIdentityTypeUserAssigned),
+			UserAssignedIdentities: map[string]*armcompute.UserAssignedIdentitiesValue{
+				p.cfg.WorkerIdentityID: {},
+			},
+		}
+	}
+
+	log.Printf("azure: creating VM %s (size=%s, image=%s, identity=%v)", vmName, vmSize, imageID, p.cfg.WorkerIdentityID != "")
 	vmPoller, err := p.vmClient.BeginCreateOrUpdate(ctx, p.cfg.ResourceGroup, vmName, armcompute.VirtualMachine{
 		Location: to.Ptr(p.cfg.Region),
 		Tags: map[string]*string{
 			"Name":       to.Ptr(vmName),
 			azureTagRole: to.Ptr("worker"),
 		},
+		Identity: identity,
 		Properties: &armcompute.VirtualMachineProperties{
 			HardwareProfile: &armcompute.HardwareProfile{
 				VMSize: to.Ptr(armcompute.VirtualMachineSizeTypes(vmSize)),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,15 @@ type Config struct {
 	AzureSubnetID       string // Full resource ID of the VNet subnet
 	AzureSSHPublicKey   string // SSH public key for worker VMs
 	AzureKeyVaultName   string // Key Vault name for dynamic image ID refresh (e.g. "opensandbox-prod")
+	// AzureWorkerIdentityID is the full resource ID of a UserAssigned managed
+	// identity to attach to every worker VM. The identity must already have
+	// "Key Vault Secrets Officer" on the regional KV so workers can fetch
+	// the shared secrets-proxy CA. Created once per region as a bootstrap
+	// step (see deploy/azure/bootstrap-worker-identity.sh). Without this,
+	// workers can't reach KV for the shared CA and live migration of
+	// secret-store-using sandboxes will fail TLS substitution after the
+	// migration completes (per-worker CAs don't match each other).
+	AzureWorkerIdentityID string
 
 	// Cloudflare (custom hostname for org sandbox domains)
 	CFAPIToken string // Cloudflare API token with Custom Hostnames permission
@@ -196,6 +205,7 @@ func Load() (*Config, error) {
 		AzureSubnetID:       os.Getenv("OPENSANDBOX_AZURE_SUBNET_ID"),
 		AzureSSHPublicKey:   os.Getenv("OPENSANDBOX_AZURE_SSH_PUBLIC_KEY"),
 		AzureKeyVaultName:   os.Getenv("OPENSANDBOX_AZURE_KEY_VAULT_NAME"),
+		AzureWorkerIdentityID: os.Getenv("OPENSANDBOX_AZURE_WORKER_IDENTITY_ID"),
 
 		CFAPIToken: os.Getenv("OPENSANDBOX_CF_API_TOKEN"),
 		CFZoneID:   os.Getenv("OPENSANDBOX_CF_ZONE_ID"),

--- a/internal/controlplane/scaler.go
+++ b/internal/controlplane/scaler.go
@@ -1455,6 +1455,10 @@ func (s *Scaler) liveMigrateSandbox(ctx context.Context, sandboxID, sourceWorker
 		OverlayMode:         true,
 		SourceGoldenVersion: sourceGoldenVersion,
 		TargetMemoryMb:      actualMemMB,
+		// Carry secrets-proxy session from source to target (see PreCopyDrives).
+		SealedTokens:    preCopyResp.SealedTokens,
+		EgressAllowlist: preCopyResp.EgressAllowlist,
+		TokenHosts:      preCopyResp.TokenHosts,
 	})
 	if err != nil {
 		return fmt.Errorf("prepare target: %w", err)

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -313,6 +313,42 @@ func (m *Manager) sealSandboxEnvs(ctx context.Context, sandboxID string, netCfg 
 	return sealed
 }
 
+// reinstallProxyCA overwrites the proxy CA cert in the guest's trust store
+// with the destination worker's current CA. Called from any handoff path
+// where the sandbox can land on a different worker than it was created on:
+// live migration, hibernate→wake (cross-worker), checkpoint fork.
+//
+// The guest's env vars (SSL_CERT_FILE / REQUESTS_CA_BUNDLE / NODE_EXTRA_CA_CERTS)
+// point at the fixed path the proxy injected at sandbox creation, so we
+// only need to overwrite the file content; no update-ca-certificates run
+// is required because the consuming libraries read the file directly.
+//
+// Idempotent: in steady state where every worker shares the same CA via KV,
+// the destination's CA equals the source's and this is a no-op write. The
+// value is in the transition window (sandboxes created before shared-CA
+// rollout) and any future "the destination's CA differs" scenario (cross-
+// cell migration, planned CA rotation, etc.).
+//
+// Best-effort — errors are logged but don't fail the handoff. A migration
+// that successfully moves the workload but fails to refresh the cert is
+// strictly better than refusing the migration.
+func (m *Manager) reinstallProxyCA(ctx context.Context, sandboxID string, agent *AgentClient) {
+	if m.secretsProxy == nil || agent == nil {
+		return
+	}
+	certPEM := m.secretsProxy.CACertPEM()
+	if len(certPEM) == 0 {
+		return
+	}
+	writeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := agent.WriteFile(writeCtx, "/usr/local/share/ca-certificates/opensandbox-proxy.crt", certPEM); err != nil {
+		log.Printf("qemu: %s: reinstall proxy CA failed: %v (sandbox is alive but TLS substitution may break until next handoff)", sandboxID, err)
+		return
+	}
+	log.Printf("qemu: %s: reinstalled proxy CA on guest", sandboxID)
+}
+
 // PrepareGoldenSnapshot boots a temporary VM, waits for the agent, then
 // hibernates it to create a reusable snapshot. Subsequent Create() calls
 // restore from this snapshot instead of cold-booting, cutting start time
@@ -2981,6 +3017,12 @@ func (m *Manager) ForkFromCheckpoint(ctx context.Context, checkpointID string, c
 	m.mu.Lock()
 	m.vms[id] = vm
 	m.mu.Unlock()
+
+	// Refresh the proxy CA in the forked guest's trust store. The fork
+	// inherits the source checkpoint's disk + RAM, so its trust store has
+	// whatever CA the original sandbox was created against — which is
+	// probably a different worker. Idempotent in the shared-CA case.
+	m.reinstallProxyCA(ctx, id, agent)
 
 	// Notify metadata server
 	if m.onSandboxReady != nil {

--- a/internal/qemu/migration.go
+++ b/internal/qemu/migration.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/opensandbox/opensandbox/internal/sandbox"
 	"github.com/opensandbox/opensandbox/internal/storage"
 	"github.com/opensandbox/opensandbox/pkg/types"
 	pb "github.com/opensandbox/opensandbox/proto/agent"
@@ -323,6 +324,14 @@ func (mc *MigrationCoordinator) LiveMigrate(ctx context.Context, sandboxID, inco
 		}
 	}
 
+	// Tear down the secrets-proxy session for this sandbox on the source.
+	// The destination has already re-registered it during
+	// PrepareMigrationIncoming, so leaving it here would leak plaintext
+	// secrets in the source worker's process memory until restart.
+	if mc.manager.secretsProxy != nil && vm.network != nil && vm.network.GuestIP != "" {
+		mc.manager.secretsProxy.UnregisterSession(vm.network.GuestIP)
+	}
+
 	if vm.network != nil {
 		RemoveMetadataDNAT(vm.network.TAPName, vm.network.HostIP)
 		RemoveDNAT(vm.network)
@@ -581,20 +590,38 @@ func (m *Manager) CompleteIncomingMigration(ctx context.Context, sandboxID strin
 // Always uploads the thin overlay (never flattens). The target worker rebases
 // to its own base image if golden versions differ.
 // Returns S3 keys, golden version, and base CPU/memory for QEMU matching.
-func (m *Manager) PreCopyDrives(ctx context.Context, sandboxID string, checkpointStore *storage.CheckpointStore) (rootfsKey, workspaceKey, goldenVer string, baseCPU, baseMem, actualMem int, err error) {
+// See sandbox.MigrationSecrets for the canonical type. We use the shared
+// type so the worker gRPC layer can refer to it without an import cycle.
+
+func (m *Manager) PreCopyDrives(ctx context.Context, sandboxID string, checkpointStore *storage.CheckpointStore) (rootfsKey, workspaceKey, goldenVer string, baseCPU, baseMem, actualMem int, secrets sandbox.MigrationSecrets, err error) {
 	m.mu.RLock()
 	vm, exists := m.vms[sandboxID]
 	var pid int
+	var guestIP string
 	if exists {
 		goldenVer = vm.goldenVersion
 		baseCPU = vm.CpuCount
 		baseMem = vm.baseMemoryMB
 		pid = vm.pid
+		if vm.network != nil {
+			guestIP = vm.network.GuestIP
+		}
 	}
 	m.mu.RUnlock()
 
 	if pid > 0 {
 		actualMem = readProcRSSMB(pid)
+	}
+
+	// Capture secrets-proxy state BEFORE we start uploading drives. The
+	// proxy session is keyed by guest IP; we look it up here so the
+	// orchestrator can hand it to the target via PrepareMigrationIncoming.
+	// Empty maps when no secrets are registered — orchestrator just passes
+	// nil/empty through and target's ReregisterSession is a no-op.
+	if m.secretsProxy != nil && guestIP != "" {
+		secrets.SealedTokens = m.secretsProxy.GetSessionTokens(guestIP)
+		secrets.EgressAllowlist = m.secretsProxy.GetSessionAllowlist(guestIP)
+		secrets.TokenHosts = m.secretsProxy.GetSessionTokenHosts(guestIP)
 	}
 
 	mc := &MigrationCoordinator{
@@ -612,7 +639,15 @@ func (m *Manager) PreCopyDrives(ctx context.Context, sandboxID string, checkpoin
 // matches the target's current golden version, a fast metadata-only repoint is used.
 // When versions differ, a full rebase downloads the old base from S3 and migrates
 // the overlay to the current base — same logic as checkpoint fork rebase.
-func (m *Manager) PrepareIncomingMigrationWithS3(ctx context.Context, sandboxID, rootfsS3Key, workspaceS3Key string, cpus, memMB, guestPort int, template string, checkpointStore *storage.CheckpointStore, overlayMode bool, sourceGoldenVersion string) (incomingAddr string, hostPort int, err error) {
+//
+// secrets is the per-sandbox secrets-proxy state captured by PreCopyDrives on
+// the source. We register it with this worker's secrets proxy AFTER the
+// destination QEMU is staged (so vm.network.GuestIP is known) but BEFORE the
+// source initiates the live migration. Once the migration completes and
+// CompleteIncomingMigration unpauses the VM, the first outbound HTTPS
+// request finds its substitution map already in place. Empty maps are a
+// no-op (sandboxes without a secret store).
+func (m *Manager) PrepareIncomingMigrationWithS3(ctx context.Context, sandboxID, rootfsS3Key, workspaceS3Key string, cpus, memMB, guestPort int, template string, checkpointStore *storage.CheckpointStore, overlayMode bool, sourceGoldenVersion string, secrets sandbox.MigrationSecrets) (incomingAddr string, hostPort int, err error) {
 	sandboxDir := filepath.Join(m.cfg.DataDir, "sandboxes", sandboxID)
 	// Clean any leftover state from a prior failed prepare attempt. Without this,
 	// zstd refuses to overwrite an existing workspace.qcow2 and the retry fails
@@ -691,7 +726,25 @@ func (m *Manager) PrepareIncomingMigrationWithS3(ctx context.Context, sandboxID,
 		return "", 0, r.err
 	}
 
-	return m.PrepareIncomingMigration(ctx, sandboxID, rootfsPath, workspacePath, cpus, memMB, guestPort, template)
+	incomingAddr, hostPort, err = m.PrepareIncomingMigration(ctx, sandboxID, rootfsPath, workspacePath, cpus, memMB, guestPort, template)
+	if err != nil {
+		return "", 0, err
+	}
+
+	// Re-register the secrets-proxy session on this worker, keyed by the
+	// guest IP we just allocated in PrepareIncomingMigration. Done before
+	// returning so the source can issue the LiveMigrate RPC immediately
+	// without a races window where the migrated VM is running but the
+	// proxy has no substitution map.
+	if m.secretsProxy != nil && len(secrets.SealedTokens) > 0 {
+		if vm, getErr := m.getVM(sandboxID); getErr == nil && vm.network != nil && vm.network.GuestIP != "" {
+			m.secretsProxy.ReregisterSession(sandboxID, vm.network.GuestIP, secrets.SealedTokens, secrets.EgressAllowlist, secrets.TokenHosts)
+			log.Printf("qemu: migration %s: re-registered secrets proxy session (%d tokens, guestIP=%s)",
+				sandboxID, len(secrets.SealedTokens), vm.network.GuestIP)
+		}
+	}
+
+	return incomingAddr, hostPort, nil
 }
 
 // downloadS3ToFile downloads an S3 object to a local file.

--- a/internal/qemu/migration.go
+++ b/internal/qemu/migration.go
@@ -563,6 +563,18 @@ func (m *Manager) CompleteIncomingMigration(ctx context.Context, sandboxID strin
 		log.Printf("qemu: migration %s: clock sync failed: %v", sandboxID, err)
 	}
 
+	// Re-install the secrets-proxy CA cert into the guest so the destination
+	// worker's cert chain is trusted by anything the guest does next. Even
+	// with the shared-CA-via-KV path, this is belt-and-suspenders that also
+	// retrofits sandboxes which were created BEFORE the shared CA rollout
+	// (their trust store has the source's per-worker CA baked in). The
+	// guest's env vars (SSL_CERT_FILE / REQUESTS_CA_BUNDLE / NODE_EXTRA_CA_CERTS)
+	// already point to this fixed path; overwriting the file is enough — no
+	// update-ca-certificates run required because consumers read the file
+	// directly. Cheap (~1ms agent RPC) and idempotent: in steady state the
+	// new content equals the old, so this is a no-op write.
+	m.reinstallProxyCA(ctx, sandboxID, agentClient)
+
 	// Sync VM memory tracking with actual QEMU state.
 	// After migration, the QEMU process has the source's virtio-mem hotplugged memory,
 	// but the Go struct still has the prep values (virtioMemRequestedMB=0, MemoryMB=baseMem).

--- a/internal/qemu/snapshot.go
+++ b/internal/qemu/snapshot.go
@@ -491,6 +491,11 @@ func (m *Manager) doWake(ctx context.Context, sandboxID, checkpointKey string, c
 		m.secretsProxy.ReregisterSession(sandboxID, netCfg.GuestIP, meta.SealedTokens, meta.EgressAllowlist, meta.TokenHosts)
 		log.Printf("qemu: wake %s: re-registered secrets proxy session (%d tokens)", sandboxID, len(meta.SealedTokens))
 	}
+	// Refresh the proxy CA in the guest's trust store. Wake may land on a
+	// different worker than the one that hibernated the sandbox, in which
+	// case the cert in the guest's trust store no longer matches what this
+	// worker's proxy presents. Idempotent on same-worker wake.
+	m.reinstallProxyCA(context.Background(), sandboxID, agentClient)
 
 	log.Printf("qemu: wake %s: golden restore complete (port=%d, tap=%s)",
 		sandboxID, hostPort, netCfg.TAPName)

--- a/internal/sandbox/interface.go
+++ b/internal/sandbox/interface.go
@@ -15,6 +15,22 @@ type HibernateResult struct {
 	SizeBytes      int64  `json:"sizeBytes"`
 }
 
+// MigrationSecrets is the per-sandbox secrets-proxy state that must move
+// with the VM during a live migration. The proxy keeps these in-process
+// per-worker (see internal/secretsproxy), so without an explicit handoff
+// the destination has no substitution map and the guest's env vars
+// (`osb_sealed_xxx`) leak verbatim to upstream services. Hibernate
+// persists the same data into snapshot-meta.json; live migration carries
+// it through the PreCopyDrives → PrepareMigrationIncoming RPC chain.
+//
+// Lives in package sandbox (not qemu) so the worker grpc layer can name
+// it without importing qemu (which would create a cycle).
+type MigrationSecrets struct {
+	SealedTokens    map[string]string
+	EgressAllowlist []string
+	TokenHosts      map[string][]string
+}
+
 // SandboxStats holds live resource usage for a sandbox.
 // Runtime-agnostic interface for sandbox resource stats.
 type SandboxStats struct {

--- a/internal/secretsproxy/ca_shared.go
+++ b/internal/secretsproxy/ca_shared.go
@@ -1,0 +1,194 @@
+package secretsproxy
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// KVStore is a tiny KV-shaped interface a shared CA loader uses to
+// publish/fetch the CA cert and key. Backed by Azure Key Vault, AWS Secrets
+// Manager, or anything else that maps a string name to an opaque blob.
+//
+// Implementations must:
+//   - Get returns ErrNotFound (or any error) when the name doesn't exist;
+//     the caller treats both as "go generate".
+//   - Set is allowed to overwrite. The shared-CA loader handles races by
+//     re-reading after writing — last writer wins, then everyone converges
+//     on what's actually in the store.
+type KVStore interface {
+	Get(ctx context.Context, name string) ([]byte, error)
+	Set(ctx context.Context, name string, value []byte) error
+}
+
+// ErrNotFound is the canonical "this key doesn't exist" sentinel that KVStore
+// implementations should return when a Get misses. Callers can check via
+// errors.Is — though the loader treats any Get error as a miss anyway.
+var ErrNotFound = errors.New("secretsproxy: KV key not found")
+
+// LoadOrCreateSharedCA fetches the proxy CA from a region-scoped KV, or
+// generates one and publishes it. Required for live migration: each worker
+// in the region MUST present the same CA so a sandbox migrated between
+// workers continues to trust the proxy's MITM TLS certs (the source's CA
+// cert is baked into the guest's trust store — if the destination's proxy
+// presents certs signed by a different CA, every outbound HTTPS call after
+// migration fails with "authority and subject key identifier mismatch").
+//
+// The function is idempotent under concurrent worker startup: multiple
+// workers booting at once may each generate locally, but after the
+// re-fetch step they all converge on whatever cert ended up in KV.
+//
+// fallbackDir is mirrored from KV so an operator can inspect the cert with
+// `openssl x509` and so the worker has a copy if KV becomes briefly
+// unreachable later.
+func LoadOrCreateSharedCA(ctx context.Context, kv KVStore, certName, keyName, fallbackDir string) (*CA, error) {
+	if kv == nil {
+		// No shared store configured — fall back to per-worker behavior.
+		// Live migration of secrets-proxy-using sandboxes will TLS-fail
+		// across worker boundaries, but at least single-worker setups
+		// keep working. Production deployments should always pass a KV.
+		return LoadOrCreateCA(fallbackDir)
+	}
+	if err := os.MkdirAll(fallbackDir, 0700); err != nil {
+		return nil, fmt.Errorf("create CA dir: %w", err)
+	}
+
+	// 1. Try to fetch the existing shared CA.
+	if certPEM, keyPEM, err := fetchSharedCA(ctx, kv, certName, keyName); err == nil {
+		ca, parseErr := parseCA(certPEM, keyPEM)
+		if parseErr != nil {
+			// The KV value exists but is corrupted. Refusing here is
+			// safer than regenerating (which would silently invalidate
+			// every existing sandbox's trust store).
+			return nil, fmt.Errorf("shared CA in KV is malformed: %w", parseErr)
+		}
+		if writeErr := mirrorCAToDir(fallbackDir, certPEM, keyPEM); writeErr != nil {
+			// Non-fatal — we have a valid CA in memory.
+			fmt.Fprintf(os.Stderr, "secretsproxy: mirror CA to %s failed: %v\n", fallbackDir, writeErr)
+		}
+		return ca, nil
+	}
+
+	// 2. KV miss — generate a fresh CA.
+	certPEM, keyPEM, err := generateCAPEM()
+	if err != nil {
+		return nil, fmt.Errorf("generate shared CA: %w", err)
+	}
+
+	// 3. Publish to KV. If publish fails we continue with the locally-
+	// generated CA so the worker can still serve sandboxes — but live
+	// migration to other workers will still mismatch certs until the
+	// publish succeeds on a future restart.
+	pubCertErr := kv.Set(ctx, certName, certPEM)
+	pubKeyErr := kv.Set(ctx, keyName, keyPEM)
+	if pubCertErr != nil || pubKeyErr != nil {
+		fmt.Fprintf(os.Stderr, "secretsproxy: publishing shared CA to KV failed (cert=%v key=%v) — using local CA only\n", pubCertErr, pubKeyErr)
+		ca, parseErr := parseCA(certPEM, keyPEM)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse generated CA: %w", parseErr)
+		}
+		_ = mirrorCAToDir(fallbackDir, certPEM, keyPEM)
+		return ca, nil
+	}
+
+	// 4. Race resolution: another worker may have published a CA between
+	// our miss and our Set. Re-fetch and prefer whatever's actually in
+	// the store as canonical. This converges all racing workers onto a
+	// single CA without needing a distributed lock.
+	if remoteCert, remoteKey, refetchErr := fetchSharedCA(ctx, kv, certName, keyName); refetchErr == nil {
+		if !pemEqual(remoteCert, certPEM) || !pemEqual(remoteKey, keyPEM) {
+			ca, parseErr := parseCA(remoteCert, remoteKey)
+			if parseErr == nil {
+				_ = mirrorCAToDir(fallbackDir, remoteCert, remoteKey)
+				return ca, nil
+			}
+		}
+	}
+
+	ca, parseErr := parseCA(certPEM, keyPEM)
+	if parseErr != nil {
+		return nil, fmt.Errorf("parse generated CA: %w", parseErr)
+	}
+	_ = mirrorCAToDir(fallbackDir, certPEM, keyPEM)
+	return ca, nil
+}
+
+func fetchSharedCA(ctx context.Context, kv KVStore, certName, keyName string) ([]byte, []byte, error) {
+	certPEM, certErr := kv.Get(ctx, certName)
+	if certErr != nil {
+		return nil, nil, certErr
+	}
+	keyPEM, keyErr := kv.Get(ctx, keyName)
+	if keyErr != nil {
+		return nil, nil, keyErr
+	}
+	if len(certPEM) == 0 || len(keyPEM) == 0 {
+		return nil, nil, ErrNotFound
+	}
+	return certPEM, keyPEM, nil
+}
+
+func generateCAPEM() (certPEM, keyPEM []byte, err error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate key: %w", err)
+	}
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   "OpenSandbox Proxy CA",
+			Organization: []string{"OpenSandbox"},
+		},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(caValidYears * 365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create cert: %w", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal key: %w", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM, nil
+}
+
+var mirrorMu sync.Mutex
+
+func mirrorCAToDir(dir string, certPEM, keyPEM []byte) error {
+	mirrorMu.Lock()
+	defer mirrorMu.Unlock()
+	if err := os.WriteFile(filepath.Join(dir, "ca.crt"), certPEM, 0644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "ca.key"), keyPEM, 0600)
+}
+
+func pemEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/secretsproxy/kvstore_azure.go
+++ b/internal/secretsproxy/kvstore_azure.go
@@ -1,0 +1,66 @@
+package secretsproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
+)
+
+// AzureKVStore is a KVStore backed by Azure Key Vault. Uses the
+// DefaultAzureCredential chain (managed identity in production, az-cli /
+// service principal in dev).
+type AzureKVStore struct {
+	client *azsecrets.Client
+}
+
+// NewAzureKVStore opens a client against the named Key Vault. vaultName is
+// the short name (e.g. "opensandbox-dev-kv"); the URL is derived. Returns
+// nil + error if credentials can't be obtained or the vault URL is invalid.
+func NewAzureKVStore(vaultName string) (*AzureKVStore, error) {
+	if vaultName == "" {
+		return nil, errors.New("vault name required")
+	}
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return nil, fmt.Errorf("azure credentials: %w", err)
+	}
+	url := fmt.Sprintf("https://%s.vault.azure.net/", vaultName)
+	client, err := azsecrets.NewClient(url, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("kv client: %w", err)
+	}
+	return &AzureKVStore{client: client}, nil
+}
+
+func (s *AzureKVStore) Get(ctx context.Context, name string) ([]byte, error) {
+	resp, err := s.client.GetSecret(ctx, name, "", nil)
+	if err != nil {
+		// Azure SDK doesn't expose a direct "not found" sentinel, but the
+		// ResponseError carries the status code.
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode == 404 {
+			return nil, ErrNotFound
+		}
+		// SecretNotFound is the canonical body code for the same condition;
+		// older SDK versions surface it as a string rather than via status.
+		if strings.Contains(err.Error(), "SecretNotFound") {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if resp.Value == nil {
+		return nil, ErrNotFound
+	}
+	return []byte(*resp.Value), nil
+}
+
+func (s *AzureKVStore) Set(ctx context.Context, name string, value []byte) error {
+	v := string(value)
+	_, err := s.client.SetSecret(ctx, name, azsecrets.SetSecretParameters{Value: &v}, nil)
+	return err
+}

--- a/internal/worker/grpc_server.go
+++ b/internal/worker/grpc_server.go
@@ -33,8 +33,8 @@ import (
 // LiveMigrator is implemented by VM managers that support live migration (e.g. QEMU).
 type LiveMigrator interface {
 	PrepareIncomingMigration(ctx context.Context, sandboxID, rootfsPath, workspacePath string, cpus, memMB, guestPort int, template string) (incomingAddr string, hostPort int, err error)
-	PrepareIncomingMigrationWithS3(ctx context.Context, sandboxID, rootfsS3Key, workspaceS3Key string, cpus, memMB, guestPort int, template string, checkpointStore *storage.CheckpointStore, overlayMode bool, sourceGoldenVersion string) (incomingAddr string, hostPort int, err error)
-	PreCopyDrives(ctx context.Context, sandboxID string, checkpointStore *storage.CheckpointStore) (rootfsKey, workspaceKey, goldenVersion string, baseCPU, baseMem, actualMem int, err error)
+	PrepareIncomingMigrationWithS3(ctx context.Context, sandboxID, rootfsS3Key, workspaceS3Key string, cpus, memMB, guestPort int, template string, checkpointStore *storage.CheckpointStore, overlayMode bool, sourceGoldenVersion string, secrets sandbox.MigrationSecrets) (incomingAddr string, hostPort int, err error)
+	PreCopyDrives(ctx context.Context, sandboxID string, checkpointStore *storage.CheckpointStore) (rootfsKey, workspaceKey, goldenVersion string, baseCPU, baseMem, actualMem int, secrets sandbox.MigrationSecrets, err error)
 	CompleteIncomingMigration(ctx context.Context, sandboxID string) error
 	LiveMigrate(ctx context.Context, sandboxID, incomingAddr string) error
 }
@@ -989,18 +989,31 @@ func (s *GRPCServer) PreCopyDrives(ctx context.Context, req *pb.PreCopyDrivesReq
 	if s.migrator == nil {
 		return nil, fmt.Errorf("live migration not supported on this worker")
 	}
-	rootfsKey, workspaceKey, goldenVersion, baseCPU, baseMem, actualMem, err := s.migrator.PreCopyDrives(ctx, req.SandboxId, s.checkpointStore)
+	rootfsKey, workspaceKey, goldenVersion, baseCPU, baseMem, actualMem, secrets, err := s.migrator.PreCopyDrives(ctx, req.SandboxId, s.checkpointStore)
 	if err != nil {
 		return nil, fmt.Errorf("pre-copy drives: %w", err)
 	}
-	return &pb.PreCopyDrivesResponse{
+	resp := &pb.PreCopyDrivesResponse{
 		RootfsKey:      rootfsKey,
 		WorkspaceKey:   workspaceKey,
 		GoldenVersion:  goldenVersion,
 		BaseMemoryMb:   int32(baseMem),
 		BaseCpuCount:   int32(baseCPU),
 		ActualMemoryMb: int32(actualMem),
-	}, nil
+	}
+	// Marshal the secrets-proxy session into the proto. Skipped silently
+	// when the sandbox has no secret store registered (empty maps).
+	if len(secrets.SealedTokens) > 0 {
+		resp.SealedTokens = secrets.SealedTokens
+		resp.EgressAllowlist = secrets.EgressAllowlist
+		if len(secrets.TokenHosts) > 0 {
+			resp.TokenHosts = make(map[string]*pb.HostList, len(secrets.TokenHosts))
+			for tok, hosts := range secrets.TokenHosts {
+				resp.TokenHosts[tok] = &pb.HostList{Hosts: hosts}
+			}
+		}
+	}
+	return resp, nil
 }
 
 func (s *GRPCServer) PrepareMigrationIncoming(ctx context.Context, req *pb.PrepareMigrationIncomingRequest) (*pb.PrepareMigrationIncomingResponse, error) {
@@ -1028,6 +1041,23 @@ func (s *GRPCServer) PrepareMigrationIncoming(ctx context.Context, req *pb.Prepa
 		}
 	}
 
+	// Unmarshal the secrets-proxy session from the request, if any. The
+	// orchestrator will have copied this from PreCopyDrives. Empty when
+	// the sandbox has no secret store.
+	var secrets sandbox.MigrationSecrets
+	if len(req.SealedTokens) > 0 {
+		secrets.SealedTokens = req.SealedTokens
+		secrets.EgressAllowlist = req.EgressAllowlist
+		if len(req.TokenHosts) > 0 {
+			secrets.TokenHosts = make(map[string][]string, len(req.TokenHosts))
+			for tok, hl := range req.TokenHosts {
+				if hl != nil {
+					secrets.TokenHosts[tok] = hl.Hosts
+				}
+			}
+		}
+	}
+
 	var (
 		addr     string
 		hostPort int
@@ -1036,7 +1066,7 @@ func (s *GRPCServer) PrepareMigrationIncoming(ctx context.Context, req *pb.Prepa
 	if req.RootfsS3Key != "" && req.WorkspaceS3Key != "" {
 		addr, hostPort, err = s.migrator.PrepareIncomingMigrationWithS3(ctx,
 			req.SandboxId, req.RootfsS3Key, req.WorkspaceS3Key,
-			int(req.CpuCount), int(req.MemoryMb), int(req.GuestPort), req.Template, s.checkpointStore, req.OverlayMode, req.SourceGoldenVersion)
+			int(req.CpuCount), int(req.MemoryMb), int(req.GuestPort), req.Template, s.checkpointStore, req.OverlayMode, req.SourceGoldenVersion, secrets)
 	} else {
 		addr, hostPort, err = s.migrator.PrepareIncomingMigration(ctx,
 			req.SandboxId, req.RootfsPath, req.WorkspacePath,

--- a/proto/worker/worker.pb.go
+++ b/proto/worker/worker.pb.go
@@ -2957,8 +2957,19 @@ type PreCopyDrivesResponse struct {
 	// Used for actual-memory-based scheduling instead of committed/configured
 	// memory (which over-reserves on idle sandboxes).
 	ActualMemoryMb int32 `protobuf:"varint,6,opt,name=actual_memory_mb,json=actualMemoryMb,proto3" json:"actual_memory_mb,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Secrets-proxy session state for the migrating sandbox. Live migration
+	// moves the QEMU process (which carries the in-VM env vars containing
+	// sealed token IDs) but the proxy's plaintext-substitution map is
+	// per-worker in-process state. Without these the destination worker has
+	// no way to substitute the literal `osb_sealed_xxx` strings on outbound
+	// HTTPS, so the guest's first secret-using call after migration fails
+	// auth. Mirrors the SealedTokens/EgressAllowlist/TokenHosts fields the
+	// hibernate path persists into snapshot-meta.json.
+	SealedTokens    map[string]string    `protobuf:"bytes,7,rep,name=sealed_tokens,json=sealedTokens,proto3" json:"sealed_tokens,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // sealed_id -> plaintext secret value
+	EgressAllowlist []string             `protobuf:"bytes,8,rep,name=egress_allowlist,json=egressAllowlist,proto3" json:"egress_allowlist,omitempty"`                                                                  // host allowlist for the secrets proxy
+	TokenHosts      map[string]*HostList `protobuf:"bytes,9,rep,name=token_hosts,json=tokenHosts,proto3" json:"token_hosts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`       // sealed_id -> per-token allowed hosts
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *PreCopyDrivesResponse) Reset() {
@@ -3033,6 +3044,72 @@ func (x *PreCopyDrivesResponse) GetActualMemoryMb() int32 {
 	return 0
 }
 
+func (x *PreCopyDrivesResponse) GetSealedTokens() map[string]string {
+	if x != nil {
+		return x.SealedTokens
+	}
+	return nil
+}
+
+func (x *PreCopyDrivesResponse) GetEgressAllowlist() []string {
+	if x != nil {
+		return x.EgressAllowlist
+	}
+	return nil
+}
+
+func (x *PreCopyDrivesResponse) GetTokenHosts() map[string]*HostList {
+	if x != nil {
+		return x.TokenHosts
+	}
+	return nil
+}
+
+// HostList is a wrapper because proto3 maps cannot have a repeated value type.
+type HostList struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Hosts         []string               `protobuf:"bytes,1,rep,name=hosts,proto3" json:"hosts,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HostList) Reset() {
+	*x = HostList{}
+	mi := &file_proto_worker_worker_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HostList) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HostList) ProtoMessage() {}
+
+func (x *HostList) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_worker_worker_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HostList.ProtoReflect.Descriptor instead.
+func (*HostList) Descriptor() ([]byte, []int) {
+	return file_proto_worker_worker_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *HostList) GetHosts() []string {
+	if x != nil {
+		return x.Hosts
+	}
+	return nil
+}
+
 type PrepareMigrationIncomingRequest struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	SandboxId           string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
@@ -3047,13 +3124,20 @@ type PrepareMigrationIncomingRequest struct {
 	OverlayMode         bool                   `protobuf:"varint,10,opt,name=overlay_mode,json=overlayMode,proto3" json:"overlay_mode,omitempty"`                          // if true, rootfs is thin overlay — rebase to local golden on target
 	TargetMemoryMb      int32                  `protobuf:"varint,11,opt,name=target_memory_mb,json=targetMemoryMb,proto3" json:"target_memory_mb,omitempty"`               // final memory after scale — worker checks capacity and reserves atomically
 	SourceGoldenVersion string                 `protobuf:"bytes,12,opt,name=source_golden_version,json=sourceGoldenVersion,proto3" json:"source_golden_version,omitempty"` // source's golden version — target rebases overlay if different from its own
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Secrets-proxy session state captured from the source by PreCopyDrives.
+	// Target re-registers these on its in-process secrets proxy BEFORE the
+	// VM resumes (Cont) so the first outbound HTTPS request after migration
+	// has its `osb_sealed_xxx` env vars correctly substituted.
+	SealedTokens    map[string]string    `protobuf:"bytes,13,rep,name=sealed_tokens,json=sealedTokens,proto3" json:"sealed_tokens,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	EgressAllowlist []string             `protobuf:"bytes,14,rep,name=egress_allowlist,json=egressAllowlist,proto3" json:"egress_allowlist,omitempty"`
+	TokenHosts      map[string]*HostList `protobuf:"bytes,15,rep,name=token_hosts,json=tokenHosts,proto3" json:"token_hosts,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *PrepareMigrationIncomingRequest) Reset() {
 	*x = PrepareMigrationIncomingRequest{}
-	mi := &file_proto_worker_worker_proto_msgTypes[52]
+	mi := &file_proto_worker_worker_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3065,7 +3149,7 @@ func (x *PrepareMigrationIncomingRequest) String() string {
 func (*PrepareMigrationIncomingRequest) ProtoMessage() {}
 
 func (x *PrepareMigrationIncomingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_worker_worker_proto_msgTypes[52]
+	mi := &file_proto_worker_worker_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3078,7 +3162,7 @@ func (x *PrepareMigrationIncomingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareMigrationIncomingRequest.ProtoReflect.Descriptor instead.
 func (*PrepareMigrationIncomingRequest) Descriptor() ([]byte, []int) {
-	return file_proto_worker_worker_proto_rawDescGZIP(), []int{52}
+	return file_proto_worker_worker_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *PrepareMigrationIncomingRequest) GetSandboxId() string {
@@ -3165,6 +3249,27 @@ func (x *PrepareMigrationIncomingRequest) GetSourceGoldenVersion() string {
 	return ""
 }
 
+func (x *PrepareMigrationIncomingRequest) GetSealedTokens() map[string]string {
+	if x != nil {
+		return x.SealedTokens
+	}
+	return nil
+}
+
+func (x *PrepareMigrationIncomingRequest) GetEgressAllowlist() []string {
+	if x != nil {
+		return x.EgressAllowlist
+	}
+	return nil
+}
+
+func (x *PrepareMigrationIncomingRequest) GetTokenHosts() map[string]*HostList {
+	if x != nil {
+		return x.TokenHosts
+	}
+	return nil
+}
+
 type PrepareMigrationIncomingResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	IncomingAddr  string                 `protobuf:"bytes,1,opt,name=incoming_addr,json=incomingAddr,proto3" json:"incoming_addr,omitempty"` // TCP address for source to migrate to (e.g. "10.100.1.7:49152")
@@ -3175,7 +3280,7 @@ type PrepareMigrationIncomingResponse struct {
 
 func (x *PrepareMigrationIncomingResponse) Reset() {
 	*x = PrepareMigrationIncomingResponse{}
-	mi := &file_proto_worker_worker_proto_msgTypes[53]
+	mi := &file_proto_worker_worker_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3187,7 +3292,7 @@ func (x *PrepareMigrationIncomingResponse) String() string {
 func (*PrepareMigrationIncomingResponse) ProtoMessage() {}
 
 func (x *PrepareMigrationIncomingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_worker_worker_proto_msgTypes[53]
+	mi := &file_proto_worker_worker_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3200,7 +3305,7 @@ func (x *PrepareMigrationIncomingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrepareMigrationIncomingResponse.ProtoReflect.Descriptor instead.
 func (*PrepareMigrationIncomingResponse) Descriptor() ([]byte, []int) {
-	return file_proto_worker_worker_proto_rawDescGZIP(), []int{53}
+	return file_proto_worker_worker_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *PrepareMigrationIncomingResponse) GetIncomingAddr() string {
@@ -3227,7 +3332,7 @@ type LiveMigrateRequest struct {
 
 func (x *LiveMigrateRequest) Reset() {
 	*x = LiveMigrateRequest{}
-	mi := &file_proto_worker_worker_proto_msgTypes[54]
+	mi := &file_proto_worker_worker_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3239,7 +3344,7 @@ func (x *LiveMigrateRequest) String() string {
 func (*LiveMigrateRequest) ProtoMessage() {}
 
 func (x *LiveMigrateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_worker_worker_proto_msgTypes[54]
+	mi := &file_proto_worker_worker_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3252,7 +3357,7 @@ func (x *LiveMigrateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LiveMigrateRequest.ProtoReflect.Descriptor instead.
 func (*LiveMigrateRequest) Descriptor() ([]byte, []int) {
-	return file_proto_worker_worker_proto_rawDescGZIP(), []int{54}
+	return file_proto_worker_worker_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *LiveMigrateRequest) GetSandboxId() string {
@@ -3277,7 +3382,7 @@ type LiveMigrateResponse struct {
 
 func (x *LiveMigrateResponse) Reset() {
 	*x = LiveMigrateResponse{}
-	mi := &file_proto_worker_worker_proto_msgTypes[55]
+	mi := &file_proto_worker_worker_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3289,7 +3394,7 @@ func (x *LiveMigrateResponse) String() string {
 func (*LiveMigrateResponse) ProtoMessage() {}
 
 func (x *LiveMigrateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_worker_worker_proto_msgTypes[55]
+	mi := &file_proto_worker_worker_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3302,7 +3407,7 @@ func (x *LiveMigrateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LiveMigrateResponse.ProtoReflect.Descriptor instead.
 func (*LiveMigrateResponse) Descriptor() ([]byte, []int) {
-	return file_proto_worker_worker_proto_rawDescGZIP(), []int{55}
+	return file_proto_worker_worker_proto_rawDescGZIP(), []int{56}
 }
 
 type CompleteMigrationIncomingRequest struct {
@@ -3314,7 +3419,7 @@ type CompleteMigrationIncomingRequest struct {
 
 func (x *CompleteMigrationIncomingRequest) Reset() {
 	*x = CompleteMigrationIncomingRequest{}
-	mi := &file_proto_worker_worker_proto_msgTypes[56]
+	mi := &file_proto_worker_worker_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3326,7 +3431,7 @@ func (x *CompleteMigrationIncomingRequest) String() string {
 func (*CompleteMigrationIncomingRequest) ProtoMessage() {}
 
 func (x *CompleteMigrationIncomingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_worker_worker_proto_msgTypes[56]
+	mi := &file_proto_worker_worker_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3339,7 +3444,7 @@ func (x *CompleteMigrationIncomingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CompleteMigrationIncomingRequest.ProtoReflect.Descriptor instead.
 func (*CompleteMigrationIncomingRequest) Descriptor() ([]byte, []int) {
-	return file_proto_worker_worker_proto_rawDescGZIP(), []int{56}
+	return file_proto_worker_worker_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *CompleteMigrationIncomingRequest) GetSandboxId() string {
@@ -3357,7 +3462,7 @@ type CompleteMigrationIncomingResponse struct {
 
 func (x *CompleteMigrationIncomingResponse) Reset() {
 	*x = CompleteMigrationIncomingResponse{}
-	mi := &file_proto_worker_worker_proto_msgTypes[57]
+	mi := &file_proto_worker_worker_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3369,7 +3474,7 @@ func (x *CompleteMigrationIncomingResponse) String() string {
 func (*CompleteMigrationIncomingResponse) ProtoMessage() {}
 
 func (x *CompleteMigrationIncomingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_worker_worker_proto_msgTypes[57]
+	mi := &file_proto_worker_worker_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3382,7 +3487,7 @@ func (x *CompleteMigrationIncomingResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use CompleteMigrationIncomingResponse.ProtoReflect.Descriptor instead.
 func (*CompleteMigrationIncomingResponse) Descriptor() ([]byte, []int) {
-	return file_proto_worker_worker_proto_rawDescGZIP(), []int{57}
+	return file_proto_worker_worker_proto_rawDescGZIP(), []int{58}
 }
 
 // Golden snapshot management
@@ -3394,7 +3499,7 @@ type RebuildGoldenSnapshotRequest struct {
 
 func (x *RebuildGoldenSnapshotRequest) Reset() {
 	*x = RebuildGoldenSnapshotRequest{}
-	mi := &file_proto_worker_worker_proto_msgTypes[58]
+	mi := &file_proto_worker_worker_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3406,7 +3511,7 @@ func (x *RebuildGoldenSnapshotRequest) String() string {
 func (*RebuildGoldenSnapshotRequest) ProtoMessage() {}
 
 func (x *RebuildGoldenSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_worker_worker_proto_msgTypes[58]
+	mi := &file_proto_worker_worker_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3419,7 +3524,7 @@ func (x *RebuildGoldenSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RebuildGoldenSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*RebuildGoldenSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_proto_worker_worker_proto_rawDescGZIP(), []int{58}
+	return file_proto_worker_worker_proto_rawDescGZIP(), []int{59}
 }
 
 type RebuildGoldenSnapshotResponse struct {
@@ -3432,7 +3537,7 @@ type RebuildGoldenSnapshotResponse struct {
 
 func (x *RebuildGoldenSnapshotResponse) Reset() {
 	*x = RebuildGoldenSnapshotResponse{}
-	mi := &file_proto_worker_worker_proto_msgTypes[59]
+	mi := &file_proto_worker_worker_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3444,7 +3549,7 @@ func (x *RebuildGoldenSnapshotResponse) String() string {
 func (*RebuildGoldenSnapshotResponse) ProtoMessage() {}
 
 func (x *RebuildGoldenSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_worker_worker_proto_msgTypes[59]
+	mi := &file_proto_worker_worker_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3457,7 +3562,7 @@ func (x *RebuildGoldenSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RebuildGoldenSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*RebuildGoldenSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_proto_worker_worker_proto_rawDescGZIP(), []int{59}
+	return file_proto_worker_worker_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *RebuildGoldenSnapshotResponse) GetOldVersion() string {
@@ -3717,7 +3822,7 @@ const file_proto_worker_worker_proto_rawDesc = "" +
 	"\x18SetSandboxLimitsResponse\";\n" +
 	"\x14PreCopyDrivesRequest\x12\x1d\n" +
 	"\n" +
-	"sandbox_id\x18\x01 \x01(\tR\tsandboxIdJ\x04\b\x02\x10\x03\"\xf8\x01\n" +
+	"sandbox_id\x18\x01 \x01(\tR\tsandboxIdJ\x04\b\x02\x10\x03\"\xdb\x04\n" +
 	"\x15PreCopyDrivesResponse\x12\x1d\n" +
 	"\n" +
 	"rootfs_key\x18\x01 \x01(\tR\trootfsKey\x12#\n" +
@@ -3725,7 +3830,19 @@ const file_proto_worker_worker_proto_rawDesc = "" +
 	"\x0egolden_version\x18\x03 \x01(\tR\rgoldenVersion\x12$\n" +
 	"\x0ebase_memory_mb\x18\x04 \x01(\x05R\fbaseMemoryMb\x12$\n" +
 	"\x0ebase_cpu_count\x18\x05 \x01(\x05R\fbaseCpuCount\x12(\n" +
-	"\x10actual_memory_mb\x18\x06 \x01(\x05R\x0eactualMemoryMb\"\xcc\x03\n" +
+	"\x10actual_memory_mb\x18\x06 \x01(\x05R\x0eactualMemoryMb\x12T\n" +
+	"\rsealed_tokens\x18\a \x03(\v2/.worker.PreCopyDrivesResponse.SealedTokensEntryR\fsealedTokens\x12)\n" +
+	"\x10egress_allowlist\x18\b \x03(\tR\x0fegressAllowlist\x12N\n" +
+	"\vtoken_hosts\x18\t \x03(\v2-.worker.PreCopyDrivesResponse.TokenHostsEntryR\n" +
+	"tokenHosts\x1a?\n" +
+	"\x11SealedTokensEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aO\n" +
+	"\x0fTokenHostsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12&\n" +
+	"\x05value\x18\x02 \x01(\v2\x10.worker.HostListR\x05value:\x028\x01\" \n" +
+	"\bHostList\x12\x14\n" +
+	"\x05hosts\x18\x01 \x03(\tR\x05hosts\"\xc3\x06\n" +
 	"\x1fPrepareMigrationIncomingRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x1f\n" +
@@ -3742,7 +3859,17 @@ const file_proto_worker_worker_proto_rawDesc = "" +
 	"\foverlay_mode\x18\n" +
 	" \x01(\bR\voverlayMode\x12(\n" +
 	"\x10target_memory_mb\x18\v \x01(\x05R\x0etargetMemoryMb\x122\n" +
-	"\x15source_golden_version\x18\f \x01(\tR\x13sourceGoldenVersion\"d\n" +
+	"\x15source_golden_version\x18\f \x01(\tR\x13sourceGoldenVersion\x12^\n" +
+	"\rsealed_tokens\x18\r \x03(\v29.worker.PrepareMigrationIncomingRequest.SealedTokensEntryR\fsealedTokens\x12)\n" +
+	"\x10egress_allowlist\x18\x0e \x03(\tR\x0fegressAllowlist\x12X\n" +
+	"\vtoken_hosts\x18\x0f \x03(\v27.worker.PrepareMigrationIncomingRequest.TokenHostsEntryR\n" +
+	"tokenHosts\x1a?\n" +
+	"\x11SealedTokensEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aO\n" +
+	"\x0fTokenHostsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12&\n" +
+	"\x05value\x18\x02 \x01(\v2\x10.worker.HostListR\x05value:\x028\x01\"d\n" +
 	" PrepareMigrationIncomingResponse\x12#\n" +
 	"\rincoming_addr\x18\x01 \x01(\tR\fincomingAddr\x12\x1b\n" +
 	"\thost_port\x18\x02 \x01(\x05R\bhostPort\"X\n" +
@@ -3806,7 +3933,7 @@ func file_proto_worker_worker_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_worker_worker_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_proto_worker_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 65)
+var file_proto_worker_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 70)
 var file_proto_worker_worker_proto_goTypes = []any{
 	(ExecOutputChunk_Stream)(0),               // 0: worker.ExecOutputChunk.Stream
 	(*CreateSandboxRequest)(nil),              // 1: worker.CreateSandboxRequest
@@ -3861,94 +3988,105 @@ var file_proto_worker_worker_proto_goTypes = []any{
 	(*SetSandboxLimitsResponse)(nil),          // 50: worker.SetSandboxLimitsResponse
 	(*PreCopyDrivesRequest)(nil),              // 51: worker.PreCopyDrivesRequest
 	(*PreCopyDrivesResponse)(nil),             // 52: worker.PreCopyDrivesResponse
-	(*PrepareMigrationIncomingRequest)(nil),   // 53: worker.PrepareMigrationIncomingRequest
-	(*PrepareMigrationIncomingResponse)(nil),  // 54: worker.PrepareMigrationIncomingResponse
-	(*LiveMigrateRequest)(nil),                // 55: worker.LiveMigrateRequest
-	(*LiveMigrateResponse)(nil),               // 56: worker.LiveMigrateResponse
-	(*CompleteMigrationIncomingRequest)(nil),  // 57: worker.CompleteMigrationIncomingRequest
-	(*CompleteMigrationIncomingResponse)(nil), // 58: worker.CompleteMigrationIncomingResponse
-	(*RebuildGoldenSnapshotRequest)(nil),      // 59: worker.RebuildGoldenSnapshotRequest
-	(*RebuildGoldenSnapshotResponse)(nil),     // 60: worker.RebuildGoldenSnapshotResponse
-	nil,                                       // 61: worker.CreateSandboxRequest.EnvsEntry
-	nil,                                       // 62: worker.CreateSandboxRequest.SecretAllowedHostsEntry
-	nil,                                       // 63: worker.CreateSandboxRequest.SecretEnvsEntry
-	nil,                                       // 64: worker.ExecCommandRequest.EnvsEntry
-	nil,                                       // 65: worker.ExecSessionCreateRequest.EnvsEntry
+	(*HostList)(nil),                          // 53: worker.HostList
+	(*PrepareMigrationIncomingRequest)(nil),   // 54: worker.PrepareMigrationIncomingRequest
+	(*PrepareMigrationIncomingResponse)(nil),  // 55: worker.PrepareMigrationIncomingResponse
+	(*LiveMigrateRequest)(nil),                // 56: worker.LiveMigrateRequest
+	(*LiveMigrateResponse)(nil),               // 57: worker.LiveMigrateResponse
+	(*CompleteMigrationIncomingRequest)(nil),  // 58: worker.CompleteMigrationIncomingRequest
+	(*CompleteMigrationIncomingResponse)(nil), // 59: worker.CompleteMigrationIncomingResponse
+	(*RebuildGoldenSnapshotRequest)(nil),      // 60: worker.RebuildGoldenSnapshotRequest
+	(*RebuildGoldenSnapshotResponse)(nil),     // 61: worker.RebuildGoldenSnapshotResponse
+	nil,                                       // 62: worker.CreateSandboxRequest.EnvsEntry
+	nil,                                       // 63: worker.CreateSandboxRequest.SecretAllowedHostsEntry
+	nil,                                       // 64: worker.CreateSandboxRequest.SecretEnvsEntry
+	nil,                                       // 65: worker.ExecCommandRequest.EnvsEntry
+	nil,                                       // 66: worker.ExecSessionCreateRequest.EnvsEntry
+	nil,                                       // 67: worker.PreCopyDrivesResponse.SealedTokensEntry
+	nil,                                       // 68: worker.PreCopyDrivesResponse.TokenHostsEntry
+	nil,                                       // 69: worker.PrepareMigrationIncomingRequest.SealedTokensEntry
+	nil,                                       // 70: worker.PrepareMigrationIncomingRequest.TokenHostsEntry
 }
 var file_proto_worker_worker_proto_depIdxs = []int32{
-	61, // 0: worker.CreateSandboxRequest.envs:type_name -> worker.CreateSandboxRequest.EnvsEntry
-	62, // 1: worker.CreateSandboxRequest.secret_allowed_hosts:type_name -> worker.CreateSandboxRequest.SecretAllowedHostsEntry
-	63, // 2: worker.CreateSandboxRequest.secret_envs:type_name -> worker.CreateSandboxRequest.SecretEnvsEntry
+	62, // 0: worker.CreateSandboxRequest.envs:type_name -> worker.CreateSandboxRequest.EnvsEntry
+	63, // 1: worker.CreateSandboxRequest.secret_allowed_hosts:type_name -> worker.CreateSandboxRequest.SecretAllowedHostsEntry
+	64, // 2: worker.CreateSandboxRequest.secret_envs:type_name -> worker.CreateSandboxRequest.SecretEnvsEntry
 	10, // 3: worker.ListSandboxesResponse.sandboxes:type_name -> worker.GetSandboxResponse
-	64, // 4: worker.ExecCommandRequest.envs:type_name -> worker.ExecCommandRequest.EnvsEntry
+	65, // 4: worker.ExecCommandRequest.envs:type_name -> worker.ExecCommandRequest.EnvsEntry
 	0,  // 5: worker.ExecOutputChunk.stream:type_name -> worker.ExecOutputChunk.Stream
 	21, // 6: worker.ListDirResponse.entries:type_name -> worker.DirEntry
 	26, // 7: worker.PTYInput.resize:type_name -> worker.PTYResize
-	65, // 8: worker.ExecSessionCreateRequest.envs:type_name -> worker.ExecSessionCreateRequest.EnvsEntry
+	66, // 8: worker.ExecSessionCreateRequest.envs:type_name -> worker.ExecSessionCreateRequest.EnvsEntry
 	40, // 9: worker.ExecSessionListResponse.sessions:type_name -> worker.ExecSessionInfoEntry
-	1,  // 10: worker.SandboxWorker.CreateSandbox:input_type -> worker.CreateSandboxRequest
-	3,  // 11: worker.SandboxWorker.DestroySandbox:input_type -> worker.DestroySandboxRequest
-	9,  // 12: worker.SandboxWorker.GetSandbox:input_type -> worker.GetSandboxRequest
-	11, // 13: worker.SandboxWorker.ListSandboxes:input_type -> worker.ListSandboxesRequest
-	13, // 14: worker.SandboxWorker.ExecCommand:input_type -> worker.ExecCommandRequest
-	13, // 15: worker.SandboxWorker.ExecCommandStream:input_type -> worker.ExecCommandRequest
-	16, // 16: worker.SandboxWorker.ReadFile:input_type -> worker.ReadFileRequest
-	18, // 17: worker.SandboxWorker.WriteFile:input_type -> worker.WriteFileRequest
-	20, // 18: worker.SandboxWorker.ListDir:input_type -> worker.ListDirRequest
-	23, // 19: worker.SandboxWorker.CreatePTY:input_type -> worker.CreatePTYRequest
-	25, // 20: worker.SandboxWorker.PTYStream:input_type -> worker.PTYInput
-	36, // 21: worker.SandboxWorker.ExecSessionCreate:input_type -> worker.ExecSessionCreateRequest
-	38, // 22: worker.SandboxWorker.ExecSessionList:input_type -> worker.ExecSessionListRequest
-	41, // 23: worker.SandboxWorker.ExecSessionKill:input_type -> worker.ExecSessionKillRequest
-	28, // 24: worker.SandboxWorker.HibernateSandbox:input_type -> worker.HibernateSandboxRequest
-	30, // 25: worker.SandboxWorker.WakeSandbox:input_type -> worker.WakeSandboxRequest
-	5,  // 26: worker.SandboxWorker.RebootSandbox:input_type -> worker.RebootSandboxRequest
-	7,  // 27: worker.SandboxWorker.PowerCycleSandbox:input_type -> worker.PowerCycleSandboxRequest
-	32, // 28: worker.SandboxWorker.SaveAsTemplate:input_type -> worker.SaveAsTemplateRequest
-	45, // 29: worker.SandboxWorker.CreateCheckpoint:input_type -> worker.CreateCheckpointRequest
-	47, // 30: worker.SandboxWorker.RestoreCheckpoint:input_type -> worker.RestoreCheckpointRequest
-	34, // 31: worker.SandboxWorker.BuildTemplate:input_type -> worker.BuildTemplateRequest
-	43, // 32: worker.SandboxWorker.GetSandboxStats:input_type -> worker.GetSandboxStatsRequest
-	49, // 33: worker.SandboxWorker.SetSandboxLimits:input_type -> worker.SetSandboxLimitsRequest
-	51, // 34: worker.SandboxWorker.PreCopyDrives:input_type -> worker.PreCopyDrivesRequest
-	53, // 35: worker.SandboxWorker.PrepareMigrationIncoming:input_type -> worker.PrepareMigrationIncomingRequest
-	55, // 36: worker.SandboxWorker.LiveMigrate:input_type -> worker.LiveMigrateRequest
-	57, // 37: worker.SandboxWorker.CompleteMigrationIncoming:input_type -> worker.CompleteMigrationIncomingRequest
-	59, // 38: worker.SandboxWorker.RebuildGoldenSnapshot:input_type -> worker.RebuildGoldenSnapshotRequest
-	2,  // 39: worker.SandboxWorker.CreateSandbox:output_type -> worker.CreateSandboxResponse
-	4,  // 40: worker.SandboxWorker.DestroySandbox:output_type -> worker.DestroySandboxResponse
-	10, // 41: worker.SandboxWorker.GetSandbox:output_type -> worker.GetSandboxResponse
-	12, // 42: worker.SandboxWorker.ListSandboxes:output_type -> worker.ListSandboxesResponse
-	14, // 43: worker.SandboxWorker.ExecCommand:output_type -> worker.ExecCommandResponse
-	15, // 44: worker.SandboxWorker.ExecCommandStream:output_type -> worker.ExecOutputChunk
-	17, // 45: worker.SandboxWorker.ReadFile:output_type -> worker.ReadFileResponse
-	19, // 46: worker.SandboxWorker.WriteFile:output_type -> worker.WriteFileResponse
-	22, // 47: worker.SandboxWorker.ListDir:output_type -> worker.ListDirResponse
-	24, // 48: worker.SandboxWorker.CreatePTY:output_type -> worker.CreatePTYResponse
-	27, // 49: worker.SandboxWorker.PTYStream:output_type -> worker.PTYOutput
-	37, // 50: worker.SandboxWorker.ExecSessionCreate:output_type -> worker.ExecSessionCreateResponse
-	39, // 51: worker.SandboxWorker.ExecSessionList:output_type -> worker.ExecSessionListResponse
-	42, // 52: worker.SandboxWorker.ExecSessionKill:output_type -> worker.ExecSessionKillResponse
-	29, // 53: worker.SandboxWorker.HibernateSandbox:output_type -> worker.HibernateSandboxResponse
-	31, // 54: worker.SandboxWorker.WakeSandbox:output_type -> worker.WakeSandboxResponse
-	6,  // 55: worker.SandboxWorker.RebootSandbox:output_type -> worker.RebootSandboxResponse
-	8,  // 56: worker.SandboxWorker.PowerCycleSandbox:output_type -> worker.PowerCycleSandboxResponse
-	33, // 57: worker.SandboxWorker.SaveAsTemplate:output_type -> worker.SaveAsTemplateResponse
-	46, // 58: worker.SandboxWorker.CreateCheckpoint:output_type -> worker.CreateCheckpointResponse
-	48, // 59: worker.SandboxWorker.RestoreCheckpoint:output_type -> worker.RestoreCheckpointResponse
-	35, // 60: worker.SandboxWorker.BuildTemplate:output_type -> worker.BuildTemplateResponse
-	44, // 61: worker.SandboxWorker.GetSandboxStats:output_type -> worker.GetSandboxStatsResponse
-	50, // 62: worker.SandboxWorker.SetSandboxLimits:output_type -> worker.SetSandboxLimitsResponse
-	52, // 63: worker.SandboxWorker.PreCopyDrives:output_type -> worker.PreCopyDrivesResponse
-	54, // 64: worker.SandboxWorker.PrepareMigrationIncoming:output_type -> worker.PrepareMigrationIncomingResponse
-	56, // 65: worker.SandboxWorker.LiveMigrate:output_type -> worker.LiveMigrateResponse
-	58, // 66: worker.SandboxWorker.CompleteMigrationIncoming:output_type -> worker.CompleteMigrationIncomingResponse
-	60, // 67: worker.SandboxWorker.RebuildGoldenSnapshot:output_type -> worker.RebuildGoldenSnapshotResponse
-	39, // [39:68] is the sub-list for method output_type
-	10, // [10:39] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	67, // 10: worker.PreCopyDrivesResponse.sealed_tokens:type_name -> worker.PreCopyDrivesResponse.SealedTokensEntry
+	68, // 11: worker.PreCopyDrivesResponse.token_hosts:type_name -> worker.PreCopyDrivesResponse.TokenHostsEntry
+	69, // 12: worker.PrepareMigrationIncomingRequest.sealed_tokens:type_name -> worker.PrepareMigrationIncomingRequest.SealedTokensEntry
+	70, // 13: worker.PrepareMigrationIncomingRequest.token_hosts:type_name -> worker.PrepareMigrationIncomingRequest.TokenHostsEntry
+	53, // 14: worker.PreCopyDrivesResponse.TokenHostsEntry.value:type_name -> worker.HostList
+	53, // 15: worker.PrepareMigrationIncomingRequest.TokenHostsEntry.value:type_name -> worker.HostList
+	1,  // 16: worker.SandboxWorker.CreateSandbox:input_type -> worker.CreateSandboxRequest
+	3,  // 17: worker.SandboxWorker.DestroySandbox:input_type -> worker.DestroySandboxRequest
+	9,  // 18: worker.SandboxWorker.GetSandbox:input_type -> worker.GetSandboxRequest
+	11, // 19: worker.SandboxWorker.ListSandboxes:input_type -> worker.ListSandboxesRequest
+	13, // 20: worker.SandboxWorker.ExecCommand:input_type -> worker.ExecCommandRequest
+	13, // 21: worker.SandboxWorker.ExecCommandStream:input_type -> worker.ExecCommandRequest
+	16, // 22: worker.SandboxWorker.ReadFile:input_type -> worker.ReadFileRequest
+	18, // 23: worker.SandboxWorker.WriteFile:input_type -> worker.WriteFileRequest
+	20, // 24: worker.SandboxWorker.ListDir:input_type -> worker.ListDirRequest
+	23, // 25: worker.SandboxWorker.CreatePTY:input_type -> worker.CreatePTYRequest
+	25, // 26: worker.SandboxWorker.PTYStream:input_type -> worker.PTYInput
+	36, // 27: worker.SandboxWorker.ExecSessionCreate:input_type -> worker.ExecSessionCreateRequest
+	38, // 28: worker.SandboxWorker.ExecSessionList:input_type -> worker.ExecSessionListRequest
+	41, // 29: worker.SandboxWorker.ExecSessionKill:input_type -> worker.ExecSessionKillRequest
+	28, // 30: worker.SandboxWorker.HibernateSandbox:input_type -> worker.HibernateSandboxRequest
+	30, // 31: worker.SandboxWorker.WakeSandbox:input_type -> worker.WakeSandboxRequest
+	5,  // 32: worker.SandboxWorker.RebootSandbox:input_type -> worker.RebootSandboxRequest
+	7,  // 33: worker.SandboxWorker.PowerCycleSandbox:input_type -> worker.PowerCycleSandboxRequest
+	32, // 34: worker.SandboxWorker.SaveAsTemplate:input_type -> worker.SaveAsTemplateRequest
+	45, // 35: worker.SandboxWorker.CreateCheckpoint:input_type -> worker.CreateCheckpointRequest
+	47, // 36: worker.SandboxWorker.RestoreCheckpoint:input_type -> worker.RestoreCheckpointRequest
+	34, // 37: worker.SandboxWorker.BuildTemplate:input_type -> worker.BuildTemplateRequest
+	43, // 38: worker.SandboxWorker.GetSandboxStats:input_type -> worker.GetSandboxStatsRequest
+	49, // 39: worker.SandboxWorker.SetSandboxLimits:input_type -> worker.SetSandboxLimitsRequest
+	51, // 40: worker.SandboxWorker.PreCopyDrives:input_type -> worker.PreCopyDrivesRequest
+	54, // 41: worker.SandboxWorker.PrepareMigrationIncoming:input_type -> worker.PrepareMigrationIncomingRequest
+	56, // 42: worker.SandboxWorker.LiveMigrate:input_type -> worker.LiveMigrateRequest
+	58, // 43: worker.SandboxWorker.CompleteMigrationIncoming:input_type -> worker.CompleteMigrationIncomingRequest
+	60, // 44: worker.SandboxWorker.RebuildGoldenSnapshot:input_type -> worker.RebuildGoldenSnapshotRequest
+	2,  // 45: worker.SandboxWorker.CreateSandbox:output_type -> worker.CreateSandboxResponse
+	4,  // 46: worker.SandboxWorker.DestroySandbox:output_type -> worker.DestroySandboxResponse
+	10, // 47: worker.SandboxWorker.GetSandbox:output_type -> worker.GetSandboxResponse
+	12, // 48: worker.SandboxWorker.ListSandboxes:output_type -> worker.ListSandboxesResponse
+	14, // 49: worker.SandboxWorker.ExecCommand:output_type -> worker.ExecCommandResponse
+	15, // 50: worker.SandboxWorker.ExecCommandStream:output_type -> worker.ExecOutputChunk
+	17, // 51: worker.SandboxWorker.ReadFile:output_type -> worker.ReadFileResponse
+	19, // 52: worker.SandboxWorker.WriteFile:output_type -> worker.WriteFileResponse
+	22, // 53: worker.SandboxWorker.ListDir:output_type -> worker.ListDirResponse
+	24, // 54: worker.SandboxWorker.CreatePTY:output_type -> worker.CreatePTYResponse
+	27, // 55: worker.SandboxWorker.PTYStream:output_type -> worker.PTYOutput
+	37, // 56: worker.SandboxWorker.ExecSessionCreate:output_type -> worker.ExecSessionCreateResponse
+	39, // 57: worker.SandboxWorker.ExecSessionList:output_type -> worker.ExecSessionListResponse
+	42, // 58: worker.SandboxWorker.ExecSessionKill:output_type -> worker.ExecSessionKillResponse
+	29, // 59: worker.SandboxWorker.HibernateSandbox:output_type -> worker.HibernateSandboxResponse
+	31, // 60: worker.SandboxWorker.WakeSandbox:output_type -> worker.WakeSandboxResponse
+	6,  // 61: worker.SandboxWorker.RebootSandbox:output_type -> worker.RebootSandboxResponse
+	8,  // 62: worker.SandboxWorker.PowerCycleSandbox:output_type -> worker.PowerCycleSandboxResponse
+	33, // 63: worker.SandboxWorker.SaveAsTemplate:output_type -> worker.SaveAsTemplateResponse
+	46, // 64: worker.SandboxWorker.CreateCheckpoint:output_type -> worker.CreateCheckpointResponse
+	48, // 65: worker.SandboxWorker.RestoreCheckpoint:output_type -> worker.RestoreCheckpointResponse
+	35, // 66: worker.SandboxWorker.BuildTemplate:output_type -> worker.BuildTemplateResponse
+	44, // 67: worker.SandboxWorker.GetSandboxStats:output_type -> worker.GetSandboxStatsResponse
+	50, // 68: worker.SandboxWorker.SetSandboxLimits:output_type -> worker.SetSandboxLimitsResponse
+	52, // 69: worker.SandboxWorker.PreCopyDrives:output_type -> worker.PreCopyDrivesResponse
+	55, // 70: worker.SandboxWorker.PrepareMigrationIncoming:output_type -> worker.PrepareMigrationIncomingResponse
+	57, // 71: worker.SandboxWorker.LiveMigrate:output_type -> worker.LiveMigrateResponse
+	59, // 72: worker.SandboxWorker.CompleteMigrationIncoming:output_type -> worker.CompleteMigrationIncomingResponse
+	61, // 73: worker.SandboxWorker.RebuildGoldenSnapshot:output_type -> worker.RebuildGoldenSnapshotResponse
+	45, // [45:74] is the sub-list for method output_type
+	16, // [16:45] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_proto_worker_worker_proto_init() }
@@ -3966,7 +4104,7 @@ func file_proto_worker_worker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_worker_worker_proto_rawDesc), len(file_proto_worker_worker_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   65,
+			NumMessages:   70,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/worker/worker.proto
+++ b/proto/worker/worker.proto
@@ -367,6 +367,22 @@ message PreCopyDrivesResponse {
   // Used for actual-memory-based scheduling instead of committed/configured
   // memory (which over-reserves on idle sandboxes).
   int32 actual_memory_mb = 6;
+  // Secrets-proxy session state for the migrating sandbox. Live migration
+  // moves the QEMU process (which carries the in-VM env vars containing
+  // sealed token IDs) but the proxy's plaintext-substitution map is
+  // per-worker in-process state. Without these the destination worker has
+  // no way to substitute the literal `osb_sealed_xxx` strings on outbound
+  // HTTPS, so the guest's first secret-using call after migration fails
+  // auth. Mirrors the SealedTokens/EgressAllowlist/TokenHosts fields the
+  // hibernate path persists into snapshot-meta.json.
+  map<string, string> sealed_tokens = 7;       // sealed_id -> plaintext secret value
+  repeated string egress_allowlist = 8;        // host allowlist for the secrets proxy
+  map<string, HostList> token_hosts = 9;       // sealed_id -> per-token allowed hosts
+}
+
+// HostList is a wrapper because proto3 maps cannot have a repeated value type.
+message HostList {
+  repeated string hosts = 1;
 }
 
 message PrepareMigrationIncomingRequest {
@@ -382,6 +398,13 @@ message PrepareMigrationIncomingRequest {
   bool overlay_mode = 10;       // if true, rootfs is thin overlay — rebase to local golden on target
   int32 target_memory_mb = 11;  // final memory after scale — worker checks capacity and reserves atomically
   string source_golden_version = 12;  // source's golden version — target rebases overlay if different from its own
+  // Secrets-proxy session state captured from the source by PreCopyDrives.
+  // Target re-registers these on its in-process secrets proxy BEFORE the
+  // VM resumes (Cont) so the first outbound HTTPS request after migration
+  // has its `osb_sealed_xxx` env vars correctly substituted.
+  map<string, string> sealed_tokens = 13;
+  repeated string egress_allowlist = 14;
+  map<string, HostList> token_hosts = 15;
 }
 
 message PrepareMigrationIncomingResponse {


### PR DESCRIPTION
  # Live migration carries secrets-proxy state

  ## Summary

  Live migration silently broke secrets-proxy substitution. The proxy keeps its `osb_sealed_xxx → real_value` map in worker process memory
  keyed by guest IP — hibernate/wake serialized this through `snapshot-meta.json`, but live migration didn't carry it at all. After migration
  the destination worker had no session for the migrated guest's IP, so outbound HTTPS leaked the literal sealed token to upstream services
  and auth failed on every secret-using call.

  This PR fixes that with three layered changes:

  1. **Session handoff** — sealed tokens + egress allowlist + per-token host restrictions move from source to destination through the existing
   `PreCopyDrives → PrepareMigrationIncoming` RPC chain. Source captures, target re-registers before the VM unpauses, source unregisters
  after.
  2. **Region-scoped shared CA** — the proxy MITMs HTTPS using a CA whose cert is in the guest's trust store. Without a shared CA, every
  worker generates its own; even with the session handoff, post-migration TLS handshakes fail with `authority and subject key identifier
  mismatch`. KV-backed shared CA gives every worker in the region the same cert chain so steady-state migrations Just Work.
  3. **Migrate-time CA refresh** — on every cross-worker handoff (live migration, hibernate→wake, fork-from-checkpoint), the destination
  worker overwrites the proxy CA file in the guest. Idempotent in steady state (the file content is the same), but solves the transition
  window for sandboxes that pre-date the shared-CA rollout, enables cross-cell migration (each cell's KV has its own CA), and makes CA
  rotation operationally cheap.

  The three layers are independent and complementary. Together they make secrets-proxy survival across worker handoffs robust to any topology
  change short of "the destination has no proxy at all".

  ## Architecture

  ### 1. Session handoff
  - Source `PreCopyDrives` looks up `secretsProxy.GetSessionTokens / Allowlist / TokenHosts` by guest IP and returns them in the gRPC
  response. Captured before drive upload starts.
  - Target `PrepareMigrationIncoming` accepts the secrets, stages QEMU, and calls `secretsProxy.ReregisterSession` keyed by the destination's
  guest IP — done before returning so the source can issue the cutover with no race window.
  - Source `LiveMigrate` cleanup calls `secretsProxy.UnregisterSession` after QMP migrate completes. Without this, plaintext tokens linger on
  the source until the worker process restarts.
  - `proto/worker/worker.proto` carries `sealed_tokens`, `egress_allowlist`, and `token_hosts` (wrapped in `HostList` because proto3 maps
  can't have a repeated value type) on `PreCopyDrivesResponse` and `PrepareMigrationIncomingRequest`.
  - Three CP orchestration callers (`api/sandbox.go` migrateSandbox, `api/sandbox.go` migrateForScale, `controlplane/scaler.go` scaler-driven
  evacuation) forward the secrets through.

  ### 2. Shared CA
  - `secretsproxy.LoadOrCreateSharedCA(ctx, kv, certName, keyName, fallbackDir)` fetches the CA from a `KVStore`-shaped backend, or generates
  and publishes one. Race-resilient: multiple workers booting concurrently each generate locally, but a re-fetch after the publish converges
  everyone onto whatever ended up in KV.
  - `KVStore` is a 2-method interface (`Get`, `Set`) with an Azure adapter. Future EC2/SSM backends drop in without touching the loader.
  - Falls back to per-worker `LoadOrCreateCA` when no KV is configured (dev/EC2 without the bridge).
  - KV cert + key are mirrored to a local fallback dir for `openssl x509` inspection and brief KV-outage tolerance.

  ### 3. Migrate-time CA refresh
  - `Manager.reinstallProxyCA(ctx, sandboxID, agent)` overwrites `/usr/local/share/ca-certificates/opensandbox-proxy.crt` in the guest with
  the destination worker's current CA. Single `agent.WriteFile` call.
  - The guest's env vars (`SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`) already point to that fixed path, so consumers read
  the file directly. No `update-ca-certificates` run needed.
  - Called from `CompleteIncomingMigration`, `doWake`, and `ForkFromCheckpoint` — every code path where a sandbox can land on a different
  worker than it was created on.
  - Idempotent: in steady state (every worker shares the same CA via KV), the new content equals the old. Cost: ~1 ms agent RPC.

  ### Worker identity
  Workers need read+write on the regional KV to fetch the shared CA. Done via a single per-region UserAssigned managed identity (option (2) in
   our discussion — single shared identity beats per-VM SystemAssigned: O(1) role assignments instead of O(N), no per-VM token propagation
  delay, identity persists across worker churn):
  - `internal/compute/azure.go` attaches the identity to every worker VM at create time when `WorkerIdentityID` is configured.
  - `cmd/server/main.go` reads `OPENSANDBOX_AZURE_WORKER_IDENTITY_ID` and passes it to the AzurePool.
  - The worker's cloud-init now also includes `OPENSANDBOX_AZURE_KEY_VAULT_NAME` so the worker knows which KV to fetch from.
  - One-time per-region bootstrap (`deploy/azure/bootstrap-worker-identity.sh`): creates the identity, grants `Key Vault Secrets Officer` on
  the regional KV, prints the resource ID.

  ## Security note

  Sharing the CA across workers in the same region/cell does not materially expand blast radius. Workers already see plaintext secrets when
  injecting envs, so the trust boundary is already "any worker in the region". The CA key is a signing key, not a session key — modern TLS
  uses ECDHE, so stealing it can't decrypt past traffic. Cross-region sharing is intentionally **not** done; data residency / compliance
  boundaries require per-region CAs.

  The migrate-time CA refresh further reduces blast-radius dependence on the shared CA: even if you wanted per-cell or per-worker CAs
  (different blast-radius envelope), migration still works because the destination's CA gets installed at handoff time.

  ## Migration

  None — no DB schema changes. Only adds proto fields (proto3 backward-compatible) and reads two new env vars on the CP.

  ## Behavioral changes visible to existing callers

  None. New code paths only fire when:
  - A live migration touches a sandbox with a secret store (was broken before, now works).
  - A hibernate→wake or fork-from-checkpoint lands on a different worker than the source (was undertested, now provably correct).
  - The CP is configured with `OPENSANDBOX_AZURE_WORKER_IDENTITY_ID` (otherwise unchanged).

  If all three are absent, behavior is identical to today.

  ## Rollout plan

  ```
  T0 — bootstrap (no effect on running services)
       bash deploy/azure/bootstrap-worker-identity.sh opencomputer-prod opencomputer-prod-kv

  T1 — set env on prod CP (current binary ignores it)
       OPENSANDBOX_AZURE_WORKER_IDENTITY_ID=<output of T0>

  T2 — deploy new CP binary
       New worker VMs get the identity attached. Existing workers keep working.

  T3 — deploy new worker binary
       Existing workers get new code. Migration code paths now fire correctly.
       Migrate-time CA refresh handles any sandbox that has an old per-worker
       CA in its trust store — they get retrofitted on first migration.

  (no T4 required)
       The previous "must roll the worker pool" step is no longer needed.
       Sandboxes pick up the shared CA naturally as they migrate or hibernate.
  ```

  T0 and T1 are already applied on prod and have no effect until T2.

  ## Testing on dev

  End-to-end validated on `dev.opensandbox.ai` with two workers in `opensandbox-prod / westus2`:

  | Step | Result |
  |---|---|
  | Bootstrap creates UserAssigned identity + KV role | ✓ |
  | Worker A and Worker B fetch the **same** CA fingerprint from KV (`51:CA:01:55:...`) | ✓ |
  | Create secret store with `egressAllowlist: ["httpbin.org"]` and value `real_value_xyz789` | ✓ |
  | Sandbox env shows `TEST_SECRET=osb_sealed_xxx` | ✓ |
  | Pre-migration outbound HTTPS to httpbin.org echoes `X-Test: real_value_xyz789` | ✓ |
  | Live-migrate worker A → worker B (~600 ms) | ✓ |
  | Target journal: `secrets-proxy: re-registered session sandbox=X ip=Y secrets=1 allowlist=1 tokenHosts=1` | ✓ |
  | Target journal: `qemu: X: reinstalled proxy CA on guest` | ✓ |
  | Post-migration outbound HTTPS still echoes `X-Test: real_value_xyz789` | ✓ |
  | **Cross-CA simulation**: force worker B onto a different (per-worker) CA, migrate sandbox A → B, verify post-migration HTTPS still works because migrate-time install ran | ✓  |

  Without the shared-CA fix, post-migration HTTPS failed with `SSL certificate problem: authority and subject key identifier mismatch` —
  verified by deploying the session-handoff fix alone first, observing the cert mismatch, then layering the shared CA + migrate-time refresh
  on top and observing substitution work end-to-end.

  ## Files changed

  **New**
  - `internal/secretsproxy/ca_shared.go` — shared CA loader with KV-backed publish/refetch race resolution
  - `internal/secretsproxy/kvstore_azure.go` — Azure Key Vault adapter implementing `KVStore`
  - `deploy/azure/bootstrap-worker-identity.sh` — one-time per-region identity + role bootstrap

  **Modified**
  - `proto/worker/worker.proto` — adds `sealed_tokens`, `egress_allowlist`, `token_hosts`, `HostList` to PreCopyDrives +
  PrepareMigrationIncoming messages
  - `proto/worker/*.pb.go` — regenerated
  - `internal/sandbox/interface.go` — adds `MigrationSecrets` shared type
  - `internal/qemu/migration.go` — `PreCopyDrives` captures secrets; `PrepareIncomingMigrationWithS3` accepts + re-registers; `LiveMigrate`
  unregisters on source; `CompleteIncomingMigration` calls `reinstallProxyCA`
  - `internal/qemu/manager.go` — adds `reinstallProxyCA` helper; calls it from `ForkFromCheckpoint`
  - `internal/qemu/snapshot.go` — `doWake` calls `reinstallProxyCA`
  - `internal/worker/grpc_server.go` — handler marshals/unmarshals secrets; updated `LiveMigrator` interface
  - `internal/api/sandbox.go` — both migration call sites forward secrets through
  - `internal/controlplane/scaler.go` — scaler-driven evacuation forwards secrets through
  - `internal/compute/azure.go` — adds `WorkerIdentityID` config field; attaches `Identity` on VM create when set
  - `internal/config/config.go` — adds `AzureWorkerIdentityID` (env: `OPENSANDBOX_AZURE_WORKER_IDENTITY_ID`)
  - `cmd/server/main.go` — passes identity to AzurePool; injects `OPENSANDBOX_AZURE_KEY_VAULT_NAME` into worker.env template
  - `cmd/worker/main.go` — uses `LoadOrCreateSharedCA` instead of `LoadOrCreateCA` when KV configured

  ## Risks / known limitations

  - **Workers must have managed identity attached** for shared-CA fetch to succeed. If T2 deploys without T0+T1, fresh workers fall back to
  per-worker CAs. Mitigation: T0+T1 are already done on prod; verify before merging. **Even without managed identity / shared CA, migrate-time
   refresh still works** — it just installs the destination's per-worker CA, which is correct.
  - **Long-lived TLS connections in the guest** (e.g., open websockets) cached the old cert chain pre-migration. They keep trusting the old CA
   until reconnect. Edge case for our workloads.
  - **No CA rotation flow yet.** With the migrate-time refresh, rotation is now operationally tractable: write new CA to KV, restart workers,
  sandboxes naturally retrofit on next migration/wake/fork. Without explicit rotation, sandboxes that never hibernate or migrate keep their
  old CA — probably fine for our use case (most sandboxes are short-lived).
