### PR TITLE
fix(sandbox): default networkEnabled=true so dashboard stops mislabeling sandboxes

### DIFF
--- a/internal/api/image_builder.go
+++ b/internal/api/image_builder.go
@@ -399,7 +399,8 @@ func (s *Server) buildImage(ctx context.Context, orgID uuid.UUID, manifest *Imag
 		}
 		_ = resp
 	} else if s.manager != nil {
-		cfg.NetworkEnabled = true
+		t := true
+		cfg.NetworkEnabled = &t
 		sb, err := s.manager.Create(ctx, cfg)
 		if err != nil {
 			return uuid.Nil, fmt.Errorf("failed to create build sandbox: %w", err)

--- a/internal/api/sandbox.go
+++ b/internal/api/sandbox.go
@@ -26,6 +26,9 @@ func (s *Server) createSandbox(c echo.Context) error {
 			"error": "invalid request body: " + err.Error(),
 		})
 	}
+	// Default networkEnabled=true when caller omits it, so the value persisted
+	// to sandbox_sessions.config_json is explicit and forks inherit it correctly.
+	cfg.EnsureNetworkEnabledDefault()
 
 	// Validate CPU/memory against allowed tiers.
 	// Allowed tiers (memoryMB → vCPU): 1024→1, 4096→1, 8192→2, 16384→4, 32768→8, 65536→16.
@@ -485,7 +488,7 @@ func (s *Server) createSandboxRemote(c echo.Context, ctx context.Context, cfg ty
 		Template:             cfg.Template,
 		Timeout:              int32(cfg.Timeout),
 		Envs:                 cfg.Envs,
-		NetworkEnabled:       cfg.NetworkEnabled,
+		NetworkEnabled:       cfg.IsNetworkEnabled(),
 		Port:                 int32(cfg.Port),
 		TemplateRootfsKey:    templateRootfsKey,
 		TemplateWorkspaceKey: templateWorkspaceKey,
@@ -2254,6 +2257,10 @@ func (s *Server) createFromCheckpointCore(c echo.Context, userEnvs map[string]st
 	// Parse the original sandbox config to reuse settings
 	var originalCfg types.SandboxConfig
 	_ = json.Unmarshal(cp.SandboxConfig, &originalCfg)
+	// Older checkpoints predate the networkEnabled default-to-true normalization
+	// and persisted no value (or false from the old non-pointer bool). Forks
+	// should still come up with networking on.
+	originalCfg.EnsureNetworkEnabledDefault()
 
 	// Secret store resolution — supports layering:
 	// Resolve stores in order: BaseSecretStore → SecretStore → user's store.
@@ -2396,7 +2403,7 @@ func (s *Server) createFromCheckpointCore(c echo.Context, userEnvs map[string]st
 			Envs:                 originalCfg.Envs,
 			MemoryMb:             int32(originalCfg.MemoryMB),
 			CpuCount:             int32(originalCfg.CpuCount),
-			NetworkEnabled:       originalCfg.NetworkEnabled,
+			NetworkEnabled:       originalCfg.IsNetworkEnabled(),
 			Port:                 int32(originalCfg.Port),
 			TemplateRootfsKey:    *cp.RootfsS3Key,
 			TemplateWorkspaceKey: *cp.WorkspaceS3Key,

--- a/internal/worker/grpc_server.go
+++ b/internal/worker/grpc_server.go
@@ -152,7 +152,7 @@ func (s *GRPCServer) CreateSandbox(ctx context.Context, req *pb.CreateSandboxReq
 		Envs:               req.Envs,
 		MemoryMB:           int(req.MemoryMb),
 		CpuCount:           int(req.CpuCount),
-		NetworkEnabled:     req.NetworkEnabled,
+		NetworkEnabled:     &req.NetworkEnabled,
 		ImageRef:           req.ImageRef,
 		Port:               int(req.Port),
 		SandboxID:          req.SandboxId,    // use server-assigned ID if provided

--- a/pkg/types/sandbox.go
+++ b/pkg/types/sandbox.go
@@ -48,7 +48,9 @@ type SandboxConfig struct {
 	DiskMB     int               `json:"diskMB,omitempty"`    // workspace disk in MB (default 20480)
 	Envs       map[string]string `json:"envs,omitempty"`
 	Port       int               `json:"port,omitempty"`       // container port to expose via subdomain (default 80)
-	NetworkEnabled bool          `json:"networkEnabled,omitempty"`
+	// NetworkEnabled is a pointer so we can distinguish "unset" from
+	// "explicitly false". Unset defaults to true (see IsNetworkEnabled).
+	NetworkEnabled *bool         `json:"networkEnabled,omitempty"`
 	ImageRef       string        `json:"imageRef,omitempty"`       // resolved ECR URI for custom templates
 	// Sandbox snapshot template: S3 keys for rootfs and workspace drives.
 	// When set, the sandbox boots from these drives instead of the standard base image.
@@ -105,6 +107,26 @@ var AllowedResourceTiers = []ResourceTier{
 	{MemoryMB: 16384, VCPUs: 4},
 	{MemoryMB: 32768, VCPUs: 8},
 	{MemoryMB: 65536, VCPUs: 16},
+}
+
+// IsNetworkEnabled returns the effective NetworkEnabled value, defaulting to
+// true when unset. Direct deref is unsafe because older persisted configs and
+// clients that omit the field produce nil.
+func (c SandboxConfig) IsNetworkEnabled() bool {
+	if c.NetworkEnabled == nil {
+		return true
+	}
+	return *c.NetworkEnabled
+}
+
+// EnsureNetworkEnabledDefault sets NetworkEnabled to true when unset, so the
+// value persisted into the DB is explicit and survives round-trips (e.g. fork
+// from checkpoint).
+func (c *SandboxConfig) EnsureNetworkEnabledDefault() {
+	if c.NetworkEnabled == nil {
+		t := true
+		c.NetworkEnabled = &t
+	}
 }
 
 // ValidateMemoryMB checks that memoryMB matches an allowed tier and returns the corresponding vCPU count.


### PR DESCRIPTION
## Summary

`SandboxConfig.NetworkEnabled` was a non-pointer `bool`, so any client that omitted the field — `oc sandbox create`, `oc checkpoint spawn`, the TS SDK, `sessions-api`'s agent-create path — ended up with the zero value `false`. That value got persisted into `sandbox_sessions.config_json` and rendered in the dashboard as **"Disabled"** even though the worker (`internal/qemu/manager.go` `Create`) sets up the TAP/DNAT unconditionally and the sandbox actually has networking. Forks inherited the same `false` from the parent checkpoint's persisted config, so spawning from a checkpoint produced more "Disabled" sandboxes.

The controlplane already had a `*bool` + nil-default-to-true path (`internal/controlplane/server.go:112-115`), but the comment there gave the game away: "the worker currently sets up networking unconditionally, so a missing field that marshaled to false caused the UI to mislabel sandboxes as 'Disabled'." The API server and fork-from-checkpoint flow didn't have the same defaulting, so the fix never reached the sandboxes most users actually create.

## Changes

- **`pkg/types/sandbox.go`** — flip `NetworkEnabled bool` → `*bool`; add `IsNetworkEnabled()` (nil → true) and `EnsureNetworkEnabledDefault()` helpers so the rule lives in one place.
- **`internal/api/sandbox.go`**
  - `createSandbox`: call `cfg.EnsureNetworkEnabledDefault()` after `Bind`, so the value persisted to `sandbox_sessions.config_json` is explicitly `true` when the client omits the field.
  - `createFromCheckpointCore`: default `originalCfg` after unmarshal so forks of older checkpoints (which were persisted with `false` from the previous bug, or with no value at all) come up as Enabled.
  - Both gRPC `CreateSandboxRequest` sites use `IsNetworkEnabled()`.
- **`internal/api/image_builder.go`** — combined-mode build path now assigns a `*bool` instead of the bool literal.
- **`internal/worker/grpc_server.go`** — wraps the proto `bool` into `*bool` when constructing the internal `SandboxConfig`.

## Test plan

- [x] `go build ./pkg/types ./internal/api ./internal/controlplane ./internal/worker ./internal/qemu ./internal/sandbox ./cmd/oc/...` — clean.
- [x] `go test ./pkg/types/... ./internal/api/...` — pass.
- [ ] Create a sandbox via `oc sandbox create` and confirm the dashboard now shows **Enabled**.
- [ ] Fork a checkpoint via `oc checkpoint spawn` and confirm the resulting sandbox also shows **Enabled** (including for forks of pre-fix parents).
- [ ] Confirm explicit `{"networkEnabled": false}` over the raw API still persists as Disabled (the pointer correctly distinguishes unset vs explicit false).

🤖 Generated with [Claude Code](https://claude.com/claude-code)