### PR TITLE
ui(sessions): hide Network row from session details

### DIFF
--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -382,7 +382,6 @@ export default function SessionDetail() {
           <DetailRow label="Timeout" value={session.config?.timeout ? `${session.config.timeout}s` : '300s'} />
           <DetailRow label="CPUs" value={String(session.config?.cpuCount ?? 1)} />
           <DetailRow label="Memory" value={`${session.config?.memoryMB ?? 512} MB`} />
-          <DetailRow label="Network" value={session.config?.networkEnabled ? 'Enabled' : 'Disabled'} />
           <DetailRow label="Started" value={new Date(session.startedAt).toLocaleString()} />
           {session.stoppedAt && (
             <DetailRow label="Stopped" value={new Date(session.stoppedAt).toLocaleString()} />


### PR DESCRIPTION
## Summary

Every sandbox in the dashboard currently shows **Network: Disabled** because `SandboxConfig.NetworkEnabled` is a non-pointer `bool` and every creation path (`oc sandbox create`, `oc checkpoint spawn`, the TS SDK, `sessions-api`'s agent flow) omits the field — so it deserializes to `false` and is rendered as "Disabled" even though the worker (`internal/qemu/manager.go`) brings up TAP/DNAT unconditionally.

The Go-side fix that flips the field to `*bool` and defaults to `true` is in #219. Until that ships and the worker daemon is rolled, hide the row so users don't see misleading state.

## Changes

- `web/src/pages/SessionDetail.tsx` — drop the `Network` `DetailRow` entry. No data fetch changes; field stays in `web/src/api/client.ts` for when we re-enable it.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [ ] Open the session detail page; confirm the Network row is gone and the surrounding grid lays out correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)