### PR TITLE
fix(secrets-proxy): register session for allowlist-only secret stores

### DIFF
--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -300,7 +300,7 @@ func (m *Manager) sealSandboxEnvs(ctx context.Context, sandboxID string, netCfg 
 		}
 		return merged
 	}
-	if len(cfg.Envs) == 0 && len(cfg.SecretEnvs) == 0 {
+	if len(cfg.Envs) == 0 && len(cfg.SecretEnvs) == 0 && len(cfg.EgressAllowlist) == 0 {
 		return cfg.Envs
 	}
 	sealed := m.secretsProxy.CreateSealedEnvs(sandboxID, netCfg.GuestIP, netCfg.HostIP, cfg.Envs, cfg.SecretEnvs, cfg.EgressAllowlist, cfg.SecretAllowedHosts)
@@ -2709,10 +2709,11 @@ func (m *Manager) RestoreFromCheckpoint(ctx context.Context, sandboxID, checkpoi
 		log.Printf("qemu: RestoreFromCheckpoint %s: clock sync failed: %v", sandboxID, err)
 	}
 
-	// Re-register secrets proxy session from checkpoint metadata.
-	if m.secretsProxy != nil && len(cpMeta.SealedTokens) > 0 {
+	// Re-register secrets proxy session from checkpoint metadata. An allowlist
+	// alone is enough — without a session the proxy 407s every request.
+	if m.secretsProxy != nil && (len(cpMeta.SealedTokens) > 0 || len(cpMeta.EgressAllowlist) > 0) {
 		m.secretsProxy.ReregisterSession(sandboxID, netCfg.GuestIP, cpMeta.SealedTokens, cpMeta.EgressAllowlist, cpMeta.TokenHosts)
-		log.Printf("qemu: RestoreFromCheckpoint %s: re-registered secrets proxy session (%d tokens)", sandboxID, len(cpMeta.SealedTokens))
+		log.Printf("qemu: RestoreFromCheckpoint %s: re-registered secrets proxy session (%d tokens, %d allowlist)", sandboxID, len(cpMeta.SealedTokens), len(cpMeta.EgressAllowlist))
 	}
 
 	// Step 8: Update VM instance

--- a/internal/qemu/migration.go
+++ b/internal/qemu/migration.go
@@ -748,11 +748,12 @@ func (m *Manager) PrepareIncomingMigrationWithS3(ctx context.Context, sandboxID,
 	// returning so the source can issue the LiveMigrate RPC immediately
 	// without a races window where the migrated VM is running but the
 	// proxy has no substitution map.
-	if m.secretsProxy != nil && len(secrets.SealedTokens) > 0 {
+	// An allowlist alone is enough — without a session the proxy 407s every request.
+	if m.secretsProxy != nil && (len(secrets.SealedTokens) > 0 || len(secrets.EgressAllowlist) > 0) {
 		if vm, getErr := m.getVM(sandboxID); getErr == nil && vm.network != nil && vm.network.GuestIP != "" {
 			m.secretsProxy.ReregisterSession(sandboxID, vm.network.GuestIP, secrets.SealedTokens, secrets.EgressAllowlist, secrets.TokenHosts)
-			log.Printf("qemu: migration %s: re-registered secrets proxy session (%d tokens, guestIP=%s)",
-				sandboxID, len(secrets.SealedTokens), vm.network.GuestIP)
+			log.Printf("qemu: migration %s: re-registered secrets proxy session (%d tokens, %d allowlist, guestIP=%s)",
+				sandboxID, len(secrets.SealedTokens), len(secrets.EgressAllowlist), vm.network.GuestIP)
 		}
 	}
 

--- a/internal/qemu/snapshot.go
+++ b/internal/qemu/snapshot.go
@@ -486,10 +486,11 @@ func (m *Manager) doWake(ctx context.Context, sandboxID, checkpointKey string, c
 		log.Printf("qemu: wake %s: clock sync failed: %v", sandboxID, err)
 	}
 
-	// Re-register secrets proxy session from persisted tokens.
-	if m.secretsProxy != nil && len(meta.SealedTokens) > 0 {
+	// Re-register secrets proxy session from persisted tokens. An allowlist
+	// alone is enough — without a session the proxy 407s every request.
+	if m.secretsProxy != nil && (len(meta.SealedTokens) > 0 || len(meta.EgressAllowlist) > 0) {
 		m.secretsProxy.ReregisterSession(sandboxID, netCfg.GuestIP, meta.SealedTokens, meta.EgressAllowlist, meta.TokenHosts)
-		log.Printf("qemu: wake %s: re-registered secrets proxy session (%d tokens)", sandboxID, len(meta.SealedTokens))
+		log.Printf("qemu: wake %s: re-registered secrets proxy session (%d tokens, %d allowlist)", sandboxID, len(meta.SealedTokens), len(meta.EgressAllowlist))
 	}
 	// Refresh the proxy CA in the guest's trust store. Wake may land on a
 	// different worker than the one that hibernated the sandbox, in which

--- a/internal/secretsproxy/proxy.go
+++ b/internal/secretsproxy/proxy.go
@@ -198,12 +198,14 @@ func (p *SecretsProxy) ReregisterSession(sandboxID, guestIP string, tokens map[s
 // CreateSealedEnvs generates sealed tokens for the given env vars, registers a
 // proxy session, and returns the complete env map to inject into the VM.
 // Includes sealed tokens + proxy config vars (HTTP_PROXY, CA certs, etc.).
-// Returns nil if envVars is empty.
+// Returns nil only if there is nothing to enforce: no envs, no secrets, and no
+// allowlist. An allowlist alone is still enough to require routing through the
+// proxy so the allowlist actually gates egress.
 //
 // allowlist controls which hosts the sandbox can reach (nil = all).
 // secretAllowedHosts maps env var name → allowed hosts for that secret (nil = all allowed hosts).
 func (p *SecretsProxy) CreateSealedEnvs(sandboxID, guestIP, gatewayIP string, plaintextEnvs, secretEnvs map[string]string, allowlist []string, secretAllowedHosts map[string][]string) map[string]string {
-	if len(plaintextEnvs) == 0 && len(secretEnvs) == 0 {
+	if len(plaintextEnvs) == 0 && len(secretEnvs) == 0 && len(allowlist) == 0 {
 		return nil
 	}
 
@@ -237,8 +239,11 @@ func (p *SecretsProxy) CreateSealedEnvs(sandboxID, guestIP, gatewayIP string, pl
 		}
 	}
 
-	// Only register a proxy session if there's actually something to substitute.
-	if len(tokenMap) > 0 {
+	// Register a proxy session whenever the sandbox has anything for the proxy
+	// to act on: tokens to substitute OR an egress allowlist to enforce. Without
+	// a session the proxy rejects every CONNECT with 407 no_session, so an
+	// allowlist-only store would otherwise leave the sandbox with zero egress.
+	if len(tokenMap) > 0 || len(allowlist) > 0 {
 		p.RegisterSession(guestIP, &Session{
 			SandboxID:  sandboxID,
 			Secrets:    tokenMap,

--- a/internal/secretsproxy/proxy_test.go
+++ b/internal/secretsproxy/proxy_test.go
@@ -1,0 +1,108 @@
+package secretsproxy
+
+import (
+	"io"
+	"log"
+	"reflect"
+	"testing"
+)
+
+// newProxyForTest builds a SecretsProxy with no listener — sufficient for
+// exercising session registration / CreateSealedEnvs without going on the wire.
+//
+// Sets the package-global log output to io.Discard for the duration of the
+// test. bench_test.go leaves log.SetOutput(nil) behind on cleanup, which would
+// otherwise panic any log.Printf in tests that run after it.
+func newProxyForTest(t *testing.T) *SecretsProxy {
+	t.Helper()
+	log.SetOutput(io.Discard)
+	return &SecretsProxy{
+		sessions: make(map[string]*Session),
+		closed:   make(chan struct{}),
+	}
+}
+
+func TestCreateSealedEnvs_AllowlistOnlyRegistersSession(t *testing.T) {
+	p := newProxyForTest(t)
+
+	allowlist := []string{"example.com", "api.openai.com"}
+	envs := p.CreateSealedEnvs("sb-test", "10.0.0.5", "10.0.0.1",
+		map[string]string{"FOO": "bar"}, // user envs
+		nil,                             // no secret envs
+		allowlist,                       // allowlist only
+		nil,
+	)
+
+	if envs == nil {
+		t.Fatal("CreateSealedEnvs returned nil; expected non-nil env map for allowlist-only sandbox")
+	}
+	if envs["HTTPS_PROXY"] == "" {
+		t.Errorf("expected HTTPS_PROXY to be injected when allowlist is set; got %q", envs["HTTPS_PROXY"])
+	}
+
+	got := p.sessions["10.0.0.5"]
+	if got == nil {
+		t.Fatal("no session registered for guest IP; allowlist-only sandboxes must still get a session")
+	}
+	if !reflect.DeepEqual(got.Allowlist, allowlist) {
+		t.Errorf("session allowlist = %v, want %v", got.Allowlist, allowlist)
+	}
+	if len(got.Secrets) != 0 {
+		t.Errorf("session unexpectedly has secrets: %v", got.Secrets)
+	}
+}
+
+func TestCreateSealedEnvs_NoEnvsNoSecretsNoAllowlistReturnsNil(t *testing.T) {
+	p := newProxyForTest(t)
+	envs := p.CreateSealedEnvs("sb-empty", "10.0.0.6", "10.0.0.1", nil, nil, nil, nil)
+	if envs != nil {
+		t.Errorf("expected nil env map when there is nothing to enforce; got %v", envs)
+	}
+	if _, exists := p.sessions["10.0.0.6"]; exists {
+		t.Errorf("did not expect a registered session when there is nothing to enforce")
+	}
+}
+
+func TestCreateSealedEnvs_AllowlistOnlyEnforcesViaSession(t *testing.T) {
+	p := newProxyForTest(t)
+	p.CreateSealedEnvs("sb-allow", "10.0.0.7", "10.0.0.1",
+		map[string]string{"K": "v"},
+		nil,
+		[]string{"example.com"},
+		nil,
+	)
+
+	sess := p.sessions["10.0.0.7"]
+	if sess == nil {
+		t.Fatal("allowlist-only session should be registered")
+	}
+	if !hostAllowed("example.com", sess.Allowlist) {
+		t.Errorf("example.com should be allowed by registered session")
+	}
+	if hostAllowed("evil.com", sess.Allowlist) {
+		t.Errorf("evil.com should NOT be allowed by registered session")
+	}
+}
+
+func TestCreateSealedEnvs_SecretsOnlyStillRegisters(t *testing.T) {
+	// Regression guard: the pre-fix behavior (register only when secrets exist)
+	// must still hold. Sandboxes with secrets but no allowlist get a session.
+	p := newProxyForTest(t)
+	p.CreateSealedEnvs("sb-secret", "10.0.0.8", "10.0.0.1",
+		nil,
+		map[string]string{"API_KEY": "real-secret"},
+		nil,
+		nil,
+	)
+
+	sess := p.sessions["10.0.0.8"]
+	if sess == nil {
+		t.Fatal("session must still register when only secrets are present")
+	}
+	if len(sess.Secrets) != 1 {
+		t.Errorf("expected 1 sealed secret in session; got %d", len(sess.Secrets))
+	}
+	if len(sess.Allowlist) != 0 {
+		t.Errorf("expected empty allowlist; got %v", sess.Allowlist)
+	}
+}


### PR DESCRIPTION
## Summary
- Register a proxy session whenever a sandbox has tokens **or** an egress allowlist; previously the session was only created when the store had ≥1 sealed secret, so allowlist-only stores produced `407 no_session` for every outbound request and the allowlist was dead config.
- Mirror the same fix on the wake / restore-from-checkpoint / cross-worker-migration re-register paths so hibernated sandboxes recover allowlist enforcement on resume.
- Stop `qemu.sealSandboxEnvs` from early-returning when both env maps are empty if an allowlist is set — otherwise `HTTP_PROXY` is never injected and the sandbox bypasses the proxy entirely (worse failure mode: unrestricted egress).

## Background
Reported by USER sandbox couldn't reach an ngrok HOST even though it was in their `XXXX` store's egress allowlist. Worker logs showed the proxy receiving CONNECTs and rejecting with `audit src=… action=rejected reason=no_session`. Root-caused to `internal/secretsproxy/proxy.go` registering a session only when `len(tokenMap) > 0`. Their store had 12 hosts in the allowlist but zero secret entries.

Same `> 0` guard existed in three lifecycle paths:
- `internal/qemu/manager.go:2713` (RestoreFromCheckpoint)
- `internal/qemu/snapshot.go:490` (wake from hibernation)
- `internal/qemu/migration.go:751` (cross-worker migration)

All four are updated to also register/re-register when there's an allowlist alone.

## Test plan
- [x] New unit tests in `internal/secretsproxy/proxy_test.go` covering: allowlist-only registers session, allowlist-only enforces correctly, no-config returns nil, secrets-only still registers (regression).
- [x] `go test ./internal/secretsproxy/...` passes.
- [x] `GOOS=linux GOARCH=amd64 go build ./internal/qemu/...` succeeds.
- [ ] Manual e2e: create allowlist-only store via `oc secret-store create --egress example.com`, create sandbox with at least one env var, `curl https://example.com/` from inside → expect HTTP 200 (was 407 before fix). `curl https://evil.com/` → expect 403 host-not-in-allowlist.
- [ ] Manual e2e: hibernate then wake an allowlist-only sandbox; verify allowlist still enforces.

## Out of scope (separate work)
- Live propagation of `UpdateSecretStore` to running sandboxes (today running sandboxes still need recreation to pick up store updates — same limitation as before this PR).
- Fork-path missing `RecordScaleEvent` billing leak — separate PR.

## Workaround for affected users (no code change)
Add any secret entry to the store, then recreate the sandbox:
```
oc secret set <store-id> KEEPALIVE x
oc sandbox kill <sandbox-id>   # recreate via your normal flow
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)