### PR TITLE
ci(deploy-server): expose PostHog VITE env vars to web build

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -42,6 +42,9 @@ jobs:
             -o bin/opensandbox-server ./cmd/server/
 
       - name: Build web dashboard
+        env:
+          VITE_PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
+          VITE_PUBLIC_POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
         run: cd web && npm ci && npm run build
 
       - name: Package web assets


### PR DESCRIPTION
## Summary
Wires `POSTHOG_PROJECT_TOKEN` and `POSTHOG_HOST` repo secrets into the `Build web dashboard` step of the control-plane deploy workflow, re-exporting them as `VITE_PUBLIC_POSTHOG_PROJECT_TOKEN` and `VITE_PUBLIC_POSTHOG_HOST` so Vite inlines them into `web/dist` at build time.

Without this, the prod bundle's `posthog.init` guard sees no token and stays a no-op — analytics + replay never reach PostHog.

Companion to #223 (the SPA wire-in). Was meant to land in that PR but got missed by the squash-merge.

## Required action before merging
Add two repo secrets at **Settings → Secrets and variables → Actions**:

| Secret | Value |
|---|---|
| `POSTHOG_PROJECT_TOKEN` | the prod project's `phc_*` token (recommend a separate prod PostHog project, not the dev token) |
| `POSTHOG_HOST` | `https://us.i.posthog.com` (or `https://eu.i.posthog.com`) |

Or via CLI:
```sh
gh secret set POSTHOG_PROJECT_TOKEN --repo diggerhq/opencomputer --body 'phc_...'
gh secret set POSTHOG_HOST          --repo diggerhq/opencomputer --body 'https://us.i.posthog.com'
```

## Test plan
- [ ] Add the two secrets above.
- [ ] Merge → workflow runs → check the `Build web dashboard` step doesn't fail.
- [ ] After deploy, on prod: `curl -s https://app.opencomputer.dev/ | grep -oE '/assets/index-[A-Za-z0-9_-]+\.js' | xargs -I{} curl -s "https://app.opencomputer.dev{}" | grep -oE 'phc_[A-Za-z0-9]{10}' | head -1` should print the token prefix.
- [ ] Open prod, log in, click around → `\$pageview` events arrive in PostHog within ~30s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)