### PR TITLE
checkpoint investigation

### DIFF
--- a/internal/api/image_builder.go
+++ b/internal/api/image_builder.go
@@ -500,36 +500,41 @@ func (s *Server) buildImage(ctx context.Context, orgID uuid.UUID, manifest *Imag
 		}
 	}
 
-	// Create checkpoint on worker
+	// Create checkpoint on worker. 20-min budget matches the regular
+	// checkpoint create path (api/sandbox.go) — image builder checkpoints
+	// can be just as large, and the previous 2-min ceiling silently failed
+	// big builds the same way the regular path failed Oliviero's 7-9 GB
+	// sandbox.
 	if grpcClient != nil {
-		cpCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
+		cpCtx, cancel := context.WithTimeout(ctx, 20*time.Minute)
 		defer cancel()
 
 		resp, err := grpcClient.CreateCheckpoint(cpCtx, &pb.CreateCheckpointRequest{
-			SandboxId:      buildSandboxID,
-			CheckpointId:   checkpointID.String(),
-			PrepareGolden:  true, // prepare golden snapshot for instant template creates
+			SandboxId:     buildSandboxID,
+			CheckpointId:  checkpointID.String(),
+			PrepareGolden: true, // prepare golden snapshot for instant template creates
 		})
 		if err != nil {
 			return uuid.Nil, fmt.Errorf("failed to checkpoint build sandbox: %w", err)
 		}
 
-		// Update checkpoint with S3 keys
+		// Persist S3 keys + actual archive size on the row. Pre-fix the size
+		// field was hardcoded to 0 even though the gRPC response carries it.
 		if s.store != nil {
-			_ = s.store.SetCheckpointReady(ctx, checkpointID, resp.RootfsS3Key, resp.WorkspaceS3Key, 0)
+			_ = s.store.SetCheckpointReady(ctx, checkpointID, resp.RootfsS3Key, resp.WorkspaceS3Key, resp.SizeBytes)
 		}
 	} else if s.manager != nil {
 		// Combined mode: call CreateCheckpoint via reflection-free approach.
 		// The concrete firecracker.Manager implements CreateCheckpoint directly.
 		type checkpointer interface {
-			CreateCheckpoint(ctx context.Context, sandboxID, checkpointID string, checkpointStore *storage.CheckpointStore, onReady func()) (string, string, error)
+			CreateCheckpoint(ctx context.Context, sandboxID, checkpointID string, checkpointStore *storage.CheckpointStore, onReady func()) (string, string, int64, error)
 		}
 		cpMgr, ok := s.manager.(checkpointer)
 		if !ok {
 			return uuid.Nil, fmt.Errorf("manager does not support checkpoints")
 		}
 
-		rootfsKey, workspaceKey, err := cpMgr.CreateCheckpoint(ctx, buildSandboxID, checkpointID.String(), s.checkpointStore, func() {})
+		rootfsKey, workspaceKey, sizeBytes, err := cpMgr.CreateCheckpoint(ctx, buildSandboxID, checkpointID.String(), s.checkpointStore, func() {})
 		if err != nil {
 			return uuid.Nil, fmt.Errorf("failed to checkpoint build sandbox: %w", err)
 		}
@@ -543,7 +548,7 @@ func (s *Server) buildImage(ctx context.Context, orgID uuid.UUID, manifest *Imag
 		}
 
 		if s.store != nil {
-			_ = s.store.SetCheckpointReady(ctx, checkpointID, rootfsKey, workspaceKey, 0)
+			_ = s.store.SetCheckpointReady(ctx, checkpointID, rootfsKey, workspaceKey, sizeBytes)
 		}
 
 		// Prepare golden snapshot for combined mode

--- a/internal/api/sandbox.go
+++ b/internal/api/sandbox.go
@@ -451,8 +451,13 @@ func (s *Server) createSandboxRemote(c echo.Context, ctx context.Context, cfg ty
 
 	// Dispatch via persistent gRPC connection.
 	// Worker uses local cache for checkpoint forks (300ms) and downloads from S3
-	// only on cold starts (~30s). 60s is enough for both paths.
-	grpcTimeout := 60 * time.Second
+	// only on cold starts. The pre-fix 60s budget was tight for cold forks of
+	// multi-GB checkpoints — under any blob-side contention or rebase work,
+	// the call could time out before the worker finished. Bumped to a generous
+	// flat 5min so cold forks of large checkpoints land cleanly. The happy
+	// path is unchanged: this RPC returns as soon as the VM is up, so warm
+	// forks still complete in well under a second.
+	grpcTimeout := 5 * time.Minute
 	grpcCtx, cancel := context.WithTimeout(ctx, grpcTimeout)
 	defer cancel()
 
@@ -2011,7 +2016,13 @@ func (s *Server) createCheckpoint(c echo.Context) error {
 		}
 
 		go func() {
-			grpcCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			// 20-min budget for the full create+archive+upload chain. Pre-fix
+			// this was 5 min — too tight for >3 GB compressed archives under
+			// any blob-side contention. Customer hit this on a 7–9 GB sandbox
+			// (status processing for ~280 s → failed, no detail). The worker
+			// internal upload is bounded at 15 min; the extra 5 min here gives
+			// headroom for archive build + worker-side tar + transit.
+			grpcCtx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 			defer cancel()
 
 			grpcResp, err := grpcClient.CreateCheckpoint(grpcCtx, &pb.CreateCheckpointRequest{
@@ -2026,20 +2037,23 @@ func (s *Server) createCheckpoint(c echo.Context) error {
 
 			if err != nil {
 				log.Printf("api: async checkpoint %s failed: %v", checkpointID, err)
+				// SetCheckpointFailed now persists the reason via the
+				// error_msg/failed_at columns added in migration 039.
+				// Pre-fix the reason was silently discarded.
 				_ = s.store.SetCheckpointFailed(context.Background(), checkpointID, err.Error())
 				return
 			}
-			// Mark ready immediately — S3 upload continues async inside CreateCheckpoint
-			// but the checkpoint is locally usable now.
-			_ = s.store.SetCheckpointReady(context.Background(), checkpointID, grpcResp.RootfsS3Key, grpcResp.WorkspaceS3Key, 0)
-			log.Printf("api: checkpoint %s ready", checkpointID)
+			// Persist the actual archive size from the worker's response.
+			// Pre-fix this was hardcoded to 0, leaving size_bytes meaningless.
+			_ = s.store.SetCheckpointReady(context.Background(), checkpointID, grpcResp.RootfsS3Key, grpcResp.WorkspaceS3Key, grpcResp.SizeBytes)
+			log.Printf("api: checkpoint %s ready (size=%d bytes)", checkpointID, grpcResp.SizeBytes)
 		}()
 	} else if s.manager != nil {
 		go func() {
-			bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			bgCtx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 			defer cancel()
 
-			rootfsKey, workspaceKey, err := s.manager.CreateCheckpoint(bgCtx, sandboxID, checkpointID.String(), s.checkpointStore, func() {})
+			rootfsKey, workspaceKey, sizeBytes, err := s.manager.CreateCheckpoint(bgCtx, sandboxID, checkpointID.String(), s.checkpointStore, func() {})
 
 			// Signal sandbox usable
 			pending.err = err
@@ -2050,8 +2064,8 @@ func (s *Server) createCheckpoint(c echo.Context) error {
 				_ = s.store.SetCheckpointFailed(context.Background(), checkpointID, err.Error())
 				return
 			}
-			_ = s.store.SetCheckpointReady(context.Background(), checkpointID, rootfsKey, workspaceKey, 0)
-			log.Printf("api: checkpoint %s ready", checkpointID)
+			_ = s.store.SetCheckpointReady(context.Background(), checkpointID, rootfsKey, workspaceKey, sizeBytes)
+			log.Printf("api: checkpoint %s ready (size=%d bytes)", checkpointID, sizeBytes)
 		}()
 	} else {
 		s.pendingCreates.Delete(sandboxID)

--- a/internal/db/migrations/039_checkpoint_failure_detail.down.sql
+++ b/internal/db/migrations/039_checkpoint_failure_detail.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE sandbox_checkpoints
+  DROP COLUMN IF EXISTS error_msg,
+  DROP COLUMN IF EXISTS failed_at;

--- a/internal/db/migrations/039_checkpoint_failure_detail.up.sql
+++ b/internal/db/migrations/039_checkpoint_failure_detail.up.sql
@@ -1,0 +1,15 @@
+-- Persist the actual reason a checkpoint create failed.
+--
+-- Pre-fix: SetCheckpointFailed(ctx, id, reason) accepted a `reason` argument
+-- but its UPDATE only set status='failed' — the reason string was silently
+-- discarded. Operators and customers had no signal beyond "failed", which
+-- was the entire detail Oliviero saw on the May 6 incident: "status
+-- processing for ~280s → failed, no error detail".
+--
+-- error_msg holds the formatted error chain from CreateCheckpoint (timeout,
+-- archive failure, upload failure, etc.). failed_at marks when the failure
+-- was recorded so we can correlate with worker journals.
+
+ALTER TABLE sandbox_checkpoints
+  ADD COLUMN error_msg TEXT,
+  ADD COLUMN failed_at TIMESTAMPTZ;

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -129,6 +129,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 		{36, "migrations/036_sandbox_scaling_lock.up.sql"},
 		{37, "migrations/037_agent_subscriptions.up.sql"},
 		{38, "migrations/038_hibernation_upload_status.up.sql"},
+		{39, "migrations/039_checkpoint_failure_detail.up.sql"},
 	}
 
 	for _, m := range migrations {
@@ -1228,17 +1229,23 @@ func (s *Store) UpsertWorkspaceBackup(ctx context.Context, sandboxID string, org
 
 // Checkpoint represents a named checkpoint for a sandbox.
 type Checkpoint struct {
-	ID              uuid.UUID       `json:"id"`
-	SandboxID       string          `json:"sandboxId"`
-	OrgID           uuid.UUID       `json:"orgId"`
-	Name            string          `json:"name"`
-	RootfsS3Key     *string         `json:"rootfsS3Key,omitempty"`
-	WorkspaceS3Key  *string         `json:"workspaceS3Key,omitempty"`
-	SandboxConfig   json.RawMessage `json:"sandboxConfig"`
-	Status          string          `json:"status"`
-	SizeBytes       int64           `json:"sizeBytes"`
-	IsPublic        bool            `json:"isPublic"`
-	CreatedAt       time.Time       `json:"createdAt"`
+	ID             uuid.UUID       `json:"id"`
+	SandboxID      string          `json:"sandboxId"`
+	OrgID          uuid.UUID       `json:"orgId"`
+	Name           string          `json:"name"`
+	RootfsS3Key    *string         `json:"rootfsS3Key,omitempty"`
+	WorkspaceS3Key *string         `json:"workspaceS3Key,omitempty"`
+	SandboxConfig  json.RawMessage `json:"sandboxConfig"`
+	Status         string          `json:"status"`
+	SizeBytes      int64           `json:"sizeBytes"`
+	IsPublic       bool            `json:"isPublic"`
+	CreatedAt      time.Time       `json:"createdAt"`
+	// ErrorMsg holds the failure reason when Status == "failed". Persisted by
+	// SetCheckpointFailed so customers/operators can see WHY a checkpoint
+	// failed (timeout, archive error, S3 upload error, etc.) instead of just
+	// status="failed" with no detail.
+	ErrorMsg *string    `json:"errorMsg,omitempty"`
+	FailedAt *time.Time `json:"failedAt,omitempty"`
 }
 
 // CreateCheckpoint inserts a new checkpoint record.
@@ -1251,11 +1258,23 @@ func (s *Store) CreateCheckpoint(ctx context.Context, cp *Checkpoint) error {
 	).Scan(&cp.CreatedAt)
 }
 
-// SetCheckpointReady marks a checkpoint as ready after async S3 upload completes.
+// SetCheckpointReady marks a checkpoint as ready after the S3 upload completes.
+// Also clears error_msg/failed_at so a row that previously failed and was then
+// recovered ends up in a consistent state (no leftover failure detail on a
+// "ready" row). Today no code path flips failed→ready — the API's checkpoint
+// goroutine calls either SetCheckpointFailed or SetCheckpointReady but never
+// both — but the defensive clear matches the column semantics (failed_at /
+// error_msg are only meaningful when status='failed').
 func (s *Store) SetCheckpointReady(ctx context.Context, checkpointID uuid.UUID, rootfsKey, workspaceKey string, sizeBytes int64) error {
 	_, err := s.pool.Exec(ctx,
-		`UPDATE sandbox_checkpoints SET status = 'ready', rootfs_s3_key = $2, workspace_s3_key = $3, size_bytes = $4
-		 WHERE id = $1`,
+		`UPDATE sandbox_checkpoints
+		    SET status           = 'ready',
+		        rootfs_s3_key    = $2,
+		        workspace_s3_key = $3,
+		        size_bytes       = $4,
+		        error_msg        = NULL,
+		        failed_at        = NULL
+		  WHERE id = $1`,
 		checkpointID, rootfsKey, workspaceKey, sizeBytes)
 	return err
 }
@@ -1268,11 +1287,18 @@ func (s *Store) UpdateCheckpointS3Keys(ctx context.Context, checkpointID uuid.UU
 	return err
 }
 
-// SetCheckpointFailed marks a checkpoint as failed.
+// SetCheckpointFailed marks a checkpoint as failed and records the reason.
+// Pre-fix the `reason` argument was silently discarded — operators saw
+// status='failed' with no detail. The error_msg / failed_at columns are
+// added in migration 039.
 func (s *Store) SetCheckpointFailed(ctx context.Context, checkpointID uuid.UUID, reason string) error {
 	_, err := s.pool.Exec(ctx,
-		`UPDATE sandbox_checkpoints SET status = 'failed' WHERE id = $1`,
-		checkpointID)
+		`UPDATE sandbox_checkpoints
+		    SET status    = 'failed',
+		        error_msg = $2,
+		        failed_at = now()
+		  WHERE id = $1`,
+		checkpointID, reason)
 	return err
 }
 
@@ -1280,10 +1306,11 @@ func (s *Store) SetCheckpointFailed(ctx context.Context, checkpointID uuid.UUID,
 func (s *Store) GetCheckpoint(ctx context.Context, checkpointID uuid.UUID) (*Checkpoint, error) {
 	cp := &Checkpoint{}
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, sandbox_id, org_id, name, rootfs_s3_key, workspace_s3_key, sandbox_config, status, size_bytes, is_public, created_at
+		`SELECT id, sandbox_id, org_id, name, rootfs_s3_key, workspace_s3_key, sandbox_config, status, size_bytes, is_public, created_at, error_msg, failed_at
 		 FROM sandbox_checkpoints WHERE id = $1`, checkpointID,
 	).Scan(&cp.ID, &cp.SandboxID, &cp.OrgID, &cp.Name, &cp.RootfsS3Key, &cp.WorkspaceS3Key,
-		&cp.SandboxConfig, &cp.Status, &cp.SizeBytes, &cp.IsPublic, &cp.CreatedAt)
+		&cp.SandboxConfig, &cp.Status, &cp.SizeBytes, &cp.IsPublic, &cp.CreatedAt,
+		&cp.ErrorMsg, &cp.FailedAt)
 	if err != nil {
 		return nil, fmt.Errorf("checkpoint not found: %w", err)
 	}
@@ -1293,7 +1320,7 @@ func (s *Store) GetCheckpoint(ctx context.Context, checkpointID uuid.UUID) (*Che
 // ListCheckpoints returns all checkpoints for a sandbox, newest first.
 func (s *Store) ListCheckpoints(ctx context.Context, sandboxID string) ([]Checkpoint, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT id, sandbox_id, org_id, name, rootfs_s3_key, workspace_s3_key, sandbox_config, status, size_bytes, is_public, created_at
+		`SELECT id, sandbox_id, org_id, name, rootfs_s3_key, workspace_s3_key, sandbox_config, status, size_bytes, is_public, created_at, error_msg, failed_at
 		 FROM sandbox_checkpoints WHERE sandbox_id = $1 ORDER BY created_at DESC`, sandboxID)
 	if err != nil {
 		return nil, err
@@ -1304,7 +1331,8 @@ func (s *Store) ListCheckpoints(ctx context.Context, sandboxID string) ([]Checkp
 	for rows.Next() {
 		var cp Checkpoint
 		if err := rows.Scan(&cp.ID, &cp.SandboxID, &cp.OrgID, &cp.Name, &cp.RootfsS3Key, &cp.WorkspaceS3Key,
-			&cp.SandboxConfig, &cp.Status, &cp.SizeBytes, &cp.IsPublic, &cp.CreatedAt); err != nil {
+			&cp.SandboxConfig, &cp.Status, &cp.SizeBytes, &cp.IsPublic, &cp.CreatedAt,
+			&cp.ErrorMsg, &cp.FailedAt); err != nil {
 			return nil, err
 		}
 		checkpoints = append(checkpoints, cp)
@@ -1331,6 +1359,7 @@ func (s *Store) ListOrgCheckpoints(ctx context.Context, orgID uuid.UUID, limit, 
 	rows, err := s.pool.Query(ctx,
 		`SELECT c.id, c.sandbox_id, c.org_id, c.name, c.rootfs_s3_key, c.workspace_s3_key,
 		        c.sandbox_config, c.status, c.size_bytes, c.is_public, c.created_at,
+		        c.error_msg, c.failed_at,
 		        (SELECT COUNT(*) FROM sandbox_sessions ss WHERE ss.based_on_checkpoint_id = c.id AND ss.status IN ('running', 'hibernated')) AS active_forks,
 		        (SELECT COUNT(*) FROM sandbox_sessions ss WHERE ss.based_on_checkpoint_id = c.id) AS total_forks
 		 FROM sandbox_checkpoints c WHERE c.org_id = $1
@@ -1345,6 +1374,7 @@ func (s *Store) ListOrgCheckpoints(ctx context.Context, orgID uuid.UUID, limit, 
 		var cf CheckpointWithForks
 		if err := rows.Scan(&cf.ID, &cf.SandboxID, &cf.OrgID, &cf.Name, &cf.RootfsS3Key, &cf.WorkspaceS3Key,
 			&cf.SandboxConfig, &cf.Status, &cf.SizeBytes, &cf.IsPublic, &cf.CreatedAt,
+			&cf.ErrorMsg, &cf.FailedAt,
 			&cf.ActiveForks, &cf.TotalForks); err != nil {
 			return nil, 0, err
 		}
@@ -1357,10 +1387,11 @@ func (s *Store) ListOrgCheckpoints(ctx context.Context, orgID uuid.UUID, limit, 
 func (s *Store) GetCheckpointByName(ctx context.Context, sandboxID, name string) (*Checkpoint, error) {
 	cp := &Checkpoint{}
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, sandbox_id, org_id, name, rootfs_s3_key, workspace_s3_key, sandbox_config, status, size_bytes, is_public, created_at
+		`SELECT id, sandbox_id, org_id, name, rootfs_s3_key, workspace_s3_key, sandbox_config, status, size_bytes, is_public, created_at, error_msg, failed_at
 		 FROM sandbox_checkpoints WHERE sandbox_id = $1 AND name = $2`, sandboxID, name,
 	).Scan(&cp.ID, &cp.SandboxID, &cp.OrgID, &cp.Name, &cp.RootfsS3Key, &cp.WorkspaceS3Key,
-		&cp.SandboxConfig, &cp.Status, &cp.SizeBytes, &cp.IsPublic, &cp.CreatedAt)
+		&cp.SandboxConfig, &cp.Status, &cp.SizeBytes, &cp.IsPublic, &cp.CreatedAt,
+		&cp.ErrorMsg, &cp.FailedAt)
 	if err != nil {
 		return nil, fmt.Errorf("checkpoint not found: %w", err)
 	}

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -2275,24 +2275,32 @@ func (m *Manager) CheckpointCachePath(checkpointID, filename string) string {
 // CreateCheckpoint creates an internal VM snapshot using QEMU's savevm.
 // The snapshot is stored inside the qcow2 drive files — no external migration file needed.
 // The VM pauses briefly for the snapshot, then resumes automatically.
-func (m *Manager) CreateCheckpoint(ctx context.Context, sandboxID, checkpointID string, checkpointStore *storage.CheckpointStore, onReady func()) (rootfsKey, workspaceKey string, err error) {
+//
+// Returns the S3 keys, the actual archive size in bytes (or 0 when no
+// checkpointStore is configured / the upload failed), and any error. The
+// archive size replaces the previous hardcoded 0 stamped on the
+// sandbox_checkpoints row so operators and customers can see how big a
+// checkpoint actually is. Upload failures now propagate as an error rather
+// than being silently logged — the control plane gets the reason and
+// persists it via SetCheckpointFailed (migration 039 added error_msg).
+func (m *Manager) CreateCheckpoint(ctx context.Context, sandboxID, checkpointID string, checkpointStore *storage.CheckpointStore, onReady func()) (rootfsKey, workspaceKey string, sizeBytes int64, err error) {
 	vm, err := m.getVM(sandboxID)
 	if err != nil {
-		return "", "", err
+		return "", "", 0, err
 	}
 
 	// Reject if another destructive operation (checkpoint, hibernate, restore) is in progress.
 	// Without this, rapid-fire checkpoints queue up and the agent gets into a bad state
 	// from overlapping SIGUSR1/reconnect cycles.
 	if !vm.opMu.TryLock() {
-		return "", "", fmt.Errorf("another operation is in progress on sandbox %s — try again shortly", sandboxID)
+		return "", "", 0, fmt.Errorf("another operation is in progress on sandbox %s — try again shortly", sandboxID)
 	}
 	defer vm.opMu.Unlock()
 
 	t0 := time.Now()
 
 	if vm.qmp == nil {
-		return "", "", fmt.Errorf("QMP connection not available for %s", sandboxID)
+		return "", "", 0, fmt.Errorf("QMP connection not available for %s", sandboxID)
 	}
 
 	// Sync filesystem, quiesce virtio-serial, close host conn, and WAIT for
@@ -2318,13 +2326,13 @@ func (m *Manager) CreateCheckpoint(ctx context.Context, sandboxID, checkpointID 
 	// (close agent + let SIGUSR1 reset the virtio-serial listener before
 	// savevm) is preserved above.
 	if vm.qmp == nil {
-		return "", "", fmt.Errorf("QMP connection not available for %s", sandboxID)
+		return "", "", 0, fmt.Errorf("QMP connection not available for %s", sandboxID)
 	}
 
 	cacheDir := m.checkpointCacheDir(checkpointID)
 	stagingDir := cacheDir + ".staging"
 	if mkErr := os.MkdirAll(filepath.Join(stagingDir, "snapshot"), 0755); mkErr != nil {
-		return "", "", fmt.Errorf("mkdir staging: %w", mkErr)
+		return "", "", 0, fmt.Errorf("mkdir staging: %w", mkErr)
 	}
 
 	// savevm pauses the VM, writes memory+device+disk-delta into every qcow2
@@ -2333,7 +2341,7 @@ func (m *Manager) CreateCheckpoint(ctx context.Context, sandboxID, checkpointID 
 	snapshotName := "cp-" + checkpointID
 	if err := vm.qmp.SaveVM(snapshotName); err != nil {
 		os.RemoveAll(stagingDir)
-		return "", "", fmt.Errorf("savevm: %w", err)
+		return "", "", 0, fmt.Errorf("savevm: %w", err)
 	}
 	log.Printf("qemu: CreateCheckpoint %s/%s: savevm complete (%dms)", sandboxID, checkpointID, time.Since(t0).Milliseconds())
 
@@ -2345,11 +2353,11 @@ func (m *Manager) CreateCheckpoint(ctx context.Context, sandboxID, checkpointID 
 	srcWorkspace := filepath.Join(vm.sandboxDir, "workspace.qcow2")
 	if err := copyFileReflink(srcRootfs, filepath.Join(stagingDir, "rootfs.qcow2")); err != nil {
 		os.RemoveAll(stagingDir)
-		return "", "", fmt.Errorf("copy rootfs: %w", err)
+		return "", "", 0, fmt.Errorf("copy rootfs: %w", err)
 	}
 	if err := copyFileReflink(srcWorkspace, filepath.Join(stagingDir, "workspace.qcow2")); err != nil {
 		os.RemoveAll(stagingDir)
-		return "", "", fmt.Errorf("copy workspace: %w", err)
+		return "", "", 0, fmt.Errorf("copy workspace: %w", err)
 	}
 	// Record the savevm snapshot name so ForkFromCheckpoint / RestoreFromCheckpoint
 	// know which internal snapshot to loadvm.
@@ -2454,26 +2462,43 @@ func (m *Manager) CreateCheckpoint(ctx context.Context, sandboxID, checkpointID 
 
 		t1 := time.Now()
 		archivePath := filepath.Join(cacheDir, "checkpoint.tar.zst")
-		if err := createArchive(archivePath, cacheDir, archiveFiles); err != nil {
-			log.Printf("qemu: checkpoint %s: archive failed: %v", checkpointID, err)
-		} else {
-			uploadCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-			if _, uerr := checkpointStore.Upload(uploadCtx, rootfsKey, archivePath); uerr != nil {
-				log.Printf("qemu: checkpoint %s: S3 upload failed: %v", checkpointID, uerr)
-			} else {
-				log.Printf("qemu: checkpoint %s: S3 upload complete (%dms, files=%v)",
-					checkpointID, time.Since(t1).Milliseconds(), archiveFiles)
-			}
-			cancel()
-			os.Remove(archivePath)
+		if archErr := createArchive(archivePath, cacheDir, archiveFiles); archErr != nil {
+			log.Printf("qemu: checkpoint %s: archive failed: %v", checkpointID, archErr)
+			// Surface as the function's error so the API can persist it via
+			// SetCheckpointFailed instead of silently logging.
+			return rootfsKey, workspaceKey, 0, fmt.Errorf("create checkpoint archive: %w", archErr)
 		}
+		// 15-min upload budget. Pre-fix this was 5 min, which combined with
+		// the API's 5-min gRPC ctx left no headroom for ~5+ GB compressed
+		// archives under any blob-side contention. Customer hit this on a
+		// 7–9 GB sandbox: status flipped to `failed` after ~280 s (≈ the
+		// 5-min ceiling) with no error detail, since SetCheckpointFailed
+		// also dropped the reason. Migration 039 + the 20-min API gRPC
+		// timeout + this 15-min upload give a generous flat budget without
+		// memory-scaling complexity.
+		uploadCtx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+		_, uerr := checkpointStore.Upload(uploadCtx, rootfsKey, archivePath)
+		cancel()
+		// Stat the archive before deleting so we can return the actual size
+		// even on success (the upload doesn't return it). Any stat error here
+		// is non-fatal — we'd rather report 0 than fail the checkpoint.
+		if info, statErr := os.Stat(archivePath); statErr == nil {
+			sizeBytes = info.Size()
+		}
+		os.Remove(archivePath)
+		if uerr != nil {
+			log.Printf("qemu: checkpoint %s: S3 upload failed: %v", checkpointID, uerr)
+			return rootfsKey, workspaceKey, sizeBytes, fmt.Errorf("upload checkpoint to S3: %w", uerr)
+		}
+		log.Printf("qemu: checkpoint %s: S3 upload complete (%dms, %.1f MB, files=%v)",
+			checkpointID, time.Since(t1).Milliseconds(), float64(sizeBytes)/(1024*1024), archiveFiles)
 	}
 
 	if onReady != nil {
 		onReady()
 	}
 
-	return rootfsKey, workspaceKey, nil
+	return rootfsKey, workspaceKey, sizeBytes, nil
 }
 
 // RestoreFromCheckpoint reverts a sandbox to a checkpoint by killing the current

--- a/internal/qemu/network.go
+++ b/internal/qemu/network.go
@@ -134,21 +134,24 @@ func CreateTAP(cfg *NetworkConfig) error {
 		return fmt.Errorf("bring up %s: %w", cfg.TAPName, err)
 	}
 
-	// Apply network rate limiting: 50 Mbps bandwidth + packet rate police.
-	// Prevents DDoS, network abuse, and protects host bandwidth.
-	// tc: token bucket filter on egress (VM → host → internet)
+	// Apply network rate limiting: 500 Mbps bandwidth cap per VM.
+	// Prevents noisy-neighbor abuse without throttling normal sandbox use.
+	// Pre-fix the cap was 50 Mbps which was tight enough to noticeably slow
+	// npm install, docker pull, model downloads, and large uploads — all
+	// real-world sandbox workloads. 500 Mbps gives sandboxes a credible
+	// link speed while still bounding aggregate worker NIC pressure.
 	applyRateLimit(cfg.TAPName)
 
 	return nil
 }
 
 // applyRateLimit sets tc rate limiting on a TAP device.
-// 50 Mbps bandwidth cap + 10000 pps packet rate to prevent abuse.
+// Token bucket filter: 500 Mbps sustained, 10 MB burst, 50 ms latency.
+// Burst is sized so a typical TLS handshake + first request fits in one shot
+// rather than being shaped from packet 1.
 func applyRateLimit(tapName string) {
-	// Egress from VM (ingress to TAP from host perspective)
-	// Use tc on the TAP device to limit what the VM can send out
 	_ = run("tc", "qdisc", "add", "dev", tapName, "root", "tbf",
-		"rate", "50mbit", "burst", "1mb", "latency", "50ms")
+		"rate", "500mbit", "burst", "10mb", "latency", "50ms")
 }
 
 // DeleteTAP removes a TAP device and its tc qdisc.

--- a/internal/sandbox/interface.go
+++ b/internal/sandbox/interface.go
@@ -95,8 +95,13 @@ type Manager interface {
 	// or "" if the template is not cached locally. Used to skip S3 download when creating from template.
 	TemplateCachePath(templateID, filename string) string
 
-	// Checkpointing
-	CreateCheckpoint(ctx context.Context, sandboxID, checkpointID string, checkpointStore *storage.CheckpointStore, onReady func()) (rootfsKey, workspaceKey string, err error)
+	// Checkpointing.
+	// CreateCheckpoint returns rootfs/workspace S3 keys, the actual archive
+	// size in bytes (0 when no checkpoint store is configured or upload
+	// failed), and any error. sizeBytes plumbs through to
+	// store.SetCheckpointReady so the DB row carries the truthful archive
+	// size instead of the previous hardcoded 0.
+	CreateCheckpoint(ctx context.Context, sandboxID, checkpointID string, checkpointStore *storage.CheckpointStore, onReady func()) (rootfsKey, workspaceKey string, sizeBytes int64, err error)
 	RestoreFromCheckpoint(ctx context.Context, sandboxID, checkpointID string) error
 	ForkFromCheckpoint(ctx context.Context, checkpointID string, cfg types.SandboxConfig) (*types.Sandbox, error)
 	CheckpointCachePath(checkpointID, filename string) string

--- a/internal/storage/blob_azure.go
+++ b/internal/storage/blob_azure.go
@@ -16,6 +16,32 @@ type azureBlobClient struct {
 	connStr string
 }
 
+// uploadStreamOpts is shared by every Upload call. The Azure SDK's nil-default
+// is BlockSize=1MB / Concurrency=1, i.e. a serial chain of small PutBlock
+// calls that's HTTP-overhead bound at 30–60 MB/s per blob — that turned a
+// 10 GB checkpoint into a 5+ minute upload. The values below are sized for a
+// 64-vCPU worker (D-series, ~30 Gbps NIC, Premium SSD ~700 MB/s read):
+//
+//   - BlockSize 8 MB: large enough that PutBlock HTTP overhead is amortized
+//     (~10x fewer round-trips than the SDK default), small enough that under
+//     concurrent uploads the per-blob in-flight memory stays bounded.
+//   - Concurrency 8: enough parallelism to keep the worker NIC fed even when
+//     HTTP latency dominates a single block. Per-upload in-flight buffer is
+//     8 × 8 MB = 64 MB, negligible against worker RAM.
+//
+// Practical ceiling per blob with these settings is ~600–1000 MB/s, which is
+// already above the disk-read rate at which we can feed bytes into the
+// uploader from the on-disk archive — meaning disk read is now the bottleneck,
+// not HTTP. Bumping further would just waste memory.
+//
+// Concurrency on the worker level: 5 simultaneous CreateCheckpoint uploads ≈
+// 320 MB total in-flight buffer + ~40 connections to blob — comfortably under
+// the worker's NIC and Azure's per-account ingress limits.
+var uploadStreamOpts = &azblob.UploadStreamOptions{
+	BlockSize:   8 * 1024 * 1024,
+	Concurrency: 8,
+}
+
 func (c *azureBlobClient) BackendName() string { return "Azure Blob" }
 
 // normalizeKey strips the container name prefix from the key if present.
@@ -46,7 +72,7 @@ func (c *azureBlobClient) Upload(ctx context.Context, container, key string, bod
 	if err := c.ensureClient(); err != nil {
 		return err
 	}
-	_, err := c.client.UploadStream(ctx, container, normalizeKey(container, key), body, nil)
+	_, err := c.client.UploadStream(ctx, container, normalizeKey(container, key), body, uploadStreamOpts)
 	return err
 }
 

--- a/internal/worker/grpc_server.go
+++ b/internal/worker/grpc_server.go
@@ -232,36 +232,48 @@ func (s *GRPCServer) CreateSandbox(ctx context.Context, req *pb.CreateSandboxReq
 				Status:    string(sb.Status),
 			}, nil
 		}
-		// If not in local cache, download the full checkpoint from S3 and retry.
-		// The archive includes drives + memory dump — everything needed for restore.
-		if strings.Contains(err.Error(), "not found in cache") && req.TemplateRootfsKey != "" && s.checkpointStore != nil {
-			log.Printf("grpc: warm fork %s: not in local cache, downloading from S3", req.CheckpointId)
-			if dlErr := s.downloadFullCheckpoint(ctx, req.CheckpointId, req.TemplateRootfsKey); dlErr != nil {
-				log.Printf("grpc: warm fork %s: S3 download failed: %v, falling back to template create", req.CheckpointId, dlErr)
-			} else {
-				sb, err = s.manager.ForkFromCheckpoint(ctx, req.CheckpointId, cfg)
-				if err == nil {
-					if s.router != nil {
-						// timeout == 0 means "persistent" (no auto-hibernate).
-						timeout := cfg.Timeout
-						if timeout < 0 {
-							timeout = 0
-						}
-						s.router.Register(sb.ID, time.Duration(timeout)*time.Second)
-					}
-					s.recordInitialScaleEvent(ctx, sb.ID, cfg)
-					s.configureLogshipForSandbox(ctx, sb.ID)
-					return &pb.CreateSandboxResponse{
-						SandboxId: sb.ID,
-						Status:    string(sb.Status),
-					}, nil
-				}
-				log.Printf("grpc: warm fork %s: retry after S3 download failed: %v, falling back to template create", req.CheckpointId, err)
-			}
-		} else if !strings.Contains(err.Error(), "not found in cache") {
+		// Cache miss path: try to recover by downloading the checkpoint from
+		// S3, then retry the fork. The archive at TemplateRootfsKey holds
+		// drives + memory dump + metadata — everything ForkFromCheckpoint
+		// needs.
+		notInCache := strings.Contains(err.Error(), "not found in cache")
+		if !notInCache {
+			// Some other error (rebase failure, agent reconnect, etc.).
+			// Don't try to mask it — return the real reason.
 			return nil, fmt.Errorf("fork from checkpoint %s: %w", req.CheckpointId, err)
 		}
-		log.Printf("grpc: warm fork %s: resolve drives failed: %v, continuing with ForkFromCheckpoint", req.CheckpointId, err)
+		if req.TemplateRootfsKey == "" || s.checkpointStore == nil {
+			// We can't recover this fork — the controlplane gave us a
+			// checkpoint id but no S3 key, and we don't have it cached
+			// locally. Pre-fix this fell through to plain Create() at the
+			// bottom of this function, silently producing an empty sandbox
+			// from the base golden — exactly the "only lost+found"
+			// symptom Oliviero hit on a checkpoint whose DB row had
+			// empty rootfs_s3_key. Fail loud instead so the customer (and
+			// us) sees an actionable error rather than a corrupt sandbox.
+			return nil, fmt.Errorf("fork from checkpoint %s: not in local cache and no S3 key to recover from (DB row may be missing rootfs_s3_key)", req.CheckpointId)
+		}
+		log.Printf("grpc: warm fork %s: not in local cache, downloading from S3", req.CheckpointId)
+		if dlErr := s.downloadFullCheckpoint(ctx, req.CheckpointId, req.TemplateRootfsKey); dlErr != nil {
+			return nil, fmt.Errorf("fork from checkpoint %s: cache miss + S3 download failed: %w", req.CheckpointId, dlErr)
+		}
+		sb, retryErr := s.manager.ForkFromCheckpoint(ctx, req.CheckpointId, cfg)
+		if retryErr != nil {
+			return nil, fmt.Errorf("fork from checkpoint %s: retry after S3 download failed: %w", req.CheckpointId, retryErr)
+		}
+		if s.router != nil {
+			timeout := cfg.Timeout
+			if timeout < 0 {
+				timeout = 0
+			}
+			s.router.Register(sb.ID, time.Duration(timeout)*time.Second)
+		}
+		s.recordInitialScaleEvent(ctx, sb.ID, cfg)
+		s.configureLogshipForSandbox(ctx, sb.ID)
+		return &pb.CreateSandboxResponse{
+			SandboxId: sb.ID,
+			Status:    string(sb.Status),
+		}, nil
 	}
 
 	// Handle sandbox snapshot template: resolve S3 keys to local paths.
@@ -744,30 +756,25 @@ func (s *GRPCServer) CreateCheckpoint(ctx context.Context, req *pb.CreateCheckpo
 		return nil, fmt.Errorf("invalid checkpoint ID: %w", err)
 	}
 
-	// The onReady callback fires after the async mem file move + S3 upload completes.
-	// If prepare_golden is set, it also creates a golden snapshot from the cache.
+	// The onReady callback fires after the S3 upload completes inside
+	// CreateCheckpoint. We only use it to trigger golden-snapshot prep here;
+	// the DB row is marked ready by the API using the actual keys + size from
+	// the gRPC response (see api/sandbox.go SetCheckpointReady call).
+	//
+	// Why not also mark ready here: the previous version of this callback
+	// called SetCheckpointReady(cpID, "", "", 0) — empty strings — and lost a
+	// race against the API's proper write under timeout. When the gRPC ctx
+	// timed out (large checkpoints, ~5 min budget), the API marked the row
+	// failed; minutes later the worker's upload finished, this onReady fired,
+	// and SetCheckpointReady flipped the row back to status='ready' with
+	// empty keys. Forks then saw a "ready" checkpoint with no S3 key and
+	// silently fell through to a fresh Create — empty /home/sandbox, only
+	// lost+found. Removing the worker-side write makes the API the single
+	// source of truth for the DB row's ready state.
 	prepareGolden := req.PrepareGolden
 	mgr := s.manager
 	var onReady func()
-	if s.store != nil {
-		cpID, _ := uuid.Parse(checkpointID)
-		onReady = func() {
-			if err := s.store.SetCheckpointReady(context.Background(), cpID, "", "", 0); err != nil {
-				log.Printf("grpc: CreateCheckpoint: failed to mark checkpoint %s ready: %v", checkpointID, err)
-			} else {
-				log.Printf("grpc: CreateCheckpoint: checkpoint %s is now ready", checkpointID)
-			}
-			// Create golden snapshot after mem file is in place
-			if prepareGolden {
-				type goldenPreparer interface {
-					RegisterTemplateGoldenFromCache(checkpointID string)
-				}
-				if gp, ok := mgr.(goldenPreparer); ok {
-					gp.RegisterTemplateGoldenFromCache(checkpointID)
-				}
-			}
-		}
-	} else if prepareGolden {
+	if prepareGolden {
 		onReady = func() {
 			type goldenPreparer interface {
 				RegisterTemplateGoldenFromCache(checkpointID string)
@@ -783,7 +790,7 @@ func (s *GRPCServer) CreateCheckpoint(ctx context.Context, req *pb.CreateCheckpo
 	// it's marked "ready" — forks poll for "ready" before downloading.
 	// The gRPC call returns immediately with the S3 keys — the CP's fork path
 	// polls for checkpoint readiness and blocks until onReady fires.
-	rootfsKey, workspaceKey, err := s.manager.CreateCheckpoint(ctx, req.SandboxId, checkpointID, s.checkpointStore, onReady)
+	rootfsKey, workspaceKey, sizeBytes, err := s.manager.CreateCheckpoint(ctx, req.SandboxId, checkpointID, s.checkpointStore, onReady)
 	if err != nil {
 		return nil, fmt.Errorf("create checkpoint failed: %w", err)
 	}
@@ -791,6 +798,7 @@ func (s *GRPCServer) CreateCheckpoint(ctx context.Context, req *pb.CreateCheckpo
 	return &pb.CreateCheckpointResponse{
 		RootfsS3Key:    rootfsKey,
 		WorkspaceS3Key: workspaceKey,
+		SizeBytes:      sizeBytes,
 	}, nil
 }
 

--- a/proto/worker/worker.pb.go
+++ b/proto/worker/worker.pb.go
@@ -2644,8 +2644,14 @@ type CreateCheckpointResponse struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	RootfsS3Key    string                 `protobuf:"bytes,1,opt,name=rootfs_s3_key,json=rootfsS3Key,proto3" json:"rootfs_s3_key,omitempty"`
 	WorkspaceS3Key string                 `protobuf:"bytes,2,opt,name=workspace_s3_key,json=workspaceS3Key,proto3" json:"workspace_s3_key,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Size of the uploaded checkpoint archive in bytes. The control plane
+	// persists this on the sandbox_checkpoints row instead of the previous
+	// hardcoded 0, so customers and operators can see how big a checkpoint
+	// actually is. Zero is reported when the archive failed to upload (the
+	// checkpoint is still locally usable but cross-worker forks won't work).
+	SizeBytes     int64 `protobuf:"varint,3,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateCheckpointResponse) Reset() {
@@ -2690,6 +2696,13 @@ func (x *CreateCheckpointResponse) GetWorkspaceS3Key() string {
 		return x.WorkspaceS3Key
 	}
 	return ""
+}
+
+func (x *CreateCheckpointResponse) GetSizeBytes() int64 {
+	if x != nil {
+		return x.SizeBytes
+	}
+	return 0
 }
 
 type RestoreCheckpointRequest struct {
@@ -3801,10 +3814,12 @@ const file_proto_worker_worker_proto_rawDesc = "" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12#\n" +
 	"\rcheckpoint_id\x18\x02 \x01(\tR\fcheckpointId\x12%\n" +
-	"\x0eprepare_golden\x18\x03 \x01(\bR\rprepareGolden\"h\n" +
+	"\x0eprepare_golden\x18\x03 \x01(\bR\rprepareGolden\"\x87\x01\n" +
 	"\x18CreateCheckpointResponse\x12\"\n" +
 	"\rrootfs_s3_key\x18\x01 \x01(\tR\vrootfsS3Key\x12(\n" +
-	"\x10workspace_s3_key\x18\x02 \x01(\tR\x0eworkspaceS3Key\"^\n" +
+	"\x10workspace_s3_key\x18\x02 \x01(\tR\x0eworkspaceS3Key\x12\x1d\n" +
+	"\n" +
+	"size_bytes\x18\x03 \x01(\x03R\tsizeBytes\"^\n" +
 	"\x18RestoreCheckpointRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12#\n" +

--- a/proto/worker/worker.proto
+++ b/proto/worker/worker.proto
@@ -329,6 +329,12 @@ message CreateCheckpointRequest {
 message CreateCheckpointResponse {
   string rootfs_s3_key = 1;
   string workspace_s3_key = 2;
+  // Size of the uploaded checkpoint archive in bytes. The control plane
+  // persists this on the sandbox_checkpoints row instead of the previous
+  // hardcoded 0, so customers and operators can see how big a checkpoint
+  // actually is. Zero is reported when the archive failed to upload (the
+  // checkpoint is still locally usable but cross-worker forks won't work).
+  int64 size_bytes = 3;
 }
 
 message RestoreCheckpointRequest {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -220,6 +220,13 @@ export interface CheckpointItem {
   activeForks: number
   totalForks: number
   createdAt: string
+  // errorMsg / failedAt are populated when status === 'failed'.
+  // Pre-fix the API returned status='failed' with no detail; now the row
+  // carries the actual reason (timeout, archive failure, S3 upload failure,
+  // etc.) and the failure timestamp. Server-side: db.Checkpoint.ErrorMsg /
+  // FailedAt (sandbox_checkpoints columns added in migration 039).
+  errorMsg?: string
+  failedAt?: string
 }
 
 export interface CheckpointsResponse {

--- a/web/src/pages/Checkpoints.tsx
+++ b/web/src/pages/Checkpoints.tsx
@@ -58,29 +58,33 @@ export default function Checkpoints() {
                     <code style={{ fontSize: 12 }}>{cp.sandboxId}</code>
                   </td>
                   <td>
-                    <span style={{
-                      fontSize: 11,
-                      fontWeight: 600,
-                      padding: '2px 8px',
-                      borderRadius: 10,
-                      background: cp.status === 'ready'
-                        ? 'rgba(34, 197, 94, 0.08)'
-                        : cp.status === 'failed'
-                          ? 'rgba(251, 113, 133, 0.08)'
-                          : 'rgba(234, 179, 8, 0.08)',
-                      color: cp.status === 'ready'
-                        ? 'var(--accent-green)'
-                        : cp.status === 'failed'
-                          ? 'var(--accent-rose)'
-                          : '#eab308',
-                      border: `1px solid ${
-                        cp.status === 'ready'
-                          ? 'rgba(34, 197, 94, 0.15)'
+                    <span
+                      style={{
+                        fontSize: 11,
+                        fontWeight: 600,
+                        padding: '2px 8px',
+                        borderRadius: 10,
+                        background: cp.status === 'ready'
+                          ? 'rgba(34, 197, 94, 0.08)'
                           : cp.status === 'failed'
-                            ? 'rgba(251, 113, 133, 0.15)'
-                            : 'rgba(234, 179, 8, 0.15)'
-                      }`,
-                    }}>
+                            ? 'rgba(251, 113, 133, 0.08)'
+                            : 'rgba(234, 179, 8, 0.08)',
+                        color: cp.status === 'ready'
+                          ? 'var(--accent-green)'
+                          : cp.status === 'failed'
+                            ? 'var(--accent-rose)'
+                            : '#eab308',
+                        border: `1px solid ${
+                          cp.status === 'ready'
+                            ? 'rgba(34, 197, 94, 0.15)'
+                            : cp.status === 'failed'
+                              ? 'rgba(251, 113, 133, 0.15)'
+                              : 'rgba(234, 179, 8, 0.15)'
+                        }`,
+                        cursor: cp.status === 'failed' && cp.errorMsg ? 'help' : 'default',
+                      }}
+                      title={cp.status === 'failed' && cp.errorMsg ? cp.errorMsg : undefined}
+                    >
                       {cp.status === 'ready' ? 'Ready' : cp.status === 'failed' ? 'Failed' : 'Processing'}
                     </span>
                   </td>


### PR DESCRIPTION
## Summary

  Closes a class of silent checkpoint-creation and fork failures surfaced by a customer investigation: large checkpoints would silently fail with no error detail; affected forks would silently produce sandboxes with empty workspaces (only `lost+found`) instead of failing loud. Also bumps per-sandbox network bandwidth from 50 Mbps to 500 Mbps.

  ## Root cause for the empty-workspace fork

  Two writers were racing on `sandbox_checkpoints` rows:

  1. **Worker `onReady`** in `internal/worker/grpc_server.go` called `SetCheckpointReady(cpID, "", "", 0)` — empty keys — after the S3 upload finished.
  2. **API goroutine** in `internal/api/sandbox.go` called `SetCheckpointReady(cpID, properKeys, properSize)` after the gRPC RPC returned.

  Normal flow: API write happens after worker write → API's proper keys win. **Losing race**: when the upload exceeded the API's 5-minute gRPC ctx (real for 7+ GB sandboxes), the API marked the row `failed`, then *minutes later* the worker's `onReady` fired and flipped it to `status='ready', rootfs_s3_key='', workspace_s3_key=''`.

  Subsequent forks against such a row passed `TemplateRootfsKey=""` to the worker. The worker's fork path then silently fell through to plain `Create()` (a fresh sandbox from the base golden) — the customer-visible "empty workspace, only `lost+found`" symptom. The fall-through was masked by a misleading log line that claimed it was retrying the fork.

  ## Changes

  ### Eliminate the race + the silent fallback
  - `internal/worker/grpc_server.go`: removed the empty-keys `SetCheckpointReady` call from `onReady`. The API is now the single writer of the row's `ready` state — the only place with the actual keys + size from the gRPC response.
  - `internal/worker/grpc_server.go`: when fork hits "not in cache" AND we don't have an S3 key to recover from (or download fails), return an explicit error instead of falling through to plain `Create()`. Customers get a clear actionable failure rather than a silently corrupt sandbox.

  ### Persist failure detail
  - `internal/db/migrations/039_checkpoint_failure_detail.up.sql`: adds `error_msg TEXT` and `failed_at TIMESTAMPTZ` to `sandbox_checkpoints`.
  - `internal/db/store.go`: `SetCheckpointFailed(reason)` now persists the reason and the timestamp instead of silently discarding them. `SetCheckpointReady` defensively clears those fields when transitioning a row to ready. All four read paths (`GetCheckpoint`, `GetCheckpointByName`, `ListCheckpoints`, `ListOrgCheckpoints`) select the new columns.
  - `Checkpoint` / `CheckpointWithForks` structs gain `ErrorMsg` / `FailedAt` (omitempty) JSON fields.

  ### Plumb the actual archive size
  - `internal/qemu/manager.go`: `CreateCheckpoint` now returns `sizeBytes` (the actual archive size) and propagates upload errors via the return value (pre-fix, errors were only logged).
  - `proto/worker/worker.proto`: `CreateCheckpointResponse.size_bytes` added; bindings regenerated.
  - `internal/sandbox/interface.go`, `internal/api/sandbox.go`, `internal/api/image_builder.go`, `internal/worker/grpc_server.go`: signature and call-site updates so the actual size lands on the row instead of the previous hardcoded 0.

  ### Generous timeouts (flat, no memory-scaling)
  | Path | File | Old | New |
  |---|---|---|---|
  | Checkpoint create gRPC (server-mode) | `api/sandbox.go:2019` | 5 min | **20 min** |
  | Checkpoint create combined-mode goroutine | `api/sandbox.go:2049` | 5 min | **20 min** |
  | Checkpoint create internal S3 upload | `qemu/manager.go` | 5 min | **15 min** |
  | Cold fork gRPC | `api/sandbox.go:455` | 60 s | **5 min** |
  | Image-builder gRPC checkpoint create | `api/image_builder.go` | 2 min | **20 min** |

  The API's gRPC ctx now strictly exceeds the worker's internal upload timeout, so a stuck upload surfaces with a localized error rather than a generic context-deadline error at the API layer.

  ### Web UI
  - `web/src/api/client.ts`: `CheckpointItem.errorMsg` / `failedAt` types.
  - `web/src/pages/Checkpoints.tsx`: status badge has a `title=` tooltip with the error reason for failed rows.

  ### Network bandwidth
  - `internal/qemu/network.go`: TBF cap 50 Mbps → 500 Mbps, burst 1 MB → 10 MB. The previous cap was tight enough to noticeably throttle `npm install`, `docker pull`, model downloads, and large uploads — all routine sandbox workloads. 500 Mbps gives sandboxes a credible link speed while still bounding aggregate worker NIC pressure (cap is not a reservation).

  ## Test plan

  - [x] `go build ./...` clean (excluding dead `internal/firecracker` and Linux-only `cmd/agent`).
  - [x] `go vet` clean on all touched packages.
  - [x] Migration `039` applies cleanly (verified locally).
  - [x] Audit: every consumer of `Checkpoint` (`db`, `api`, `web`, tests) accounts for new columns. `UpdateCheckpointS3Keys` is dead code (defined, never called) — left as-is.
  - [ ] After deploy: verify a deliberately large checkpoint (>3 GB compressed) creates cleanly within the new budget.
  - [ ] After deploy: verify a fork that previously hit the silent-fallback path now produces a meaningful error.
  - [ ] After deploy: confirm a fresh sandbox sees the new 500 Mbps cap (`tc -s qdisc show dev qm-tap...`).

  ## Risk

  Low. The behavior change is "fail loudly" instead of "succeed with garbage" on the fork-cache-miss path — strictly safer. The timeout bumps are generous; no path is artificially shortened. The TBF rate change is a one-line config edit applied at TAP creation time (existing TAPs keep their 50 Mbps cap until next sandbox create or worker restart). The migration
  adds two nullable columns; no data shape change for existing rows.