### PR TITLE
organize .env, point at keyvault

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"strconv"
-	"strings"
 	"os/signal"
 	"syscall"
 
@@ -179,28 +178,24 @@ func main() {
 		var poolName string
 
 		if cfg.AzureSubscriptionID != "" && (cfg.AzureImageID != "" || cfg.AzureKeyVaultName != "") {
-			// Build worker env template — new VMs get this via cloud-init.
-			// GRPC_ADVERTISE, HTTP_ADDR, and WORKER_ID are patched by cloud-init
-			// with the VM's actual private IP and hostname.
-			// Workers need to reach Postgres/Redis on the control plane's private IP,
-			// not localhost. Replace localhost with the control plane's IP.
-			cpIP := os.Getenv("OPENSANDBOX_CONTROLPLANE_IP")
-			workerDBURL := cfg.DatabaseURL
-			workerRedisURL := cfg.RedisURL
-			if cpIP != "" {
-				workerDBURL = strings.ReplaceAll(workerDBURL, "localhost", cpIP)
-				workerDBURL = strings.ReplaceAll(workerDBURL, "127.0.0.1", cpIP)
-				workerRedisURL = strings.ReplaceAll(workerRedisURL, "localhost", cpIP)
-				workerRedisURL = strings.ReplaceAll(workerRedisURL, "127.0.0.1", cpIP)
-			}
-
-			// Warn loud if we're about to bake an empty AXIOM_INGEST_TOKEN
-			// into a worker. Reachable when the server's cfg was empty at
-			// startup but the secret has since been added to KV and no
-			// restart has happened yet — every worker minted from here will
-			// silently skip log shipping.
-			if cfg.AxiomIngestToken == "" {
-				log.Printf("opensandbox: WARNING: spawning Azure-pool worker with empty AXIOM_INGEST_TOKEN — this worker will not ship sandbox session logs (restart this control plane after the secret is in KV)")
+			// Build worker bootstrap env — new VMs get this via cloud-init.
+			// Only per-instance values + the SECRETS_VAULT_NAME pointer go in
+			// here. Everything else (DB/Redis URLs, JWT, S3 creds, sandbox
+			// defaults, domain, Axiom tokens) is loaded from Key Vault at
+			// worker startup by LoadSecretsFromKeyVault.
+			//
+			// GRPC_ADVERTISE, HTTP_ADDR, and WORKER_ID are placeholders that
+			// cloud-init patches with the VM's actual private IP and hostname
+			// (see internal/compute/azure.go's user-data script).
+			//
+			// SECRETS_VAULT_NAME is the linchpin: without it the worker starts
+			// with only this bootstrap env and KV loading no-ops, which means
+			// no DB/Redis/S3 config and a fast crash. The CP's own
+			// SECRETS_VAULT_NAME is reused for spawned workers since they
+			// share a vault.
+			secretsVault := os.Getenv("SECRETS_VAULT_NAME")
+			if secretsVault == "" {
+				log.Printf("opensandbox: WARNING: spawning Azure-pool workers with empty SECRETS_VAULT_NAME — workers will fail to load DB/Redis/S3 config from Key Vault and will crash on startup")
 			}
 
 			workerEnv := fmt.Sprintf(
@@ -212,46 +207,14 @@ func main() {
 					"OPENSANDBOX_IMAGES_DIR=/data/firecracker/images\n"+
 					"OPENSANDBOX_GRPC_ADVERTISE=PLACEHOLDER:9090\n"+
 					"OPENSANDBOX_HTTP_ADDR=http://PLACEHOLDER:8081\n"+
-					"OPENSANDBOX_JWT_SECRET=%s\n"+
 					"OPENSANDBOX_WORKER_ID=PLACEHOLDER\n"+
+					"OPENSANDBOX_PORT=8081\n"+
 					"OPENSANDBOX_REGION=%s\n"+
 					"OPENSANDBOX_MAX_CAPACITY=%d\n"+
-					"OPENSANDBOX_PORT=8081\n"+
-					"OPENSANDBOX_DEFAULT_SANDBOX_MEMORY_MB=%d\n"+
-					"OPENSANDBOX_DEFAULT_SANDBOX_CPUS=%d\n"+
-					"OPENSANDBOX_DATABASE_URL=%s\n"+
-					"OPENSANDBOX_REDIS_URL=%s\n"+
-					"OPENSANDBOX_S3_BUCKET=%s\n"+
-					"OPENSANDBOX_S3_REGION=%s\n"+
-					"OPENSANDBOX_S3_ENDPOINT=%s\n"+
-					"OPENSANDBOX_S3_ACCESS_KEY_ID=%s\n"+
-					"OPENSANDBOX_S3_SECRET_ACCESS_KEY=%s\n"+
-					"OPENSANDBOX_S3_FORCE_PATH_STYLE=%v\n"+
-					"OPENSANDBOX_SANDBOX_DOMAIN=%s\n"+
-					"OPENSANDBOX_DEFAULT_SANDBOX_DISK_MB=%d\n"+
-					"OPENSANDBOX_AZURE_KEY_VAULT_NAME=%s\n"+
-					"SEGMENT_WRITE_KEY=%s\n"+
-					"AXIOM_INGEST_TOKEN=%s\n"+
-					"AXIOM_DATASET=%s\n",
-				cfg.JWTSecret,
+					"SECRETS_VAULT_NAME=%s\n",
 				cfg.Region,
 				cfg.MaxCapacity,
-				cfg.DefaultSandboxMemoryMB,
-				cfg.DefaultSandboxCPUs,
-				workerDBURL,
-				workerRedisURL,
-				cfg.S3Bucket,
-				cfg.S3Region,
-				cfg.S3Endpoint,
-				cfg.S3AccessKeyID,
-				cfg.S3SecretAccessKey,
-				cfg.S3ForcePathStyle,
-				cfg.SandboxDomain,
-				cfg.DefaultSandboxDiskMB,
-				cfg.AzureKeyVaultName,
-				cfg.SegmentWriteKey,
-				cfg.AxiomIngestToken,
-				cfg.AxiomDataset,
+				secretsVault,
 			)
 			workerEnvB64 := base64.StdEncoding.EncodeToString([]byte(workerEnv))
 

--- a/internal/config/keyvault.go
+++ b/internal/config/keyvault.go
@@ -30,43 +30,95 @@ import (
 
 // secretMapping maps Key Vault secret names to environment variable names.
 // Only secrets in this map are loaded — unknown secrets in the vault are ignored.
+//
+// Prefix conventions:
+//
+//	server-*  — loaded only when OPENSANDBOX_MODE=server (control-plane secrets,
+//	            autoscaler/Azure config, billing/auth integrations)
+//	worker-*  — loaded only when OPENSANDBOX_MODE=worker. New worker-only
+//	            secrets are rare; most are shared with the server. Existing
+//	            entries are kept as legacy aliases until the cleanup PR drops them.
+//	shared-*  — loaded in both modes. Use this for any secret or config value
+//	            both binaries consume (DB/Redis URLs, JWT secret, S3, Axiom,
+//	            sandbox defaults, sandbox domain). Prefer this prefix for new
+//	            entries to avoid duplicating values across server-/worker-.
+//	pg-       — grandfathered shared prefix; loaded in both modes.
 var secretMapping = map[string]string{
-	// Server secrets
-	"server-database-url":           "OPENSANDBOX_DATABASE_URL",
-	"server-redis-url":              "OPENSANDBOX_REDIS_URL",
-	"server-jwt-secret":             "OPENSANDBOX_JWT_SECRET",
-	"server-api-key":                "OPENSANDBOX_API_KEY",
-	"server-secret-encryption-key":  "OPENSANDBOX_SECRET_ENCRYPTION_KEY",
-	"server-workos-api-key":         "WORKOS_API_KEY",
-	"server-workos-client-id":       "WORKOS_CLIENT_ID",
-	"server-cf-api-token":           "OPENSANDBOX_CF_API_TOKEN",
-	"server-cf-zone-id":             "OPENSANDBOX_CF_ZONE_ID",
-	"server-stripe-secret-key":      "STRIPE_SECRET_KEY",
-	"server-stripe-webhook-secret":  "STRIPE_WEBHOOK_SECRET",
-	"server-sentry-dsn":             "OPENSANDBOX_SENTRY_DSN",
-	// Legacy Axiom mappings — kept for backwards compat with existing prod
-	// KVs that pre-date the `shared-` prefix. New deploys should use
-	// `shared-axiom-*` instead. Safe to leave: in server mode only
-	// `server-axiom-*` is loaded; in worker mode only `worker-axiom-*`. New
-	// `shared-*` mappings below win for new envs that have only those.
-	"server-axiom-query-token":      "AXIOM_QUERY_TOKEN",
-	"server-axiom-dataset":          "AXIOM_DATASET",
+	// ── Server-only ──────────────────────────────────────────────────────
+	// Auth & API
+	"server-api-key":               "OPENSANDBOX_API_KEY",
+	"server-secret-encryption-key": "OPENSANDBOX_SECRET_ENCRYPTION_KEY",
+	// WorkOS (auth provider)
+	"server-workos-api-key":        "WORKOS_API_KEY",
+	"server-workos-client-id":      "WORKOS_CLIENT_ID",
+	"server-workos-redirect-uri":   "WORKOS_REDIRECT_URI",
+	"server-workos-cookie-domain":  "WORKOS_COOKIE_DOMAIN",
+	"server-workos-frontend-url":   "WORKOS_FRONTEND_URL",
+	// Cloudflare (custom hostnames)
+	"server-cf-api-token":          "OPENSANDBOX_CF_API_TOKEN",
+	"server-cf-zone-id":            "OPENSANDBOX_CF_ZONE_ID",
+	// Stripe (billing)
+	"server-stripe-secret-key":     "STRIPE_SECRET_KEY",
+	"server-stripe-webhook-secret": "STRIPE_WEBHOOK_SECRET",
+	// Observability
+	"server-sentry-dsn":            "OPENSANDBOX_SENTRY_DSN",
+	// Azure compute pool / autoscaler
+	"server-azure-resource-group":     "OPENSANDBOX_AZURE_RESOURCE_GROUP",
+	"server-azure-subscription-id":    "OPENSANDBOX_AZURE_SUBSCRIPTION_ID",
+	"server-azure-vm-size":            "OPENSANDBOX_AZURE_VM_SIZE",
+	"server-azure-subnet-id":          "OPENSANDBOX_AZURE_SUBNET_ID",
+	"server-azure-ssh-public-key":     "OPENSANDBOX_AZURE_SSH_PUBLIC_KEY",
+	"server-azure-worker-identity-id": "OPENSANDBOX_AZURE_WORKER_IDENTITY_ID",
+	"server-azure-key-vault-name":     "OPENSANDBOX_AZURE_KEY_VAULT_NAME",
+	"server-min-workers":              "OPENSANDBOX_MIN_WORKERS",
+	"server-max-workers":              "OPENSANDBOX_MAX_WORKERS",
+	"server-idle-reserve":             "OPENSANDBOX_IDLE_RESERVE",
+	// Legacy server-only duplicates of values now in shared-*. Kept so old KVs
+	// that pre-date the shared- prefix keep working. A follow-up cleanup PR
+	// will drop these once every deployment has a populated shared-* set.
+	"server-database-url":          "OPENSANDBOX_DATABASE_URL",
+	"server-redis-url":             "OPENSANDBOX_REDIS_URL",
+	"server-jwt-secret":            "OPENSANDBOX_JWT_SECRET",
+	"server-axiom-query-token":     "AXIOM_QUERY_TOKEN",
+	"server-axiom-dataset":         "AXIOM_DATASET",
 
-	// Worker secrets
+	// ── Worker-only ──────────────────────────────────────────────────────
+	// Observability
+	"worker-sentry-dsn": "OPENSANDBOX_SENTRY_DSN",
+	// Legacy worker-only duplicates of values now in shared-*. Same story as
+	// the server- legacy block: kept so unmigrated KVs still work; cleanup PR
+	// drops them.
 	"worker-jwt-secret":         "OPENSANDBOX_JWT_SECRET",
 	"worker-database-url":       "OPENSANDBOX_DATABASE_URL",
 	"worker-redis-url":          "OPENSANDBOX_REDIS_URL",
 	"worker-s3-access-key":      "OPENSANDBOX_S3_ACCESS_KEY_ID",
 	"worker-s3-secret-key":      "OPENSANDBOX_S3_SECRET_ACCESS_KEY",
-	"worker-sentry-dsn":         "OPENSANDBOX_SENTRY_DSN",
-	"worker-axiom-ingest-token": "AXIOM_INGEST_TOKEN", // legacy; superseded by shared-axiom-ingest-token
-	"worker-axiom-dataset":      "AXIOM_DATASET",      // legacy; superseded by shared-axiom-dataset
+	"worker-axiom-ingest-token": "AXIOM_INGEST_TOKEN",
+	"worker-axiom-dataset":      "AXIOM_DATASET",
 
-	// Shared (mode-agnostic — loaded in both server and worker)
-	"pg-password":               "OPENSANDBOX_PG_PASSWORD",
+	// ── Shared (loaded in both modes) ────────────────────────────────────
+	// Connection strings
+	"shared-database-url": "OPENSANDBOX_DATABASE_URL",
+	"shared-redis-url":    "OPENSANDBOX_REDIS_URL",
+	// Auth
+	"shared-jwt-secret": "OPENSANDBOX_JWT_SECRET",
+	// S3 / blob (checkpoint store)
+	"shared-s3-bucket":            "OPENSANDBOX_S3_BUCKET",
+	"shared-s3-region":            "OPENSANDBOX_S3_REGION",
+	"shared-s3-endpoint":          "OPENSANDBOX_S3_ENDPOINT",
+	"shared-s3-access-key-id":     "OPENSANDBOX_S3_ACCESS_KEY_ID",
+	"shared-s3-secret-access-key": "OPENSANDBOX_S3_SECRET_ACCESS_KEY",
+	// Sandbox defaults
+	"shared-sandbox-domain":            "OPENSANDBOX_SANDBOX_DOMAIN",
+	"shared-default-sandbox-memory-mb": "OPENSANDBOX_DEFAULT_SANDBOX_MEMORY_MB",
+	"shared-default-sandbox-cpus":      "OPENSANDBOX_DEFAULT_SANDBOX_CPUS",
+	"shared-default-sandbox-disk-mb":   "OPENSANDBOX_DEFAULT_SANDBOX_DISK_MB",
+	// Axiom (sandbox session logs)
 	"shared-axiom-ingest-token": "AXIOM_INGEST_TOKEN",
 	"shared-axiom-query-token":  "AXIOM_QUERY_TOKEN",
 	"shared-axiom-dataset":      "AXIOM_DATASET",
+	// Postgres (grandfathered shared prefix)
+	"pg-password": "OPENSANDBOX_PG_PASSWORD",
 }
 
 // LoadSecretsFromKeyVault fetches secrets from Azure Key Vault and sets them

--- a/internal/config/keyvault.go
+++ b/internal/config/keyvault.go
@@ -58,8 +58,14 @@ var secretMapping = map[string]string{
 	"server-cf-api-token":          "OPENSANDBOX_CF_API_TOKEN",
 	"server-cf-zone-id":            "OPENSANDBOX_CF_ZONE_ID",
 	// Stripe (billing)
-	"server-stripe-secret-key":     "STRIPE_SECRET_KEY",
-	"server-stripe-webhook-secret": "STRIPE_WEBHOOK_SECRET",
+	"server-stripe-secret-key":              "STRIPE_SECRET_KEY",
+	"server-stripe-webhook-secret":          "STRIPE_WEBHOOK_SECRET",
+	"server-stripe-success-url":             "STRIPE_SUCCESS_URL",
+	"server-stripe-cancel-url":              "STRIPE_CANCEL_URL",
+	"server-stripe-telegram-agent-price-id": "STRIPE_TELEGRAM_AGENT_PRICE_ID",
+	// Public-facing CP URL (different from per-instance worker HTTP_ADDR which
+	// stays as bootstrap)
+	"server-http-addr": "OPENSANDBOX_HTTP_ADDR",
 	// Observability
 	"server-sentry-dsn":            "OPENSANDBOX_SENTRY_DSN",
 	// Azure compute pool / autoscaler
@@ -113,6 +119,11 @@ var secretMapping = map[string]string{
 	"shared-default-sandbox-memory-mb": "OPENSANDBOX_DEFAULT_SANDBOX_MEMORY_MB",
 	"shared-default-sandbox-cpus":      "OPENSANDBOX_DEFAULT_SANDBOX_CPUS",
 	"shared-default-sandbox-disk-mb":   "OPENSANDBOX_DEFAULT_SANDBOX_DISK_MB",
+	"shared-max-capacity":              "OPENSANDBOX_MAX_CAPACITY",
+	// S3 client knob
+	"shared-s3-force-path-style": "OPENSANDBOX_S3_FORCE_PATH_STYLE",
+	// Analytics — both binaries write Segment events
+	"shared-segment-write-key": "SEGMENT_WRITE_KEY",
 	// Axiom (sandbox session logs)
 	"shared-axiom-ingest-token": "AXIOM_INGEST_TOKEN",
 	"shared-axiom-query-token":  "AXIOM_QUERY_TOKEN",


### PR DESCRIPTION
## Summary

Reorganizes runtime config so Key Vault is the source of truth for everything that isn't strictly per-instance bootstrap. `.env` files keep covering the bootstrap (mode, region, paths, ports, per-worker IDs, the KV pointer); KV holds everything else — DB/Redis URLs, JWT secret, S3 credentials, sandbox defaults, autoscaler/Azure config, billing keys, observability tokens, and so on.

This PR is the code half. The prod-side prep (populating `opencomputer-prod-kv`, fixing drift, and pointing each prod VM at the vault) has already been done out-of-band so the merge can be safely landed without further setup.

## Code changes (two files)

| File | Change |
| --- | --- |
| `internal/config/keyvault.go` | Adds 29 mappings to `secretMapping`. New `shared-*` prefix for values both server and worker need (DB URL, Redis URL, JWT secret, S3, sandbox defaults, sandbox domain, MAX_CAPACITY, S3 path-style, Segment write key, Axiom). Adds the missing `server-*` mappings for autoscaler/Azure pool config, the WorkOS extras, the public CP HTTP_ADDR, the three Stripe URLs (success / cancel / Telegram-agent price ID). Existing `server-*` and `worker-*` entries are kept as legacy aliases so unmigrated KVs continue to work. |
| `cmd/server/main.go` | Thins the `workerEnv` template the autoscaler bakes into new worker VMs via cloud-init. Drops the 14 fat values that are now KV-loaded at worker startup (`JWT_SECRET`, `DATABASE_URL`, `REDIS_URL`, all `S3_*`, sandbox defaults, sandbox domain, Axiom tokens, Segment write key, the dead-on-worker `AZURE_KEY_VAULT_NAME`). Adds `SECRETS_VAULT_NAME` so spawned workers know which KV to query. Drops the `localhost`→`CONTROLPLANE_IP` rewrite block since KV holds real private IPs already. |

## Why merging is safe

`LoadSecretsFromKeyVault` only sets an env var if the var is currently unset (`keyvault.go:111`). With the existing fat `.env` files in place, every value the binary needs is already populated by `EnvironmentFile=` before KV loading runs, so KV-sourced values get skipped. You'll see one log line at startup: `keyvault: loaded N secrets from <vault> (M skipped, already set)` with M >> N. Functional config is byte-for-byte identical to today.

For autoscaler-launched workers: the new `workerEnv` template writes a lean bootstrap `.env` that includes `SECRETS_VAULT_NAME=opencomputer-prod-kv`. The worker boots, KV loads `shared-*` (DB, Redis, JWT, S3, sandbox defaults, domain, etc.) into its empty env, and the worker behaves identically to a worker that booted off the old fat template. **Same end-state, sourced differently.**

## Pre-merge prep (already complete on prod)

| Step | What was done | Where |
| --- | --- | --- |
| Bootstrap pointer | `SECRETS_VAULT_NAME=opencomputer-prod-kv` appended to `/etc/opensandbox/server.env` on `oc-controlplane-2` and to `/etc/opensandbox/worker.env` on each running worker. No restart triggered — picks up on next deploy. | 4 VMs in `opencomputer-prod` |
| KV population | Every value in the live `.env` files that isn't bootstrap (and has a corresponding mapping in this PR's `secretMapping`) is now present in `opencomputer-prod-kv`. 30+ entries added across `shared-*` and `server-*`. | `opencomputer-prod-kv` (62 secrets total, was 31) |
| Drift fix | 4 stale entries in prod KV (`server-database-url`, `server-redis-url`, `worker-database-url`, `worker-redis-url`) all had old `localhost` / wrong CP IP / wrong Redis protocol. All updated to match current `.env`. | `opencomputer-prod-kv` |

The same prep was applied earlier to `opensandbox-dev-kv` and validated end-to-end (smoke test: create sandbox → exec → success).

## What this means for prod after merge

| Path | Behavior |
| --- | --- |
| CP redeploy via CI | Reads new `SECRETS_VAULT_NAME` from `.env`, queries KV, every value is "skipped, already set" → boot identical to today. |
| Existing workers | Untouched. Their `.env` is unchanged, they don't depend on KV. |
| Autoscaler-spawned new workers | Receive lean `worker.env` template via cloud-init, pull `shared-*` from KV, boot cleanly with the same effective env as old fat-template workers. |
| Worker fails to boot from KV | Worker never registers in Redis → `GetLeastLoadedWorker` never picks it → no sandboxes placed → autoscaler terminates after `pendingWorkerTTL` (10 min) and retries with backoff. **Existing sandboxes and workers untouched.** |

## Sentry footnote

`server-sentry-dsn` and `worker-sentry-dsn` were already populated in prod KV (pre-this-PR), but `OPENSANDBOX_SENTRY_DSN` is not in the current `.env`. After the post-merge restart, KV will load that DSN into the env and Sentry will start firing on the CP and any workers that subsequently restart. If that's intended (the values in KV suggest someone deliberately set them up), no action needed; otherwise `az keyvault secret delete` them before the deploy lands.

## Optional: full cutover (separate operation, not in this PR)

When you want `.env` to actually shrink (rather than just be redundant with KV), run a per-VM thin operation:

1. Back up the live `.env` (`cp /etc/opensandbox/server.env /etc/opensandbox/server.env.bak-<ts>`).
2. Replace it with bootstrap-only (mode + region + paths + ports + per-instance IDs + `SECRETS_VAULT_NAME`).
3. `systemctl daemon-reload && systemctl restart opensandbox-{server,worker}`.

After restart, the journalctl log line should show `keyvault: loaded N secrets … M skipped` with N now ≈ 30 on the CP and ≈ 16 on each worker (vs. ~5 pre-cutover; M is the duplication between `server-*`/`worker-*` legacy aliases and `shared-*`).

Rollback for the cutover is `cp /etc/opensandbox/server.env.bak-<ts> /etc/opensandbox/server.env && systemctl daemon-reload && systemctl restart` — ~30 s of CP downtime per VM.

This PR doesn't perform the cutover; it only makes it possible. Cutover is opt-in per environment, applied when convenient, with no coupling to the merge.

## Future cleanup

Once every environment is fully cut over and stable, drop the legacy aliases (`server-database-url`, `server-redis-url`, `server-jwt-secret`, `server-axiom-*`, `worker-database-url`, `worker-redis-url`, `worker-jwt-secret`, `worker-s3-*`, `worker-axiom-*`) from `secretMapping` and `az keyvault secret delete` their KV duplicates. They're functionally redundant with `shared-*` after both prefixes hold the same values, but kept here so unmigrated environments continue to work during the rollout window.