### PR TITLE
api: enforce concurrent sandbox limit on the fork path

### DIFF
--- a/internal/api/sandbox.go
+++ b/internal/api/sandbox.go
@@ -2269,6 +2269,22 @@ func (s *Server) createFromCheckpointCore(c echo.Context, userEnvs map[string]st
 		return nil, http.StatusUnauthorized, fmt.Errorf("org context required")
 	}
 
+	// Enforce per-org concurrency limit on the fork path, mirroring the gate
+	// in the direct-create path at the top of CreateSandbox (around line 50).
+	// Without this, callers using POST /api/sandboxes/from-checkpoint/<id>
+	// (i.e. `oc checkpoint spawn` and equivalent SDK calls) can fork unbounded
+	// sandboxes past their plan's max_concurrent_sandboxes — every other
+	// per-plan gate (free-tier credits, machine size, disk size) is also
+	// missing on this path, but concurrency is the load-bearing one because
+	// it directly drives runaway billing.
+	//
+	// Fail-open on DB errors to match the existing direct-create behavior.
+	if org, gerr := s.store.GetOrg(ctx, orgID); gerr == nil {
+		if count, cerr := s.store.CountActiveSandboxes(ctx, orgID); cerr == nil && count >= org.MaxConcurrentSandboxes {
+			return nil, http.StatusTooManyRequests, fmt.Errorf("concurrent sandbox limit reached")
+		}
+	}
+
 	checkpointID, err := uuid.Parse(checkpointIDStr)
 	if err != nil {
 		return nil, http.StatusBadRequest, fmt.Errorf("invalid checkpoint ID")


### PR DESCRIPTION
## Summary

The direct-create endpoint `POST /api/sandboxes` enforces `org.MaxConcurrentSandboxes` and returns HTTP 429 if the org is at cap (`internal/api/sandbox.go` ~line 50). The fork endpoint `POST /api/sandboxes/from-checkpoint/<id>` — used by `oc checkpoint spawn` and equivalent SDK calls — has **no such gate**.

That means a caller using forks (a common pattern for build/test pipelines) can sail past their plan's `max_concurrent_sandboxes` limit. We've observed an org on a 20-cap plan hit **52 concurrent sandboxes** purely via the fork path. Every sandbox over the cap meters normally, so this directly produces surprise bills proportional to the overrun rather than the intended cap.

## Fix

Add the same `CountActiveSandboxes` ≥ `MaxConcurrentSandboxes` check at the top of `createFromCheckpointCore`, before the checkpoint lookup so over-cap requests fail fast with no DB I/O on the checkpoint:

```go
if org, gerr := s.store.GetOrg(ctx, orgID); gerr == nil {
    if count, cerr := s.store.CountActiveSandboxes(ctx, orgID); cerr == nil && count >= org.MaxConcurrentSandboxes {
        return nil, http.StatusTooManyRequests, fmt.Errorf("concurrent sandbox limit reached")
    }
}
```

Behavior matches the direct-create path:
- HTTP 429 + `"concurrent sandbox limit reached"` on cap violation
- Fail-open on DB errors (matches the `if err == nil` pattern at line 49 of the original)

## Out of scope

Three other per-plan gates live only on the direct-create path and are equally missing from the fork path — listed here so they're not forgotten:

- Free-tier credit exhaustion check (`org.Plan == "free"` ⇒ refuse if `FreeCreditsRemainingCents <= 0`)
- Machine-size restriction for free plans (`MemoryMB > 4096 || CpuCount > 1`)
- Per-org disk-size cap (`MaxDiskMB`)

These should land in a follow-up. None are as load-bearing as concurrency for billing impact, but free-tier abuse via forks is the next-most-likely overrun path.

## Test plan

- [x] `go build ./internal/api/...` — clean
- [x] `go vet ./internal/api/...` — clean
- [x] `go test -count=1 ./internal/api/...` — all pass
- [ ] Manual: hit POST `/api/sandboxes/from-checkpoint/<id>` once when the org is at cap, expect 429
- [ ] Manual: hit it once when under cap, expect normal 201/202

## Note

This is the same class of bug as the existing TOCTOU race in the direct-create path (count → check → create is not atomic). A truly correct fix would do the count + insert in a single transaction with a row-level lock or an advisory lock per org. That's a larger change and worth its own PR; this commit brings the fork path to *parity* with the existing direct-create path, which is the immediate priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)