### PR TITLE
vector: populator uses OPENSANDBOX_AZURE_KEY_VAULT_NAME (prod env match)

### DIFF
--- a/.github/workflows/build-worker-ami.yml
+++ b/.github/workflows/build-worker-ami.yml
@@ -31,6 +31,10 @@ on:
       - 'deploy/azure/setup-azure-host.sh'
       - 'deploy/ec2/build-rootfs-docker.sh'
       - 'deploy/packer/**'
+      # Vector configs + install.sh + KV populator are all baked into the
+      # AMI by the Packer provisioner (deploy/packer/worker-ami.pkr.hcl §4.5).
+      # A change here needs to roll through a new AMI to reach prod workers.
+      - 'deploy/vector/**'
       - 'scripts/claude-agent-wrapper/**'
       - 'go.mod'
       - 'go.sum'

--- a/deploy/vector/populate-vector-env.service
+++ b/deploy/vector/populate-vector-env.service
@@ -1,10 +1,12 @@
-# Pulls AXIOM_PLATFORM_TOKEN from Key Vault via the VM's managed identity
-# and writes /etc/opensandbox/vector.env before vector.service starts.
+# Pulls AXIOM_PLATFORM_TOKEN + AXIOM_PLATFORM_DATASET from Key Vault via
+# the VM's managed identity and writes /etc/opensandbox/vector.env before
+# vector.service starts.
 #
-# Reads SECRETS_VAULT_NAME (and OPENCOMPUTER_CELL_ID/REGION for tagging)
-# from whichever role-env file exists — worker.env on workers, server.env
-# on the control plane. EnvironmentFile lines with a leading `-` are
-# silently skipped if the file is absent, so this unit works on both roles.
+# Reads OPENSANDBOX_AZURE_KEY_VAULT_NAME (and OPENCOMPUTER_CELL_ID /
+# OPENSANDBOX_REGION for tagging) from whichever role-env file exists —
+# worker.env on workers, server.env on the control plane. EnvironmentFile
+# lines with a leading `-` are silently skipped if the file is absent, so
+# this unit works on both roles.
 
 [Unit]
 Description=Populate /etc/opensandbox/vector.env from Key Vault
@@ -12,6 +14,11 @@ After=network-online.target
 Wants=network-online.target
 Before=vector.service
 DefaultDependencies=no
+# Retry budget for the Restart= below. StartLimit* belongs in [Unit] per
+# systemd 229+; in [Service] systemd-255 logs an "Unknown key" warning
+# and ignores them (then Restart=on-failure can crash-loop without a cap).
+StartLimitBurst=5
+StartLimitIntervalSec=120
 
 [Service]
 Type=oneshot
@@ -19,13 +26,11 @@ EnvironmentFile=-/etc/opensandbox/worker.env
 EnvironmentFile=-/etc/opensandbox/server.env
 ExecStart=/usr/local/bin/populate-vector-env.sh
 RemainAfterExit=yes
-# Retry a few times if KV is briefly unreachable at boot.
+# Retry a few times if KV is briefly unreachable at boot. The script
+# itself exits 0 on graceful failure paths (no IMDS, no secret, etc.) so
+# this only fires on truly unexpected errors.
 Restart=on-failure
 RestartSec=10s
-# Cap retries — after this the unit fails; vector still starts (Wants=
-# from vector's drop-in, not Requires=).
-StartLimitBurst=5
-StartLimitIntervalSec=120
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/vector/populate-vector-env.sh
+++ b/deploy/vector/populate-vector-env.sh
@@ -7,8 +7,10 @@
 # vector.service. Idempotent on every boot.
 #
 # Required env (sourced from /etc/opensandbox/worker.env or server.env by
-# the systemd unit's EnvironmentFile=):
-#   SECRETS_VAULT_NAME       Key Vault name (e.g. opencomputer-prod-kv)
+# the systemd unit's EnvironmentFile=). This is the same var the
+# autoscaler bakes into prod worker.env at VM-create time, so the
+# populator picks it up automatically without any extra plumbing.
+#   OPENSANDBOX_AZURE_KEY_VAULT_NAME   Key Vault name (e.g. opencomputer-prod-kv)
 #
 # Optional env (used to enrich Vector's host envelope for non-JSON lines):
 #   OPENCOMPUTER_CELL_ID     e.g. eastus2-default
@@ -24,7 +26,7 @@
 # (don't break the worker boot path over a missing logging credential).
 set -euo pipefail
 
-VAULT_NAME="${SECRETS_VAULT_NAME:-}"
+VAULT_NAME="${OPENSANDBOX_AZURE_KEY_VAULT_NAME:-}"
 ENV_FILE=/etc/opensandbox/vector.env
 TOKEN_SECRET=shared-axiom-platform-ingest-token
 DATASET_SECRET=shared-axiom-platform-dataset
@@ -32,7 +34,7 @@ DATASET_SECRET=shared-axiom-platform-dataset
 log() { logger -t populate-vector-env "$*"; echo "$*"; }
 
 if [ -z "$VAULT_NAME" ]; then
-    log "SECRETS_VAULT_NAME not set — skipping (Vector will start without a token)"
+    log "OPENSANDBOX_AZURE_KEY_VAULT_NAME not set — skipping (Vector will start without a token)"
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

Follow-up to #240. After that merged, control-plane logs flowed into Axiom cleanly but worker logs did not, because the populator (introduced in #240) looks for the vault name under \`SECRETS_VAULT_NAME\` — which isn't what prod workers actually have in their env.

Prod \`/etc/opensandbox/worker.env\` (baked by the autoscaler at VM-create time) sets \`OPENSANDBOX_AZURE_KEY_VAULT_NAME=opencomputer-prod-kv\`. So the populator was silently no-op'ing on every new worker, leaving Vector with no token/dataset → healthcheck fail → systemd start-loop hits the (ignored) cap.

This PR:
- **Switches the populator to read \`OPENSANDBOX_AZURE_KEY_VAULT_NAME\`** directly. No fallback chain — that's the canonical var name in prod, and adding a second alias just hides the contract.
- **Moves \`StartLimitBurst\` / \`StartLimitIntervalSec\` from \`[Service]\` to \`[Unit]\`** in the populator service file. They were in the wrong section per systemd 229+ — silently ignored and logged as "Unknown key name". The visible symptom is the warning lines in journald; the invisible symptom is that the `Restart=on-failure` retry budget had no actual cap.

## Validation

Patched live on \`osb-worker-8c7f81f2\` (a fresh worker from AMI 1.0.71, which had the broken #240 populator baked in) by overriding the vault-name env at populator runtime:

\`\`\`
vault from worker.env: opencomputer-prod-kv
populated /etc/opensandbox/vector.env (token+dataset from opencomputer-prod-kv, host_ip=10.200.1.102)
vector: active
Healthcheck passed.
\`\`\`

No Axiom 403, no event drops in the journal, events flowing for that worker in \`oc-platform-logs-prod\`.

## Rollout

Once this merges:
1. \`build-worker-ami.yml\` rebuilds the worker AMI with the fix.
2. Existing workers (on AMI 1.0.71, broken populator) stay broken until cycled out by the autoscaler — same recycle dynamic as #240's original rollout.
3. To unblock workers already running 1.0.71 *without* waiting for AMI rebuild + recycle, manually trigger the populator via:
   \`\`\`bash
   az vm run-command invoke -g opencomputer-prod -n <worker-name> --command-id RunShellScript --scripts '
     VAULT=\$(sudo grep "^OPENSANDBOX_AZURE_KEY_VAULT_NAME=" /etc/opensandbox/worker.env | cut -d= -f2-)
     sudo -E SECRETS_VAULT_NAME="\$VAULT" bash /usr/local/bin/populate-vector-env.sh
     sudo systemctl restart vector'
   \`\`\`
   (Uses the env-var override trick that worked on osb-worker-8c7f81f2. After the fix lands in a new AMI, new workers won't need this.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)