### PR TITLE
hotfix: cross-tenant leak still present — Axiom drops AND-wrapped filters

### DIFF
--- a/internal/api/sandbox_logs.go
+++ b/internal/api/sandbox_logs.go
@@ -28,10 +28,17 @@ var allowedSources = map[string]struct{}{
 }
 
 // WARNING: Axiom's /v1/datasets/<dataset>/query endpoint silently
-// ignores unknown body fields. Sending `{"apl": "..."}` returns 200
-// with every event in the dataset (no filter applied). Always send the
-// `filter` field, and verify against a real response when changing the
-// body shape.
+// ignores body it doesn't recognize — including AND-wrapped filter
+// trees. Empirically, `{"filter":{"op":"and","filters":[{...}]}}`
+// returns the unfiltered dataset (full leak); only a FLAT predicate
+// `{"filter":{"op":"==","field":"sandbox_id","value":"..."}}` actually
+// narrows. So toFilter() returns a single flat predicate on sandbox_id;
+// secondary filters (text search, source list) are applied client-side
+// in applyClientFilters after the query returns.
+//
+// The Filters slice is kept on the type for potential future
+// composition (e.g. if Axiom adds support, or if we move to /v1/datasets/_apl)
+// but is unset in the current shape.
 type queryFilter struct {
 	Op      string        `json:"op"`
 	Field   string        `json:"field,omitempty"`
@@ -137,6 +144,7 @@ func (s *Server) getSandboxLogs(c echo.Context) error {
 		writeSSEComment(c.Response(), "initial query failed")
 		return nil
 	}
+	rows = applyClientFilters(rows, q)
 	for _, ev := range rows {
 		writeSSEEvent(c.Response(), ev)
 	}
@@ -188,6 +196,7 @@ func (s *Server) getSandboxLogs(c echo.Context) error {
 				log.Printf("api: sandbox %s logs: tail poll failed: %v", sandboxID, err)
 				continue
 			}
+			newRows = applyClientFilters(newRows, tailQ)
 			for _, ev := range newRows {
 				if !ev.Time.After(cursor) {
 					continue
@@ -301,31 +310,47 @@ func (q logQuery) timeWindow(tail bool) (time.Time, time.Time) {
 	return q.since, end
 }
 
-// toFilter: sandbox_id == q.sandboxID is ALWAYS the first conjunct
-// under the top-level AND. Do not add a path that omits or mutates it;
-// the regression test in sandbox_logs_test.go pins this.
+// toFilter returns a FLAT `sandbox_id == q.sandboxID` predicate. Do not
+// wrap it in {op:"and", filters:[...]} — Axiom's per-dataset /query
+// endpoint silently drops AND-wrapped filters and returns the full
+// dataset (cross-tenant leak). The regression test in
+// sandbox_logs_test.go pins the flat shape.
+//
+// Secondary predicates (text search via `q`, source list via `source`)
+// are applied client-side in applyClientFilters after the query
+// returns — Axiom doesn't compose them in the per-dataset filter shape.
 func (q logQuery) toFilter() queryFilter {
-	root := queryFilter{
-		Op: "and",
-		Filters: []queryFilter{
-			{Op: "==", Field: "sandbox_id", Value: q.sandboxID},
-		},
+	return queryFilter{Op: "==", Field: "sandbox_id", Value: q.sandboxID}
+}
+
+// applyClientFilters narrows a row set by predicates Axiom did not apply
+// server-side (text contains, source list). The sandbox_id predicate is
+// always applied by Axiom via toFilter; this function is purely UX —
+// it must NOT be relied on for tenant isolation.
+func applyClientFilters(rows []logEvent, q logQuery) []logEvent {
+	if q.text == "" && len(q.sources) == 0 {
+		return rows
 	}
-	if q.text != "" {
-		root.Filters = append(root.Filters, queryFilter{
-			Op: "contains", Field: "line", Value: q.text,
-		})
-	}
+	var sourceSet map[string]struct{}
 	if len(q.sources) > 0 {
-		srcOr := queryFilter{Op: "or"}
+		sourceSet = make(map[string]struct{}, len(q.sources))
 		for _, s := range q.sources {
-			srcOr.Filters = append(srcOr.Filters, queryFilter{
-				Op: "==", Field: "source", Value: s,
-			})
+			sourceSet[s] = struct{}{}
 		}
-		root.Filters = append(root.Filters, srcOr)
 	}
-	return root
+	out := rows[:0]
+	for _, ev := range rows {
+		if q.text != "" && !strings.Contains(ev.Line, q.text) {
+			continue
+		}
+		if sourceSet != nil {
+			if _, ok := sourceSet[ev.Source]; !ok {
+				continue
+			}
+		}
+		out = append(out, ev)
+	}
+	return out
 }
 
 // toRequest: time range goes in startTime/endTime (server-side bound);

--- a/internal/api/sandbox_logs_test.go
+++ b/internal/api/sandbox_logs_test.go
@@ -8,12 +8,15 @@ import (
 	"time"
 )
 
-// TestFilter_AlwaysFiltersSandboxID is the load-bearing security test:
-// no matter what the user supplies in query params, the rendered filter
-// must have sandbox_id == the URL-path value as the first conjunct under
-// the top-level AND. Break this and a user who can hit
-// /api/sandboxes/X/logs but only owns Y could read X's logs.
-func TestFilter_AlwaysFiltersSandboxID(t *testing.T) {
+// TestFilter_AlwaysFlatSandboxID is the load-bearing security test:
+// no matter what the user supplies in query params, the filter sent
+// to Axiom must be a FLAT `sandbox_id == <url-path>` predicate.
+//
+// Axiom's per-dataset /query endpoint silently drops AND-wrapped
+// filters and returns the unfiltered dataset (verified empirically
+// against api.axiom.co), so a wrapped shape == a tenant leak. The
+// flat shape is the only one Axiom actually honors.
+func TestFilter_AlwaysFlatSandboxID(t *testing.T) {
 	cases := []struct {
 		name string
 		qs   url.Values
@@ -36,36 +39,19 @@ func TestFilter_AlwaysFiltersSandboxID(t *testing.T) {
 			}
 			f := q.toFilter()
 
-			if f.Op != "and" {
-				t.Errorf("top-level op = %q, want and", f.Op)
+			if f.Op != "==" {
+				t.Errorf("filter op = %q, want == (NEVER and/or — Axiom drops those)", f.Op)
 			}
-			if len(f.Filters) == 0 {
-				t.Fatalf("top-level filter has no sub-filters")
+			if f.Field != "sandbox_id" {
+				t.Errorf("filter field = %q, want sandbox_id", f.Field)
 			}
-			first := f.Filters[0]
-			if first.Op != "==" || first.Field != "sandbox_id" || first.Value != "sb-target" {
-				t.Errorf("first conjunct = %+v, want sandbox_id == sb-target", first)
+			if f.Value != "sb-target" {
+				t.Errorf("filter value = %v, want sb-target", f.Value)
+			}
+			if len(f.Filters) != 0 {
+				t.Errorf("filter must be flat (no nested .Filters), got %d sub-filters", len(f.Filters))
 			}
 		})
-	}
-}
-
-// TestFilter_QInjectionStaysInValue: a malicious `q` parameter ends up as
-// a plain string in the JSON value, not as a sibling predicate.
-func TestFilter_QInjectionStaysInValue(t *testing.T) {
-	mal := `" or sandbox_id != "anything`
-	q, err := parseLogQuery("sb-target", time.Now(), url.Values{"q": {mal}})
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	f := q.toFilter()
-	// The text predicate is the second conjunct.
-	if len(f.Filters) < 2 {
-		t.Fatalf("expected at least 2 sub-filters, got %d", len(f.Filters))
-	}
-	txt := f.Filters[1]
-	if txt.Op != "contains" || txt.Field != "line" || txt.Value != mal {
-		t.Errorf("text predicate = %+v, expected contains(line, %q)", txt, mal)
 	}
 }
 
@@ -83,34 +69,15 @@ func TestFilter_RejectsBadSource(t *testing.T) {
 }
 
 // TestFilter_RejectsControlCharsInQ: newlines / NULs in `q` are rejected
-// at parse time to avoid any operator-side quirk with embedded control
-// characters.
+// at parse time. We rely on this since q.text is applied client-side
+// via strings.Contains — any operator-side parsing here is moot, but
+// defending against control chars protects future code paths.
 func TestFilter_RejectsControlCharsInQ(t *testing.T) {
 	for _, bad := range []string{"hello\nworld", "x\x00y", "\r"} {
 		_, err := parseLogQuery("sb-x", time.Now(), url.Values{"q": {bad}})
 		if err == nil {
 			t.Errorf("expected error for q=%q", bad)
 		}
-	}
-}
-
-// TestFilter_SourceList_Or: multiple sources become an OR subtree, not a
-// list-in-value.
-func TestFilter_SourceList_Or(t *testing.T) {
-	q, err := parseLogQuery("sb-x", time.Now(), url.Values{"source": {"exec_stdout,exec_stderr"}})
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
-	f := q.toFilter()
-	if len(f.Filters) < 2 {
-		t.Fatalf("expected sandbox_id + source-or, got %d sub-filters", len(f.Filters))
-	}
-	srcOr := f.Filters[1]
-	if srcOr.Op != "or" {
-		t.Errorf("source subtree op = %q, want or", srcOr.Op)
-	}
-	if len(srcOr.Filters) != 2 {
-		t.Fatalf("source OR has %d filters, want 2", len(srcOr.Filters))
 	}
 }
 
@@ -133,7 +100,7 @@ func TestRequest_TailOmitsLimit(t *testing.T) {
 
 // TestRequest_BodyShape — full marshaled-JSON smoke test. Failure here
 // likely means the body shape has drifted in a way Axiom won't
-// understand; cross-reference against the API docs before changing.
+// understand; verify with an actual Axiom probe before changing.
 func TestRequest_BodyShape(t *testing.T) {
 	q, err := parseLogQuery("sb-x", time.Now().Add(-time.Hour), url.Values{
 		"q":      {"oops"},
@@ -152,10 +119,8 @@ func TestRequest_BodyShape(t *testing.T) {
 	for _, must := range []string{
 		`"startTime":"2026-05-13T00:00:00Z"`,
 		`"endTime":"2026-05-13T01:00:00Z"`,
-		`"filter":{"op":"and",`,
-		`"op":"==","field":"sandbox_id","value":"sb-x"`,
-		`"op":"contains","field":"line","value":"oops"`,
-		`"op":"==","field":"source","value":"exec_stdout"`,
+		// Flat filter — exactly what Axiom honors.
+		`"filter":{"op":"==","field":"sandbox_id","value":"sb-x"}`,
 		`"limit":1000`,
 		`"order":[{"field":"_time"}]`,
 	} {
@@ -163,12 +128,14 @@ func TestRequest_BodyShape(t *testing.T) {
 			t.Errorf("body missing %q:\n%s", must, body)
 		}
 	}
-	// And it must NOT contain an `apl` field — the regression that
-	// caused the cross-tenant leak. The per-dataset endpoint silently
-	// ignores unknown body fields, so {"apl": "..."} comes back with
-	// every event in the dataset.
-	if strings.Contains(string(body), `"apl"`) {
-		t.Errorf("body contains an `apl` field — this is the bug we're guarding against:\n%s", body)
+	// Regression: the body must NOT carry an `apl` field (legacy bug
+	// fixed in #242) AND must NOT use the AND wrapper (broken in #242,
+	// fixed by this change — Axiom silently drops AND-wrapped filter
+	// trees and returns every event in the dataset, see commit message).
+	for _, mustNot := range []string{`"apl"`, `"op":"and"`, `"op":"or"`} {
+		if strings.Contains(string(body), mustNot) {
+			t.Errorf("body contains %q — Axiom drops this shape:\n%s", mustNot, body)
+		}
 	}
 }
 
@@ -181,5 +148,68 @@ func TestParseLogQuery_LimitClamp(t *testing.T) {
 	}
 	if q.limit != 10000 {
 		t.Errorf("expected limit clamped to 10000, got %d", q.limit)
+	}
+}
+
+// TestApplyClientFilters_NoOp: when the query has no text/source
+// narrowing, all rows pass through.
+func TestApplyClientFilters_NoOp(t *testing.T) {
+	rows := []logEvent{
+		{Line: "alpha", Source: "exec_stdout"},
+		{Line: "beta", Source: "var_log"},
+	}
+	got := applyClientFilters(rows, logQuery{})
+	if len(got) != 2 {
+		t.Errorf("got %d rows, want 2 (no narrowing)", len(got))
+	}
+}
+
+// TestApplyClientFilters_TextSubstring: q.text narrows by substring on
+// the line field, case-sensitive (matches Axiom's `contains` operator
+// semantics — we just don't trust Axiom to apply it).
+func TestApplyClientFilters_TextSubstring(t *testing.T) {
+	rows := []logEvent{
+		{Line: "hello world", Source: "exec_stdout"},
+		{Line: "goodbye", Source: "exec_stdout"},
+		{Line: "Hello again", Source: "exec_stdout"},
+	}
+	got := applyClientFilters(rows, logQuery{text: "hello"})
+	if len(got) != 1 || got[0].Line != "hello world" {
+		t.Errorf("got %v, want only 'hello world'", got)
+	}
+}
+
+// TestApplyClientFilters_SourceList: q.sources narrows to the listed
+// sources; events with other source values are dropped.
+func TestApplyClientFilters_SourceList(t *testing.T) {
+	rows := []logEvent{
+		{Line: "a", Source: "exec_stdout"},
+		{Line: "b", Source: "exec_stderr"},
+		{Line: "c", Source: "var_log"},
+		{Line: "d", Source: "agent"},
+	}
+	got := applyClientFilters(rows, logQuery{sources: []string{"exec_stdout", "exec_stderr"}})
+	if len(got) != 2 {
+		t.Fatalf("got %d rows, want 2 (exec_stdout + exec_stderr only)", len(got))
+	}
+	if got[0].Source != "exec_stdout" || got[1].Source != "exec_stderr" {
+		t.Errorf("unexpected sources: %v", got)
+	}
+}
+
+// TestApplyClientFilters_TextAndSourceComposed: both predicates apply
+// (AND semantics — row must satisfy both).
+func TestApplyClientFilters_TextAndSourceComposed(t *testing.T) {
+	rows := []logEvent{
+		{Line: "error in foo", Source: "exec_stderr"},
+		{Line: "error in bar", Source: "var_log"},
+		{Line: "ok in foo", Source: "exec_stderr"},
+	}
+	got := applyClientFilters(rows, logQuery{
+		text:    "error",
+		sources: []string{"exec_stderr"},
+	})
+	if len(got) != 1 || got[0].Line != "error in foo" {
+		t.Errorf("got %v, want only 'error in foo'", got)
 	}
 }


### PR DESCRIPTION
## Summary

**The cross-tenant leak that #242 was supposed to fix is still happening in prod.** I verified by re-running \`./scripts/test-sandbox-logs-isolation.sh\` against the patched server — it still reports the leak. Then I bypassed our handler entirely and probed Axiom directly with the **exact body shape** that the patched server sends, and got the smoking gun:

\`\`\`
test 1: wrapped AND, single conjunct, impossible sandbox_id → 50 events, mixed ids   ❌
test 2: flat ==,     no wrapper,        impossible sandbox_id →  0 events             ✅
test 3: wrapped AND, no filters at all                       → 50 events             ❌
test 4: wrapped AND, real sandbox_id                         → 50 events, mixed ids   ❌
\`\`\`

Axiom's per-dataset \`/v1/datasets/<dataset>/query\` endpoint silently drops AND-wrapped filter trees the same way it dropped the unknown \`apl\` field in the original bug. So #242's switch from \`{"apl":...}\` to \`{"filter":{"op":"and","filters":[...]}}\` was equivalent: another shape Axiom doesn't honor.

Only the **flat** predicate \`{"filter":{"op":"==","field":"sandbox_id","value":"<id>"}}\` actually narrows. Verified:

\`\`\`
flat ==, real sandbox_id sb-5b1696d4 → 13 events, all from sb-5b1696d4
\`\`\`

## Fix

- \`toFilter()\` now returns a flat \`==\` predicate. No \`.Filters\` slice population, no AND wrapper.
- New \`applyClientFilters()\` helper applies text-substring (q) and source-list (source) predicates **client-side**, after \`queryAxiom\` returns. Axiom doesn't compose those in the per-dataset filter shape; trying to AND them with sandbox_id would re-introduce the dropped-wrapper bug.
- Comment on \`queryFilter\` rewritten to warn explicitly about the wrapper trap so the next person isn't tempted to "improve" composition.

## Tests

| Test | Pins |
| --- | --- |
| **TestFilter_AlwaysFlatSandboxID** | The filter is always flat \`==\` on \`sandbox_id\`, no nested filters, regardless of caller input |
| **TestRequest_BodyShape** | The marshaled body must NOT contain \`"apl"\` (legacy #240 bug), \`"op":"and"\` (the #242 bug), or \`"op":"or"\` — any of those = Axiom drops the filter |
| **TestApplyClientFilters_*** (4 tests) | text substring, source list, composed AND of both, no-op pass-through |

All 11 tests pass.

\`\`\`
ok  github.com/opensandbox/opensandbox/internal/api  1.670s
\`\`\`

## Why client-side secondary filters?

The text and source predicates are pure UX, not security. Composing them server-side requires either:

1. AND-wrapping with the sandbox_id predicate → broken (this PR's reason).
2. Switching to the APL endpoint \`/v1/datasets/_apl\` → bigger surface change (URL + response parser).
3. Server-side post-filter → tiny diff, no Axiom-shape dependency.

Going with (3) for the hotfix; (2) is a clean follow-up if we want richer server-side query semantics.

The sandbox_id predicate stays Axiom-side. Tenant isolation does not depend on \`applyClientFilters\` (per its docstring) — even if a future bug skipped it, the events Axiom returned would already be sandbox-scoped.

## Verification before merge

Run \`./scripts/test-sandbox-logs-isolation.sh\` against any deployment that includes this commit. With the leak: it fails with cross-marker hits. With the fix: it prints \`PASS\`.

Direct Axiom probe:
\`\`\`bash
# Should return 0 events:
curl -X POST "https://api.axiom.co/v1/datasets/oc-sandbox-logs/query" \\
  -H "Authorization: Bearer $AXIOM_QUERY_TOKEN" \\
  -d '{"startTime":"...","endTime":"...","filter":{"op":"==","field":"sandbox_id","value":"sb-IMPOSSIBLE"}}'
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)