### PR TITLE
fix(logship): stopped-sandbox event duplication + oc logs 404

### DIFF
--- a/cmd/oc/internal/commands/logs.go
+++ b/cmd/oc/internal/commands/logs.go
@@ -79,7 +79,9 @@ Examples:
 			qs.Set("limit", strconv.Itoa(limit))
 		}
 
-		path := "/api/sandboxes/" + url.PathEscape(sandboxID) + "/logs"
+		// client.New() already appends /api to baseURL — use the bare
+		// path here, matching the convention in exec/sandbox commands.
+		path := "/sandboxes/" + url.PathEscape(sandboxID) + "/logs"
 		if encoded := qs.Encode(); encoded != "" {
 			path += "?" + encoded
 		}

--- a/internal/api/sandbox_logs.go
+++ b/internal/api/sandbox_logs.go
@@ -159,6 +159,26 @@ func (s *Server) getSandboxLogs(c echo.Context) error {
 		return nil
 	}
 
+	// If the sandbox is not running, no new events will arrive — skip
+	// the Axiom poll loop entirely. But keep the SSE connection open
+	// with keepalive comments so the browser EventSource doesn't
+	// interpret a server-side close as a disconnect and auto-reconnect
+	// (which would re-fetch the historical batch and visibly duplicate
+	// events: see the 3× duplication report after #243).
+	if session.Status != "running" {
+		keepalive := time.NewTicker(15 * time.Second)
+		defer keepalive.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-keepalive.C:
+				writeSSEComment(c.Response(), "keepalive")
+				c.Response().Flush()
+			}
+		}
+	}
+
 	// Live tail. Cursor starts at the last historical event's _time.
 	// Tail polls strictly require `ev.Time.After(cursor)`, so events
 	// at exactly the cursor are skipped — no double-emit of historical
@@ -233,16 +253,22 @@ type logQuery struct {
 
 // applySessionState narrows a parsed query based on the sandbox's
 // lifecycle. For stopped/error/hibernated sandboxes:
-//   - tail is forced false (no new events will arrive)
-//   - until is capped at stoppedAt + 30s grace (avoid polling into a void
-//     of empty Axiom windows)
+//   - until is capped at stoppedAt + 30s grace (the in-VM shipper
+//     finishes flushing within a few seconds of process exit; 30s
+//     covers ingest latency comfortably)
+//
+// q.tail is preserved — it reflects the client's explicit intent
+// (URL ?tail=false / CLI --no-tail). The handler reads session.Status
+// separately to decide whether to actually poll Axiom; for non-running
+// sandboxes it holds the SSE connection open with keepalives instead
+// of closing, so the browser EventSource doesn't auto-reconnect and
+// re-fetch the historical batch (which visibly duplicated events).
 //
 // Pure function (no DB dep) so the lifecycle behaviour is unit-testable.
 func applySessionState(q logQuery, status string, stoppedAt *time.Time) logQuery {
 	if status == "running" {
 		return q
 	}
-	q.tail = false
 	if stoppedAt != nil {
 		bound := stoppedAt.Add(30 * time.Second)
 		if q.until.IsZero() || q.until.After(bound) {

--- a/internal/api/sandbox_logs_test.go
+++ b/internal/api/sandbox_logs_test.go
@@ -227,15 +227,26 @@ func TestApplySessionState_RunningPassthrough(t *testing.T) {
 	}
 }
 
-// TestApplySessionState_StoppedForcesHistorical: any non-running status
-// flips tail off. New events can't arrive once the sandbox is gone.
-func TestApplySessionState_StoppedForcesHistorical(t *testing.T) {
-	for _, status := range []string{"stopped", "error", "hibernated", "migrating"} {
+// TestApplySessionState_PreservesTail: q.tail reflects the client's
+// explicit intent (URL ?tail=false / CLI --no-tail) and is NOT
+// rewritten by applySessionState. The handler reads session.Status
+// separately to decide whether to actually poll Axiom; on non-running
+// sandboxes it holds the SSE connection open with keepalives.
+//
+// History: an earlier version flipped q.tail=false for non-running
+// sandboxes. The handler then `return nil`-ed after the historical
+// batch, closing the SSE stream. Browsers' EventSource auto-reconnects
+// on close → server re-sent the same historical batch → events
+// visibly duplicated in the UI (one copy per reconnect). Reverted.
+func TestApplySessionState_PreservesTail(t *testing.T) {
+	for _, status := range []string{"running", "stopped", "error", "hibernated", "migrating"} {
 		t.Run(status, func(t *testing.T) {
-			q := logQuery{tail: true}
-			got := applySessionState(q, status, nil)
-			if got.tail {
-				t.Errorf("status=%s: tail = true, want false", status)
+			for _, clientTail := range []bool{true, false} {
+				q := logQuery{tail: clientTail}
+				got := applySessionState(q, status, nil)
+				if got.tail != clientTail {
+					t.Errorf("status=%s clientTail=%v: tail = %v, want preserved", status, clientTail, got.tail)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Two follow-up bugs from #243, found post-merge.

### 1. \`oc logs <sandbox-id>\` returns \`API error 404: Not Found\`

Path was constructed as \`/api/sandboxes/<id>/logs\`. But \`client.New()\` already appends \`/api\` to the base URL — so the actual request URL becomes \`/api/api/sandboxes/<id>/logs\` and Echo's router 404s.

Every other command in \`cmd/oc/internal/commands/\` uses the bare \`/sandboxes/...\` form (\`exec.go\`, \`sandbox.go\`); aligning logs to that.

### 2. Stopped sandboxes show each event 3+ times in the UI

\`\`\`
13:39:43.169 stdout 917900
13:39:43.282 stdout 4063628
13:39:44.999 stdout leakcheck-B-...
13:39:43.169 stdout 917900        ← REPEAT
13:39:43.282 stdout 4063628       ← REPEAT
13:39:44.999 stdout leakcheck-B   ← REPEAT
\`\`\`

Sequence: \`applySessionState\` flipped \`q.tail=false\` for non-running sandboxes → handler \`return nil\`-ed after the historical batch → SSE stream closed from the server → browser's \`EventSource\` interpreted the close as a disconnect and **auto-reconnected** → handler re-sent the same historical batch → repeat forever. Each reconnect appended duplicate events to LogsPanel state.

Fix:
- Don't flip \`q.tail\` in \`applySessionState\` — preserve the client's explicit intent (URL \`?tail=false\` / CLI \`--no-tail\`).
- In the handler, when the client requested \`tail=true\` but the sandbox is not running: skip the Axiom poll loop, but hold the SSE connection open with keepalive comments. EventSource doesn't reconnect on an open connection, so events render once and the stream stays quiet.
- CLI users who pass \`--no-tail\` still get close-on-completion (q.tail=false comes from the URL, independent of session state).

### Tests

Replaced \`TestApplySessionState_StoppedForcesHistorical\` with \`TestApplySessionState_PreservesTail\` — for every status × every clientTail value, q.tail comes through unchanged. The until-cap behaviour (already tested separately) is unchanged.

All 13 tests in \`internal/api\` pass; all 4 in \`cmd/oc/internal/commands\` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)