### PR TITLE
metrics: stamp correct cell_id via shared-cell-id KV secret

### DIFF
--- a/deploy/vector/populate-vector-env.sh
+++ b/deploy/vector/populate-vector-env.sh
@@ -21,6 +21,7 @@
 #   shared-axiom-platform-dataset              → AXIOM_PLATFORM_DATASET        (required — logs)
 #   shared-axiom-platform-metrics-ingest-token → AXIOM_PLATFORM_METRICS_TOKEN  (optional — metrics)
 #   shared-axiom-platform-metrics-dataset      → AXIOM_PLATFORM_METRICS_DATASET (optional — metrics)
+#   shared-cell-id                             → OPENCOMPUTER_CELL_ID          (optional — cell tag)
 #
 # Logs secrets are hard-required: missing → exit 0 without writing env file,
 # Vector fails healthcheck and buffers to disk until the secret appears
@@ -30,6 +31,11 @@
 # with logs creds set, metrics ones empty. The metrics sink fails healthcheck
 # and buffers to disk independently. Lets operators roll out the metrics
 # dataset asynchronously without coordinating with the worker fleet.
+#
+# shared-cell-id is soft-optional too: missing → fall back to whatever
+# OPENCOMPUTER_CELL_ID was already in the populator's shell env (typically
+# unset on prod), then to literal "unknown". Vector keeps shipping; events
+# just won't be tagged with the right cell until KV gets the secret.
 set -euo pipefail
 
 VAULT_NAME="${OPENSANDBOX_AZURE_KEY_VAULT_NAME:-}"
@@ -38,6 +44,7 @@ TOKEN_SECRET=shared-axiom-platform-ingest-token
 DATASET_SECRET=shared-axiom-platform-dataset
 METRICS_TOKEN_SECRET=shared-axiom-platform-metrics-ingest-token
 METRICS_DATASET_SECRET=shared-axiom-platform-metrics-dataset
+CELL_ID_SECRET=shared-cell-id
 
 log() { logger -t populate-vector-env "$*"; echo "$*"; }
 
@@ -88,6 +95,15 @@ if [ -z "$METRICS_TOKEN_VALUE" ] || [ -z "$METRICS_DATASET_VALUE" ]; then
     log "metrics secrets ($METRICS_TOKEN_SECRET / $METRICS_DATASET_SECRET) missing — metrics sink will buffer to disk until configured"
 fi
 
+# Cell tag — fall through KV → inherited env → "unknown". KV wins so the
+# value matches what the Go binary will load via secretMapping in
+# internal/config/keyvault.go; events from both pipelines stay coherent.
+CELL_ID_VALUE=$(kv_get "$CELL_ID_SECRET")
+if [ -z "$CELL_ID_VALUE" ]; then
+    CELL_ID_VALUE="${OPENCOMPUTER_CELL_ID:-unknown}"
+    log "secret $CELL_ID_SECRET not found in $VAULT_NAME — falling back to OPENCOMPUTER_CELL_ID=$CELL_ID_VALUE"
+fi
+
 # Auto-detect HOST_IP via the kernel's source-address selection (skips link-local).
 HOST_IP=$(ip route get 8.8.8.8 2>/dev/null | awk '/src/ {for(i=1;i<NF;i++) if($i=="src") print $(i+1); exit}' || true)
 
@@ -98,7 +114,7 @@ AXIOM_PLATFORM_TOKEN=${TOKEN_VALUE}
 AXIOM_PLATFORM_DATASET=${DATASET_VALUE}
 AXIOM_PLATFORM_METRICS_TOKEN=${METRICS_TOKEN_VALUE}
 AXIOM_PLATFORM_METRICS_DATASET=${METRICS_DATASET_VALUE}
-OPENCOMPUTER_CELL_ID=${OPENCOMPUTER_CELL_ID:-unknown}
+OPENCOMPUTER_CELL_ID=${CELL_ID_VALUE}
 OPENSANDBOX_REGION=${OPENSANDBOX_REGION:-unknown}
 OPENCOMPUTER_HOST_IP=${HOST_IP:-unknown}
 EOF
@@ -110,4 +126,4 @@ metrics_status="absent"
 if [ -n "$METRICS_TOKEN_VALUE" ] && [ -n "$METRICS_DATASET_VALUE" ]; then
     metrics_status="present"
 fi
-log "populated $ENV_FILE (logs token+dataset from $VAULT_NAME, metrics=$metrics_status, host_ip=${HOST_IP:-unknown})"
+log "populated $ENV_FILE (logs token+dataset from $VAULT_NAME, metrics=$metrics_status, cell_id=$CELL_ID_VALUE, host_ip=${HOST_IP:-unknown})"

--- a/internal/config/keyvault.go
+++ b/internal/config/keyvault.go
@@ -85,6 +85,14 @@ var secretMapping = map[string]string{
 	//      config (e.g. an admin endpoint) gets them for free.
 	"shared-axiom-platform-ingest-token": "AXIOM_PLATFORM_TOKEN",
 	"shared-axiom-platform-dataset":      "AXIOM_PLATFORM_DATASET",
+	// Cell identifier — stamped on every log + metric event so platform
+	// dashboards can filter per cell. Same dual-consumer pattern as the
+	// platform-* secrets above: Vector reads it from /etc/opensandbox/vector.env
+	// (written by populate-vector-env.sh) for its remap substitutions, and the
+	// Go binary reads it from os.Getenv("OPENCOMPUTER_CELL_ID") (config.go) so
+	// app-side logging and metrics get the same value. Per-cell KV stores a
+	// different literal here (e.g. eastus2-default, westeurope-dev).
+	"shared-cell-id": "OPENCOMPUTER_CELL_ID",
 }
 
 // LoadSecretsFromKeyVault fetches secrets from Azure Key Vault and sets them


### PR DESCRIPTION
## Summary

Vector's metrics envelope (`deploy/vector/control-plane.yaml:73`, same in `worker.yaml`) writes `cell_id = "${OPENCOMPUTER_CELL_ID:-unknown}"` **unconditionally**, so prom-scraped platform metrics ship to Axiom tagged `cell_id: unknown` whenever the env isn't set in Vector's process env — which is the current state in prod, since `OPENCOMPUTER_CELL_ID` isn't in Key Vault.

Logs aren't affected because the Go binary derives a fallback in `internal/config/config.go:284-285` (`cfg.CellID = cfg.Region + "-default"`) and the obslog handler stamps it on every record (`internal/obslog/obslog.go:79-80`), so journald lines arrive at Vector with `cell_id` already set and the `if !exists(.cell_id)` guard on the logs remap skips the env substitution entirely.

Wires `shared-cell-id` through the same dual-consumer pattern as the existing `shared-axiom-platform-*` secrets:

- **`internal/config/keyvault.go`** — adds `"shared-cell-id": "OPENCOMPUTER_CELL_ID"` to `secretMapping`. Keeps the file's documented role as the single source of truth for required `shared-*` KV secrets; lets the Go binary load it into its own env at startup so future app-side emitters get it without further plumbing.
- **`deploy/vector/populate-vector-env.sh`** — fetches `shared-cell-id` from KV and writes `OPENCOMPUTER_CELL_ID=...` into `/etc/opensandbox/vector.env`. Soft-fails to the populator's inherited shell env, then to literal `unknown`, so a missing KV secret doesn't break Vector boot — events just stay tagged `unknown` until the operator adds it.

## Per-cell action item

Add a `shared-cell-id` secret to each cell's Key Vault:
- `opencomputer-prod-kv` → `eastus2-default`
- dev KV → `westeurope-dev`

## Test plan

- [ ] On a prod-equivalent host, `systemctl restart populate-vector-env vector` and confirm `/etc/opensandbox/vector.env` now has `OPENCOMPUTER_CELL_ID=eastus2-default`
- [ ] In Axiom: `['oc-platform-metrics-prod'] | summarize count() by cell_id` shows `eastus2-default` for new events (still `unknown` for backlog)
- [ ] Per-cell dashboards under `terraform/axiom` (opencomputer-infra repo) populate without code change
- [ ] Confirm logs path unchanged — Go-side fallback still produces `eastus2-default` for hosts without the KV secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)