### PR TITLE
telemetry: fix cloud-init race + wire 3 unset dashboard gauges

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -504,10 +504,12 @@ func main() {
 	// memory (sum of MemoryMB across running VMs), CPU pressure (PSI 'some'
 	// avg10/avg60/avg300, or loadavg/nproc fallback).
 	var allocator worker.MemoryAllocator
+	var sbCounter worker.SandboxCounter
 	if qemuMgr != nil {
 		allocator = qemuMgr
+		sbCounter = qemuMgr
 	}
-	worker.StartResourceMetricsTick(ctx, allocator, cfg.Region, cfg.WorkerID, cfg.DataDir, 30*time.Second)
+	worker.StartResourceMetricsTick(ctx, allocator, sbCounter, cfg.Region, cfg.WorkerID, cfg.DataDir, 30*time.Second)
 
 	// gRPC server (nil builder — template building via podman not needed for QEMU)
 	grpcServer := worker.NewGRPCServer(mgr, ptyMgr, execMgr, sandboxDBMgr, checkpointStore, sbRouter, nil, store)

--- a/deploy/vector/populate-vector-env.service
+++ b/deploy/vector/populate-vector-env.service
@@ -7,11 +7,20 @@
 # worker.env on workers, server.env on the control plane. EnvironmentFile
 # lines with a leading `-` are silently skipped if the file is absent, so
 # this unit works on both roles.
+#
+# Ordering note: on Azure workers, cloud-init's final stage writes
+# /etc/opensandbox/worker.env from a base64 payload baked by the control
+# plane (internal/compute/azure.go). Without `After=cloud-final.service`
+# the populator races cloud-init, reads an empty environ, exits 0 on
+# the "OPENSANDBOX_AZURE_KEY_VAULT_NAME not set" branch, and never
+# retries (Restart=on-failure doesn't fire on exit 0). Vector then can't
+# start because vector.env was never written. Ordering after cloud-final
+# guarantees worker.env exists by the time we read it.
 
 [Unit]
 Description=Populate /etc/opensandbox/vector.env from Key Vault
-After=network-online.target
-Wants=network-online.target
+After=network-online.target cloud-final.service
+Wants=network-online.target cloud-final.service
 Before=vector.service
 DefaultDependencies=no
 # Retry budget for the Restart= below. StartLimit* belongs in [Unit] per

--- a/internal/auth/oauth_handlers.go
+++ b/internal/auth/oauth_handlers.go
@@ -10,7 +10,16 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/workos/workos-go/v4/pkg/usermanagement"
+
+	"github.com/opensandbox/opensandbox/internal/metrics"
 )
+
+// authType label values for opensandbox_auth_attempts_total. The type
+// column groups by entry point (WorkOS callback today; add more on demand).
+// Result is the binary outcome — success when the session cookie is set,
+// failure for any earlier error return. Sub-reasons live in logs, not in
+// metric labels, to keep label cardinality bounded.
+const authTypeWorkOS = "workos"
 
 // OAuthHandlers provides HTTP handlers for WorkOS OAuth flow.
 type OAuthHandlers struct {
@@ -64,6 +73,7 @@ func (h *OAuthHandlers) HandleCallback(c echo.Context) error {
 	state := c.QueryParam("state")
 
 	if code == "" {
+		metrics.AuthAttemptsTotal.WithLabelValues(authTypeWorkOS, "failure").Inc()
 		return c.JSON(http.StatusBadRequest, map[string]string{
 			"error": "missing authorization code",
 		})
@@ -75,6 +85,7 @@ func (h *OAuthHandlers) HandleCallback(c echo.Context) error {
 	if err == nil {
 		// Cookie exists — verify it matches (normal login flow)
 		if stateCookie.Value != state {
+			metrics.AuthAttemptsTotal.WithLabelValues(authTypeWorkOS, "failure").Inc()
 			return c.JSON(http.StatusBadRequest, map[string]string{
 				"error": "invalid state parameter",
 			})
@@ -98,6 +109,7 @@ func (h *OAuthHandlers) HandleCallback(c echo.Context) error {
 		Code:     code,
 	})
 	if err != nil {
+		metrics.AuthAttemptsTotal.WithLabelValues(authTypeWorkOS, "failure").Inc()
 		log.Printf("workos: callback authentication failed: %v", err)
 		return c.JSON(http.StatusUnauthorized, map[string]string{
 			"error": "authentication failed",
@@ -118,6 +130,7 @@ func (h *OAuthHandlers) HandleCallback(c echo.Context) error {
 	orgName := authResult.User.Email
 	localUser, err := h.workos.ProvisionOrgAndUser(ctx, authResult.User.Email, name, orgName, authResult.User.ID, authResult.OrganizationID)
 	if err != nil {
+		metrics.AuthAttemptsTotal.WithLabelValues(authTypeWorkOS, "failure").Inc()
 		log.Printf("workos: provisioning failed: %v", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "failed to provision user",
@@ -141,6 +154,8 @@ func (h *OAuthHandlers) HandleCallback(c echo.Context) error {
 		Secure:   isSecureRequest(c),
 		SameSite: http.SameSiteLaxMode,
 	})
+
+	metrics.AuthAttemptsTotal.WithLabelValues(authTypeWorkOS, "success").Inc()
 
 	// Redirect to dashboard after login
 	return c.Redirect(http.StatusFound, "/")

--- a/internal/controlplane/redis_registry.go
+++ b/internal/controlplane/redis_registry.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 
 	"github.com/opensandbox/opensandbox/internal/grpctls"
+	"github.com/opensandbox/opensandbox/internal/metrics"
 
 	pb "github.com/opensandbox/opensandbox/proto/worker"
 )
@@ -270,6 +271,24 @@ func (r *RedisWorkerRegistry) reconcileAndPrune() {
 				delete(r.clients, id)
 			}
 		}
+	}
+
+	// Publish the opensandbox_workers_total gauge, keyed by (region, status).
+	// Reset first so a region that drained to zero stops reporting its last
+	// non-zero value forever; only the (region, status) combos still observed
+	// in r.workers will emit a time series on this tick.
+	metrics.WorkersTotal.Reset()
+	type key struct{ region, status string }
+	counts := make(map[key]int)
+	for _, w := range r.workers {
+		status := "active"
+		if w.Draining {
+			status = "draining"
+		}
+		counts[key{w.Region, status}]++
+	}
+	for k, n := range counts {
+		metrics.WorkersTotal.WithLabelValues(k.region, k.status).Set(float64(n))
 	}
 }
 

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -435,6 +435,22 @@ func (m *Manager) MemoryAllocatedBytes() uint64 {
 	return total
 }
 
+// ActiveSandboxesByTemplate returns the count of currently-running sandboxes
+// grouped by template. Drives the opensandbox_sandboxes_active gauge from
+// the worker's resource-stats tick.
+func (m *Manager) ActiveSandboxesByTemplate() map[string]int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	counts := make(map[string]int)
+	for _, vm := range m.vms {
+		if vm == nil {
+			continue
+		}
+		counts[vm.Template]++
+	}
+	return counts
+}
+
 // sealSandboxEnvs runs cfg.Envs through the secrets proxy to swap real values
 // for sealed tokens, registers a proxy session for the guest IP, and writes the
 // proxy CA cert into the guest trust store. Returns the env map that should be

--- a/internal/worker/resource_metrics.go
+++ b/internal/worker/resource_metrics.go
@@ -16,17 +16,24 @@ type MemoryAllocator interface {
 	MemoryAllocatedBytes() uint64
 }
 
+// SandboxCounter reports the count of currently-active sandboxes grouped by
+// template, used to drive the opensandbox_sandboxes_active gauge.
+type SandboxCounter interface {
+	ActiveSandboxesByTemplate() map[string]int
+}
+
 // StartResourceMetricsTick runs a goroutine that samples disk, memory, allocated
-// memory, and CPU pressure every interval and writes them to the worker-side
-// Prometheus gauges. Cancel via the provided context.
+// memory, CPU pressure, and active-sandbox count every interval and writes them
+// to the worker-side Prometheus gauges. Cancel via the provided context.
 //
 // dataDir is the worker data directory (e.g. /data/sandboxes) — its mountpoint
 // is what the disk gauges report on. mount is just the label value, defaulted
 // to filepath.Clean(dataDir).
 //
-// allocator may be nil (e.g. on a non-QEMU backend); allocated-memory gauge is
+// allocator may be nil (non-QEMU backend); allocated-memory gauge is then left
+// unwritten. counter may be nil for the same reason; sandboxes_active gauge is
 // then left unwritten.
-func StartResourceMetricsTick(ctx context.Context, allocator MemoryAllocator, region, workerID, dataDir string, interval time.Duration) {
+func StartResourceMetricsTick(ctx context.Context, allocator MemoryAllocator, counter SandboxCounter, region, workerID, dataDir string, interval time.Duration) {
 	if interval <= 0 {
 		interval = 30 * time.Second
 	}
@@ -34,7 +41,7 @@ func StartResourceMetricsTick(ctx context.Context, allocator MemoryAllocator, re
 	go func() {
 		// Emit one sample immediately so the gauges aren't reported empty for
 		// the first interval after worker boot.
-		collectAndPublish(allocator, region, workerID, dataDir, mount)
+		collectAndPublish(allocator, counter, region, workerID, dataDir, mount)
 		t := time.NewTicker(interval)
 		defer t.Stop()
 		for {
@@ -42,14 +49,14 @@ func StartResourceMetricsTick(ctx context.Context, allocator MemoryAllocator, re
 			case <-ctx.Done():
 				return
 			case <-t.C:
-				collectAndPublish(allocator, region, workerID, dataDir, mount)
+				collectAndPublish(allocator, counter, region, workerID, dataDir, mount)
 			}
 		}
 	}()
 	log.Printf("opensandbox-worker: resource-stats tick started (interval=%s, mount=%s)", interval, mount)
 }
 
-func collectAndPublish(allocator MemoryAllocator, region, workerID, dataDir, mount string) {
+func collectAndPublish(allocator MemoryAllocator, counter SandboxCounter, region, workerID, dataDir, mount string) {
 	if total, used, avail, err := DiskBytes(dataDir); err == nil {
 		metrics.WorkerDiskTotalBytes.WithLabelValues(region, workerID, mount).Set(float64(total))
 		metrics.WorkerDiskUsedBytes.WithLabelValues(region, workerID, mount).Set(float64(used))
@@ -69,4 +76,23 @@ func collectAndPublish(allocator MemoryAllocator, region, workerID, dataDir, mou
 	metrics.WorkerCPUPressure.WithLabelValues(region, workerID, "avg10", psi.Source).Set(psi.Avg10)
 	metrics.WorkerCPUPressure.WithLabelValues(region, workerID, "avg60", psi.Source).Set(psi.Avg60)
 	metrics.WorkerCPUPressure.WithLabelValues(region, workerID, "avg300", psi.Source).Set(psi.Avg300)
+
+	if counter != nil {
+		// Reset clears stale template label combos (sandbox stopped → its
+		// template would otherwise stay at its last value forever). The
+		// Reset/re-emit window is sub-microsecond and Vector scrapes on a
+		// 15-30s cadence, so the race is negligible.
+		metrics.SandboxesActive.Reset()
+		counts := counter.ActiveSandboxesByTemplate()
+		if len(counts) == 0 {
+			// Heartbeat so the dashboard query has at least one row to
+			// summarize on (otherwise APL trips on the by-tags.worker_id
+			// group-by with "field not found").
+			metrics.SandboxesActive.WithLabelValues(region, workerID, "").Set(0)
+		} else {
+			for tmpl, n := range counts {
+				metrics.SandboxesActive.WithLabelValues(region, workerID, tmpl).Set(float64(n))
+			}
+		}
+	}
 }


### PR DESCRIPTION
Two related fixes that together get the prod dashboard's worker panels populating:

## 1. \`fix(vector): wait for cloud-final.service so worker.env is written\`

On freshly-booted Azure workers, \`populate-vector-env.service\` was racing cloud-init:
1. cloud-init's final stage base64-decodes the worker.env payload baked by the control plane (\`internal/compute/azure.go:651-655\`) and writes \`/etc/opensandbox/worker.env\` — including \`OPENSANDBOX_AZURE_KEY_VAULT_NAME=opencomputer-prod-kv\`.
2. The populator only declared \`After=network-online.target\`, so systemd was free to start it before cloud-final. Its \`EnvironmentFile=-/etc/opensandbox/worker.env\` (leading \`-\`) silently skipped the missing file.
3. The script saw \`OPENSANDBOX_AZURE_KEY_VAULT_NAME\` unset, logged \`"not set — skipping"\`, and exited 0.
4. Exit 0 means \`Restart=on-failure\` never fires → populator wedged for the rest of boot.
5. \`vector.service\` then failed to start because \`/etc/opensandbox/vector.env\` was never written and its \`${AXIOM_PLATFORM_TOKEN}\` / \`${OPENCOMPUTER_CELL_ID}\` substitutions had no values.

**Fix:** add \`After=cloud-final.service\` + \`Wants=cloud-final.service\` so the populator only runs once cloud-init has finished writing worker.env.

## 2. \`metrics: wire three dashboard gauges that were registered but never set\`

\`opensandbox_workers_total\`, \`opensandbox_auth_attempts_total\`, and \`opensandbox_sandboxes_active\` were defined and registered in \`internal/metrics/metrics.go\` but had zero \`.Set()\` / \`.Inc()\` call sites — the corresponding dashboard panels showed either "No data" or the misleading \`field 'tags.X' not found\` APL error (which is what APL returns on empty result sets when the query group-bys a tag column).

| Metric | Producer | Wiring location |
|---|---|---|
| \`opensandbox_workers_total\` | control plane | \`internal/controlplane/redis_registry.go\` — end of \`reconcileAndPrune()\` (10s tick), grouped by (region, status) |
| \`opensandbox_auth_attempts_total\` | control plane | \`internal/auth/oauth_handlers.go\` — each return path in \`HandleCallback\`, type=workos, result=success/failure |
| \`opensandbox_sandboxes_active\` | worker | \`internal/worker/resource_metrics.go\` (existing 30s tick) — driven by a new \`SandboxCounter\` interface satisfied by \`*qemu.Manager.ActiveSandboxesByTemplate()\` |

### Design notes

- **Gauge drift.** \`WorkersTotal\` and \`SandboxesActive\` both call \`.Reset()\` before emitting. Without it, a region that drained to zero (or a template that just had its last sandbox stop) would keep reporting its last non-zero value forever. The Reset → re-emit window is sub-microsecond; Vector scrapes on a 15-30s cadence so the race is negligible.
- **Heartbeat for sandboxes_active.** When no sandboxes are running, emit \`{template="", value=0}\` so the dashboard's \`summarize by tags.worker_id\` group-by has at least one row to chew on (renders \`0\` instead of "field not found").
- **Auth label cardinality.** Failure sub-reasons (missing_code, invalid_state, upstream_auth_failed, provision_failed) stay in logs rather than as metric label values — keeps \`result\` to a tight 2-value set.

## Test plan

- [ ] \`go build ./...\` + \`go vet ./...\` clean on touched packages (verified — pre-existing firecracker errors on main are unrelated).
- [ ] On a freshly-spawned worker built from this PR: \`journalctl -u populate-vector-env\` shows the populator ran AFTER cloud-init wrote worker.env and successfully fetched tokens from KV. \`systemctl is-active vector.service\` → \`active\`.
- [ ] On a control plane built from this PR: \`curl :9092/metrics | grep opensandbox_workers_total\` shows \`{region, status}\` rows matching live worker count, including \`draining\` if any.
- [ ] Successful + failed login → \`opensandbox_auth_attempts_total{type="workos",result="success"}\` and \`...{result="failure"}\` both visible.
- [ ] Worker with no sandboxes: \`curl :9091/metrics | grep opensandbox_sandboxes_active\` shows \`{template="",value=0}\`. Start a sandbox → row appears for that template.
- [ ] Dashboard panels (Active sandboxes, Workers, Auth attempts) populate after rollout instead of showing "No data" / "field not found".

## Rollout

- Worker AMI rebuild via \`build-worker-ami.yml\`, then fleet rollover. Control plane redeploy via the existing scp+systemctl-restart pattern in \`deploy/azure/create-opencomputer-prod.sh\`.
- For currently-running workers stuck in the populator-race state, the manual unblock is \`systemctl restart populate-vector-env.service vector.service\` (worker.env is already populated by now, so the populator will succeed on retry) — this is independent of the AMI/binary rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)