### PR TITLE
Fix wake billing memory tier

### DIFF
--- a/internal/worker/grpc_server.go
+++ b/internal/worker/grpc_server.go
@@ -70,8 +70,8 @@ type LogshipConfigurator interface {
 type GRPCServer struct {
 	pb.UnimplementedSandboxWorkerServer
 	manager            sandbox.Manager
-	migrator           LiveMigrator      // optional, set if manager supports live migration
-	goldenRebuilder    GoldenRebuilder   // optional, set if manager supports golden rebuild
+	migrator           LiveMigrator    // optional, set if manager supports live migration
+	goldenRebuilder    GoldenRebuilder // optional, set if manager supports golden rebuild
 	router             *sandbox.SandboxRouter
 	ptyManager         *sandbox.PTYManager
 	execSessionManager *sandbox.ExecSessionManager
@@ -360,10 +360,7 @@ func (s *GRPCServer) recordInitialScaleEvent(ctx context.Context, sandboxID stri
 	if s.store == nil {
 		return
 	}
-	memMB := cfg.MemoryMB
-	if memMB <= 0 {
-		memMB = 1024
-	}
+	memMB := scaleEventMemoryMB(cfg.MemoryMB)
 	cpuPct := (memMB * 100) / 1024
 	if cpuPct < 100 {
 		cpuPct = 100
@@ -729,7 +726,7 @@ func (s *GRPCServer) WakeSandbox(ctx context.Context, req *pb.WakeSandboxRequest
 	// Resume billing scale event after wake. Disk size is preserved across wake —
 	// pass 0 so RecordScaleEvent inherits disk_mb from the prior event.
 	if s.store != nil {
-		memMB := 1024 // TODO: get actual memory from sandbox state
+		memMB := scaleEventMemoryMB(sb.MemoryMB)
 		cpuPct := 100
 		orgID, _ := s.store.GetSandboxOrgID(ctx, sb.ID)
 		if orgID != "" {
@@ -743,6 +740,13 @@ func (s *GRPCServer) WakeSandbox(ctx context.Context, req *pb.WakeSandboxRequest
 		SandboxId: sb.ID,
 		Status:    string(sb.Status),
 	}, nil
+}
+
+func scaleEventMemoryMB(memoryMB int) int {
+	if memoryMB > 0 {
+		return memoryMB
+	}
+	return 1024
 }
 
 func (s *GRPCServer) RebootSandbox(ctx context.Context, req *pb.RebootSandboxRequest) (*pb.RebootSandboxResponse, error) {

--- a/internal/worker/grpc_server_test.go
+++ b/internal/worker/grpc_server_test.go
@@ -1,0 +1,23 @@
+package worker
+
+import "testing"
+
+func TestScaleEventMemoryMB(t *testing.T) {
+	tests := []struct {
+		name     string
+		memoryMB int
+		want     int
+	}{
+		{name: "uses sandbox memory", memoryMB: 4096, want: 4096},
+		{name: "defaults missing memory", memoryMB: 0, want: 1024},
+		{name: "defaults invalid negative memory", memoryMB: -1, want: 1024},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := scaleEventMemoryMB(tt.memoryMB); got != tt.want {
+				t.Fatalf("scaleEventMemoryMB(%d) = %d, want %d", tt.memoryMB, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Use the restored sandbox memory tier when resuming the wake billing scale event.
- Keep the existing 1024MB fallback for missing or legacy memory values.
- Share the fallback behavior with initial scale-event recording so create and wake use the same default.

## Why this matters
Hibernation ends the current sandbox_scale_events row. Wake starts a fresh row, but it was hard-coded to 1024MB. Any sandbox restored above 1GB would be under-recorded in sandbox_scale_events after wake until another scale event occurred. Usage reporting and billing aggregation read memory_mb from those scale events, so this fixes a real accounting/usage-reporting bug rather than just removing a TODO comment.

Disk is still passed as 0 intentionally so RecordScaleEvent inherits the previous disk size, matching the existing wake comment.

## Tests
- GOCACHE=/private/tmp/opencomputer-gocache GOPATH=/private/tmp/opencomputer-gopath go test ./internal/worker -count=1