### PR TITLE
vector: poll for worker.env inside populator instead of systemd retry

### DIFF
--- a/deploy/vector/populate-vector-env.sh
+++ b/deploy/vector/populate-vector-env.sh
@@ -48,24 +48,46 @@ CELL_ID_SECRET=shared-cell-id
 
 log() { logger -t populate-vector-env "$*"; echo "$*"; }
 
-if [ -z "$VAULT_NAME" ]; then
-    # Distinguish "cloud-init hasn't written the env file yet" (transient,
-    # retry) from "this host genuinely has no KV configured" (permanent,
-    # accept). On prod Azure workers, cloud-init writes worker.env from a
-    # base64 payload baked by the control plane (internal/compute/azure.go)
-    # in its final stage — we may race ahead of it. Exit 1 so
-    # Restart=on-failure (10s × 5 = 50s budget) gives cloud-init time to
-    # land the file. After that budget, treat KV as truly absent and exit 0.
-    #
-    # We can't use After=cloud-final.service in the unit because cloud-init
-    # on Azure declares cloud-final After=multi-user.target — any ordering
-    # dep on it from a unit WantedBy=multi-user.target creates a systemd
-    # cycle and Vector never boots (#249 hit this, see PR-todo to revert).
-    if [ ! -f /etc/opensandbox/worker.env ] && [ ! -f /etc/opensandbox/server.env ]; then
-        log "no role env file at /etc/opensandbox/{worker,server}.env yet — cloud-init may still be running; exiting 1 to trigger systemd retry"
-        exit 1
+# On Azure prod workers, cloud-init writes /etc/opensandbox/worker.env in
+# its final stage from a base64 payload baked by the control plane
+# (internal/compute/azure.go). We can race ahead of it.
+#
+# We don't pull cloud-init into our unit graph (cycle: cloud-final and
+# cloud-init.target both declare After=multi-user.target on this image, so
+# any ordering dep on them from a unit WantedBy=multi-user.target wedges
+# systemd's job graph and vector.service/start gets silently deleted —
+# observed in #249, reverted in #254).
+#
+# Earlier #254 exited 1 here so systemd's Restart=on-failure could retry.
+# That hit a different issue: when vector.service repeatedly tries to
+# start (Restart=always), each attempt re-requests this unit and the
+# StartLimitBurst=5 / IntervalSec=120 budget gets burnt in <2 seconds —
+# all 5 "restarts" land before RestartSec=10s can pace them, populator
+# enters `failed`, vector also `failed`, both stuck until manual
+# intervention. Observed on osb-worker-c0741893: 5 retries between
+# 00:43:08 and 00:43:10, worker.env written at 00:44 — too late.
+#
+# Poll inside the script instead: single systemd invocation, internal
+# wait of up to 90s. No restart-budget interaction.
+DEADLINE=$(($(date +%s) + 90))
+while [ $(date +%s) -lt $DEADLINE ]; do
+    if [ -f /etc/opensandbox/worker.env ] || [ -f /etc/opensandbox/server.env ]; then
+        break
     fi
-    log "OPENSANDBOX_AZURE_KEY_VAULT_NAME not set — skipping (Vector will start without a token)"
+    log "waiting for cloud-init to write /etc/opensandbox/{worker,server}.env..."
+    sleep 5
+done
+
+# Re-source whichever env file exists. systemd's EnvironmentFile= already
+# loaded these at unit start, but they may have appeared during our wait.
+# shellcheck disable=SC1091
+[ -f /etc/opensandbox/worker.env ] && . /etc/opensandbox/worker.env
+# shellcheck disable=SC1091
+[ -f /etc/opensandbox/server.env ] && . /etc/opensandbox/server.env
+VAULT_NAME="${OPENSANDBOX_AZURE_KEY_VAULT_NAME:-}"
+
+if [ -z "$VAULT_NAME" ]; then
+    log "OPENSANDBOX_AZURE_KEY_VAULT_NAME still unset after 90s wait — host genuinely has no KV configured (e.g. dev VM without managed identity); skipping (Vector will start without a token)"
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

#254 (just merged) made the populator \`exit 1\` when \`/etc/opensandbox/{worker,server}.env\` was missing, expecting systemd's \`Restart=on-failure\` to retry until cloud-init lands the file. **It hit a follow-up bug on prod** that the in-place dev test in #254 didn't catch.

## What broke on prod

Observed on \`osb-worker-c0741893\` (rotated to the post-#254 AMI):

\`\`\`
vector.service: failed
populate-vector-env.service: failed
worker.env mtime: 00:44:00 (cloud-init wrote it)
populator journal:
  00:43:08 populator: Start request repeated too quickly
  00:43:08 populator: Failed with result 'exit-code'
  00:43:09 populator: Start request repeated too quickly
  00:43:09 populator: Failed
  ... 5 more in <2 seconds
\`\`\`

Mechanism:
1. \`vector.service\` has \`Restart=always\`.
2. Each Vector restart re-requests \`populate-vector-env.service\` (Wants= dep).
3. systemd counts those re-requests against the populator's \`StartLimitBurst=5\` / \`IntervalSec=120\`.
4. Vector restarts faster than \`RestartSec=10s\` can pace the populator's own retries — burst exhausts in 2 seconds.
5. Populator enters \`failed\`. Vector also \`failed\`. Both stuck until manual intervention.
6. ~50 seconds later, cloud-init writes worker.env. Too late — both units are dead.

## Fix

Poll inside the script instead of relying on systemd retry. Single invocation, internal wait up to 90s. No restart-budget interaction:

\`\`\`bash
DEADLINE=\$((\$(date +%s) + 90))
while [ \$(date +%s) -lt \$DEADLINE ]; do
    [ -f /etc/opensandbox/worker.env ] || [ -f /etc/opensandbox/server.env ] && break
    log "waiting for cloud-init to write env file..."
    sleep 5
done
[ -f /etc/opensandbox/worker.env ] && . /etc/opensandbox/worker.env
[ -f /etc/opensandbox/server.env ] && . /etc/opensandbox/server.env
VAULT_NAME="\${OPENSANDBOX_AZURE_KEY_VAULT_NAME:-}"
\`\`\`

Behaves identically on dev (env file already exists → first iteration breaks out, no wait).

## Why #254 dev test didn't catch this

The dev test in #254 confirmed that the systemd ordering cycle was gone. It did NOT exercise the cloud-init-delay path because:

- Dev cluster's \`bootstrap.sh\` writes \`/etc/opensandbox/worker.env\` BEFORE Vector's install step.
- So at boot on dev, \`worker.env\` always exists when the populator runs — the script's "missing env file" branch is never hit.
- The cycle test happened to pass because it didn't depend on retry timing; the retry-burst test would have needed an artificial cloud-init delay (e.g. \`systemd-run --on-active=60s touch /etc/opensandbox/worker.env\` before reboot) to reproduce.

Adding a runbook for that simulation would close this gap going forward.

## Test plan

- [ ] Apply on dev — \`worker.env\` exists, populator should run once and succeed immediately (no wait).
- [ ] Simulate cloud-init delay on dev: \`rm /etc/opensandbox/worker.env\` + \`systemd-run --on-active=45 sh -c 'echo OPENSANDBOX_AZURE_KEY_VAULT_NAME=opencomputer-dev-kv > /etc/opensandbox/worker.env'\` + reboot. Confirm populator waits, succeeds at ~45s, vector starts.
- [ ] Roll to prod via AMI rebake + worker rotation. Confirm \`vector.service: active\` on freshly-booted prod workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)