### PR TITLE
vector: bump populator poll to 600s + ExecStartPost vector restart

### DIFF
--- a/deploy/vector/populate-vector-env.service
+++ b/deploy/vector/populate-vector-env.service
@@ -44,6 +44,14 @@ Type=oneshot
 EnvironmentFile=-/etc/opensandbox/worker.env
 EnvironmentFile=-/etc/opensandbox/server.env
 ExecStart=/usr/local/bin/populate-vector-env.sh
+# On prod, vector.service may have started at boot before worker.env
+# arrived and entered failed state via Restart=always/StartLimit hit.
+# Once populator's 600s poll lands the env file and writes vector.env,
+# reset-failed + restart brings vector back. `-` prefix ignores
+# errors (vector may not be installed in some packer-bake paths).
+# `--no-block` avoids deadlock on vector's After=this-service.
+ExecStartPost=-/bin/systemctl --no-block reset-failed vector.service
+ExecStartPost=-/bin/systemctl --no-block restart vector.service
 RemainAfterExit=yes
 # Retry a few times if KV is briefly unreachable at boot. The script
 # itself exits 0 on graceful failure paths (no IMDS, no secret, etc.) so

--- a/deploy/vector/populate-vector-env.sh
+++ b/deploy/vector/populate-vector-env.sh
@@ -68,8 +68,16 @@ log() { logger -t populate-vector-env "$*"; echo "$*"; }
 # 00:43:08 and 00:43:10, worker.env written at 00:44 — too late.
 #
 # Poll inside the script instead: single systemd invocation, internal
-# wait of up to 90s. No restart-budget interaction.
-DEADLINE=$(($(date +%s) + 90))
+# wait. No restart-budget interaction.
+#
+# 600s (10 min) — #256 used 90s and gave up too early. Observed on
+# osb-worker-0b42c8be: cloud-init wrote worker.env at +4m into boot,
+# our 90s poll already ended at +90s. Vector was started without an
+# env, failed-restart-looped into a `failed` state, and worker.env
+# arriving later didn't help. Azure cloud-init can take 3-5 min on
+# Standard_D-series VMs; 10 min covers the observed long tail with
+# margin. If something exceeds 10 min, the host is broken anyway.
+DEADLINE=$(($(date +%s) + 600))
 while [ $(date +%s) -lt $DEADLINE ]; do
     if [ -f /etc/opensandbox/worker.env ] || [ -f /etc/opensandbox/server.env ]; then
         break
@@ -87,7 +95,7 @@ done
 VAULT_NAME="${OPENSANDBOX_AZURE_KEY_VAULT_NAME:-}"
 
 if [ -z "$VAULT_NAME" ]; then
-    log "OPENSANDBOX_AZURE_KEY_VAULT_NAME still unset after 90s wait — host genuinely has no KV configured (e.g. dev VM without managed identity); skipping (Vector will start without a token)"
+    log "OPENSANDBOX_AZURE_KEY_VAULT_NAME still unset after 600s wait — host genuinely has no KV configured (e.g. dev VM without managed identity); skipping (Vector will start without a token)"
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

Two-line behavioral fix to populator that addresses the prod symptom from #256: cloud-init takes longer than 90s on Azure prod workers, populator exits before env file arrives, vector enters failed state and never recovers.

## Changes

1. **Poll deadline 90s → 600s** in \`populate-vector-env.sh\`. Observed on \`osb-worker-0b42c8be\`: cloud-init wrote worker.env at +4 minutes into boot; #256's 90s budget expired at +1.5 minutes. Azure cloud-init on Standard_D-series VMs takes 3–5 min in practice; 10 minutes covers the long tail with margin.

2. **\`ExecStartPost\` on the service** that does \`systemctl --no-block reset-failed vector.service\` + \`systemctl --no-block restart vector.service\`. When populator finally writes vector.env, vector may already be in failed state from earlier restart-loops. reset-failed clears that, restart picks up the new env. \`--no-block\` avoids deadlock with vector's \`After=populator\` dep.

## What we explored but didn't ship

systemd Path unit (\`populate-vector-env.path\` watching either worker.env or cloud-init's boot-finished marker). Eight dev-test reboots surfaced four distinct subtle bugs in succession:

1. \`After=cloud-final.service\` creates a systemd ordering cycle (cloud-init declares After=multi-user.target on this Azure image)
2. \`RemainAfterExit=yes\` makes path-unit's \`systemctl start\` a no-op
3. Vector's \`Wants=populator\` cascades on vector restart, burns populator's StartLimit in <1s
4. Dir-level inotify storms: 50–250 populator starts per second when cloud-init writes any file in the watched directory (even watching boot-finished in /var/lib/cloud/instance/ tripped this)

Each fix surfaced the next bug. Concluded path-unit-on-shared-dir interaction is the wrong tool for this; the poll approach is simpler with a known-bounded failure mode (timeout at 10 min).

## Test plan

- [x] Dev reboot with fake-cloud-init writing worker.env at +240s: populator polls correctly, finds the file inside its budget, exits cleanly
- [ ] AMI rebake + prod worker rotation: confirm vector reaches \`active\` on freshly-booted prod workers (worker.env arriving at +3-5min from cloud-init)
- [ ] In-place patch on existing prod workers: run new script + service file via az run-command, restart populate-vector-env.service, confirm vector starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)