### PR TITLE
vector: detach populator from boot when role env is missing

### DIFF
--- a/deploy/vector/install.sh
+++ b/deploy/vector/install.sh
@@ -55,11 +55,16 @@ install -m 0644 "$CONFIG_SRC" /etc/vector/vector.yaml
 chown -R vector:vector /var/lib/vector
 
 # --- Install the KV → env-file populator (oneshot, runs Before=vector.service) ---
-# Both the script and the unit file are tracked in this dir so they roll
-# atomically with config changes.
+# Plus a companion wait unit that polls for worker.env asynchronously when
+# the main populator races ahead of cloud-init on Azure first boot. All
+# four files are tracked in this dir so they roll atomically with config
+# changes.
 install -m 0755 "$SCRIPT_DIR/populate-vector-env.sh" /usr/local/bin/populate-vector-env.sh
+install -m 0755 "$SCRIPT_DIR/populate-vector-env-wait.sh" /usr/local/bin/populate-vector-env-wait.sh
 install -m 0644 "$SCRIPT_DIR/populate-vector-env.service" \
     /etc/systemd/system/populate-vector-env.service
+install -m 0644 "$SCRIPT_DIR/populate-vector-env-wait.service" \
+    /etc/systemd/system/populate-vector-env-wait.service
 
 # --- Wire env file + KV oneshot into the vector.service unit ---
 # Use a drop-in instead of editing the package file so a Vector upgrade
@@ -98,6 +103,9 @@ fi
 
 # --- Start ---
 systemctl daemon-reload
+# The wait unit is started imperatively by populate-vector-env.sh only
+# when role env is missing — don't enable it for boot, just have it
+# present so the populator can `systemctl start` it on demand.
 systemctl enable populate-vector-env.service vector.service
 
 # In a Packer image bake, systemd may not actually run units (the image is

--- a/deploy/vector/populate-vector-env-wait.service
+++ b/deploy/vector/populate-vector-env-wait.service
@@ -1,0 +1,29 @@
+# Background companion to populate-vector-env.service.
+#
+# On Azure first boot, cloud-final.service writes /etc/opensandbox/worker.env
+# AFTER multi-user.target is reached. populate-vector-env.service can't
+# synchronously wait for it (would deadlock multi-user ↔ cloud-final, see
+# the long comment in populate-vector-env.sh). Instead, populator writes a
+# stub vector.env and starts THIS unit, which polls in the background and
+# repopulates with real creds + restarts vector once worker.env appears.
+#
+# Deliberately NOT WantedBy=multi-user.target: boot must not wait on us.
+# Started imperatively by populate-vector-env.sh via
+#   `systemctl --no-block start populate-vector-env-wait.service`
+# only when role env files are missing at boot.
+
+[Unit]
+Description=Wait for cloud-init to write worker.env, then populate vector.env
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/populate-vector-env-wait.sh
+# Generous timeout — the script has its own deadline (30 min default) and
+# exits 0 either way. systemd's default 90s TimeoutStartSec would kill the
+# poller before cloud-final on a slow VM.
+TimeoutStartSec=infinity
+# One-shot in practice — the script exits 0 once it's done (or given up).
+# Don't restart on success or failure.
+Restart=no

--- a/deploy/vector/populate-vector-env-wait.sh
+++ b/deploy/vector/populate-vector-env-wait.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# populate-vector-env-wait.sh — Background poller that waits for cloud-init
+# to write /etc/opensandbox/worker.env (or server.env), then re-runs the
+# main populator to fetch real Axiom creds from Key Vault and restarts
+# vector.service so it picks them up.
+#
+# Started imperatively by populate-vector-env.sh when neither worker.env
+# nor server.env exists at populator-run time (Azure first-boot race —
+# cloud-final.service writes worker.env *after* multi-user.target, so the
+# main populator can't synchronously wait for it without deadlocking the
+# boot).
+#
+# Not WantedBy=multi-user.target — boot doesn't wait on this. Runs as a
+# long-lived Type=simple service so systemd tracks it cleanly and the
+# logs land in journald under populate-vector-env-wait.service.
+set -uo pipefail
+
+ROLE_WORKER=/etc/opensandbox/worker.env
+ROLE_SERVER=/etc/opensandbox/server.env
+DEADLINE_SECONDS=${POPULATE_WAIT_DEADLINE_SECONDS:-1800}
+POLL_SECONDS=${POPULATE_WAIT_POLL_SECONDS:-5}
+
+log() { logger -t populate-vector-env-wait "$*"; echo "$*"; }
+
+deadline=$(($(date +%s) + DEADLINE_SECONDS))
+log "polling for $ROLE_WORKER or $ROLE_SERVER every ${POLL_SECONDS}s (deadline ${DEADLINE_SECONDS}s)"
+
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    if [ -f "$ROLE_WORKER" ] || [ -f "$ROLE_SERVER" ]; then
+        log "role env appeared after $(( $(date +%s) - (deadline - DEADLINE_SECONDS) ))s, repopulating vector.env"
+        if /usr/local/bin/populate-vector-env.sh; then
+            log "populator succeeded; reset-failed + restart vector.service to pick up real creds"
+            # reset-failed: clears any failed state from vector's earlier
+            # start with the stub env (axiom sink healthcheck failures may
+            # have tripped Restart=always's burst budget).
+            systemctl reset-failed vector.service 2>/dev/null || true
+            systemctl restart vector.service 2>/dev/null || log "vector.service restart returned non-zero"
+        else
+            log "populator exited non-zero; leaving vector.service with stub env (axiom sink will keep buffering)"
+        fi
+        exit 0
+    fi
+    sleep "$POLL_SECONDS"
+done
+
+log "role env never appeared after ${DEADLINE_SECONDS}s; giving up (vector.service stays on stub env, axiom sink keeps buffering)"
+exit 0

--- a/deploy/vector/populate-vector-env.service
+++ b/deploy/vector/populate-vector-env.service
@@ -1,6 +1,6 @@
-# Pulls AXIOM_PLATFORM_TOKEN + AXIOM_PLATFORM_DATASET from Key Vault via
-# the VM's managed identity and writes /etc/opensandbox/vector.env before
-# vector.service starts.
+# Pulls AXIOM_PLATFORM_TOKEN + AXIOM_PLATFORM_DATASET (and metrics tokens)
+# from Key Vault via the VM's managed identity and writes
+# /etc/opensandbox/vector.env before vector.service starts.
 #
 # Reads OPENSANDBOX_AZURE_KEY_VAULT_NAME (and OPENCOMPUTER_CELL_ID /
 # OPENSANDBOX_REGION for tagging) from whichever role-env file exists —
@@ -8,24 +8,27 @@
 # lines with a leading `-` are silently skipped if the file is absent, so
 # this unit works on both roles.
 #
-# Ordering note: on Azure workers, cloud-init's final stage writes
+# Azure first-boot race: cloud-init's cloud-final.service writes
 # /etc/opensandbox/worker.env from a base64 payload baked by the control
-# plane (internal/compute/azure.go). The populator races cloud-init and
-# may run before worker.env exists.
+# plane (internal/compute/azure.go). On Ubuntu Azure images, cloud-final
+# is ordered After=multi-user.target — so worker.env doesn't exist when
+# this unit runs (we're WantedBy=multi-user.target).
 #
-# #249 tried to solve this with `After=cloud-final.service` + `Wants=`.
-# That broke prod: on Azure, both `cloud-final.service` and
-# `cloud-init.target` declare `After=multi-user.target` — so ANY ordering
-# dependency on a cloud-init unit from a unit WantedBy=multi-user.target
-# creates a systemd cycle. systemd resolves it by silently deleting
-# vector.service/start, and Vector never boots. Observed on a prod
-# worker after #249 merged: load=10, vector inactive, journal contained
-# "Job vector.service/start deleted to break ordering cycle".
+# Earlier attempts to handle this in-unit all failed:
+#   #249: After=cloud-final.service → systemd cycle (vector silently dropped).
+#   #254: exit 1 + Restart=on-failure → vector's restart-burst burnt the
+#         StartLimit budget faster than RestartSec= could pace.
+#   #256: internal 90s poll → multi-user blocked 90s, vector burnt its
+#         own restart budget, cloud-final still hadn't run.
+#   #257: internal 600s poll → boot deadlock (multi-user ↔ cloud-final),
+#         every new Azure worker reaped at exactly 600s by pendingWorkerTTL.
 #
-# The fix lives in populate-vector-env.sh: when neither worker.env nor
-# server.env exists, the script exits 1, Restart=on-failure here retries
-# (10s × 5 = 50s budget) until cloud-init writes the file. No new
-# systemd dependencies needed → no cycle.
+# Current design (populate-vector-env.sh):
+#   - If worker.env/server.env exists → populate synchronously, exit 0.
+#   - If both missing → write stub vector.env, start
+#     populate-vector-env-wait.service asynchronously, exit 0 in ~1s.
+#   The wait unit polls in the background and re-runs the populator +
+#   restarts vector once worker.env appears. Boot proceeds either way.
 
 [Unit]
 Description=Populate /etc/opensandbox/vector.env from Key Vault
@@ -33,11 +36,6 @@ After=network-online.target
 Wants=network-online.target
 Before=vector.service
 DefaultDependencies=no
-# Retry budget for the Restart= below. StartLimit* belongs in [Unit] per
-# systemd 229+; in [Service] systemd-255 logs an "Unknown key" warning
-# and ignores them (then Restart=on-failure can crash-loop without a cap).
-StartLimitBurst=5
-StartLimitIntervalSec=120
 
 [Service]
 Type=oneshot
@@ -45,11 +43,11 @@ EnvironmentFile=-/etc/opensandbox/worker.env
 EnvironmentFile=-/etc/opensandbox/server.env
 ExecStart=/usr/local/bin/populate-vector-env.sh
 RemainAfterExit=yes
-# Retry a few times if KV is briefly unreachable at boot. The script
-# itself exits 0 on graceful failure paths (no IMDS, no secret, etc.) so
-# this only fires on truly unexpected errors.
-Restart=on-failure
-RestartSec=10s
+# Script exits 0 on every graceful path (missing role env → stub + kick
+# waiter; missing IMDS / vault / secret → log + skip). Restart= would only
+# fire on truly unexpected errors (set -e tripping), and even then the
+# right move is to leave the unit in failed state for an operator to
+# inspect rather than crash-loop.
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/vector/populate-vector-env.sh
+++ b/deploy/vector/populate-vector-env.sh
@@ -50,36 +50,66 @@ log() { logger -t populate-vector-env "$*"; echo "$*"; }
 
 # On Azure prod workers, cloud-init writes /etc/opensandbox/worker.env in
 # its final stage from a base64 payload baked by the control plane
-# (internal/compute/azure.go). We can race ahead of it.
+# (internal/compute/azure.go). cloud-final.service on Ubuntu Azure images
+# is ordered After=multi-user.target, so worker.env doesn't exist until
+# AFTER multi-user is reached.
 #
-# We don't pull cloud-init into our unit graph (cycle: cloud-final and
-# cloud-init.target both declare After=multi-user.target on this image, so
-# any ordering dep on them from a unit WantedBy=multi-user.target wedges
-# systemd's job graph and vector.service/start gets silently deleted —
-# observed in #249, reverted in #254).
+# This puts us in a bind: we can't synchronously wait for worker.env from
+# inside a unit WantedBy=multi-user.target — multi-user won't reach active
+# while we're waiting, so cloud-final never runs, so worker.env never
+# appears, so our wait spins for nothing. (Observed: #257/#46e660f shipped
+# a 600s in-script wait; it deadlocked multi-user.target ↔ cloud-final
+# and every new Azure worker was reaped after exactly 600s by the
+# scaler's pendingWorkerTTL.)
 #
-# Earlier #254 exited 1 here so systemd's Restart=on-failure could retry.
-# That hit a different issue: when vector.service repeatedly tries to
-# start (Restart=always), each attempt re-requests this unit and the
-# StartLimitBurst=5 / IntervalSec=120 budget gets burnt in <2 seconds —
-# all 5 "restarts" land before RestartSec=10s can pace them, populator
-# enters `failed`, vector also `failed`, both stuck until manual
-# intervention. Observed on osb-worker-c0741893: 5 retries between
-# 00:43:08 and 00:43:10, worker.env written at 00:44 — too late.
+# Previous attempts and why they didn't work:
+#   #249  After=cloud-final.service + Wants= → systemd cycle (both
+#         cloud-final and cloud-init.target declare After=multi-user.target
+#         on Azure Ubuntu, so any WantedBy=multi-user.target unit ordering
+#         after them wedges the job graph; vector.service/start gets
+#         silently deleted).
+#   #254  exit 1 + Restart=on-failure → vector's Restart=always re-requests
+#         this unit faster than RestartSec=10s can pace; StartLimitBurst=5
+#         budget burnt in <2s; both units enter failed.
+#   #256  internal 90s poll → multi-user blocked 90s; vector hits restart
+#         budget while populator waits; usually exits before cloud-final
+#         arrives at ~4min anyway.
+#   #257  internal 600s poll → boot deadlock (above).
 #
-# Poll inside the script instead: single systemd invocation, internal
-# wait of up to 90s. No restart-budget interaction.
-DEADLINE=$(($(date +%s) + 90))
-while [ $(date +%s) -lt $DEADLINE ]; do
-    if [ -f /etc/opensandbox/worker.env ] || [ -f /etc/opensandbox/server.env ]; then
-        break
-    fi
-    log "waiting for cloud-init to write /etc/opensandbox/{worker,server}.env..."
-    sleep 5
-done
+# This iteration: when role env is missing, write a stub vector.env so
+# vector.service can pass validation and start, then kick off a separate
+# wait unit (populate-vector-env-wait.service) to poll asynchronously and
+# repopulate + restart vector once cloud-final writes worker.env. The
+# main populator exits 0 in ~1s, multi-user.target reaches active,
+# cloud-final runs, the waiter does its job. No boot blocking, no
+# systemd cycle, no restart-burst.
+
+if [ ! -f /etc/opensandbox/worker.env ] && [ ! -f /etc/opensandbox/server.env ]; then
+    log "neither worker.env nor server.env present (cloud-init not finished yet); writing stub $ENV_FILE and starting wait unit, exiting 0 so boot can proceed"
+    install -d -m 0755 /etc/opensandbox
+    umask 077
+    # Stub with all expected vars defined-but-empty so `vector validate`
+    # passes (Vector's ${VAR} substitution fails on truly-unset vars; an
+    # empty value satisfies the substitution and the axiom sink fails its
+    # healthcheck and buffers to disk until the waiter writes real creds).
+    cat > "${ENV_FILE}.tmp" <<EOF
+AXIOM_PLATFORM_TOKEN=
+AXIOM_PLATFORM_DATASET=
+AXIOM_PLATFORM_METRICS_TOKEN=
+AXIOM_PLATFORM_METRICS_DATASET=
+OPENCOMPUTER_CELL_ID=unknown
+OPENSANDBOX_REGION=unknown
+OPENCOMPUTER_HOST_IP=unknown
+EOF
+    chmod 0600 "${ENV_FILE}.tmp"
+    mv -f "${ENV_FILE}.tmp" "$ENV_FILE"
+    systemctl --no-block start populate-vector-env-wait.service || log "could not start populate-vector-env-wait.service"
+    exit 0
+fi
 
 # Re-source whichever env file exists. systemd's EnvironmentFile= already
-# loaded these at unit start, but they may have appeared during our wait.
+# loaded these at unit start, but the populator may have been invoked
+# manually or by the wait unit after the file appeared.
 # shellcheck disable=SC1091
 [ -f /etc/opensandbox/worker.env ] && . /etc/opensandbox/worker.env
 # shellcheck disable=SC1091
@@ -87,7 +117,7 @@ done
 VAULT_NAME="${OPENSANDBOX_AZURE_KEY_VAULT_NAME:-}"
 
 if [ -z "$VAULT_NAME" ]; then
-    log "OPENSANDBOX_AZURE_KEY_VAULT_NAME still unset after 90s wait — host genuinely has no KV configured (e.g. dev VM without managed identity); skipping (Vector will start without a token)"
+    log "OPENSANDBOX_AZURE_KEY_VAULT_NAME unset — host has no KV configured (e.g. dev VM without managed identity); skipping (Vector will use whatever vector.env is on disk)"
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

- Make `populate-vector-env.sh` exit fast in **every** boot path. When `/etc/opensandbox/{worker,server}.env` is missing (Azure first boot, cloud-init not yet finished), it writes a stub `vector.env` so `vector validate` passes, then kicks a new companion unit `populate-vector-env-wait.service` to poll asynchronously. Boot proceeds in ~1s.
- The wait unit (not `WantedBy=multi-user.target`, so it cannot block boot) polls for the role env file for up to 30 min, then re-runs the populator (which now goes through the synchronous Key Vault path) and `systemctl reset-failed + restart vector.service` so the disk-buffered events flush with the real Axiom token.

## Why

`#257` shipped a 600s synchronous in-script wait. On Azure that deadlocked the boot graph: `cloud-final.service` is ordered `After=multi-user.target` on Ubuntu Azure images, and `cloud-final` is what writes `worker.env` — but `multi-user.target` couldn't reach active while the populator was waiting (`vector.service` Wants= populator, `multi-user.target` Wants= vector). Every new Azure worker was reaped at exactly 600s by `scaler.go`'s `pendingWorkerTTL=10min` and replaced, ad infinitum.

Reverted in #259. This PR is the proper fix.

## What prior attempts hit (full history in `populate-vector-env.sh` header)

| PR | Approach | Failure mode |
|----|----------|--------------|
| #249 | `After=cloud-final.service` | systemd cycle, `vector.service/start` silently deleted |
| #254 | `exit 1` + `Restart=on-failure` | vector's restart-burst burned `StartLimitBurst=5` in <2s |
| #256 | internal 90s in-script poll | multi-user blocked 90s, vector burned its own restart budget |
| #257 | internal 600s in-script poll | full boot deadlock, every Azure worker reaped at 10min |

## Test plan

- [ ] `bash -n` syntax check on both shell scripts (done locally)
- [ ] Build worker AMI on `opencomputer-deployment-test` from this branch
- [ ] Provision a worker from the new AMI in test Azure environment
- [ ] Confirm via `az vm run-command`:
  - [ ] `cloud-init status` reaches `done` (not stuck at `running`)
  - [ ] `populate-vector-env.service` exits 0 within a few seconds
  - [ ] `populate-vector-env-wait.service` is `activating`/`running`
  - [ ] `vector.service` reaches active with the stub env (axiom sink unhealthy + buffering — expected)
  - [ ] After `cloud-final` writes `worker.env`, waiter re-runs populator and vector restarts with real creds (axiom sink healthy)
  - [ ] Worker registers with control plane within `pendingWorkerTTL`
  - [ ] Worker logs appear in Axiom
- [ ] Confirm dev-host install path still goes through the synchronous branch (no waiter spawn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)