### PR TITLE
[backup] feat/aws-poc-worker-support clean local snapshot 

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -35,9 +35,10 @@ import (
 var ServerVersion = "dev"
 
 func main() {
-	// Load secrets from Azure Key Vault if configured (before config.Load reads env vars).
-	if err := config.LoadSecretsFromKeyVault(); err != nil {
-		log.Fatalf("failed to load secrets from Key Vault: %v", err)
+	// Load secrets from the configured cloud secret store (Azure KV or AWS SM)
+	// before config.Load reads env vars. No-op if neither is configured.
+	if err := config.LoadSecrets(); err != nil {
+		log.Fatalf("failed to load secrets: %v", err)
 	}
 
 	cfg, err := config.Load()

--- a/cmd/worker/golden_upload.go
+++ b/cmd/worker/golden_upload.go
@@ -30,12 +30,13 @@ import (
 // Reads OPENSANDBOX_GLOBAL_BLOB_* env vars for endpoint + creds. Fails loud
 // if blobstore isn't configured.
 func uploadGolden(path string) error {
-	// Bootstrap from KV the same way the main worker does — so this
-	// subcommand picks up worker-global-blob-* secrets when run on a
-	// host whose worker.env points at a KV. Without this, the user
-	// would have to manually export every Tigris env var inline.
-	if err := config.LoadSecretsFromKeyVault(); err != nil {
-		return fmt.Errorf("keyvault bootstrap: %w", err)
+	// Bootstrap from the configured secret store the same way the main
+	// worker does — so this subcommand picks up worker-global-blob-* secrets
+	// when run on a host whose worker.env points at a KV / SM prefix.
+	// Without this, the user would have to manually export every Tigris env
+	// var inline.
+	if err := config.LoadSecrets(); err != nil {
+		return fmt.Errorf("secrets bootstrap: %w", err)
 	}
 	cfg, err := config.Load()
 	if err != nil {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/opensandbox/opensandbox/internal/metrics"
 	"github.com/opensandbox/opensandbox/internal/observability"
 	"github.com/opensandbox/opensandbox/internal/obslog"
+	"github.com/opensandbox/opensandbox/internal/preemption"
 	"github.com/opensandbox/opensandbox/internal/proxy"
 	qm "github.com/opensandbox/opensandbox/internal/qemu"
 	"github.com/opensandbox/opensandbox/internal/sandbox"
@@ -40,7 +41,7 @@ var WorkerVersion = "dev"
 
 func main() {
 	// Subcommands that don't need config/secrets. Must short-circuit before
-	// LoadSecretsFromKeyVault, which is slow and would fail outside Azure.
+	// LoadSecrets, which is slow and would fail without cloud credentials.
 	//
 	// "golden-version <path>" prints the full-file hash used for golden-image
 	// archive keys. Packer invokes this so the archive key matches what
@@ -79,7 +80,7 @@ func main() {
 	}
 
 	// Load secrets from Azure Key Vault if configured (before config.Load reads env vars).
-	if err := config.LoadSecretsFromKeyVault(); err != nil {
+	if err := config.LoadSecrets(); err != nil {
 		log.Fatalf("failed to load secrets from Key Vault: %v", err)
 	}
 
@@ -644,6 +645,31 @@ func main() {
 			}
 			defer hb.Stop()
 			log.Println("opensandbox-worker: Redis heartbeat started")
+
+			// Spot-preemption monitor. NewMonitor returns a no-op on
+			// non-cloud deployments — the goroutine still spins but
+			// never fires. When OPENSANDBOX_CLOUD=aws the AWS monitor
+			// polls IMDSv2 every 5s for /latest/meta-data/spot/instance-action.
+			//
+			// On a Notice we drain in the most minimal way possible for
+			// the PoC: stop the heartbeat so the CP sees us as gone and
+			// re-schedules our sandboxes. The hibernate-each-sandbox path
+			// is the next iteration — for now, sandboxes on a preempted
+			// host fail and the customer re-creates. This matches the
+			// "PoC accepts sandbox state loss on reclaim" risk in the plan.
+			preemptMon := preemption.NewMonitor()
+			go func() {
+				notices := preemptMon.Watch(ctx)
+				for notice := range notices {
+					log.Printf("opensandbox-worker: PREEMPTION notice from %s — action=%s eta=%s, draining now",
+						preemptMon.Name(), notice.Action, notice.ETA.Format(time.RFC3339))
+					hb.Stop()
+					// TODO: hibernate live sandboxes via mgr to S3 within
+					// the ETA budget before exiting. Until then the
+					// kernel/systemd terminates us when the cloud reclaims.
+					return
+				}
+			}()
 		}
 	}
 

--- a/deploy/packer/worker-ami-aws.pkr.hcl
+++ b/deploy/packer/worker-ami-aws.pkr.hcl
@@ -82,6 +82,12 @@ variable "rootfs_context" {
   description = "Pre-built tarball of rootfs + agent wrapper sources."
 }
 
+variable "vector_context" {
+  type        = string
+  default     = "/tmp/packer-vector-ctx.tar.gz"
+  description = "Pre-built tarball of deploy/vector/ (config + populator + units). Pre-create with: tar czf /tmp/packer-vector-ctx.tar.gz deploy/vector/"
+}
+
 variable "golden_cache_bucket" {
   type        = string
   default     = ""
@@ -174,10 +180,20 @@ build {
     destination = "/tmp/opensandbox-worker.service"
   }
 
-  # 4. Upload Vector config + populator.
+  # 4. Upload Vector config + populator. Packer's file provisioner doesn't
+  #    do recursive directory upload reliably across SSH clients, so we
+  #    tar/extract the same way we do the rootfs context above. See
+  #    var.vector_context for the pre-build command.
   provisioner "file" {
-    source      = "deploy/vector/"
-    destination = "/tmp/vector/"
+    source      = var.vector_context
+    destination = "/tmp/vector-ctx.tar.gz"
+  }
+  provisioner "shell" {
+    inline = [
+      "mkdir -p /tmp/vector",
+      "tar xzf /tmp/vector-ctx.tar.gz -C /tmp/vector --strip-components=2", # strip deploy/vector/ prefix
+      "rm /tmp/vector-ctx.tar.gz",
+    ]
   }
 
   # 5. Run the (misleadingly-named-but-cloud-agnostic) setup script. Installs

--- a/deploy/packer/worker-ami-aws.pkr.hcl
+++ b/deploy/packer/worker-ami-aws.pkr.hcl
@@ -1,0 +1,275 @@
+# worker-ami-aws.pkr.hcl — Build an immutable AMI for OpenSandbox workers (QEMU backend) on AWS.
+#
+# Mirrors deploy/packer/worker-ami.pkr.hcl (Azure variant) but targets the
+# amazon-ebs builder. The setup script (`deploy/azure/setup-azure-host.sh`)
+# is cloud-agnostic in practice — it installs QEMU + kernel modules + systemd
+# units + Vector and never talks to Azure-specific APIs. We reuse it as-is.
+#
+# Differences from the Azure file:
+#   - amazon-ebs source on Ubuntu 24.04 LTS x86_64 instead of azure-arm.
+#   - No rootfs blob caching (the Azure variant's elaborate Azure-blob cache
+#     dance was the only Azure-API touch; for the PoC we just rebuild the
+#     rootfs each time, ~10min extra per bake — acceptable for low rebuild
+#     frequency).
+#   - Installs awscli (needed by deploy/vector/populate-vector-env.sh AWS path
+#     and by the worker user-data shared-disk attach).
+#   - Tags the AMI for the terraform `aws_ami` data source lookup
+#     (opensandbox-role=worker, opensandbox-cloud=aws).
+#
+# Usage:
+#   # 1. Build binaries for linux/amd64:
+#   CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.WorkerVersion=$(git rev-parse --short HEAD)" \
+#     -o bin/opensandbox-worker ./cmd/worker/
+#   CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/osb-agent ./cmd/agent/
+#
+#   # 2. Build the rootfs context tarball:
+#   tar czf /tmp/packer-rootfs-ctx.tar.gz deploy/firecracker/rootfs/ deploy/ec2/build-rootfs-docker.sh scripts/claude-agent-wrapper/
+#
+#   # 3. Run packer:
+#   packer init deploy/packer/worker-ami-aws.pkr.hcl
+#   packer build -var "worker_version=$(git rev-parse --short HEAD)" deploy/packer/worker-ami-aws.pkr.hcl
+#
+#   # 4. The data source in opencomputer-infra/terraform/aws/us-east-2-poc/ami.tf
+#   #    picks up the new AMI on the next `tofu apply`.
+
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 1.3.0"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------
+# Variables
+# ---------------------------------------------------------------------
+
+variable "worker_version" {
+  type        = string
+  description = "Worker version (git SHA). Baked into AMI name and tags."
+}
+
+variable "agent_version" {
+  type    = string
+  default = ""
+}
+
+variable "region" {
+  type    = string
+  default = "us-east-2"
+}
+
+variable "instance_type" {
+  type        = string
+  default     = "c5.4xlarge"
+  description = "Builder instance type. Needs enough memory for Docker rootfs build (~8GB) but doesn't need to run guest VMs, so non-metal is fine and saves ~10× vs c5.metal."
+}
+
+variable "worker_binary" {
+  type    = string
+  default = "bin/opensandbox-worker"
+}
+
+variable "agent_binary" {
+  type    = string
+  default = "bin/osb-agent"
+}
+
+variable "rootfs_context" {
+  type        = string
+  default     = "/tmp/packer-rootfs-ctx.tar.gz"
+  description = "Pre-built tarball of rootfs + agent wrapper sources."
+}
+
+variable "golden_cache_bucket" {
+  type        = string
+  default     = ""
+  description = "Optional S3 bucket to upload the bake's golden default.ext4 to (under bases/<golden_version>/). Cell-scoped — e.g. oc-aws-us-east-2-poc-golden-cache. Empty = skip upload."
+}
+
+# ---------------------------------------------------------------------
+# Source
+# ---------------------------------------------------------------------
+
+source "amazon-ebs" "worker" {
+  region        = var.region
+  instance_type = var.instance_type
+  ssh_username  = "ubuntu"
+  ssh_pty       = true
+
+  ami_name        = "opensandbox-worker-${var.worker_version}-${formatdate("YYYYMMDD-hhmm", timestamp())}"
+  ami_description = "OpenSandbox worker AMI (Ubuntu 24.04, QEMU/KVM nested-virt). Built from git ${var.worker_version}."
+
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
+      architecture        = "x86_64"
+      virtualization-type = "hvm"
+      root-device-type    = "ebs"
+    }
+    most_recent = true
+    owners      = ["099720109477"] # Canonical
+  }
+
+  ena_support   = true
+  sriov_support = true
+
+  launch_block_device_mappings {
+    device_name           = "/dev/sda1"
+    volume_size           = 50
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
+  # AMI tags — the terraform `aws_ami` data source in the AWS leaf filters
+  # on these to pick the most-recent worker AMI for this cloud.
+  tags = {
+    Name                  = "opensandbox-worker-${var.worker_version}"
+    "opensandbox-role"    = "worker"
+    "opensandbox-cloud"   = "aws"
+    "opensandbox-version" = var.worker_version
+  }
+
+  # Volume snapshot tag — propagates so the EBS snapshot underlying the AMI
+  # has the same provenance metadata as the AMI itself.
+  snapshot_tags = {
+    "opensandbox-role"    = "worker"
+    "opensandbox-cloud"   = "aws"
+    "opensandbox-version" = var.worker_version
+  }
+
+  run_tags = {
+    Name = "packer-opensandbox-worker-build"
+  }
+}
+
+# ---------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------
+
+build {
+  sources = ["source.amazon-ebs.worker"]
+
+  # 1. Upload pre-built binaries.
+  provisioner "file" {
+    source      = var.worker_binary
+    destination = "/tmp/opensandbox-worker"
+  }
+  provisioner "file" {
+    source      = var.agent_binary
+    destination = "/tmp/osb-agent"
+  }
+
+  # 2. Upload rootfs build context.
+  provisioner "file" {
+    source      = var.rootfs_context
+    destination = "/tmp/rootfs-ctx.tar.gz"
+  }
+
+  # 3. Upload the EC2 worker systemd unit (the Azure variant uses a different
+  #    unit; the EC2 one was already drafted at deploy/ec2/opensandbox-worker.service).
+  provisioner "file" {
+    source      = "deploy/ec2/opensandbox-worker.service"
+    destination = "/tmp/opensandbox-worker.service"
+  }
+
+  # 4. Upload Vector config + populator.
+  provisioner "file" {
+    source      = "deploy/vector/"
+    destination = "/tmp/vector/"
+  }
+
+  # 5. Run the (misleadingly-named-but-cloud-agnostic) setup script. Installs
+  #    QEMU, kernel modules, Docker for rootfs build, Vector, systemd units.
+  provisioner "shell" {
+    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
+    script          = "deploy/azure/setup-azure-host.sh"
+  }
+
+  # 6. AWS-specific: install awscli (used by populate-vector-env.sh and by
+  #    the worker user-data's shared-disk attach), then install binaries and
+  #    build the golden rootfs.
+  provisioner "shell" {
+    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
+    inline = [
+      # awscli v2 — apt's `awscli` is v1 and missing some commands we use.
+      "apt-get update -qq",
+      "apt-get install -y -qq unzip",
+      "curl -fsSL 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip' -o /tmp/awscliv2.zip",
+      "cd /tmp && unzip -q awscliv2.zip && ./aws/install --update",
+      "rm -rf /tmp/awscliv2.zip /tmp/aws",
+      "aws --version",
+
+      # Install worker + agent binaries.
+      "mv /tmp/opensandbox-worker /usr/local/bin/opensandbox-worker",
+      "chmod +x /usr/local/bin/opensandbox-worker",
+      "mv /tmp/osb-agent /usr/local/bin/osb-agent",
+      "chmod +x /usr/local/bin/osb-agent",
+
+      # Install systemd unit.
+      "mv /tmp/opensandbox-worker.service /etc/systemd/system/opensandbox-worker.service",
+      "systemctl daemon-reload",
+      "systemctl enable opensandbox-worker.service",
+
+      # Build the golden rootfs (no caching for PoC — every bake builds from scratch).
+      "mkdir -p /tmp/rootfs-ctx",
+      "cd /tmp/rootfs-ctx && tar xzf /tmp/rootfs-ctx.tar.gz",
+      "INPUT_HASH=$({ sha256sum /usr/local/bin/osb-agent; find /tmp/rootfs-ctx -type f | sort | xargs sha256sum; sha256sum /opt/opensandbox/guest-modules/*.ko* 2>/dev/null; } | sha256sum | awk '{print $1}')",
+      "echo \"Rootfs input hash: $INPUT_HASH\"",
+      "ROOTFS_UUID=$(echo \"$INPUT_HASH\" | head -c 32 | sed 's/\\(........\\)\\(....\\)\\(....\\)\\(....\\)\\(............\\)/\\1-\\2-\\3-\\4-\\5/')",
+      "export ROOTFS_UUID",
+      "mkdir -p /data/firecracker/images /opt/opensandbox/images",
+      "cd /tmp/rootfs-ctx && bash deploy/ec2/build-rootfs-docker.sh /usr/local/bin/osb-agent /data/firecracker/images default",
+      "cp /data/firecracker/images/default.ext4 /opt/opensandbox/images/default.ext4",
+
+      # Inject guest kernel modules into rootfs.
+      "GUEST_MODDIR=/opt/opensandbox/guest-modules",
+      "if [ -d \"$GUEST_MODDIR\" ] && [ -f /opt/opensandbox/images/default.ext4 ]; then",
+      "  MNTDIR=$(mktemp -d)",
+      "  mount -o loop /opt/opensandbox/images/default.ext4 $MNTDIR",
+      "  mkdir -p $MNTDIR/lib/modules/extra",
+      "  cp $GUEST_MODDIR/*.ko* $MNTDIR/lib/modules/extra/ 2>/dev/null || true",
+      "  umount $MNTDIR",
+      "  rmdir $MNTDIR",
+      "fi",
+
+      # Stamp the golden version (hash of the final ext4) — workers read this
+      # at boot to decide whether to fetch a newer golden from S3.
+      "GOLDEN_VERSION=$(/usr/local/bin/opensandbox-worker golden-version /opt/opensandbox/images/default.ext4 2>/dev/null || sha256sum /opt/opensandbox/images/default.ext4 | awk '{print $1}')",
+      "echo \"$GOLDEN_VERSION\" > /opt/opensandbox/images/golden-version",
+      "echo \"Golden version: $GOLDEN_VERSION\"",
+    ]
+  }
+
+  # 7. Optional: upload the golden to S3 so the cell's shared-disk seeder
+  #    + future per-instance prefetch path can fetch it without rebuilding.
+  provisioner "shell" {
+    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
+    environment_vars = [
+      "GOLDEN_CACHE_BUCKET=${var.golden_cache_bucket}",
+      "AWS_DEFAULT_REGION=${var.region}",
+    ]
+    inline = [
+      "set -e",
+      "if [ -z \"$GOLDEN_CACHE_BUCKET\" ]; then",
+      "  echo 'No golden_cache_bucket set; skipping S3 upload (worker AMI still includes the baked golden)'",
+      "  exit 0",
+      "fi",
+      "GOLDEN_VERSION=$(cat /opt/opensandbox/images/golden-version)",
+      "S3_KEY=\"bases/$GOLDEN_VERSION/default.ext4\"",
+      "echo \"Uploading default.ext4 → s3://$GOLDEN_CACHE_BUCKET/$S3_KEY (~4GB, will take a moment)\"",
+      # Instance profile credentials — the bake runs on an EC2 instance and
+      # picks up its role via the metadata service. If the builder role
+      # doesn't have s3:PutObject on the cell's bucket, the upload fails
+      # gracefully and the AMI still works (just without S3-side hydration).
+      "aws s3 cp /opt/opensandbox/images/default.ext4 \"s3://$GOLDEN_CACHE_BUCKET/$S3_KEY\" || echo 'S3 upload failed — continuing (AMI golden is the only copy)'",
+    ]
+  }
+
+  # 8. Write a manifest so external tooling can pin to the resulting AMI ID.
+  post-processor "manifest" {
+    output     = "packer-manifest-aws.json"
+    strip_path = true
+  }
+}

--- a/deploy/vector/populate-vector-env.sh
+++ b/deploy/vector/populate-vector-env.sh
@@ -114,42 +114,102 @@ fi
 [ -f /etc/opensandbox/worker.env ] && . /etc/opensandbox/worker.env
 # shellcheck disable=SC1091
 [ -f /etc/opensandbox/server.env ] && . /etc/opensandbox/server.env
-VAULT_NAME="${OPENSANDBOX_AZURE_KEY_VAULT_NAME:-}"
 
-if [ -z "$VAULT_NAME" ]; then
-    log "OPENSANDBOX_AZURE_KEY_VAULT_NAME unset — host has no KV configured (e.g. dev VM without managed identity); skipping (Vector will use whatever vector.env is on disk)"
-    exit 0
-fi
-
-# IMDS → AAD token for Key Vault
-IMDS_RESP=$(curl -sf -H 'Metadata: true' \
-    "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net" \
-    || true)
-AAD_TOKEN=$(echo "$IMDS_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null)
-if [ -z "$AAD_TOKEN" ]; then
-    log "failed to acquire IMDS token (managed identity not attached?); skipping"
-    exit 0
-fi
-
-# Helper: fetch one secret value or empty string.
-kv_get() {
-    local name=$1
-    local resp
-    resp=$(curl -sf -H "Authorization: Bearer $AAD_TOKEN" \
-        "https://${VAULT_NAME}.vault.azure.net/secrets/${name}?api-version=7.4" \
-        || true)
-    echo "$resp" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("value",""))' 2>/dev/null
+# Cloud detection — explicit OPENSANDBOX_CLOUD wins, else probe IMDS endpoints.
+detect_cloud() {
+    if [ -n "${OPENSANDBOX_CLOUD:-}" ]; then
+        echo "$OPENSANDBOX_CLOUD"; return
+    fi
+    # AWS IMDSv2 token PUT — succeeds only on AWS.
+    if curl -fsS -X PUT --max-time 2 \
+        -H "X-aws-ec2-metadata-token-ttl-seconds: 60" \
+        http://169.254.169.254/latest/api/token >/dev/null 2>&1; then
+        echo "aws"; return
+    fi
+    # Azure IMDS — requires Metadata: true header and api-version.
+    if curl -fsS -H 'Metadata: true' --max-time 2 \
+        "http://169.254.169.254/metadata/instance?api-version=2018-02-01" \
+        >/dev/null 2>&1; then
+        echo "azure"; return
+    fi
+    echo "none"
 }
+CLOUD=$(detect_cloud)
+log "detected cloud: $CLOUD"
+
+# kv_get is the cloud-agnostic secret-fetch front. The provider-specific
+# setup happens once below (Azure: get an AAD token; AWS: nothing — aws CLI
+# uses the EC2 instance profile via the SDK's default chain) and then each
+# logical secret name is dereferenced the same way regardless of cloud.
+
+case "$CLOUD" in
+azure)
+    VAULT_NAME="${OPENSANDBOX_AZURE_KEY_VAULT_NAME:-}"
+    if [ -z "$VAULT_NAME" ]; then
+        log "OPENSANDBOX_AZURE_KEY_VAULT_NAME unset — host has no KV configured (e.g. dev VM without managed identity); skipping (Vector will use whatever vector.env is on disk)"
+        exit 0
+    fi
+    IMDS_RESP=$(curl -sf -H 'Metadata: true' \
+        "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net" \
+        || true)
+    AAD_TOKEN=$(echo "$IMDS_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null)
+    if [ -z "$AAD_TOKEN" ]; then
+        log "failed to acquire IMDS token (managed identity not attached?); skipping"
+        exit 0
+    fi
+    kv_get() {
+        local name=$1
+        local resp
+        resp=$(curl -sf -H "Authorization: Bearer $AAD_TOKEN" \
+            "https://${VAULT_NAME}.vault.azure.net/secrets/${name}?api-version=7.4" \
+            || true)
+        echo "$resp" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("value",""))' 2>/dev/null
+    }
+    ;;
+
+aws)
+    SECRETS_PREFIX="${OPENSANDBOX_AWS_SECRETS_PREFIX:-}"
+    if [ -z "$SECRETS_PREFIX" ]; then
+        log "OPENSANDBOX_AWS_SECRETS_PREFIX unset — host has no Secrets Manager prefix configured; skipping (Vector will use whatever vector.env is on disk)"
+        exit 0
+    fi
+    if ! command -v aws >/dev/null 2>&1; then
+        log "aws CLI not installed in AMI — populator can't fetch from Secrets Manager. Bake awscli into the worker image (see deploy/packer/worker-ami-aws.pkr.hcl)."
+        exit 0
+    fi
+    # Auto-detect region from IMDSv2 so we don't have to plumb it via env.
+    AWS_IMDS_TOKEN=$(curl -fsS -X PUT --max-time 2 \
+        -H "X-aws-ec2-metadata-token-ttl-seconds: 60" \
+        http://169.254.169.254/latest/api/token 2>/dev/null || true)
+    AWS_REGION_DETECTED=$(curl -fsS --max-time 2 \
+        -H "X-aws-ec2-metadata-token: $AWS_IMDS_TOKEN" \
+        http://169.254.169.254/latest/meta-data/placement/region 2>/dev/null || true)
+    export AWS_REGION="${OPENSANDBOX_REGION:-${AWS_REGION_DETECTED:-us-east-2}}"
+
+    kv_get() {
+        local name=$1
+        aws secretsmanager get-secret-value \
+            --secret-id "${SECRETS_PREFIX}${name}" \
+            --query SecretString \
+            --output text 2>/dev/null || echo ""
+    }
+    ;;
+
+*)
+    log "no recognized cloud detected and OPENSANDBOX_CLOUD is empty — skipping. Vector will use whatever vector.env is on disk."
+    exit 0
+    ;;
+esac
 
 TOKEN_VALUE=$(kv_get "$TOKEN_SECRET")
 if [ -z "$TOKEN_VALUE" ]; then
-    log "secret $TOKEN_SECRET not found in $VAULT_NAME (or no access); skipping"
+    log "secret $TOKEN_SECRET not found in $CLOUD secret store (or no access); skipping"
     exit 0
 fi
 
 DATASET_VALUE=$(kv_get "$DATASET_SECRET")
 if [ -z "$DATASET_VALUE" ]; then
-    log "secret $DATASET_SECRET not found in $VAULT_NAME (or no access); skipping — Vector won't have a dataset to ship to"
+    log "secret $DATASET_SECRET not found in $CLOUD secret store (or no access); skipping — Vector won't have a dataset to ship to"
     exit 0
 fi
 
@@ -169,7 +229,7 @@ fi
 CELL_ID_VALUE=$(kv_get "$CELL_ID_SECRET")
 if [ -z "$CELL_ID_VALUE" ]; then
     CELL_ID_VALUE="${OPENCOMPUTER_CELL_ID:-unknown}"
-    log "secret $CELL_ID_SECRET not found in $VAULT_NAME — falling back to OPENCOMPUTER_CELL_ID=$CELL_ID_VALUE"
+    log "secret $CELL_ID_SECRET not found in $CLOUD secret store — falling back to OPENCOMPUTER_CELL_ID=$CELL_ID_VALUE"
 fi
 
 # Auto-detect HOST_IP via the kernel's source-address selection (skips link-local).
@@ -194,4 +254,4 @@ metrics_status="absent"
 if [ -n "$METRICS_TOKEN_VALUE" ] && [ -n "$METRICS_DATASET_VALUE" ]; then
     metrics_status="present"
 fi
-log "populated $ENV_FILE (logs token+dataset from $VAULT_NAME, metrics=$metrics_status, cell_id=$CELL_ID_VALUE, host_ip=${HOST_IP:-unknown})"
+log "populated $ENV_FILE (logs token+dataset from $CLOUD, metrics=$metrics_status, cell_id=$CELL_ID_VALUE, host_ip=${HOST_IP:-unknown})"

--- a/deploy/worker.env.example
+++ b/deploy/worker.env.example
@@ -5,10 +5,32 @@
 # Non-secret config values stay in this file.
 
 # ── Secrets Service ──────────────────────────────────────────────
-# Set this to enable secrets loading from secrets service.
-# When set, all values marked [KEY VAULT] below are fetched automatically.
-# Remove those values from this file — they're managed in the vault.
+# Set ONE of the following — whichever matches the cloud the worker runs in.
+# When set, all values marked "managed in secrets service" below are fetched
+# automatically and don't need to be set here.
+#
+# Azure Key Vault — vault name (e.g. opencomputer-prod-kv).
 SECRETS_VAULT_NAME=opencomputer-prod-kv
+# OPENSANDBOX_AZURE_KEY_VAULT_NAME=opencomputer-prod-kv  # legacy alias for SECRETS_VAULT_NAME
+#
+# AWS Secrets Manager — prefix under which the cell's secrets live, e.g.
+# "opencomputer/aws-us-east-2-poc/". The provider lists secrets under this
+# prefix and dereferences each name in secretMapping (internal/config/secrets.go).
+# OPENSANDBOX_AWS_SECRETS_PREFIX=opencomputer/aws-us-east-2-poc/
+
+# Cloud identifier — set by cloud-init from terraform on AWS workers. Used by
+# deploy/vector/populate-vector-env.sh and the Go preemption monitor to pick
+# the right backend. Leave unset for local dev (script auto-detects via IMDS).
+# OPENSANDBOX_CLOUD=aws
+
+# CPU overcommit ratio — multiplies the physical-vCPU-derived MAX_CAPACITY
+# before the worker advertises capacity to the CP via Redis heartbeat. Memory
+# is never overcommitted because host OOM is a worse failure mode than CPU
+# contention. Recommended values:
+#   1  no overcommit (Azure default, predictable performance)
+#   2  ~36% cheaper per sandbox on AWS r8i for agent workloads (typical default)
+#   3  aggressive — only if sandboxes are dominantly idle (LLM-bound)
+# OPENSANDBOX_CPU_OVERCOMMIT_RATIO=1
 
 # ── Worker Config (not secret — stays in this file) ──────────────
 OPENSANDBOX_MODE=worker

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -170,6 +170,25 @@ type Config struct {
 	// Env vars take precedence over secret values (for local overrides).
 	SecretsARN string
 
+	// AWSSecretsPrefix is the per-cell secret name prefix in AWS Secrets
+	// Manager, e.g. "opencomputer/aws-us-east-2-poc/". When set, LoadSecrets
+	// selects the AWS Secrets Manager provider and lists+loads everything
+	// under this prefix. Mirrors AzureKeyVaultName for the AWS path.
+	AWSSecretsPrefix string
+
+	// Cloud is a short identifier for the cloud the binary is running on
+	// ("aws", "azure", or empty for local/dev). Set by cloud-init from
+	// terraform — preferred over runtime probing for fast startup.
+	Cloud string
+
+	// CPUOvercommitRatio multiplies the worker's physical vCPU count when
+	// publishing capacity in the Redis heartbeat. 1 = no overcommit
+	// (matches Azure default). 2 = recommended for agent workloads on AWS
+	// — roughly halves $/sandbox without measurable UX impact for
+	// LLM-bound sandboxes. Memory is never overcommitted because host OOM
+	// is a worse failure mode than CPU contention.
+	CPUOvercommitRatio int
+
 	// Secret encryption key (hex-encoded 32 bytes / 64 hex chars) for encrypting
 	// project secrets at rest in PostgreSQL. Required if using project secrets.
 	SecretEncryptionKey string
@@ -294,6 +313,9 @@ func Load() (*Config, error) {
 		AzureSubnetID:       os.Getenv("OPENSANDBOX_AZURE_SUBNET_ID"),
 		AzureSSHPublicKey:   os.Getenv("OPENSANDBOX_AZURE_SSH_PUBLIC_KEY"),
 		AzureKeyVaultName:   os.Getenv("OPENSANDBOX_AZURE_KEY_VAULT_NAME"),
+		AWSSecretsPrefix:    os.Getenv("OPENSANDBOX_AWS_SECRETS_PREFIX"),
+		Cloud:               os.Getenv("OPENSANDBOX_CLOUD"),
+		CPUOvercommitRatio:  envOrDefaultInt("OPENSANDBOX_CPU_OVERCOMMIT_RATIO", 1),
 		AzureWorkerIdentityID: os.Getenv("OPENSANDBOX_AZURE_WORKER_IDENTITY_ID"),
 
 		CFAPIToken: os.Getenv("OPENSANDBOX_CF_API_TOKEN"),
@@ -357,6 +379,20 @@ func Load() (*Config, error) {
 	// var explicitly at provisioning time.
 	if cfg.CellID == "" {
 		cfg.CellID = cfg.Region + "-default"
+	}
+
+	// CPU overcommit: multiply the physical-capacity ceiling by the
+	// configured ratio so the worker advertises (and the CP places onto)
+	// the inflated slot count. Ratio < 1 is treated as 1 (the operator
+	// cannot under-commit via this knob — set MaxCapacity directly for
+	// that). Applied after all loading so callers see one consistent
+	// number; the heartbeat, gRPC capacity guard, and any future consumer
+	// all agree.
+	if cfg.CPUOvercommitRatio < 1 {
+		cfg.CPUOvercommitRatio = 1
+	}
+	if cfg.CPUOvercommitRatio > 1 && cfg.MaxCapacity > 0 {
+		cfg.MaxCapacity = cfg.MaxCapacity * cfg.CPUOvercommitRatio
 	}
 
 	if portStr := os.Getenv("OPENSANDBOX_PORT"); portStr != "" {

--- a/internal/config/keyvault.go
+++ b/internal/config/keyvault.go
@@ -1,19 +1,10 @@
-// Package config provides configuration loading from Azure Key Vault.
-//
-// If SECRETS_VAULT_NAME is set, LoadSecretsFromKeyVault fetches all secrets
-// from the vault and maps them to environment variables. The mapping is:
-//
-//	Key Vault secret name    →  Environment variable
-//	server-database-url      →  OPENSANDBOX_DATABASE_URL
-//	server-jwt-secret        →  OPENSANDBOX_JWT_SECRET
-//	worker-s3-secret-key     →  OPENSANDBOX_S3_SECRET_ACCESS_KEY
-//	...etc
-//
-// Secrets already set in the environment are NOT overwritten — env vars take
-// precedence over Key Vault. This allows local overrides for development.
+// Package config — Azure Key Vault implementation of SecretsProvider.
 //
 // Authentication uses Azure Default Credential (Managed Identity on VMs,
-// CLI credentials locally). No explicit credentials needed.
+// CLI credentials locally). The trigger env var is OPENSANDBOX_AZURE_KEY_VAULT_NAME
+// (legacy: SECRETS_VAULT_NAME); LoadSecrets() in secrets.go selects this
+// provider when either is set.
+
 package config
 
 import (
@@ -21,116 +12,39 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 )
 
-// secretMapping maps Key Vault secret names to environment variable names.
-// Only secrets in this map are loaded — unknown secrets in the vault are ignored.
-var secretMapping = map[string]string{
-	// Server secrets
-	"server-database-url":           "OPENSANDBOX_DATABASE_URL",
-	"server-redis-url":              "OPENSANDBOX_REDIS_URL",
-	"server-jwt-secret":             "OPENSANDBOX_JWT_SECRET",
-	"server-api-key":                "OPENSANDBOX_API_KEY",
-	"server-secret-encryption-key":  "OPENSANDBOX_SECRET_ENCRYPTION_KEY",
-	"server-workos-api-key":         "WORKOS_API_KEY",
-	"server-workos-client-id":       "WORKOS_CLIENT_ID",
-	"server-cf-api-token":           "OPENSANDBOX_CF_API_TOKEN",
-	"server-cf-zone-id":             "OPENSANDBOX_CF_ZONE_ID",
-	"server-stripe-secret-key":      "STRIPE_SECRET_KEY",
-	"server-stripe-webhook-secret":  "STRIPE_WEBHOOK_SECRET",
-	"server-sentry-dsn":             "OPENSANDBOX_SENTRY_DSN",
-	// Machine-size fallback lists (PR #209). Comma-separated ranked
-	// instance types the autoscaler tries in order on quota / capacity
-	// errors. Empty value = use the single VMSize / InstanceType
-	// configured on the pool (pre-fallback behavior).
-	"server-azure-vm-sizes":         "OPENSANDBOX_AZURE_VM_SIZES",
-	"server-ec2-instance-types":     "OPENSANDBOX_EC2_INSTANCE_TYPES",
-	// Legacy Axiom mappings — kept for backwards compat with existing prod
-	// KVs that pre-date the `shared-` prefix. New deploys should use
-	// `shared-axiom-*` instead. Safe to leave: in server mode only
-	// `server-axiom-*` is loaded; in worker mode only `worker-axiom-*`. New
-	// `shared-*` mappings below win for new envs that have only those.
-	"server-axiom-query-token":      "AXIOM_QUERY_TOKEN",
-	"server-axiom-dataset":          "AXIOM_DATASET",
-
-	// Worker secrets
-	"worker-jwt-secret":         "OPENSANDBOX_JWT_SECRET",
-	"worker-database-url":       "OPENSANDBOX_DATABASE_URL",
-	"worker-redis-url":          "OPENSANDBOX_REDIS_URL",
-	"worker-s3-access-key":      "OPENSANDBOX_S3_ACCESS_KEY_ID",
-	"worker-s3-secret-key":      "OPENSANDBOX_S3_SECRET_ACCESS_KEY",
-	"worker-sentry-dsn":         "OPENSANDBOX_SENTRY_DSN",
-	"worker-axiom-ingest-token": "AXIOM_INGEST_TOKEN", // legacy; superseded by shared-axiom-ingest-token
-	"worker-axiom-dataset":      "AXIOM_DATASET",      // legacy; superseded by shared-axiom-dataset
-
-	// Shared (mode-agnostic — loaded in both server and worker)
-	"pg-password":               "OPENSANDBOX_PG_PASSWORD",
-	"shared-axiom-ingest-token": "AXIOM_INGEST_TOKEN",
-	"shared-axiom-query-token":  "AXIOM_QUERY_TOKEN",
-	"shared-axiom-dataset":      "AXIOM_DATASET",
-	// Platform-logs (this PR): Vector reads these from
-	// /etc/opensandbox/vector.env, populated by populate-vector-env.service
-	// via its own IMDS+KV REST call (not by this Go-side loader, because
-	// Vector starts as its own systemd unit before the Go binary). The
-	// entries here exist for two reasons:
-	//   1. Discoverability — secretMapping is the single source of truth
-	//      for "what shared-* secrets does this deployment need in KV".
-	//   2. Side-effect: the Go binary ALSO loads them into its own env at
-	//      startup; future Go code that wants to surface platform-stream
-	//      config (e.g. an admin endpoint) gets them for free.
-	"shared-axiom-platform-ingest-token": "AXIOM_PLATFORM_TOKEN",
-	"shared-axiom-platform-dataset":      "AXIOM_PLATFORM_DATASET",
-	// Cell identifier — stamped on every log + metric event so platform
-	// dashboards can filter per cell. Same dual-consumer pattern as the
-	// platform-* secrets above: Vector reads it from /etc/opensandbox/vector.env
-	// (written by populate-vector-env.sh) for its remap substitutions, and the
-	// Go binary reads it from os.Getenv("OPENCOMPUTER_CELL_ID") (config.go) so
-	// app-side logging and metrics get the same value. Per-cell KV stores a
-	// different literal here (e.g. eastus2-default, westeurope-dev).
-	"shared-cell-id": "OPENCOMPUTER_CELL_ID",
+// azureKeyVaultProvider fetches secrets by listing the vault and dereferencing
+// every name that matches secretMapping for the current mode.
+type azureKeyVaultProvider struct {
+	vaultName string
 }
 
-// LoadSecretsFromKeyVault fetches secrets from Azure Key Vault and sets them
-// as environment variables. Only loads secrets relevant to the current mode
-// (server or worker), determined by the secret name prefix.
-//
-// Skips secrets that are already set in the environment.
-// Does nothing if SECRETS_VAULT_NAME is not set.
-func LoadSecretsFromKeyVault() error {
-	vaultName := os.Getenv("SECRETS_VAULT_NAME")
-	if vaultName == "" {
-		return nil // Key Vault not configured — use env file as-is
-	}
+func (p *azureKeyVaultProvider) Name() string { return "azure-keyvault" }
 
-	vaultURL := fmt.Sprintf("https://%s.vault.azure.net/", vaultName)
-	mode := os.Getenv("OPENSANDBOX_MODE") // "server" or "worker"
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+func (p *azureKeyVaultProvider) Load(ctx context.Context, mode string) (int, int, error) {
+	vaultURL := fmt.Sprintf("https://%s.vault.azure.net/", p.vaultName)
 
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
-		return fmt.Errorf("keyvault: azure credential: %w", err)
+		return 0, 0, fmt.Errorf("keyvault: azure credential: %w", err)
 	}
 
 	client, err := azsecrets.NewClient(vaultURL, cred, nil)
 	if err != nil {
-		return fmt.Errorf("keyvault: client: %w", err)
+		return 0, 0, fmt.Errorf("keyvault: client: %w", err)
 	}
 
-	loaded := 0
-	skipped := 0
+	loaded, skipped := 0, 0
 
 	pager := client.NewListSecretPropertiesPager(nil)
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			return fmt.Errorf("keyvault: list secrets: %w", err)
+			return loaded, skipped, fmt.Errorf("keyvault: list secrets: %w", err)
 		}
 
 		for _, prop := range page.Value {
@@ -139,29 +53,16 @@ func LoadSecretsFromKeyVault() error {
 			if !mapped {
 				continue
 			}
-
-			// Only load secrets matching the current mode, or mode-agnostic
-			// "shared" secrets that both server and worker need (the `pg-`
-			// prefix is grandfathered in for the same reason). Without this
-			// bypass, a single token like AXIOM_INGEST_TOKEN — which the
-			// server needs to bake into worker.env at spawn time AND the
-			// worker needs at startup — has to be duplicated under both
-			// `server-` and `worker-` prefixes in KV. The `shared-` prefix
-			// formalizes "this secret goes to both modes" as a real concept.
-			if mode != "" &&
-				!strings.HasPrefix(name, mode+"-") &&
-				!strings.HasPrefix(name, "pg-") &&
-				!strings.HasPrefix(name, "shared-") {
+			if !shouldLoadForMode(name, mode) {
 				continue
 			}
-
-			// Don't overwrite existing env vars — local config takes precedence
+			// Skip the network round-trip when the env is already set —
+			// callers can override locally without paying for the GET.
 			if os.Getenv(envVar) != "" {
 				skipped++
 				continue
 			}
 
-			// Fetch the secret value
 			resp, err := client.GetSecret(ctx, name, "", nil)
 			if err != nil {
 				log.Printf("keyvault: failed to get secret %s: %v (skipping)", name, err)
@@ -171,11 +72,13 @@ func LoadSecretsFromKeyVault() error {
 				continue
 			}
 
-			os.Setenv(envVar, *resp.Value)
-			loaded++
+			if setIfUnset(envVar, *resp.Value) {
+				loaded++
+			} else {
+				skipped++
+			}
 		}
 	}
 
-	log.Printf("keyvault: loaded %d secrets from %s (%d skipped, already set)", loaded, vaultName, skipped)
-	return nil
+	return loaded, skipped, nil
 }

--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -1,0 +1,169 @@
+// Package config — multi-cloud secret loading.
+//
+// A SecretsProvider knows how to fetch secrets from a cloud secret store and
+// populate them as environment variables, honoring the same conventions:
+//
+//   - secretMapping is the single source of truth for "what logical secret
+//     name maps to what env var". Both Azure Key Vault and AWS Secrets
+//     Manager providers use the same map; the difference is the transport.
+//   - Mode-prefix filtering: only `<mode>-*`, `pg-*`, and `shared-*` secrets
+//     are loaded, where mode is the value of OPENSANDBOX_MODE ("server" or
+//     "worker"). Without this a server would try to load worker-only
+//     secrets and vice versa.
+//   - Env-var precedence: secrets already set in os.Environ() are NOT
+//     overwritten. Lets local dev shells override.
+//
+// LoadSecrets() is the entrypoint — it picks a provider by environment:
+//
+//	OPENSANDBOX_AZURE_KEY_VAULT_NAME or SECRETS_VAULT_NAME → Azure
+//	OPENSANDBOX_AWS_SECRETS_PREFIX                        → AWS Secrets Manager
+//	(neither set)                                          → no-op
+//
+// Both env vars set is treated as "both providers run in order" — useful for
+// migrations.
+
+package config
+
+import (
+	"context"
+	"log"
+	"os"
+	"strings"
+	"time"
+)
+
+// SecretsProvider is implemented by per-cloud secret loaders. Implementations
+// must honor mode-prefix filtering and env-var precedence; see Load doc.
+type SecretsProvider interface {
+	// Name returns a short identifier used only for log messages.
+	Name() string
+
+	// Load fetches secrets and sets matching env vars. Returns (loaded,
+	// skipped, err). `mode` is the value of OPENSANDBOX_MODE; pass ""
+	// for mode-agnostic loaders.
+	Load(ctx context.Context, mode string) (loaded int, skipped int, err error)
+}
+
+// secretMapping is the canonical map of "logical secret name → env var
+// name". Implementations look up each fetched secret's logical name here
+// to decide what env var to set.
+//
+// Logical secret names are prefixed:
+//
+//	server-*  loaded only when OPENSANDBOX_MODE=server
+//	worker-*  loaded only when OPENSANDBOX_MODE=worker
+//	pg-*      grandfathered shared (Postgres password) — loaded in both modes
+//	shared-*  mode-agnostic; loaded in both modes
+//
+// Backends apply different transports for fetching these by name (KV list-
+// then-get, SM list-by-prefix-then-get). The names themselves are the same
+// across clouds — operators see the same logical inventory regardless of
+// where the cell runs.
+var secretMapping = map[string]string{
+	// ----- Server secrets -----
+	"server-database-url":          "OPENSANDBOX_DATABASE_URL",
+	"server-redis-url":             "OPENSANDBOX_REDIS_URL",
+	"server-jwt-secret":            "OPENSANDBOX_JWT_SECRET",
+	"server-api-key":               "OPENSANDBOX_API_KEY",
+	"server-secret-encryption-key": "OPENSANDBOX_SECRET_ENCRYPTION_KEY",
+	"server-workos-api-key":        "WORKOS_API_KEY",
+	"server-workos-client-id":      "WORKOS_CLIENT_ID",
+	"server-cf-api-token":          "OPENSANDBOX_CF_API_TOKEN",
+	"server-cf-zone-id":            "OPENSANDBOX_CF_ZONE_ID",
+	"server-stripe-secret-key":     "STRIPE_SECRET_KEY",
+	"server-stripe-webhook-secret": "STRIPE_WEBHOOK_SECRET",
+	"server-sentry-dsn":            "OPENSANDBOX_SENTRY_DSN",
+	"server-azure-vm-sizes":        "OPENSANDBOX_AZURE_VM_SIZES",
+	"server-ec2-instance-types":    "OPENSANDBOX_EC2_INSTANCE_TYPES",
+
+	// Legacy Axiom mappings — kept for backwards compat with existing prod
+	// KVs that pre-date the `shared-` prefix. New deploys should use
+	// `shared-axiom-*` instead.
+	"server-axiom-query-token": "AXIOM_QUERY_TOKEN",
+	"server-axiom-dataset":     "AXIOM_DATASET",
+
+	// ----- Worker secrets -----
+	"worker-jwt-secret":         "OPENSANDBOX_JWT_SECRET",
+	"worker-database-url":       "OPENSANDBOX_DATABASE_URL",
+	"worker-redis-url":          "OPENSANDBOX_REDIS_URL",
+	"worker-s3-access-key":      "OPENSANDBOX_S3_ACCESS_KEY_ID",
+	"worker-s3-secret-key":      "OPENSANDBOX_S3_SECRET_ACCESS_KEY",
+	"worker-sentry-dsn":         "OPENSANDBOX_SENTRY_DSN",
+	"worker-axiom-ingest-token": "AXIOM_INGEST_TOKEN",
+	"worker-axiom-dataset":      "AXIOM_DATASET",
+
+	// ----- Shared / mode-agnostic -----
+	"pg-password":                        "OPENSANDBOX_PG_PASSWORD",
+	"shared-axiom-ingest-token":          "AXIOM_INGEST_TOKEN",
+	"shared-axiom-query-token":           "AXIOM_QUERY_TOKEN",
+	"shared-axiom-dataset":               "AXIOM_DATASET",
+	"shared-axiom-platform-ingest-token": "AXIOM_PLATFORM_TOKEN",
+	"shared-axiom-platform-dataset":      "AXIOM_PLATFORM_DATASET",
+	"shared-cell-id":                     "OPENCOMPUTER_CELL_ID",
+}
+
+// shouldLoadForMode returns true if the given logical secret name applies to
+// the running mode. Empty mode loads everything; otherwise only matching
+// prefixes plus `pg-*` and `shared-*` pass.
+func shouldLoadForMode(name, mode string) bool {
+	if mode == "" {
+		return true
+	}
+	return strings.HasPrefix(name, mode+"-") ||
+		strings.HasPrefix(name, "pg-") ||
+		strings.HasPrefix(name, "shared-")
+}
+
+// setIfUnset writes name=value to the process environment, but only when
+// name is not already set. Returns true if the value was applied.
+func setIfUnset(name, value string) bool {
+	if os.Getenv(name) != "" {
+		return false
+	}
+	_ = os.Setenv(name, value)
+	return true
+}
+
+// LoadSecrets picks a provider by environment and loads secrets from it.
+// Mode is read from OPENSANDBOX_MODE. Returns nil and does nothing if no
+// provider is configured — local dev with a worker.env file works as-is.
+//
+// If both Azure and AWS providers are configured (unusual but legal during
+// a cross-cloud migration), both run in declaration order.
+func LoadSecrets() error {
+	mode := os.Getenv("OPENSANDBOX_MODE")
+
+	var providers []SecretsProvider
+	if name := azureVaultName(); name != "" {
+		providers = append(providers, &azureKeyVaultProvider{vaultName: name})
+	}
+	if prefix := os.Getenv("OPENSANDBOX_AWS_SECRETS_PREFIX"); prefix != "" {
+		providers = append(providers, &awsSecretsManagerProvider{prefix: prefix})
+	}
+
+	if len(providers) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	for _, p := range providers {
+		loaded, skipped, err := p.Load(ctx, mode)
+		if err != nil {
+			return err
+		}
+		log.Printf("secrets: %s loaded %d, skipped %d (already set)", p.Name(), loaded, skipped)
+	}
+	return nil
+}
+
+// azureVaultName reads the Azure KV name from either of the two env vars
+// historically used. Kept here so both `secrets.go` and `keyvault.go` see
+// the same lookup precedence.
+func azureVaultName() string {
+	if v := os.Getenv("OPENSANDBOX_AZURE_KEY_VAULT_NAME"); v != "" {
+		return v
+	}
+	return os.Getenv("SECRETS_VAULT_NAME")
+}

--- a/internal/config/secretsmanager.go
+++ b/internal/config/secretsmanager.go
@@ -1,0 +1,114 @@
+// Package config — AWS Secrets Manager implementation of SecretsProvider.
+//
+// Authentication uses the AWS Default Credential chain (EC2 IAM role on
+// instances, AWS_PROFILE / SSO / env locally). The trigger env var is
+// OPENSANDBOX_AWS_SECRETS_PREFIX; LoadSecrets() in secrets.go selects this
+// provider when it is set.
+//
+// Layout: secrets are stored under a flat per-cell prefix, e.g.
+//
+//	opencomputer/aws-us-east-2-poc/worker-jwt-secret
+//	opencomputer/aws-us-east-2-poc/worker-redis-url
+//	opencomputer/aws-us-east-2-poc/shared-axiom-ingest-token
+//
+// The provider lists everything under the prefix, strips it, looks up the
+// remaining logical name in secretMapping (cloud-agnostic, defined in
+// secrets.go), and sets the matching env var if not already populated.
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+)
+
+// awsSecretsManagerProvider fetches secrets by listing the cell's prefix and
+// dereferencing every name that matches secretMapping for the current mode.
+type awsSecretsManagerProvider struct {
+	prefix string
+}
+
+func (p *awsSecretsManagerProvider) Name() string { return "aws-secretsmanager" }
+
+func (p *awsSecretsManagerProvider) Load(ctx context.Context, mode string) (int, int, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("secretsmanager: load aws config: %w", err)
+	}
+	client := secretsmanager.NewFromConfig(cfg)
+
+	loaded, skipped := 0, 0
+
+	var nextToken *string
+	for {
+		out, err := client.ListSecrets(ctx, &secretsmanager.ListSecretsInput{
+			MaxResults: aws.Int32(100),
+			NextToken:  nextToken,
+			Filters: []types.Filter{
+				{
+					Key:    types.FilterNameStringTypeName,
+					Values: []string{p.prefix},
+				},
+			},
+		})
+		if err != nil {
+			return loaded, skipped, fmt.Errorf("secretsmanager: list: %w", err)
+		}
+
+		for _, entry := range out.SecretList {
+			if entry.Name == nil {
+				continue
+			}
+			fullName := *entry.Name
+			// `name` filter is a prefix-match; defensively strip and skip if not ours.
+			if !strings.HasPrefix(fullName, p.prefix) {
+				continue
+			}
+			logicalName := strings.TrimPrefix(fullName, p.prefix)
+
+			envVar, mapped := secretMapping[logicalName]
+			if !mapped {
+				continue
+			}
+			if !shouldLoadForMode(logicalName, mode) {
+				continue
+			}
+			if os.Getenv(envVar) != "" {
+				skipped++
+				continue
+			}
+
+			val, err := client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+				SecretId: aws.String(fullName),
+			})
+			if err != nil {
+				log.Printf("secretsmanager: failed to get secret %s: %v (skipping)", logicalName, err)
+				continue
+			}
+			if val.SecretString == nil {
+				continue
+			}
+
+			if setIfUnset(envVar, *val.SecretString) {
+				loaded++
+			} else {
+				skipped++
+			}
+		}
+
+		if out.NextToken == nil {
+			break
+		}
+		nextToken = out.NextToken
+	}
+
+	return loaded, skipped, nil
+}

--- a/internal/config/secretsmanager.go
+++ b/internal/config/secretsmanager.go
@@ -39,7 +39,22 @@ type awsSecretsManagerProvider struct {
 func (p *awsSecretsManagerProvider) Name() string { return "aws-secretsmanager" }
 
 func (p *awsSecretsManagerProvider) Load(ctx context.Context, mode string) (int, int, error) {
-	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	// Region: explicit env var wins (matches the cell config), else AWS_REGION,
+	// else fall through to the default chain (IMDS on EC2). Passing nothing
+	// when LoadDefaultConfig can't resolve a region anywhere makes the first
+	// API call return "Missing Region", which surfaces unclearly — prefer the
+	// explicit env-var path even on EC2.
+	region := os.Getenv("OPENSANDBOX_REGION")
+	if region == "" {
+		region = os.Getenv("AWS_REGION")
+	}
+
+	var loadOpts []func(*awsconfig.LoadOptions) error
+	if region != "" {
+		loadOpts = append(loadOpts, awsconfig.WithRegion(region))
+	}
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, loadOpts...)
 	if err != nil {
 		return 0, 0, fmt.Errorf("secretsmanager: load aws config: %w", err)
 	}

--- a/internal/preemption/aws.go
+++ b/internal/preemption/aws.go
@@ -1,0 +1,172 @@
+// AWS spot interruption monitor.
+//
+// AWS publishes interruption notices on IMDSv2 at
+//   GET /latest/meta-data/spot/instance-action
+// returning HTTP 200 with a JSON body shaped:
+//   { "action": "stop|terminate|hibernate", "time": "2026-05-19T12:34:56Z" }
+//
+// Until interruption is scheduled, the endpoint returns 404. We poll every
+// `pollInterval` (default 5s). AWS guarantees the notice lands at least
+// ~2 minutes before the instance is reclaimed, so 5s polling gives ample
+// drain budget.
+//
+// IMDSv2 requires a session token (PUT /latest/api/token). Tokens are
+// scoped per-request and expire in 6h, but we re-fetch on every poll for
+// simplicity — IMDS is link-local, the round-trip cost is negligible
+// compared to the network operations the worker is otherwise doing.
+
+package preemption
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type awsMonitor struct {
+	pollInterval time.Duration
+	imdsEndpoint string
+}
+
+func (m *awsMonitor) Name() string { return "aws-imds" }
+
+func (m *awsMonitor) Watch(ctx context.Context) <-chan Notice {
+	ch := make(chan Notice, 1)
+
+	go func() {
+		defer close(ch)
+
+		// Standalone client so the global default client's settings can't
+		// stall our 1-second IMDS round-trips with unrelated transport
+		// configuration.
+		client := &http.Client{Timeout: 2 * time.Second}
+
+		ticker := time.NewTicker(m.pollInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				notice, found, err := m.probe(ctx, client)
+				if err != nil {
+					// Don't spam — IMDS unreachability is interesting once
+					// per minute, not once per 5s.
+					log.Printf("preemption: aws probe error (will retry): %v", err)
+					continue
+				}
+				if !found {
+					continue
+				}
+				// Buffered channel — non-blocking send. If the consumer is
+				// somehow not reading, drop the second-and-later notices
+				// (the first one is what counts).
+				select {
+				case ch <- notice:
+				default:
+				}
+				// Keep polling — the action / time can change between
+				// notice issuance and reclaim, and we want the consumer to
+				// see the freshest data. Drain is idempotent.
+			}
+		}
+	}()
+
+	return ch
+}
+
+// probe issues one IMDSv2 token-then-get round trip. Returns (Notice, true,
+// nil) when interruption is imminent, (zero, false, nil) when healthy, and
+// (zero, false, err) on transport / decode failures.
+func (m *awsMonitor) probe(ctx context.Context, client *http.Client) (Notice, bool, error) {
+	token, err := m.fetchToken(ctx, client)
+	if err != nil {
+		return Notice{}, false, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		m.imdsEndpoint+"/latest/meta-data/spot/instance-action", nil)
+	if err != nil {
+		return Notice{}, false, err
+	}
+	req.Header.Set("X-aws-ec2-metadata-token", token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return Notice{}, false, err
+	}
+	defer resp.Body.Close()
+
+	// 404 = healthy. AWS specifies this endpoint returns 404 until
+	// interruption is scheduled.
+	if resp.StatusCode == http.StatusNotFound {
+		return Notice{}, false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		// Drain body to keep the connection reusable.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return Notice{}, false, nil
+	}
+
+	var body struct {
+		Action string `json:"action"`
+		Time   string `json:"time"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return Notice{}, false, err
+	}
+
+	eta, err := time.Parse(time.RFC3339, body.Time)
+	if err != nil {
+		// AWS guarantees RFC3339; if they ever change format we'd rather
+		// fire a Notice with the zero time than miss the signal — the
+		// drain budget still applies, and the caller can fallback to
+		// "drain now".
+		log.Printf("preemption: aws unexpected time format %q: %v", body.Time, err)
+	}
+
+	return Notice{
+		Action: Action(strings.ToLower(body.Action)),
+		ETA:    eta,
+		Source: "aws-imds",
+	}, true, nil
+}
+
+// fetchToken obtains an IMDSv2 session token. The token is single-use here;
+// see package doc for why that's fine.
+func (m *awsMonitor) fetchToken(ctx context.Context, client *http.Client) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+		m.imdsEndpoint+"/latest/api/token", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("X-aws-ec2-metadata-token-ttl-seconds", "60")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return "", &imdsHTTPError{code: resp.StatusCode}
+	}
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+type imdsHTTPError struct{ code int }
+
+func (e *imdsHTTPError) Error() string {
+	return "imds token fetch returned HTTP " + http.StatusText(e.code)
+}

--- a/internal/preemption/azure.go
+++ b/internal/preemption/azure.go
@@ -1,0 +1,47 @@
+// Azure Scheduled Events preemption monitor.
+//
+// Azure publishes scheduled-events on IMDS at
+//   GET /metadata/scheduledevents?api-version=2020-07-01
+// (requires header `Metadata: true`). Response shape:
+//   {
+//     "DocumentIncarnation": 42,
+//     "Events": [
+//       { "EventId": "...", "EventType": "Preempt|Reboot|Redeploy|Freeze|Terminate",
+//         "ResourceType": "VirtualMachine",
+//         "Resources": ["<vm-name>"],
+//         "EventStatus": "Scheduled|Started",
+//         "NotBefore": "Mon, 19 May 2026 12:34:56 GMT" }
+//     ]
+//   }
+//
+// "Preempt" is the spot-equivalent ("This VM is being preempted; you have
+// ~30s"). "Terminate" is unscheduled-but-imminent.
+//
+// This is a stub for the PoC — Azure cells aren't running the new
+// preemption-aware code path yet. Wiring this up later is mostly populating
+// the Watch loop with the same probe-then-emit pattern as the AWS monitor.
+
+package preemption
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+type azureMonitor struct {
+	pollInterval time.Duration
+	imdsEndpoint string
+}
+
+func (m *azureMonitor) Name() string { return "azure-scheduled-events" }
+
+func (m *azureMonitor) Watch(ctx context.Context) <-chan Notice {
+	ch := make(chan Notice, 1)
+	go func() {
+		defer close(ch)
+		log.Printf("preemption: azure monitor stubbed — TODO wire to /metadata/scheduledevents (see internal/preemption/azure.go)")
+		<-ctx.Done()
+	}()
+	return ch
+}

--- a/internal/preemption/monitor.go
+++ b/internal/preemption/monitor.go
@@ -1,0 +1,96 @@
+// Package preemption watches the cloud-specific spot-interruption signal and
+// publishes a Notice on a channel once interruption is imminent. The worker
+// binary subscribes to the channel and kicks off graceful drain:
+//
+//   1. Flip its Redis-heartbeat state to "draining" so the CP stops placing.
+//   2. Hibernate every live sandbox to S3 in parallel (existing primitive).
+//   3. Delete the heartbeat key; exit cleanly.
+//
+// On AWS the signal is IMDSv2 /latest/meta-data/spot/instance-action returning
+// 200 with a JSON body. On Azure it's /metadata/scheduledevents. The shape of
+// the work the worker does in response is identical — only the detection is
+// cloud-specific. This package abstracts that.
+//
+// LocalCloud is decided by the OPENSANDBOX_CLOUD env var (set by cloud-init
+// from terraform). If unset, the Monitor returned by NewMonitor is a no-op
+// that never fires — safe default for dev / Azure-without-AWS.
+
+package preemption
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+)
+
+// Action enumerates what the cloud says it will do to the instance.
+type Action string
+
+const (
+	ActionTerminate Action = "terminate"
+	ActionStop      Action = "stop"
+	ActionHibernate Action = "hibernate" // AWS-only; Azure preempts only with "preempt"
+)
+
+// Notice carries the advance-warning details. ETA is when the cloud says it
+// will act; the worker has roughly ETA - now to drain. AWS guarantees ~2 min
+// for spot interruption; Azure scheduled events give ~30s for preempt and
+// up to 15 min for reboot/freeze.
+type Notice struct {
+	Action Action
+	ETA    time.Time
+	// Source describes where the notice came from for logging — "aws-imds",
+	// "azure-scheduled-events", or "redis" for CP-fanout fallback.
+	Source string
+}
+
+// Monitor watches for preemption and emits a Notice on its channel when one
+// arrives. Implementations must:
+//   - Return a buffered channel (size >= 1) so a slow consumer doesn't lose
+//     the notice.
+//   - Survive transient errors (network blips polling IMDS) — log + retry.
+//   - Stop cleanly when the provided context is canceled.
+type Monitor interface {
+	Name() string
+	Watch(ctx context.Context) <-chan Notice
+}
+
+// NewMonitor returns the cloud-appropriate monitor or a no-op if no cloud
+// is configured. Callers should always call Watch — even the no-op returns
+// a channel they can select on, simplifying wire-up.
+func NewMonitor() Monitor {
+	switch os.Getenv("OPENSANDBOX_CLOUD") {
+	case "aws":
+		return &awsMonitor{
+			pollInterval: 5 * time.Second,
+			imdsEndpoint: "http://169.254.169.254",
+		}
+	case "azure":
+		return &azureMonitor{
+			pollInterval: 5 * time.Second,
+			imdsEndpoint: "http://169.254.169.254",
+		}
+	default:
+		log.Printf("preemption: no cloud configured (OPENSANDBOX_CLOUD unset) — preemption notices disabled")
+		return &noopMonitor{}
+	}
+}
+
+// noopMonitor never emits anything. Used for dev and any deployment where
+// the cloud's preemption signal isn't worth wiring up (on-demand-only,
+// bare-metal-colo, etc.).
+type noopMonitor struct{}
+
+func (noopMonitor) Name() string { return "noop" }
+func (noopMonitor) Watch(ctx context.Context) <-chan Notice {
+	ch := make(chan Notice, 1)
+	// Channel left open; the caller's select will simply never fire on
+	// this case. Closing on ctx.Done would also work but would make
+	// receivers reading via "n, ok := <-ch" misinterpret it as a notice.
+	go func() {
+		<-ctx.Done()
+		close(ch)
+	}()
+	return ch
+}

--- a/internal/worker/redis_heartbeat.go
+++ b/internal/worker/redis_heartbeat.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"sync"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -65,6 +66,7 @@ type RedisHeartbeat struct {
 	workerVersion string
 	wasDown       bool   // true if the last publish failed (used to detect reconnect)
 	stop          chan struct{}
+	stopOnce      sync.Once // guards close(stop) + rdb.Del — Stop() may be called from preemption handler and defer
 }
 
 // NewRedisHeartbeat creates a new heartbeat publisher.
@@ -218,14 +220,18 @@ func (h *RedisHeartbeat) publish() {
 }
 
 // Stop stops the heartbeat publisher and closes the Redis connection.
+// Idempotent — safe to call from both the preemption-handler goroutine and
+// the normal `defer hb.Stop()` shutdown path.
 func (h *RedisHeartbeat) Stop() {
-	close(h.stop)
+	h.stopOnce.Do(func() {
+		close(h.stop)
 
-	// Remove the key so the server knows we're gone immediately
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	h.rdb.Del(ctx, "worker:"+h.workerID)
+		// Remove the key so the server knows we're gone immediately
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		h.rdb.Del(ctx, "worker:"+h.workerID)
 
-	h.rdb.Close()
-	log.Println("redis_heartbeat: stopped")
+		h.rdb.Close()
+		log.Println("redis_heartbeat: stopped")
+	})
 }


### PR DESCRIPTION
Backup of motatoes' local clean state of `feat/aws-poc-worker-support` (tip `be8a966`), pushed as a new branch so the pre-PolinRider work is preserved on the remote.

**Do not merge as-is.** This exists as a paper trail. The original `feat/aws-poc-worker-support` branch (target of PR #261) carries the PolinRider payload — `archive/microvm-tests/dashboard/tailwind.config.js` is 7112 bytes there vs 1662 bytes on this clean snapshot.

Verification at branch tip (`be8a966`):
- `archive/microvm-tests/dashboard/tailwind.config.js`: 1662 B (matches `main` — clean)
- Zero PolinRider signatures across all files (`rmcej`, `_$_1e42`, `2857687`)

Companion remediation: see the org-wide PolinRider scrub against the public repos (opencomputer-site, opencomputer-site-v1, digger-site, opentaco-site, bolt-new-poc, catty-cli) and the private-repo follow-up in progress.

Refs: StepSecurity forensic report, 2026-05-22, "Digger (diggerhq) Supply Chain Compromise — PolinRider".