### PR TITLE
fix(sdk-ts): make AgentEvent.type exhaustive for known event types

### DIFF
--- a/sdks/typescript/src/agent.ts
+++ b/sdks/typescript/src/agent.ts
@@ -1,15 +1,19 @@
+export type KnownAgentEventType =
+  | "ready"
+  | "configured"
+  | "assistant"
+  | "result"
+  | "system"
+  | "tool_use_summary"
+  | "turn_complete"
+  | "interrupted"
+  | "error";
+
 export interface AgentEvent {
-  type:
-    | "ready"
-    | "configured"
-    | "assistant"
-    | "result"
-    | "system"
-    | "tool_use_summary"
-    | "turn_complete"
-    | "interrupted"
-    | "error"
-    | string;
+  // `string & {}` keeps the known-literals union exhaustive for `switch`
+  // statements while still allowing forward-compatibility with future event
+  // types added by the server. See #302.
+  type: KnownAgentEventType | (string & {});
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
Closes #302.

## Summary

`AgentEvent.type`'s union ended in `| string`, which collapses TypeScript's exhaustiveness check: `switch (event.type)` accepts incomplete handlers and event-name typos compile silently.

## Change

Extract the literal union as `KnownAgentEventType` and combine it with `(string & {})`:

```ts
export type KnownAgentEventType =
  | "ready" | "configured" | "assistant" | "result" | "system"
  | "tool_use_summary" | "turn_complete" | "interrupted" | "error";

export interface AgentEvent {
  type: KnownAgentEventType | (string & {});
  [key: string]: unknown;
}
```

`string & {}` is the idiomatic TypeScript trick that preserves IntelliSense on the known literals while still permitting any string at runtime — so the SDK stays forward-compatible with future event types the server may emit, but `switch` statements over the known set are once again exhaustive.

## Notes

- Source-only change to the SDK type. No behavior changes at runtime.
- The exported `KnownAgentEventType` lets callers write `Record<KnownAgentEventType, Handler>` if they want compile-time enforcement.
- I don't have the SDK's TS toolchain set up locally — please CI verify on whatever your typecheck flow is.
