### PR TITLE
fix(cli): surface config file read and parse errors

### DIFF
--- a/cmd/oc/internal/config/config.go
+++ b/cmd/oc/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -71,9 +72,18 @@ func loadFile() Config {
 	var cfg Config
 	data, err := os.ReadFile(ConfigPath())
 	if err != nil {
+		// A missing config file is normal on first run. Other I/O errors
+		// are surfaced so the user sees them instead of getting a silent
+		// "no API key" later.
+		if !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "oc: warning: could not read %s: %v\n", ConfigPath(), err)
+		}
 		return cfg
 	}
-	json.Unmarshal(data, &cfg)
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "oc: warning: %s is not valid JSON: %v\n", ConfigPath(), err)
+		return Config{}
+	}
 	return cfg
 }
 


### PR DESCRIPTION
Closes #303.

## Summary

`cmd/oc/internal/config/config.go`'s `loadFile()` previously called `json.Unmarshal` without checking its return value, and ignored every `os.ReadFile` error including I/O errors. A corrupted or hand-edited `~/.oc/config.json` silently returned an empty `Config{}`, after which the user got the much less useful "no API key configured" downstream.

## Change

```go
func loadFile() Config {
    var cfg Config
    data, err := os.ReadFile(ConfigPath())
    if err != nil {
        if !os.IsNotExist(err) {
            fmt.Fprintf(os.Stderr, "oc: warning: could not read %s: %v\n", ConfigPath(), err)
        }
        return cfg
    }
    if err := json.Unmarshal(data, &cfg); err != nil {
        fmt.Fprintf(os.Stderr, "oc: warning: %s is not valid JSON: %v\n", ConfigPath(), err)
        return Config{}
    }
    return cfg
}
```

- Still returns an empty config so flags + env fallbacks keep working.
- Stays silent on `os.IsNotExist` because no config on first run is normal.
- Logs to stderr on JSON parse failure and on any other read error.

## Notes

- Behavior preserved: callers get the same `Config` shape; only the warning side-effect is new.
- No new dependencies; just `fmt` added to imports.
- I don't have Go 1.25 set up locally (go.mod requires it; I have 1.21), so I couldn't `go test` end-to-end. Diff is small and `gofmt` clean.
