### PR TITLE
fix(sdk-ts): flush residual SSE buffer before raising 'no result'

### DIFF
--- a/sdks/typescript/src/sse.ts
+++ b/sdks/typescript/src/sse.ts
@@ -18,6 +18,39 @@ export async function parseSSEStream<T>(resp: Response, onLog: (msg: string) => 
   let buffer = "";
   let result: T | null = null;
 
+  const processEvent = (part: string): void => {
+    if (!part.trim()) return;
+
+    let eventType = "";
+    let data = "";
+    for (const line of part.split("\n")) {
+      if (line.startsWith("event: ")) eventType = line.slice(7);
+      else if (line.startsWith("data: ")) data = line.slice(6);
+    }
+
+    if (!data) return;
+
+    switch (eventType) {
+      case "build_log": {
+        try {
+          onLog(JSON.parse(data).message ?? data);
+        } catch {
+          onLog(data);
+        }
+        break;
+      }
+      case "error": {
+        let msg = data;
+        try { msg = JSON.parse(data).error ?? data; } catch {}
+        throw new Error(`Build failed: ${msg}`);
+      }
+      case "result": {
+        result = JSON.parse(data);
+        break;
+      }
+    }
+  };
+
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
@@ -27,37 +60,17 @@ export async function parseSSEStream<T>(resp: Response, onLog: (msg: string) => 
     buffer = parts.pop() ?? "";
 
     for (const part of parts) {
-      if (!part.trim()) continue;
-
-      let eventType = "";
-      let data = "";
-      for (const line of part.split("\n")) {
-        if (line.startsWith("event: ")) eventType = line.slice(7);
-        else if (line.startsWith("data: ")) data = line.slice(6);
-      }
-
-      if (!data) continue;
-
-      switch (eventType) {
-        case "build_log": {
-          try {
-            onLog(JSON.parse(data).message ?? data);
-          } catch {
-            onLog(data);
-          }
-          break;
-        }
-        case "error": {
-          let msg = data;
-          try { msg = JSON.parse(data).error ?? data; } catch {}
-          throw new Error(`Build failed: ${msg}`);
-        }
-        case "result": {
-          result = JSON.parse(data);
-          break;
-        }
-      }
+      processEvent(part);
     }
+  }
+
+  // Flush the final decoder state and process any residual buffer. If the
+  // server closes the stream after a terminal event without the canonical
+  // trailing `\n\n`, the loop above will leave that event in `buffer` and
+  // we'd lose the result. See #301.
+  buffer += decoder.decode();
+  if (buffer.trim()) {
+    processEvent(buffer);
   }
 
   if (!result) throw new Error("No result received from build stream");


### PR DESCRIPTION
Closes #301.

## Summary

`parseSSEStream` splits on `\n\n` inside the read loop and discards whatever sits in the trailing `buffer` when the stream closes. If the server sends a final `result` event and closes the connection without an extra blank line, the parser raises `Build failed: No result received from build stream` even though the result was delivered — the build appears to fail when it actually succeeded.

## Change

- Extracted event-processing into a local `processEvent` helper to deduplicate the loop and the new flush path.
- After the `while (true)` loop exits, flush the `TextDecoder`'s stream state (`decoder.decode()` with no args) and call `processEvent(buffer)` once more if it's non-empty.

Behavior preserved for streams that do end with `\n\n` (empty buffer ⇒ no-op).

## Notes

- I don't have the SDK's TS test setup running locally. Please CI verify.
- A minimal regression test: a mock `Response` whose body emits `event: result\ndata: {"id":"x"}` *without* a trailing `\n\n` should now resolve to `{id: "x"}` instead of throwing.
