### PR TITLE
fix(qemu): recover panics in async hibernation upload goroutine

### DIFF
--- a/internal/qemu/snapshot.go
+++ b/internal/qemu/snapshot.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"syscall"
 	"time"
@@ -255,6 +256,17 @@ func (m *Manager) doHibernate(ctx context.Context, vm *VMInstance, checkpointSto
 		defer func() {
 			if uploadCb != nil {
 				uploadCb(sandboxID, checkpointKey, sizeBytes, goroutineErr)
+			}
+		}()
+		// Catch panics in archive/upload so the uploadCb still reports a
+		// terminal error rather than leaving the sandbox in `hibernated`
+		// with no blob. Declared *after* the uploadCb defer so it runs
+		// first (LIFO) and `goroutineErr` is observed by the callback.
+		defer func() {
+			if r := recover(); r != nil {
+				goroutineErr = fmt.Errorf("hibernation upload panicked: %v", r)
+				log.Printf("qemu: async hibernate panic for %s: %v\n%s",
+					sandboxID, r, debug.Stack())
 			}
 		}()
 


### PR DESCRIPTION
Closes #296.

## Summary

The background goroutine in `Hibernate` (around `internal/qemu/snapshot.go:248-296`) archives the staged snapshot and uploads it to S3 off the main RPC path. It has no panic boundary. A panic anywhere along the path (zstd writer, tar logic, blob client, callback itself) would:

1. unwind the goroutine,
2. skip the `uploadCb` callback,
3. leave the sandbox row in `hibernated` in the DB with no blob actually uploaded,
4. and leave no terminal error to be observed by the rest of the worker.

## Change

Two-defer trick to interoperate with the existing `uploadCb` defer:

```go
defer func() {
    if uploadCb != nil {
        uploadCb(sandboxID, checkpointKey, sizeBytes, goroutineErr)
    }
}()
defer func() {
    if r := recover(); r != nil {
        goroutineErr = fmt.Errorf("hibernation upload panicked: %v", r)
        log.Printf("qemu: async hibernate panic for %s: %v\n%s",
            sandboxID, r, debug.Stack())
    }
}()
```

The recover defer is declared **after** the `uploadCb` defer so LIFO ordering runs it first — it sets `goroutineErr`, then the `uploadCb` defer runs and observes the populated error like any other failure mode. Adds `runtime/debug` to imports for the stack trace.

## Notes

- No new behavior on the happy path.
- I don't have Go 1.25 set up locally so I couldn't `go test ./internal/qemu/...`. The change is small and additive; the existing test matrix should catch regressions.
- gofmt -l also reports the existing struct-tag alignment in the same file. Not touching that to keep the PR focused — happy to send a separate cleanup PR if it's preferred.
