### PR TITLE
fix(qemu): clean up snapshot-meta tmp file on rename failure

### DIFF
--- a/internal/qemu/snapshot.go
+++ b/internal/qemu/snapshot.go
@@ -163,12 +163,15 @@ func (m *Manager) doHibernate(ctx context.Context, vm *VMInstance, checkpointSto
 		return nil, fmt.Errorf("marshal snapshot meta: %w", err)
 	}
 	metaPath := filepath.Join(snapshotDir, "snapshot-meta.json")
-	// Atomic write: write to temp file then rename to avoid partial JSON on crash
+	// Atomic write: write to temp file then rename to avoid partial JSON on crash.
+	// On rename failure (e.g., ENOSPC, dir-inode exhaustion) remove the tmp file
+	// so the next attempt doesn't see a stale `.tmp` that may shadow recovery.
 	tmpMetaPath := metaPath + ".tmp"
 	if err := os.WriteFile(tmpMetaPath, metaJSON, 0644); err != nil {
 		return nil, fmt.Errorf("write snapshot meta: %w", err)
 	}
 	if err := os.Rename(tmpMetaPath, metaPath); err != nil {
+		_ = os.Remove(tmpMetaPath)
 		return nil, fmt.Errorf("rename snapshot meta: %w", err)
 	}
 


### PR DESCRIPTION
Partial fix for #295. Drops the QMP half — see comment on that issue.

## Summary

`Hibernate` writes snapshot metadata via the standard write-tmp-then-rename atomic pattern. If `os.Rename` fails (ENOSPC, btrfs CoW exhaustion, directory inode pressure), the `.tmp` file stays on disk. A retried hibernate overwrites it, but a later recovery flow could discover the stale `.tmp` and treat it as useful state.

## Change

```go
if err := os.Rename(tmpMetaPath, metaPath); err != nil {
    _ = os.Remove(tmpMetaPath)
    return nil, fmt.Errorf("rename snapshot meta: %w", err)
}
```

## Note on the QMP half

The original issue also flagged `_ = vm.qmp.Quit(); vm.qmp.Close()` as racy. Closer reading: `Quit()` already has a 10s timeout via `execute()` (`internal/qemu/qmp.go:192`), and `Close()` just calls `q.conn.Close()` on the unix socket — no draining, no hang. Posted a comment on #295 with this finding; happy to remove that half from the issue text or close it.
