### PR TITLE
fix(billing): source reconciler cutoff from DB clock, not host clock

### DIFF
--- a/internal/billing/capacity_reconciler.go
+++ b/internal/billing/capacity_reconciler.go
@@ -103,7 +103,21 @@ func (r *CapacityReconciler) tick() {
 	// Cutoff: only buckets whose end is at least `settle` ago are eligible.
 	// Truncate to a 15-min boundary so we don't accidentally include a
 	// half-finished bucket if `settle` happens to land mid-bucket.
-	cutoff := time.Now().UTC().Add(-r.settle).Truncate(15 * time.Minute)
+	//
+	// Source the wall clock from the database, not the reconciler host:
+	// allocator candidates and bucket boundaries are written by Postgres,
+	// so using `time.Now()` here makes the cutoff sensitive to clock skew
+	// between the reconciler host and the DB. On skew, buckets at the
+	// edge can be picked up before the DB considers them closed, or
+	// missed for a full interval if the host clock is behind. Falls back
+	// to the host clock if the DB lookup fails (interval is generous
+	// enough to recover on the next tick).
+	nowUTC, err := r.store.Now(ctx)
+	if err != nil {
+		log.Printf("capacity-reconciler: db NOW() failed (%v); falling back to host clock", err)
+		nowUTC = time.Now().UTC()
+	}
+	cutoff := nowUTC.Add(-r.settle).Truncate(15 * time.Minute)
 	lookbackStart := cutoff.Add(-r.lookback)
 
 	candidates, err := r.store.ListAllocatorCandidates(ctx, lookbackStart, cutoff, r.limit)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -62,6 +62,19 @@ func (s *Store) Ping(ctx context.Context) error {
 	return s.pool.Ping(ctx)
 }
 
+// Now returns the database's current UTC time. Prefer this over
+// `time.Now().UTC()` when the value participates in comparisons against
+// timestamps that were written by Postgres — e.g. settlement bucket
+// boundaries — so process and DB clock skew can't include or exclude
+// rows at the boundary.
+func (s *Store) Now(ctx context.Context) (time.Time, error) {
+	var t time.Time
+	if err := s.pool.QueryRow(ctx, `SELECT (NOW() AT TIME ZONE 'UTC')::timestamp`).Scan(&t); err != nil {
+		return time.Time{}, fmt.Errorf("db now: %w", err)
+	}
+	return t.UTC(), nil
+}
+
 // Close closes the connection pool.
 func (s *Store) Close() {
 	s.pool.Close()


### PR DESCRIPTION
Closes #297.

## Summary

`CapacityReconciler.tick()` computed the settlement cutoff from `time.Now()` on the reconciler host:

```go
cutoff := time.Now().UTC().Add(-r.settle).Truncate(15 * time.Minute)
```

Allocator candidates and bucket boundaries are written by Postgres, so any clock skew between the reconciler host and the DB can include a bucket the DB still considers open, or miss one for a full interval if the host lags the DB. The 30-min settle window absorbs typical NTP drift but isn't a guarantee.

## Change

- New `Store.Now(ctx)` in `internal/db/store.go` that queries `SELECT (NOW() AT TIME ZONE 'UTC')::timestamp`. Documented as the preferred source when the value participates in comparisons against DB-written timestamps.
- `CapacityReconciler.tick()` now sources `nowUTC` from `r.store.Now(ctx)`, falling back to the host clock on DB error so a transient DB hiccup doesn't drop a whole settlement tick. The outbox UNIQUE constraint already absorbs the resulting replay.

## Notes

- The fallback path logs at `log.Printf` level so it's visible in regular logs without needing structured logging changes.
- Diff is small (~28 lines across two files). The new `Now` method is generally useful — happy to wire it in elsewhere where the same pattern occurs if it'd be welcome in a follow-up.
- gofmt -l reports the file because of *pre-existing* struct-field alignment in unrelated parts of both files. The diff I'm sending is gofmt-clean on its own; not touching the existing alignment to keep the PR focused.
