### PR TITLE
fix(sandbox): schedule cleanup for failed-create router entries

### DIFF
--- a/internal/sandbox/router.go
+++ b/internal/sandbox/router.go
@@ -176,6 +176,13 @@ func (r *SandboxRouter) MarkCreated(sandboxID string, err error) {
 	if err != nil {
 		entry.wakeErr = err
 		entry.state = StateHibernated // mark as failed
+		// Schedule cleanup so a failed creation doesn't leak the map entry
+		// forever. The wakeCh close below unblocks any in-flight waiters,
+		// and a short TTL gives them time to observe wakeErr before the
+		// entry disappears. A later Route() can rediscover from the DB.
+		entry.timer = time.AfterFunc(failedCreateRetentionTTL, func() {
+			r.Unregister(sandboxID)
+		})
 	} else {
 		entry.state = StateRunning
 		if entry.timeout > 0 {
@@ -186,6 +193,12 @@ func (r *SandboxRouter) MarkCreated(sandboxID string, err error) {
 	}
 	close(entry.wakeCh)
 }
+
+// failedCreateRetentionTTL is how long a failed-creation entry sits in
+// the router map before it's unregistered. Long enough for in-flight
+// waiters to read wakeErr after wakeCh closes; short enough that the
+// map doesn't accumulate dead entries under sustained creation failure.
+const failedCreateRetentionTTL = 60 * time.Second
 
 // Unregister removes a sandbox from the router (called on kill/destroy).
 func (r *SandboxRouter) Unregister(sandboxID string) {


### PR DESCRIPTION
Closes #289.

## Summary

`SandboxRouter.MarkCreated` (`internal/sandbox/router.go:161`) registered a `time.AfterFunc` only on the success branch:

```go
if err != nil {
    entry.wakeErr = err
    entry.state = StateHibernated // mark as failed
} else {
    entry.state = StateRunning
    if entry.timeout > 0 {
        entry.timer = time.AfterFunc(entry.timeout, func() {
            r.onTimeout(sandboxID)
        })
    }
}
```

Failed creates transition to `StateHibernated`, set `wakeErr`, and close `wakeCh` — but the `*sandboxEntry` is never collected. Under sustained creation failure (worker outage, image pull churn, autoscaler thrash) the map grows unboundedly.

## Change

On the failure branch, schedule a 60-second `Unregister` via `time.AfterFunc`:

```go
entry.timer = time.AfterFunc(failedCreateRetentionTTL, func() {
    r.Unregister(sandboxID)
})
```

Long enough for any in-flight waiters to observe `wakeErr` after `wakeCh` closes; short enough that the map doesn't accumulate dead entries. A later `Route()` for the same sandbox ID rediscovers state from the DB through the existing `discoverAndEnsure` path.

## Notes

- New `failedCreateRetentionTTL` constant lives next to `MarkCreated` rather than being exported — it's an internal cleanup cadence and the value can be tuned per traffic shape if it becomes important.
- I'd suggest a follow-up that adds a metric for `sandbox_router_failed_create_total` so we can detect when this branch fires in production. Happy to add it in a separate PR.
- I can't compile-verify (Go 1.21 vs the repo's 1.25 requirement), but the change is one-call additive.
