### PR TITLE
fix(agent): close PTY session cleanup race in servePTYData

### DIFF
--- a/internal/agent/pty.go
+++ b/internal/agent/pty.go
@@ -171,13 +171,17 @@ func (s *Server) servePTYData(sess *ptySession, ctx context.Context, ready chan<
 
 	// Wait for command to exit
 	sess.cmd.Wait()
-	sess.ptyFile.Close()
-	wg.Wait()
 
-	// Clean up session
+	// Remove from the session map BEFORE closing ptyFile so a concurrent
+	// PTYAttach can't acquire this entry just to find its file descriptor
+	// closed underneath it. After the delete, no new attach can find the
+	// session — only the io.Copy goroutines still hold sess.ptyFile.
 	s.ptyMu.Lock()
 	delete(s.ptySessions, sess.id)
 	s.ptyMu.Unlock()
+
+	sess.ptyFile.Close()
+	wg.Wait()
 }
 
 // PTYAttach opens a bidirectional gRPC stream for PTY I/O.


### PR DESCRIPTION
Partial fix for #291.

## Summary

`servePTYData` (`internal/agent/pty.go:160-181`) closed `sess.ptyFile` *before* removing the session from `s.ptySessions`. A concurrent `PTYAttach` could:

1. acquire the entry under `ptyMu`,
2. release the lock,
3. attempt to `sess.ptyFile.Read(buf)` — and find the FD closed underneath it.

Mild — the symptom is an immediate read error and a cleanly-failed attach — but the race is real and the file-descriptor-after-close pattern is the kind of thing race detectors complain about.

## Change

Reorder cleanup: delete from the map under `ptyMu` first, *then* close `ptyFile` and wait on the io.Copy goroutines.

```go
sess.cmd.Wait()

s.ptyMu.Lock()
delete(s.ptySessions, sess.id)
s.ptyMu.Unlock()

sess.ptyFile.Close()
wg.Wait()
```

After the delete, no new `PTYAttach` can find the session — only the in-flight io.Copy goroutines still hold `sess.ptyFile`, and they're already inside the function.

## Not in this PR

The second half of #291 — `PTYAttach`'s reader goroutine doesn't observe `stream.Context().Done()` on client disconnect, so it stays blocked on `ptyFile.Read` until the underlying process exits. That fix requires either closing the ptyFile on disconnect (which ends the session for any reattach) or introducing a per-attach reader-relay channel pattern. Either way it's worth its own PR so this race fix is reviewable on its own. Happy to send the follow-up.
