### PR TITLE
fix(crypto,auth): log versioned-decrypt fallbacks; drop signed-URL hex round-trip

### DIFF
--- a/internal/auth/signed_url.go
+++ b/internal/auth/signed_url.go
@@ -17,13 +17,21 @@ type SignedURLParams struct {
 	ExpiresAt time.Time
 }
 
+// signURLBytes produces the raw HMAC-SHA256 signature bytes for the
+// given parameters. SignURL is a hex-encoded wrapper kept for callers
+// that need a URL-safe form; VerifyURL uses signURLBytes directly to
+// avoid an encode→decode round trip on a value we already control.
+func signURLBytes(secret []byte, params SignedURLParams) []byte {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(signPayload(params)))
+	return mac.Sum(nil)
+}
+
 // SignURL produces an HMAC-SHA256 hex signature for the given parameters.
 // The signing payload uses a domain-separated canonical format to prevent
 // parameter substitution attacks.
 func SignURL(secret []byte, params SignedURLParams) string {
-	mac := hmac.New(sha256.New, secret)
-	mac.Write([]byte(signPayload(params)))
-	return hex.EncodeToString(mac.Sum(nil))
+	return hex.EncodeToString(signURLBytes(secret, params))
 }
 
 // VerifyURL checks the HMAC signature and expiration.
@@ -32,14 +40,16 @@ func VerifyURL(secret []byte, params SignedURLParams, signature string) error {
 		return fmt.Errorf("signed URL expired")
 	}
 
-	expected := SignURL(secret, params)
 	sigBytes, err := hex.DecodeString(signature)
 	if err != nil {
 		return fmt.Errorf("invalid signature encoding")
 	}
-	expectedBytes, _ := hex.DecodeString(expected)
 
-	if !hmac.Equal(sigBytes, expectedBytes) {
+	// Compare against the byte-sum directly. Previous code called SignURL
+	// to get the hex string and decoded it again — the second decode
+	// swallowed its error with `_`, which would silently treat a corrupt
+	// internal computation as a mismatch instead of a bug.
+	if !hmac.Equal(sigBytes, signURLBytes(secret, params)) {
 		return fmt.Errorf("invalid signature")
 	}
 

--- a/internal/crypto/keyring.go
+++ b/internal/crypto/keyring.go
@@ -3,6 +3,7 @@ package crypto
 import (
 	"encoding/binary"
 	"fmt"
+	"log"
 )
 
 // KeyRing holds multiple versioned encryption keys. New data is always encrypted
@@ -59,6 +60,12 @@ func (r *KeyRing) Encrypt(plaintext []byte) ([]byte, error) {
 // Decrypt reads the version header and decrypts with the matching key.
 // Falls back to the primary key for legacy data without a version header
 // (ciphertext shorter than expected or version 0 with no v0 key registered).
+//
+// When a registered version's decrypt fails but the legacy fallback then
+// succeeds, a WARN log is emitted: this almost always signals data that
+// was *meant* to be versioned but is corrupted, mis-versioned, or
+// encrypted under a key that's no longer in the ring — investigating it
+// is more useful than silently treating it as legacy.
 func (r *KeyRing) Decrypt(data []byte) ([]byte, error) {
 	// Legacy unversioned data: try primary key directly
 	if len(data) < 2 {
@@ -66,17 +73,26 @@ func (r *KeyRing) Decrypt(data []byte) ([]byte, error) {
 	}
 
 	ver := binary.BigEndian.Uint16(data[:2])
+	versionedAttempted := false
 	if enc, ok := r.keys[ver]; ok {
+		versionedAttempted = true
 		result, err := enc.Decrypt(data[2:])
 		if err == nil {
 			return result, nil
 		}
-		// If versioned decrypt fails, fall through to legacy
+		// Versioned decrypt failed for a known version. Log and fall through
+		// to legacy so pre-rotation blobs still decode; the fallback success
+		// itself is logged below for forensic visibility.
+		log.Printf("keyring: versioned decrypt for v%d failed (%v); attempting legacy fallback", ver, err)
 	}
 
 	// Legacy fallback: data may not have a version header (pre-rotation secrets).
 	// Try primary key on the full blob.
-	return r.primary.Decrypt(data)
+	result, err := r.primary.Decrypt(data)
+	if err == nil && versionedAttempted {
+		log.Printf("keyring: legacy fallback succeeded after v%d versioned-decrypt failure — investigate the source of this blob", ver)
+	}
+	return result, err
 }
 
 // PrimaryVersion returns the version number of the active encryption key.


### PR DESCRIPTION
Closes #286.

## Summary

Two related defensive cleanups in the crypto/auth layer.

## `internal/crypto/keyring.go`

`KeyRing.Decrypt` silently fell back to primary-key decryption when a registered version's decrypt failed. That's correct for pre-rotation legacy blobs without a version header, but the silence means a *versioned* blob that's corrupted or encrypted under a missing key looks identical to a legacy blob — neither alerted nor distinguishable in logs.

```go
ver := binary.BigEndian.Uint16(data[:2])
if enc, ok := r.keys[ver]; ok {
    result, err := enc.Decrypt(data[2:])
    if err == nil {
        return result, nil
    }
    log.Printf("keyring: versioned decrypt for v%d failed (%v); attempting legacy fallback", ver, err)
}

result, err := r.primary.Decrypt(data)
if err == nil && versionedAttempted {
    log.Printf("keyring: legacy fallback succeeded after v%d versioned-decrypt failure — investigate ...", ver)
}
return result, err
```

Behavior is unchanged for healthy traffic; suspect blobs become visible in logs.

## `internal/auth/signed_url.go`

`VerifyURL` previously called `SignURL` (which returns hex) and then `hex.DecodeString`ed the result again, swallowing the decode error with `_`. The bytes are ours; the round-trip was both wasted work and a fragile pattern that could mask an internal bug as a signature mismatch.

Refactor:

```go
func signURLBytes(secret []byte, params SignedURLParams) []byte {
    mac := hmac.New(sha256.New, secret)
    mac.Write([]byte(signPayload(params)))
    return mac.Sum(nil)
}

func SignURL(secret []byte, params SignedURLParams) string {
    return hex.EncodeToString(signURLBytes(secret, params))
}

func VerifyURL(secret []byte, params SignedURLParams, signature string) error {
    if time.Now().After(params.ExpiresAt) {
        return fmt.Errorf("signed URL expired")
    }
    sigBytes, err := hex.DecodeString(signature)
    if err != nil {
        return fmt.Errorf("invalid signature encoding")
    }
    if !hmac.Equal(sigBytes, signURLBytes(secret, params)) {
        return fmt.Errorf("invalid signature")
    }
    return nil
}
```

No behavior change observable externally; cleaner internals.
