### PR TITLE
fix(agent): tighten input validation for exec, filesystem, and cgroup RPCs

### DIFF
--- a/internal/agent/exec.go
+++ b/internal/agent/exec.go
@@ -395,6 +395,15 @@ func killCgroup() {
 func (s *Server) SetResourceLimits(ctx context.Context, req *pb.SetResourceLimitsRequest) (*pb.SetResourceLimitsResponse, error) {
 	const cgroupDir = "/sys/fs/cgroup/sandbox"
 
+	// Reject negative values explicitly. The `> 0` checks below mean negative
+	// inputs are silently treated as "leave unchanged", which masks bugs in
+	// the caller (e.g., signed-int wraparound or off-by-one in the worker's
+	// scaling math).
+	if req.MaxPids < 0 || req.MaxMemoryBytes < 0 || req.CpuMaxUsec < 0 || req.CpuPeriodUsec < 0 {
+		return nil, fmt.Errorf("resource limits must be non-negative (got pids=%d memory=%d cpu_max=%d cpu_period=%d)",
+			req.MaxPids, req.MaxMemoryBytes, req.CpuMaxUsec, req.CpuPeriodUsec)
+	}
+
 	if req.MaxPids > 0 {
 		if err := os.WriteFile(cgroupDir+"/pids.max", []byte(fmt.Sprintf("%d", req.MaxPids)), 0644); err != nil {
 			return nil, fmt.Errorf("set pids.max: %w", err)

--- a/internal/agent/exec_session.go
+++ b/internal/agent/exec_session.go
@@ -43,6 +43,12 @@ type execSession struct {
 	disconnectTimer *time.Timer
 }
 
+// maxScrollbackBytes caps the per-session scrollback buffer. Callers can
+// request smaller; anything larger (or negative) is clamped to this
+// value so a misbehaving or buggy caller can't trigger multi-GB
+// allocations inside the agent.
+const maxScrollbackBytes = 16 * 1024 * 1024 // 16 MiB
+
 // ExecSessionCreate starts a command and returns a session ID.
 func (s *Server) ExecSessionCreate(ctx context.Context, req *pb.ExecSessionCreateRequest) (*pb.ExecSessionCreateResponse, error) {
 	sessionID := uuid.New().String()[:8]
@@ -87,7 +93,14 @@ func (s *Server) ExecSessionCreate(ctx context.Context, req *pb.ExecSessionCreat
 		return nil, fmt.Errorf("stderr pipe: %w", err)
 	}
 
+	// Cap caller-supplied scrollback so a misbehaving or buggy caller can't
+	// trigger multi-GB allocations inside the VM. 16 MiB is well above the
+	// largest reasonable terminal scrollback and small enough to bound a
+	// single session's memory footprint.
 	maxScrollback := int(req.ScrollbackMaxBytes)
+	if maxScrollback < 0 || maxScrollback > maxScrollbackBytes {
+		maxScrollback = maxScrollbackBytes
+	}
 	scrollback := sandbox.NewScrollbackBuffer(maxScrollback)
 
 	stdoutTee, stderrTee := s.newExecLineWriters(req.Command, req.Args)

--- a/internal/agent/filesystem.go
+++ b/internal/agent/filesystem.go
@@ -40,7 +40,10 @@ func (s *Server) WriteFile(ctx context.Context, req *pb.WriteFileRequest) (*pb.W
 		return nil, fmt.Errorf("mkdir %s: %w", dir, err)
 	}
 
-	mode := os.FileMode(req.Mode)
+	// Mask to permission bits only. Caller-supplied setuid/setgid/sticky
+	// bits would let the agent write a setuid file into a tenant-writable
+	// path; we never want to honor those here.
+	mode := os.FileMode(req.Mode) & os.ModePerm
 	if mode == 0 {
 		mode = 0644
 	}
@@ -167,7 +170,8 @@ func (s *Server) WriteFileStream(stream pb.SandboxAgent_WriteFileStreamServer) e
 	}
 
 	path := resolvePath(msg.Path)
-	mode := os.FileMode(msg.Mode)
+	// Mask to permission bits only; see WriteFile for rationale.
+	mode := os.FileMode(msg.Mode) & os.ModePerm
 	if mode == 0 {
 		mode = 0644
 	}


### PR DESCRIPTION
Closes #292.

## Summary

Four related defensive cleanups in the in-VM agent's RPC surface. All are caller-trust hardening: the agent's gRPC port is the boundary between the worker and the tenant, and these inputs flow straight into allocation, filesystem, and cgroup operations.

## Changes

**`internal/agent/exec_session.go`** — cap `ScrollbackMaxBytes` at 16 MiB:
```go
const maxScrollbackBytes = 16 * 1024 * 1024 // 16 MiB
...
maxScrollback := int(req.ScrollbackMaxBytes)
if maxScrollback < 0 || maxScrollback > maxScrollbackBytes {
    maxScrollback = maxScrollbackBytes
}
```

**`internal/agent/filesystem.go`** — `WriteFile` and `WriteFileStream` now mask the mode bits:
```go
mode := os.FileMode(req.Mode) & os.ModePerm
```
This zeroes out caller-supplied setuid/setgid/sticky bits while preserving the normal rwx tri-bits.

**`internal/agent/exec.go`** — `SetResourceLimits` rejects negative values up front:
```go
if req.MaxPids < 0 || req.MaxMemoryBytes < 0 || req.CpuMaxUsec < 0 || req.CpuPeriodUsec < 0 {
    return nil, fmt.Errorf("resource limits must be non-negative ...")
}
```
Previously the `if v > 0` guards silently treated negatives as "leave unchanged".

## Not in this PR

The fourth sub-finding from #292 — `ListDir` silently skipping entries whose `Info()` fails — needs a protobuf field to surface "partial listing" to the caller. Worth its own PR with the proto change discussed first.

## Notes

- 28 lines added across three files; gofmt-clean for the diff itself.
- These are all caller-side validation — no behavior change for well-behaved callers.
