### PR TITLE
fix(api): use org-scoped sandbox lookup in checkpoint handlers

### DIFF
--- a/internal/api/sandbox.go
+++ b/internal/api/sandbox.go
@@ -2101,13 +2101,11 @@ func (s *Server) listCheckpoints(c echo.Context) error {
 		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "org context required"})
 	}
 
-	// Verify sandbox belongs to org
-	session, err := s.store.GetSandboxSession(c.Request().Context(), sandboxID)
+	// Verify sandbox belongs to org. Use the org-scoped lookup so a
+	// wrong-org probe returns 404 instead of 403 — see #274.
+	_, err := s.store.GetSandboxSessionInOrg(c.Request().Context(), orgID, sandboxID)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "sandbox not found"})
-	}
-	if session.OrgID != orgID {
-		return c.JSON(http.StatusForbidden, map[string]string{"error": "sandbox does not belong to this organization"})
 	}
 
 	checkpoints, err := s.store.ListCheckpoints(c.Request().Context(), sandboxID)
@@ -2138,13 +2136,11 @@ func (s *Server) restoreCheckpoint(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid checkpoint ID"})
 	}
 
-	// Verify sandbox belongs to org and is running
-	session, err := s.store.GetSandboxSession(ctx, sandboxID)
+	// Verify sandbox belongs to org and is running. Use the org-scoped
+	// lookup so a wrong-org probe returns 404 instead of 403 — see #274.
+	session, err := s.store.GetSandboxSessionInOrg(ctx, orgID, sandboxID)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": "sandbox not found"})
-	}
-	if session.OrgID != orgID {
-		return c.JSON(http.StatusForbidden, map[string]string{"error": "sandbox does not belong to this organization"})
 	}
 	if session.Status != "running" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "sandbox must be running to restore a checkpoint"})

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -707,6 +707,16 @@ func (s *Store) MarkOrphanedSandboxes(ctx context.Context, liveWorkers map[strin
 	return total, nil
 }
 
+// GetSandboxSession looks up a session by sandbox ID alone, without
+// org-scoping. **Prefer [Store.GetSandboxSessionInOrg]** whenever the
+// caller has org context (most HTTP handlers do — see middleware) —
+// using the unscoped variant in handler paths leaks cross-org sandbox
+// existence via the 404-vs-403 distinction (design F12).
+//
+// This function remains for internal callers (background workers,
+// patch helpers, proxy lookups) that legitimately don't have org
+// context. New code in `internal/api/` should not call it directly;
+// see issue #274 for the in-flight migration.
 func (s *Store) GetSandboxSession(ctx context.Context, sandboxID string) (*SandboxSession, error) {
 	session := &SandboxSession{}
 	err := s.pool.QueryRow(ctx,


### PR DESCRIPTION
Partial fix for #274.

## Summary

`GetSandboxSession` looks up by sandbox ID alone. Handlers that already have org context were doing:

```go
session, err := s.store.GetSandboxSession(ctx, sandboxID)
if err != nil { return 404 }
if session.OrgID != orgID { return 403 }
```

The 404-vs-403 distinction lets an attacker enumerate sandbox IDs across orgs. The existing `GetSandboxSessionInOrg` (`internal/db/store.go:730`) is the safe variant — it filters on `(org_id, sandbox_id)` and returns the same error whether the sandbox doesn't exist or belongs to a different org.

## Changes

**Two handler call sites** in `internal/api/sandbox.go` (the two cited in the issue that follow the exact unsafe pattern and have `orgID` in scope) are converted to `GetSandboxSessionInOrg`. Wrong-org probes now return 404 identically to genuinely-unknown sandboxes:

```go
session, err := s.store.GetSandboxSessionInOrg(ctx, orgID, sandboxID)
if err != nil {
    return c.JSON(http.StatusNotFound, ...)
}
```

**Doc comment** added to `GetSandboxSession` in `internal/db/store.go` to point future handler authors at the org-scoped variant and explain why the unscoped form is still kept (legitimate non-handler callers like the background patch flow, proxy lookups, and the worker reconciliation loop don't have org context).

## Not in this PR

The grep at the top of #274 shows ~20 more unsafe call sites. Each needs per-site review:

- Some are handlers with org context — those should follow these two as exemplars.
- Some are background or worker-side callers that genuinely can't supply org. Those keep `GetSandboxSession`.
- A few (e.g., `applyPendingPatches` at `sandbox.go:2760`) look unsafe at first glance but are internal flows triggered after org has already been validated — they're acceptable but worth a comment.

I'd rather send those as follow-ups so each batch is small enough to review. Happy to pick up the remainder once these two are merged.
