### PR TITLE
fix(db): enforce templates public/org_id tenancy invariant via CHECK

### DIFF
--- a/internal/db/migrations/043_templates_public_check.down.sql
+++ b/internal/db/migrations/043_templates_public_check.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE templates DROP CONSTRAINT IF EXISTS templates_public_org_id_check;

--- a/internal/db/migrations/043_templates_public_check.up.sql
+++ b/internal/db/migrations/043_templates_public_check.up.sql
@@ -1,0 +1,45 @@
+-- 043_templates_public_check
+--
+-- The `templates` table has had a nullable `org_id` and an `is_public`
+-- boolean since 001_initial without an explicit invariant tying them
+-- together. The intent — `is_public` templates have no org, private
+-- templates do — was only encoded in convention. Without a CHECK
+-- constraint, any future INSERT or UPDATE that gets the pair wrong
+-- silently slips through, and queries that forget to filter by org
+-- can leak or hide rows.
+--
+-- This migration:
+--   1. Surfaces any existing rows that violate the invariant (so an
+--      operator can see and reconcile them before the constraint is
+--      enforced). We do NOT auto-rewrite — silent data mutation on a
+--      multi-tenant table is worse than a noisy migration failure.
+--   2. Adds the CHECK constraint.
+--
+-- Refs #299.
+
+DO $$
+DECLARE
+    bad_count INTEGER;
+BEGIN
+    SELECT count(*) INTO bad_count
+    FROM templates
+    WHERE (is_public = true  AND org_id IS NOT NULL)
+       OR (is_public = false AND org_id IS NULL);
+
+    IF bad_count > 0 THEN
+        RAISE EXCEPTION
+            'templates: % row(s) violate the public/org_id invariant. Resolve before applying this migration. '
+            'Public templates must have org_id IS NULL; private templates must have org_id IS NOT NULL.',
+            bad_count;
+    END IF;
+END$$;
+
+ALTER TABLE templates
+    ADD CONSTRAINT templates_public_org_id_check
+    CHECK (
+        (is_public = true  AND org_id IS NULL) OR
+        (is_public = false AND org_id IS NOT NULL)
+    );
+
+COMMENT ON CONSTRAINT templates_public_org_id_check ON templates IS
+    'Tenancy invariant: public templates have no org owner; private templates must.';

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -133,6 +133,7 @@ func (s *Store) Migrate(ctx context.Context) error {
 		{40, "migrations/040_add_updated_at.up.sql"},
 		{41, "migrations/041_updated_at_triggers_remaining.up.sql"},
 		{42, "migrations/042_global_sync_outbox.up.sql"},
+		{43, "migrations/043_templates_public_check.up.sql"},
 	}
 
 	for _, m := range migrations {


### PR DESCRIPTION
Closes #299.

## Summary

The `templates` table has had a nullable `org_id` and an `is_public` boolean since `001_initial.up.sql`, without an explicit invariant tying them together. The intent — public templates have no org owner, private templates do — was encoded only in convention. Without a CHECK constraint, any future INSERT/UPDATE that gets the pair wrong silently slips through, and queries that forget the right filter can leak or hide templates across tenants.

## Change

New migration `043_templates_public_check`:

1. **Pre-check** for rows that violate the invariant; abort the migration with a `RAISE EXCEPTION` if any exist. Deliberately *not* auto-rewriting data — silent mutation on a multi-tenant table is worse than a noisy migration the operator can resolve manually.

2. **Add the CHECK constraint** on `templates`:

   ```sql
   CHECK (
       (is_public = true  AND org_id IS NULL) OR
       (is_public = false AND org_id IS NOT NULL)
   )
   ```

3. `COMMENT ON CONSTRAINT` documenting the invariant for future readers.

The migration is wired into the in-memory list in `internal/db/store.go` as version 43.

A down migration is included that just drops the constraint.

## Notes

- The pre-check is fast (single `count(*)`); locks the table only briefly.
- If existing prod data has any violators, the migration will fail loudly — that's intentional. Operator follow-up: either set `is_public = true` and clear `org_id`, or vice versa, then re-run.
- I don't have a Postgres instance set up locally to confirm migration up-down-up. The SQL is straightforward; please CI verify.
