### PR TITLE
feat(deploy/terraform/security): add extra_ingress_ports knob for sidecar services

### DIFF
--- a/deploy/terraform/modules/security/main.tf
+++ b/deploy/terraform/modules/security/main.tf
@@ -39,6 +39,20 @@ resource "aws_security_group" "dev" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  # Caller-supplied extra ports (see variables.tf::extra_ingress_ports).
+  # Typical use: opening :3000 for an agent orchestrator running on the
+  # same host, or :9090 for a Prometheus scrape endpoint.
+  dynamic "ingress" {
+    for_each = var.extra_ingress_ports
+    content {
+      description = ingress.value.description
+      from_port   = ingress.value.port
+      to_port     = ingress.value.port
+      protocol    = "tcp"
+      cidr_blocks = [var.extra_ingress_cidr]
+    }
+  }
+
   # All outbound
   egress {
     description = "All outbound"

--- a/deploy/terraform/modules/security/variables.tf
+++ b/deploy/terraform/modules/security/variables.tf
@@ -17,3 +17,26 @@ variable "vpc_cidr_block" {
   description = "CIDR block of the VPC, used for intra-VPC SSH access in prod mode"
   type        = string
 }
+
+variable "extra_ingress_ports" {
+  description = <<-EOT
+    Additional TCP ports to allow inbound on the dev security group, in
+    addition to the always-on API (8080) and SSH (22). Useful if you run
+    a sidecar service on the same host (e.g. an agent orchestrator on :3000
+    or a metrics endpoint on :9090) and want it reachable without standing
+    up a full prod-mode ALB. Each entry is opened to 0.0.0.0/0; tighten via
+    the `extra_ingress_cidr` knob if you need a narrower source. Only
+    consulted in dev mode (environment = "dev*"); no-op in prod mode.
+  EOT
+  type = list(object({
+    port        = number
+    description = string
+  }))
+  default = []
+}
+
+variable "extra_ingress_cidr" {
+  description = "CIDR block for `extra_ingress_ports`. Defaults to 0.0.0.0/0 (public). Set to your office IP, a VPN CIDR, or a private subnet to scope down."
+  type        = string
+  default     = "0.0.0.0/0"
+}


### PR DESCRIPTION
## Summary

Adds an `extra_ingress_ports` list variable to the security module so operators running a sidecar on the same host (agent orchestrator, metrics endpoint, custom proxy) can open the relevant TCP ports without forking the module or attaching a second SG.

## Motivation

In dev mode the security module exposes a fixed set of ingress ports — Server API `:8080` + SSH `:22`. Running anything else on the same host (the canonical example being an agent orchestrator UI/API on `:3000`, but also Prometheus on `:9090`, custom proxies, etc.) currently requires forking the module.

## API

```hcl
module "security" {
  source = "./modules/security"
  # ...
  extra_ingress_ports = [
    { port = 3000, description = "agent dashboard" },
    { port = 9090, description = "prometheus scrape" }
  ]
  extra_ingress_cidr = "10.0.0.0/16"  # private subnet only
}
```

- `extra_ingress_ports` — list of `{port, description}` objects. Defaults to `[]` (no behavior change).
- `extra_ingress_cidr` — CIDR block for the rules above. Defaults to `0.0.0.0/0`; set to your VPC CIDR / office IP / VPN range to scope down.

## Backwards compatibility

- Existing deployments that don't set `extra_ingress_ports` see no change.
- The variable is only consulted inside the `dev` SG resource (gated on `local.is_dev`), so prod mode (`environment != "dev"`) is untouched. The ALB / Server / Worker / RDS / Redis SG topology is unaffected.

## Scope

```
deploy/terraform/modules/security/variables.tf  +23 / -0
deploy/terraform/modules/security/main.tf       +14 / -0
```

Two files, +37 lines. `terraform fmt` and `terraform validate` clean.

## Why not just open `:3000` by default

That's what I had originally — see commit history on my branch. It was the wrong abstraction: upstream users may not run `oc-agents` or any other sidecar at all on the same host, and we shouldn't open a port for a service that may not exist. A generic `extra_ingress_ports` knob is the right shape — it serves any sidecar (agent orchestrator, observability, ingress controllers, etc.) without leaking us-specific assumptions into the upstream defaults.
