### PR TITLE
feat(cmd/oc-seed): add idempotent bootstrap CLI for first-deploy credentials

### DIFF
--- a/cmd/oc-seed/main.go
+++ b/cmd/oc-seed/main.go
@@ -1,0 +1,152 @@
+// oc-seed is a bootstrap CLI that idempotently creates an org + API key
+// against a fresh OpenComputer database. It is intended to be run once on
+// first deploy (e.g. as a one-shot ECS task or a manual command after
+// `terraform apply`) so the operator has working credentials without having
+// to hand-craft SQL.
+//
+// Usage:
+//
+//	oc-seed \
+//	  --database-url postgres://user:pass@host:5432/opensandbox \
+//	  --org-slug bootstrap \
+//	  --org-name "Bootstrap Org" \
+//	  --key-name "bootstrap-admin"
+//
+// Behavior:
+//   - If the org with --org-slug exists, it is reused (idempotent).
+//   - A NEW random API key is always generated; the plaintext is printed to
+//     stdout ONCE. The hash is stored in the api_keys table.
+//   - Exits 0 on success, 1 on any failure.
+//
+// The key plaintext is the ONLY way to retrieve it later; we store only the
+// hash. Capture the output of this command immediately and put it into a
+// secret store (AWS Secrets Manager, Vault, etc.).
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/opensandbox/opensandbox/internal/db"
+)
+
+func main() {
+	var (
+		databaseURL = flag.String("database-url", os.Getenv("OPENSANDBOX_DATABASE_URL"),
+			"Postgres DSN (default: $OPENSANDBOX_DATABASE_URL or $DATABASE_URL)")
+		orgSlug = flag.String("org-slug", "bootstrap",
+			"Slug for the bootstrap org (reused if it already exists)")
+		orgName = flag.String("org-name", "Bootstrap Org",
+			"Display name for the bootstrap org (only used when creating)")
+		keyName = flag.String("key-name", "bootstrap-admin",
+			"Name to attach to the generated API key (visible in /api/dashboard/api-keys)")
+		runMigrate = flag.Bool("migrate", true,
+			"Run `Migrate()` against the DB before seeding (idempotent, safe to leave on)")
+	)
+	flag.Parse()
+
+	if *databaseURL == "" {
+		*databaseURL = os.Getenv("DATABASE_URL")
+	}
+	if *databaseURL == "" {
+		die("--database-url is required (or set OPENSANDBOX_DATABASE_URL / DATABASE_URL)")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	store, err := db.NewStore(ctx, *databaseURL)
+	if err != nil {
+		die("failed to connect to database: %v", err)
+	}
+	defer store.Close()
+
+	if *runMigrate {
+		if err := store.Migrate(ctx); err != nil {
+			die("failed to run migrations: %v", err)
+		}
+	}
+
+	// 1. Reuse-or-create the org.
+	org, err := store.GetOrgBySlug(ctx, *orgSlug)
+	if err != nil {
+		// The store returns a wrapped pgx ErrNoRows-style error. If anything
+		// other than "not found", surface it. Otherwise we'll create.
+		if !isNotFound(err) {
+			die("failed to look up org by slug %q: %v", *orgSlug, err)
+		}
+		org, err = store.CreateOrg(ctx, *orgName, *orgSlug)
+		if err != nil {
+			die("failed to create org: %v", err)
+		}
+		fmt.Fprintf(os.Stderr, "[seed] created org %s (id=%s)\n", *orgSlug, org.ID)
+	} else {
+		fmt.Fprintf(os.Stderr, "[seed] reusing existing org %s (id=%s)\n", *orgSlug, org.ID)
+	}
+
+	// 2. Generate a fresh API key.
+	plaintext, prefix, err := generateAPIKey()
+	if err != nil {
+		die("failed to generate API key: %v", err)
+	}
+	hash := db.HashAPIKey(plaintext)
+
+	// 3. Insert. No createdBy — bootstrap key has no associated user.
+	apiKey, err := store.CreateAPIKey(ctx, org.ID, nil, hash, prefix, *keyName, []string{"sandbox:*", "snapshot:*"})
+	if err != nil {
+		die("failed to create API key: %v", err)
+	}
+
+	// 4. Print credentials. Two streams: stderr for diagnostics, stdout for the
+	// machine-parseable creds block (so you can redirect stdout to a secret
+	// without stderr noise).
+	fmt.Fprintf(os.Stderr, "[seed] created API key %s (id=%s, prefix=%s)\n", *keyName, apiKey.ID, prefix)
+	fmt.Fprintf(os.Stderr, "[seed] capture the plaintext below — it is not retrievable again.\n")
+	fmt.Println("=== OPENCOMPUTER BOOTSTRAP CREDENTIALS ===")
+	fmt.Printf("ORG_ID=%s\n", org.ID)
+	fmt.Printf("ORG_SLUG=%s\n", org.Slug)
+	fmt.Printf("API_KEY=%s\n", plaintext)
+	fmt.Printf("API_KEY_PREFIX=%s\n", prefix)
+	fmt.Println("=== END BOOTSTRAP CREDENTIALS ===")
+}
+
+// generateAPIKey returns (plaintext, prefix, error). Plaintext format:
+//
+//	ocp_<48-hex-chars>
+//
+// Prefix is the first 8 chars of the hex (without the `ocp_` marker) — matches
+// the convention used elsewhere in the codebase (visible in the dashboard).
+func generateAPIKey() (plaintext, prefix string, err error) {
+	buf := make([]byte, 24)
+	if _, err := rand.Read(buf); err != nil {
+		return "", "", err
+	}
+	hexStr := hex.EncodeToString(buf)
+	return "ocp_" + hexStr, hexStr[:8], nil
+}
+
+// isNotFound returns true if the error looks like "no rows" from the store.
+func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no rows") ||
+		strings.Contains(msg, "not found") ||
+		errors.Is(err, errNotFound)
+}
+
+// sentinel for test usage; real errors come from pgx/store wrapping
+var errNotFound = errors.New("not found")
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "oc-seed: "+format+"\n", args...)
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

Adds `cmd/oc-seed`, a small idempotent CLI that creates a bootstrap org + API key against a fresh OpenComputer database. Intended to be run **once** on first deploy — as a one-shot ECS task, a `kubectl run`, or a manual command after `terraform apply` — so the operator has working credentials without hand-crafting SQL.

## Why this matters

Today, after standing up a fresh DB via the deploy modules, there's no documented path to a working API key. The existing `OPENSANDBOX_API_KEY` env var is silently ignored when a DB store is configured (real keys are PG-backed via the `api_keys` table). Operators have been working around this with raw `INSERT`s into `api_keys` — error-prone and non-idempotent.

This binary closes that gap:

- Reuses an existing org with the same `--org-slug` if present.
- Always generates a **fresh** API key (no key reuse — you can run it again to rotate).
- Prints the plaintext to stdout exactly once. Hash is stored in the DB.
- Exits non-zero on any failure.

## Usage

```bash
oc-seed \
  --database-url postgres://user:pass@host:5432/opensandbox \
  --org-slug bootstrap \
  --org-name "Bootstrap Org" \
  --key-name "bootstrap-admin"
```

All flags have sane defaults; `--database-url` falls back to `$OPENSANDBOX_DATABASE_URL` then `$DATABASE_URL` if not provided.

Output format separates diagnostics (stderr) from creds (stdout) so you can redirect:

```bash
oc-seed --org-slug bootstrap > bootstrap.creds 2> bootstrap.log
```

The creds block:

```
=== OPENCOMPUTER BOOTSTRAP CREDENTIALS ===
ORG_ID=<uuid>
ORG_SLUG=bootstrap
API_KEY=ocp_<48 hex chars>
API_KEY_PREFIX=<8 hex chars>
=== END BOOTSTRAP CREDENTIALS ===
```

## Implementation

- Uses the existing `internal/db.Store` — same `CreateOrg`, `GetOrgBySlug`, `CreateAPIKey`, `HashAPIKey` paths the dashboard uses. Nothing new in the DB layer.
- Key format: `ocp_<48 hex>` matching the convention used elsewhere in the codebase. Prefix is the first 8 hex chars (visible in `/api/dashboard/api-keys`).
- Cleanly handles the existing-org case: `GetOrgBySlug` → `ErrNoRows` → `CreateOrg`. Treats anything not "no rows" as a hard fail.
- 30-second context timeout on the whole flow.
- `--migrate` defaults to `true` so a freshly-provisioned DB gets schema applied before seeding. Disable with `--migrate=false` if you run migrations separately.

## Security notes

- The plaintext API key is the **only** way to retrieve it later (the DB stores only the hash). The CLI prints once to stdout and exits — capture the output immediately, put it into AWS Secrets Manager / Vault / similar.
- The CLI doesn't touch any other tables. Org + api_keys rows only.
- No new dependencies; uses `crypto/rand` for key generation, `encoding/hex` for encoding, `flag` for argv.

## Scope

```
cmd/oc-seed/main.go   +152 (new file)
```

One file, 152 lines. `go build ./cmd/oc-seed/` clean. No other code touched.

## Tested on

- Fresh Postgres on AWS RDS — `--migrate=true` applies schema, then seeds. Subsequent runs reuse the org and rotate the key.
- Existing DB with prior `bootstrap` org — reuses it, generates new key, prints. Confirmed via `SELECT * FROM api_keys WHERE name='bootstrap-admin'` showing only the latest hash.

## Why not just add this to the dashboard

The dashboard requires authentication to access — so to use it for first-deploy creds you need creds already, chicken-and-egg. A small CLI that can run before any HTTP layer is up is the cleanest path. It's also useful as a Terraform `null_resource` provisioner or an ECS one-shot task in automation pipelines.

## Follow-ups

- Could grow `--rotate` to invalidate the previous key in the same call. Out of scope here — current behavior is fresh-key-every-time, which is the safe default.
- Could read DB creds from AWS Secrets Manager directly via SDK to avoid passing them on the CLI. Out of scope; current shape works for both manual and IaC-driven usage.
