### PR TITLE
Fix api-edge WebSocket query auth

### DIFF
--- a/.agents/work/api-edge-websocket-query-auth.md
+++ b/.agents/work/api-edge-websocket-query-auth.md
@@ -1,0 +1,134 @@
+# API edge WebSocket query auth
+
+Status: **fix implemented on `fix/api-edge-websocket-query-auth`**.
+Implementation commit: `b6e9070`.
+
+## Summary
+
+SDK WebSocket attach worked when pointed directly at a cell endpoint, but
+failed through `app.opencomputer.dev` with:
+
+```text
+401 {"error":"missing or invalid API key"}
+```
+
+The failure was specific to WebSocket attach for sandbox exec sessions.
+Buffered exec and exec-session creation through the app endpoint still worked.
+
+## Findings
+
+The TypeScript SDK builds exec attach URLs with `?api_key=` because browser
+WebSocket APIs cannot set custom headers:
+
+```text
+wss://app.opencomputer.dev/api/sandboxes/{sandboxID}/exec/{sessionID}?api_key=...
+```
+
+The regional Go control plane already accepts query-string API keys for
+WebSocket-style routes through `auth.PGAPIKeyMiddleware`, which is why the same
+attach URL pattern succeeded when pointed directly at the cell endpoint.
+
+The global `api-edge` Worker did not match that contract. Its
+`authenticate()` helper only read `X-API-Key`, so the edge rejected SDK
+WebSocket attaches before it could mint the short-lived bearer token used for
+the cell hop.
+
+The app endpoint could still create exec sessions because those requests are
+normal HTTP requests from the SDK, which use the `X-API-Key` header.
+
+## Root Cause
+
+The edge-first SDK proxy path changed the auth boundary for sandbox runtime
+calls:
+
+```text
+SDK -> app.opencomputer.dev/api-edge -> cell control plane -> worker
+```
+
+For normal HTTP, the SDK sends `X-API-Key`, and `api-edge` authenticates it.
+For WebSocket attach, the SDK sends `?api_key=`, matching the documented
+WebSocket API and the Go cell middleware. `api-edge` had not implemented that
+WebSocket-specific query-auth compatibility.
+
+## Proposed Solution
+
+Make `api-edge` accept `?api_key=` only for WebSocket Upgrade requests, then
+strip that query parameter before forwarding to the cell. The cell should see
+only the edge-minted bearer token, not the customer's original API key.
+
+This keeps the compatibility surface narrow:
+
+- `X-API-Key` remains the normal HTTP auth path.
+- `?api_key=` is accepted only for WebSocket Upgrade requests.
+- The customer API key is not forwarded to the cell after edge auth succeeds.
+- Non-WebSocket HTTP requests with only `?api_key=` remain rejected.
+
+## Implemented Shape
+
+`cloudflare-workers/api-edge/src/index.ts` now has:
+
+- `isWebSocketUpgrade(req)` for one consistent upgrade check.
+- `apiKeyFromRequest(req)` that reads `X-API-Key`, then falls back to
+  `?api_key=` only for upgrades.
+- `stripEdgeAuthQueryParam(target)` to remove `api_key` from the forwarded
+  cell URL.
+
+The WebSocket proxy branch now clones the inbound request against the stripped
+target URL, sets `Authorization: Bearer <edge-token>`, deletes `X-API-Key`, and
+lets Cloudflare forward the WebSocket upgrade transparently.
+
+## Regression Tests
+
+Added `cloudflare-workers/api-edge/src/index.test.ts` with focused coverage:
+
+1. WebSocket sandbox exec attach using `?api_key=` authenticates at the edge,
+   proxies to the owning cell, preserves unrelated query params, strips
+   `api_key`, and injects bearer auth.
+2. Non-WebSocket HTTP with only `?api_key=` still returns `401` and does not
+   proxy.
+
+## Verification
+
+Local checks:
+
+```text
+cd cloudflare-workers/api-edge
+npm test -- --run
+npx tsc --noEmit
+```
+
+Both passed after installing package dependencies from the lockfile.
+
+`tsc` also surfaced an existing Worker WebSocket typing issue in
+`src/dashboard.ts` around `ArrayBufferView.buffer` possibly being a
+`SharedArrayBuffer`. The fix copies the view into a fresh `ArrayBuffer` before
+sending it over the WebSocket.
+
+## Rollout
+
+Deploy only the `api-edge` Worker. The Go cell control planes and workers do
+not need changes for this specific bug because their auth and attach paths
+already accept the SDK's WebSocket URL shape.
+
+Post-deploy smoke test:
+
+1. Create a fresh sandbox through `https://app.opencomputer.dev`.
+2. Start an exec session through the SDK.
+3. Attach through the SDK without overriding `sandbox.exec.apiUrl`.
+4. Expect WebSocket open to succeed and `exec.shell().run("echo ok")` or
+   equivalent streaming exec to return exit code `0`.
+
+Also verify the negative case:
+
+```text
+GET /api/sandboxes/{id}/exec/{sessionID}?api_key=...
+```
+
+without `Upgrade: websocket` should still return `401`.
+
+## Follow-ups
+
+The edge Worker and Go control plane should keep WebSocket auth behavior aligned
+as a public API contract. Any future WebSocket route added to the SDK should get
+an edge-level test for query-param auth, plus a negative HTTP test so query
+auth does not quietly expand across the whole API.

--- a/.agents/work/api-edge-websocket-query-auth.md
+++ b/.agents/work/api-edge-websocket-query-auth.md
@@ -132,3 +132,54 @@ The edge Worker and Go control plane should keep WebSocket auth behavior aligned
 as a public API contract. Any future WebSocket route added to the SDK should get
 an edge-level test for query-param auth, plus a negative HTTP test so query
 auth does not quietly expand across the whole API.
+
+## Design Concern: API Keys In WebSocket URLs
+
+The hotfix intentionally preserves the current public contract, but the contract
+itself is not ideal: long-lived API keys in URL query parameters are easier to
+leak than credentials in headers.
+
+Common leak paths:
+
+- HTTP access logs at proxies, CDNs, tunnels, or app servers.
+- Browser and SDK error messages that include the failed WebSocket URL.
+- Copy-pasted repro commands, screenshots, support tickets, and telemetry.
+- Referrer-like propagation in unusual browser/tooling contexts.
+
+The reason this exists is pragmatic, not because it is the best security shape:
+browser WebSocket clients cannot set arbitrary `X-API-Key` or `Authorization`
+headers. Node/Bun clients can often send headers depending on the WebSocket
+library, but the public SDK needs a browser-compatible path.
+
+Short-term stance:
+
+- Keep accepting `?api_key=` for WebSocket Upgrade requests for compatibility.
+- Keep it narrowly scoped to Upgrade requests only.
+- Strip it at the edge before proxying to the cell.
+- Redact credentials from SDK WebSocket error messages.
+
+Longer-term proposal:
+
+1. SDK makes a normal HTTPS request with `X-API-Key` to create or authorize an
+   attach operation.
+2. API returns a short-lived, scoped attach token or attach URL.
+3. SDK opens the WebSocket with `?token=<short-lived-token>`, not the long-lived
+   API key.
+
+The token should be scoped at least to:
+
+- org ID
+- sandbox ID
+- exec/PTY/agent session ID
+- operation, for example `exec_attach`
+
+Recommended properties:
+
+- 30-120 second TTL.
+- Signed by the control plane or edge.
+- Optionally one-time-use if the storage path is cheap enough.
+- No broad API capability if replayed.
+
+This keeps browser compatibility while reducing the blast radius of URL leaks.
+It also matches the existing direct-worker model, where SDKs already prefer a
+sandbox-scoped `?token=` when available.

--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -343,7 +343,8 @@ async function proxyWebSocket(
     }
     if (ArrayBuffer.isView(data)) {
       const v = data as ArrayBufferView;
-      const ab = v.buffer.slice(v.byteOffset, v.byteOffset + v.byteLength);
+      const ab = new ArrayBuffer(v.byteLength);
+      new Uint8Array(ab).set(new Uint8Array(v.buffer, v.byteOffset, v.byteLength));
       addBytes(ab.byteLength);
       try { target.send(ab); } catch (err) { console.error(`${label}: send (view) failed: ${(err as Error).message}`); }
       return Promise.resolve();

--- a/cloudflare-workers/api-edge/src/index.test.ts
+++ b/cloudflare-workers/api-edge/src/index.test.ts
@@ -115,4 +115,57 @@ describe("api-edge WebSocket auth", () => {
     expect(await resp.json()).toEqual({ error: "missing or invalid API key" });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+
+  it("strips api_key query params from proxied HTTP requests authenticated by header", async () => {
+    const fetchSpy = vi.fn(async (_url: string, _init?: RequestInit) => new Response("proxied", { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const resp = await worker.fetch(
+      new Request(
+        "https://app.opencomputer.dev/api/sandboxes/sb-123/exec?api_key=osb_query&stream=1",
+        {
+          headers: {
+            "X-API-Key": "osb_header",
+          },
+        },
+      ),
+      env,
+      ctx,
+    );
+
+    expect(resp.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const forwardedURL = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(forwardedURL.origin).toBe("https://cp-us-east-2.opencomputer.dev");
+    expect(forwardedURL.pathname).toBe("/api/sandboxes/sb-123/exec");
+    expect(forwardedURL.searchParams.get("stream")).toBe("1");
+    expect(forwardedURL.searchParams.has("api_key")).toBe(false);
+
+    const forwardedHeaders = new Headers(fetchSpy.mock.calls[0][1]?.headers);
+    expect(forwardedHeaders.get("authorization")).toMatch(/^Bearer /);
+    expect(forwardedHeaders.get("x-api-key")).toBeNull();
+  });
+
+  it("rejects WebSocket proxy requests without header or query auth", async () => {
+    const fetchSpy = vi.fn(async (_req: Request) => new Response("proxied", { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const resp = await worker.fetch(
+      new Request(
+        "https://app.opencomputer.dev/api/sandboxes/sb-123/exec/es-123",
+        {
+          headers: {
+            Upgrade: "websocket",
+          },
+        },
+      ),
+      env,
+      ctx,
+    );
+
+    expect(resp.status).toBe(401);
+    expect(await resp.json()).toEqual({ error: "missing or invalid API key" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
 });

--- a/cloudflare-workers/api-edge/src/index.test.ts
+++ b/cloudflare-workers/api-edge/src/index.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import worker, { type Env } from "./index";
+
+const orgID = "org-1";
+const userID = "user-1";
+const cellID = "azure-us-east-2-a";
+
+class FakeStatement {
+  constructor(private sql: string) {}
+
+  bind(..._args: unknown[]) {
+    return this;
+  }
+
+  async first<T>(): Promise<T | null> {
+    if (this.sql.includes("FROM api_keys")) {
+      return { org_id: orgID, created_by: userID, expires_at: null } as T;
+    }
+    if (this.sql.includes("FROM sandboxes_index") && this.sql.includes("SELECT cell_id, org_id")) {
+      return { cell_id: cellID, org_id: orgID } as T;
+    }
+    if (this.sql.includes("FROM cells WHERE cell_id")) {
+      return {
+        cell_id: cellID,
+        cloud: "azure",
+        region: "us-east-2",
+        base_url: "https://cp-us-east-2.opencomputer.dev",
+        status: "active",
+        available_workers: 1,
+        capacity_updated_at: Math.floor(Date.now() / 1000),
+      } as T;
+    }
+    if (this.sql.includes("SELECT plan FROM orgs")) {
+      return { plan: "pro" } as T;
+    }
+    return null;
+  }
+
+  async run() {
+    return {};
+  }
+}
+
+const env = {
+  OPENCOMPUTER_DB: {
+    prepare(sql: string) {
+      return new FakeStatement(sql);
+    },
+  },
+  SESSIONS_KV: {},
+  CREDIT_ACCOUNT: {},
+  SESSION_JWT_SECRET: "test-secret",
+  WORKOS_API_KEY: "",
+  WORKOS_CLIENT_ID: "",
+  STRIPE_API_KEY: "",
+  WORKER_ENV: "test",
+  CELLS: cellID,
+  CF_ADMIN_SECRET: "",
+  STRIPE_WEBHOOK_SECRET: "",
+  EVENT_SECRET: "",
+  SECRET_ENCRYPTION_KEY: "",
+} as unknown as Env;
+
+const ctx = {
+  waitUntil: vi.fn(),
+  passThroughOnException: vi.fn(),
+} as unknown as ExecutionContext;
+
+describe("api-edge WebSocket auth", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("accepts api_key query auth for sandbox WebSocket proxy requests", async () => {
+    const fetchSpy = vi.fn(async (_req: Request) => new Response("proxied", { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const resp = await worker.fetch(
+      new Request(
+        "https://app.opencomputer.dev/api/sandboxes/sb-123/exec/es-123?api_key=osb_test&stream=1",
+        {
+          headers: {
+            Upgrade: "websocket",
+          },
+        },
+      ),
+      env,
+      ctx,
+    );
+
+    expect(resp.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const forwarded = fetchSpy.mock.calls[0][0] as Request;
+    const forwardedURL = new URL(forwarded.url);
+    expect(forwardedURL.origin).toBe("https://cp-us-east-2.opencomputer.dev");
+    expect(forwardedURL.pathname).toBe("/api/sandboxes/sb-123/exec/es-123");
+    expect(forwardedURL.searchParams.get("stream")).toBe("1");
+    expect(forwardedURL.searchParams.has("api_key")).toBe(false);
+    expect(forwarded.headers.get("authorization")).toMatch(/^Bearer /);
+    expect(forwarded.headers.get("x-api-key")).toBeNull();
+  });
+
+  it("does not accept api_key query auth for non-WebSocket HTTP requests", async () => {
+    const fetchSpy = vi.fn(async (_req: Request) => new Response("proxied", { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const resp = await worker.fetch(
+      new Request("https://app.opencomputer.dev/api/sandboxes/sb-123/exec/es-123?api_key=osb_test"),
+      env,
+      ctx,
+    );
+
+    expect(resp.status).toBe(401);
+    expect(await resp.json()).toEqual({ error: "missing or invalid API key" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -115,7 +115,7 @@ function apiKeyFromRequest(req: Request): string | null {
   return null;
 }
 
-function stripEdgeAuthQueryParam(target: string): string {
+function stripApiKeyQueryParam(target: string): string {
   const url = new URL(target);
   url.searchParams.delete("api_key");
   return url.toString();
@@ -574,7 +574,7 @@ async function proxyToCellSDK(req: Request, env: Env, ctx: ExecutionContext, cal
   if (!cell) return json({ error: `cell ${row.cell_id} not registered` }, 503);
 
   const url = new URL(req.url);
-  const target = cell.base_url.replace(/\/$/, "") + url.pathname + url.search;
+  const target = stripApiKeyQueryParam(cell.base_url.replace(/\/$/, "") + url.pathname + url.search);
   // Look up the org's plan so the cap-token carries it (worker resolver uses
   // plan to tag usage_tick events; without it free-tier debit fan-out skips
   // the org).
@@ -637,7 +637,7 @@ async function proxyToCellSDK(req: Request, env: Env, ctx: ExecutionContext, cal
   // upgrades transparently when you pass a Request clone — same pattern
   // handlePreviewURL uses and that's verified to work end-to-end with WS.
   if (isWebSocketUpgrade(req)) {
-    const fwd = new Request(stripEdgeAuthQueryParam(target), req);
+    const fwd = new Request(target, req);
     fwd.headers.set("authorization", "Bearer " + token);
     fwd.headers.delete("x-api-key");
     return await fetch(fwd);

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -98,10 +98,35 @@ interface Caller {
   userID: string | null;
 }
 
-// Authenticate via X-API-Key (looked up by sha256 in D1 api_keys). Session-JWT
-// auth (browser flows) is a TODO; SDK/test traffic uses the API key.
+function isWebSocketUpgrade(req: Request): boolean {
+  return req.headers.get("upgrade")?.toLowerCase() === "websocket";
+}
+
+function apiKeyFromRequest(req: Request): string | null {
+  const headerKey = req.headers.get("X-API-Key");
+  if (headerKey) return headerKey;
+
+  // Browser WebSocket clients cannot set custom headers, so SDK attach uses
+  // `?api_key=`. Keep this limited to Upgrade requests to avoid normalizing
+  // query-string credentials across the whole HTTP API.
+  if (isWebSocketUpgrade(req)) {
+    return new URL(req.url).searchParams.get("api_key");
+  }
+  return null;
+}
+
+function stripEdgeAuthQueryParam(target: string): string {
+  const url = new URL(target);
+  url.searchParams.delete("api_key");
+  return url.toString();
+}
+
+// Authenticate via X-API-Key (looked up by sha256 in D1 api_keys). For
+// WebSocket Upgrade requests, also accept ?api_key= because browser WS APIs
+// cannot set custom headers. Session-JWT auth (browser flows) is a TODO;
+// SDK/test traffic uses the API key.
 async function authenticate(req: Request, env: Env): Promise<Caller | null> {
-  const apiKey = req.headers.get("X-API-Key");
+  const apiKey = apiKeyFromRequest(req);
   if (!apiKey) return null;
   const hash = await sha256Hex(apiKey);
   const row = await env.OPENCOMPUTER_DB.prepare(
@@ -611,8 +636,8 @@ async function proxyToCellSDK(req: Request, env: Env, ctx: ExecutionContext, cal
   // accept-key derivation). CF Workers + CF Tunnel forward WebSocket
   // upgrades transparently when you pass a Request clone — same pattern
   // handlePreviewURL uses and that's verified to work end-to-end with WS.
-  if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
-    const fwd = new Request(target, req);
+  if (isWebSocketUpgrade(req)) {
+    const fwd = new Request(stripEdgeAuthQueryParam(target), req);
     fwd.headers.set("authorization", "Bearer " + token);
     fwd.headers.delete("x-api-key");
     return await fetch(fwd);


### PR DESCRIPTION
## Summary
- accept `?api_key=` at api-edge only for WebSocket Upgrade requests, matching the existing SDK and Go cell middleware contract
- strip `api_key` before forwarding to the cell and replace it with the edge-minted bearer token
- add focused api-edge regression tests plus a working note documenting findings and the longer-term short-lived attach-token proposal
- fix an existing Worker WebSocket `ArrayBufferView` type issue surfaced by `tsc`

## Testing
- `cd cloudflare-workers/api-edge && npm test -- --run`
- `cd cloudflare-workers/api-edge && npx tsc --noEmit`
- `git diff --check`