### PR TITLE
Avoid route updates in api-edge CI deploy

### DIFF
--- a/.github/workflows/deploy-api-edge.yml
+++ b/.github/workflows/deploy-api-edge.yml
@@ -85,6 +85,31 @@ jobs:
           npm test -- --run
           npx tsc --noEmit
 
+      - name: Prepare CI deploy config
+        working-directory: cloudflare-workers/api-edge
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          src = Path("${{ steps.target.outputs.config }}")
+          dst = Path("wrangler.ci.toml")
+          lines = src.read_text().splitlines()
+
+          out = []
+          skipping_routes = False
+          for line in lines:
+              if line.startswith("routes = ["):
+                  skipping_routes = True
+                  continue
+              if skipping_routes:
+                  if line.strip() == "]":
+                      skipping_routes = False
+                  continue
+              out.append(line)
+
+          dst.write_text("\n".join(out).rstrip() + "\n")
+          PY
+
       - name: Deploy ${{ steps.target.outputs.name }}
         working-directory: cloudflare-workers/api-edge
         env:
@@ -94,4 +119,4 @@ jobs:
             echo "CLOUDFLARE_API_TOKEN GitHub secret is required for Wrangler deploys" >&2
             exit 1
           fi
-          npx wrangler deploy -c "${{ steps.target.outputs.config }}"
+          npx wrangler deploy -c wrangler.ci.toml


### PR DESCRIPTION
## Summary
- generate a temporary Wrangler config for CI deploys with the `routes = [...]` block removed
- keep the checked-in prod/dev Wrangler configs as the source for manual/bootstrap route setup
- deploy Worker code/assets without requiring the CI token to mutate zone routes

## Why
The first `Deploy API Edge` run uploaded `opencomputer-edge-prod`, then failed on `/zones/.../workers/routes` with Cloudflare auth error 10000. The token can deploy Worker scripts for the Mo account, but does not have zone route mutation permission. The prod route already points at `opencomputer-edge-prod`; normal deploys only need to upload the Worker version/assets.

## Testing
- YAML parse sanity check for `.github/workflows/deploy-api-edge.yml`
- generated `wrangler.ci.toml` from `wrangler.prod.toml` and verified it contains no `routes =` block
- staged local dashboard assets and ran `PATH="$NVM_BIN:$PATH" npx wrangler deploy --dry-run -c wrangler.ci.toml`
- `git diff --check`