### PR TITLE
add memoryMB-on-fork docs + Python SDK memory_mb, hibernate, wake

### DIFF
--- a/docs/api-reference/checkpoints/fork.mdx
+++ b/docs/api-reference/checkpoints/fork.mdx
@@ -21,13 +21,18 @@ Create a new sandbox from a checkpoint.
   Name of a secret store to attach. If the checkpoint already has a store, secrets are merged — the new store's values win on collision and egress allowlists are aggregated.
 </ParamField>
 
+<ParamField body="memoryMB" type="integer">
+  Memory for the forked sandbox, in MB. Clamped to a valid range: the floor is the checkpoint's own memory (a fork can't start smaller than the snapshot it restores, so a smaller value is ignored) and the ceiling is 16384 (16 GB; larger values are capped). The `memoryMB` field in the response reports the effective value after clamping.
+</ParamField>
+
 <ResponseExample>
 ```json 201
 {
   "sandboxID": "sb-def456",
   "status": "running",
   "region": "use2",
-  "workerID": "w-use2-abc123"
+  "workerID": "w-use2-abc123",
+  "memoryMB": 4096
 }
 ```
 </ResponseExample>

--- a/docs/sandboxes/templates.mdx
+++ b/docs/sandboxes/templates.mdx
@@ -167,6 +167,38 @@ curl -X POST https://app.opencomputer.dev/api/sandboxes \
 
 </CodeGroup>
 
+### Sizing a fork's memory
+
+A sandbox created from a snapshot inherits the snapshot's memory by default. Pass `memoryMB` to give it more RAM — useful when one branch needs more headroom than the base.
+
+<CodeGroup>
+
+```typescript TypeScript
+// Fork the snapshot with 8 GB instead of its captured size
+const sandbox = await Sandbox.create({ snapshot: 'data-science', memoryMB: 8192 });
+```
+
+```python Python
+# Fork the snapshot with 8 GB instead of its captured size
+sandbox = await Sandbox.create(snapshot="data-science", memory_mb=8192)
+```
+
+```bash curl
+curl -X POST https://app.opencomputer.dev/api/sandboxes \
+  -H "X-API-Key: $OPENCOMPUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"snapshot": "data-science", "memoryMB": 8192}'
+```
+
+</CodeGroup>
+
+`memoryMB` is clamped to a valid range, and the response's `memoryMB` reports the effective value:
+
+- **Floor — the snapshot's own memory.** A smaller request is ignored; a fork can't start smaller than the snapshot it restores. A 4 GB snapshot forked with `memoryMB: 1024` still boots at ~4 GB.
+- **Ceiling — 16 GB.** Larger requests are capped (`32768` → `16384`).
+
+The same `memoryMB` field works when [forking from a checkpoint](/api-reference/checkpoints/fork).
+
 ### Managing snapshots
 
 <CodeGroup>

--- a/sdks/python/opencomputer/sandbox.py
+++ b/sdks/python/opencomputer/sandbox.py
@@ -76,6 +76,7 @@ class Sandbox:
         envs: dict[str, str] | None = None,
         metadata: dict[str, str] | None = None,
         disk_mb: int | None = None,
+        memory_mb: int | None = None,
         secret_store: str | None = None,
         image: Image | None = None,
         snapshot: str | None = None,
@@ -95,6 +96,9 @@ class Sandbox:
                 comparable to EBS gp3. Closed beta: requests above 20GB
                 require the org's ``max_disk_mb`` to be raised. Contact us:
                 https://cal.com/team/digger/opencomputer-founder-chat
+            memory_mb: Memory in MB. On a snapshot/checkpoint fork the server
+                clamps this to [snapshot memory, 16 GB]; the new sandbox's
+                ``memory_mb`` reflects the effective value.
             secret_store: Secret store name — resolves encrypted secrets
                 and egress allowlist.
             image: Declarative Image definition. The server builds and caches it as a checkpoint.
@@ -132,6 +136,8 @@ class Sandbox:
             body["metadata"] = metadata
         if disk_mb is not None:
             body["diskMB"] = disk_mb
+        if memory_mb is not None:
+            body["memoryMB"] = memory_mb
         if secret_store:
             body["secretStore"] = secret_store
         if image is not None:
@@ -269,6 +275,32 @@ class Sandbox:
         """
         resp = await self._client.post(f"/sandboxes/{self.sandbox_id}/power-cycle")
         resp.raise_for_status()
+
+    async def hibernate(self) -> None:
+        """Hibernate the sandbox.
+
+        Snapshots the running VM (RAM + disk) to storage and frees its worker
+        slot. The sandbox keeps its ID, disks, env, and secrets; in-memory
+        process state is preserved and restored on :meth:`wake`. Compute
+        billing stops while hibernated (only storage is metered).
+        """
+        resp = await self._client.post(f"/sandboxes/{self.sandbox_id}/hibernate")
+        resp.raise_for_status()
+        self.status = "hibernated"
+
+    async def wake(self, timeout: int | None = None) -> None:
+        """Wake a hibernated sandbox.
+
+        Restores the VM from its hibernation snapshot on a worker — running
+        processes resume where they left off. Optionally set a new idle
+        ``timeout`` (seconds; ``0`` = persistent, never auto-hibernate).
+        """
+        body: dict[str, Any] = {}
+        if timeout is not None:
+            body["timeout"] = timeout
+        resp = await self._client.post(f"/sandboxes/{self.sandbox_id}/wake", json=body)
+        resp.raise_for_status()
+        self.status = "running"
 
     async def is_running(self) -> bool:
         """Check if the sandbox is still running."""


### PR DESCRIPTION
Document the memoryMB field on snapshot/checkpoint forks (snapshots guide + fork API reference), and bring the Python SDK to parity with TS: an optional memory_mb arg on Sandbox.create plus hibernate()/wake() methods.