### PR TITLE
prevent ghost vms from billing

### DIFF
--- a/cloudflare-workers/events-ingest/src/index.ts
+++ b/cloudflare-workers/events-ingest/src/index.ts
@@ -150,10 +150,32 @@ export default {
           SET status = 'hibernated', last_event_at = ?1
         WHERE id = ?2 AND (last_event_at IS NULL OR last_event_at < ?1)`,
     );
+    // INSERT ON CONFLICT, not plain UPDATE — the previous UPDATE-only shape
+    // relied on the api-edge's `ctx.waitUntil` POST /api/sandboxes write to
+    // have already created the row. When that waitUntil dropped (CF Worker
+    // eviction mid-request, common under batch-create load), the row never
+    // existed, this UPDATE no-op'd, and the sandbox stayed invisible in D1
+    // until the next lifecycle event also no-op'd. The empirical fingerprint
+    // was 34 of 50 still-running sandboxes for one large org being absent
+    // from sandboxes_index despite having `created` events in D1 events.
+    //
+    // With INSERT ON CONFLICT, events-ingest is self-sufficient: every
+    // `created` / `running` / `woke` event guarantees the row.
+    //
+    // Monotonic guard applies only to the UPDATE branch — a newer event
+    // wins; an out-of-order older event is ignored. On INSERT (no conflict)
+    // the row is created with this event's ts as the high-water mark.
+    //
+    // Binding order: ?1=tsSec, ?2=sandbox_id, ?3=org_id, ?4=cell_id, ?5=worker_id
     const lifecycleRunning = env.OPENCOMPUTER_DB.prepare(
-      `UPDATE sandboxes_index
-          SET status = 'running', stopped_at = NULL, last_event_at = ?1
-        WHERE id = ?2 AND (last_event_at IS NULL OR last_event_at < ?1)`,
+      `INSERT INTO sandboxes_index (id, org_id, cell_id, worker_id, status, created_at, last_event_at)
+       VALUES (?2, ?3, ?4, ?5, 'running', ?1, ?1)
+       ON CONFLICT(id) DO UPDATE SET
+         status = 'running',
+         worker_id = COALESCE(excluded.worker_id, sandboxes_index.worker_id),
+         stopped_at = NULL,
+         last_event_at = ?1
+       WHERE sandboxes_index.last_event_at IS NULL OR sandboxes_index.last_event_at < ?1`,
     );
     // Migration: sandbox moved to a new worker. Update worker_id alongside
     // status so proxyToCellSDK + dashboard reflect the new home immediately
@@ -198,10 +220,17 @@ export default {
           // worker_id field rather than payload for these events.
           return lifecycleMigrated.bind(e.worker_id ?? "", tsSec, e.sandbox_id);
         }
-        // "running", "created" set the row to running (created is handled
-        // by the edge on POST, but accept here for redundancy in case of
-        // replay against a future cell-only create path).
-        return lifecycleRunning.bind(tsSec, e.sandbox_id);
+        // "running", "created", "woke" set the row to running. Since the
+        // INSERT-ON-CONFLICT upgrade, this path also creates the row if the
+        // edge's waitUntil dropped on POST /api/sandboxes — events-ingest no
+        // longer depends on the edge having written first.
+        return lifecycleRunning.bind(
+          tsSec,
+          e.sandbox_id,
+          e.org_id ?? "",
+          e.cell_id ?? "",
+          e.worker_id ?? null,
+        );
       });
 
     // Checkpoint lifecycle: keep D1 checkpoints_index in sync with cell PG

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -184,6 +184,21 @@ func main() {
 		if err != nil {
 			log.Fatalf("failed to connect to Redis: %v", err)
 		}
+		// Reconcile-on-reconnect: when a worker rejoins after being pruned
+		// for missed heartbeats, sweep the cell's view of "stopped sandboxes
+		// on this worker" and re-issue Destroy. Closes the gap where the
+		// cell-side fallback at internal/api/sandbox.go's destroy handler
+		// published "stopped" while the worker was unreachable but qemu
+		// kept running. See internal/controlplane/reconcile.go.
+		//
+		// Captured opts.Store (set above) directly — the closure reads it
+		// at call time so any later mutations are picked up.
+		redisRegistry.OnWorkerRejoined(func(workerID string) {
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+			controlplane.ReconcileStoppedOnWorker(ctx, redisRegistry, opts.Store, workerID)
+		})
+
 		redisRegistry.Start()
 		defer redisRegistry.Stop()
 		opts.WorkerRegistry = redisRegistry

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -185,17 +185,25 @@ func main() {
 			log.Fatalf("failed to connect to Redis: %v", err)
 		}
 		// Reconcile-on-reconnect: when a worker rejoins after being pruned
-		// for missed heartbeats, sweep the cell's view of "stopped sandboxes
-		// on this worker" and re-issue Destroy. Closes the gap where the
-		// cell-side fallback at internal/api/sandbox.go's destroy handler
-		// published "stopped" while the worker was unreachable but qemu
-		// kept running. See internal/controlplane/reconcile.go.
+		// for missed heartbeats, run both directions of the cell-vs-worker
+		// state reconcile. See internal/controlplane/reconcile.go for the
+		// full rationale on each. Captured opts.Store + cfg.CellID directly;
+		// the closure reads them at call time.
 		//
-		// Captured opts.Store (set above) directly — the closure reads it
-		// at call time so any later mutations are picked up.
+		//   reverse first: cell-running but worker-doesn't-have-it →
+		//     close on cell side (UpdateSessionStatus + EndScaleEvent +
+		//     publish stopped event). Stops the billing leak immediately.
+		//
+		//   forward second: cell-stopped but worker-still-hosting →
+		//     re-issue Destroy via RPC. Cleans the worker side.
+		//
+		// Reverse runs first because the more urgent dollars-on-fire case is
+		// the still-open scale event accruing minute-by-minute, not a stray
+		// qemu the worker still has.
 		redisRegistry.OnWorkerRejoined(func(workerID string) {
-			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 			defer cancel()
+			controlplane.ReconcileRunningOnWorker(ctx, redisRegistry, opts.Store, cfg.CellID, workerID)
 			controlplane.ReconcileStoppedOnWorker(ctx, redisRegistry, opts.Store, workerID)
 		})
 

--- a/internal/controlplane/reconcile.go
+++ b/internal/controlplane/reconcile.go
@@ -2,9 +2,13 @@ package controlplane
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/opensandbox/opensandbox/internal/db"
 	pb "github.com/opensandbox/opensandbox/proto/worker"
@@ -94,4 +98,131 @@ func isSandboxNotFound(err error) bool {
 	}
 	return strings.Contains(err.Error(), "sandbox not found") ||
 		strings.Contains(err.Error(), "not found")
+}
+
+// ReconcileRunningOnWorker is the symmetric direction of ReconcileStoppedOnWorker:
+//
+//   forward  — cell says STOPPED on this worker, worker may still be hosting →
+//              re-issue Destroy via RPC. ReconcileStoppedOnWorker above.
+//   reverse  — cell says RUNNING on this worker, worker doesn't have it →
+//              close the row on the cell side. THIS function.
+//
+// Why both directions are needed:
+//   The cell-side fallback at internal/api/sandbox.go (worker-unreachable
+//   destroy path) covers the forward direction. There's no symmetric fallback
+//   for "worker died, never finished EndScaleEvent on its way out" — when a
+//   worker process crashes/OOMs/restarts, its m.vms is cleared but cell PG
+//   keeps the scale event open. usage-reporter sums (now - started_at)
+//   indefinitely; customer gets billed for compute that hasn't run for days.
+//
+// Empirical fingerprint from prod: 49 still-open scale events on two workers
+// that were known to have restarted ~3-5 days prior, accumulating ~$2k of
+// phantom Pro billing per restart event.
+//
+// Process:
+//   1. Ask cell PG: what sandboxes are status='running' on this worker?
+//   2. Ask worker (existing ListSandboxes RPC): what do you actually have?
+//   3. For each cell-PG-running entry the worker doesn't claim:
+//        - UpdateSandboxSessionStatus → stopped
+//        - EndScaleEvent → closes the open billing row
+//        - publish stopped lifecycle event so events-ingest updates D1
+func ReconcileRunningOnWorker(ctx context.Context, registry *RedisWorkerRegistry, store *db.Store, cellID, workerID string) {
+	if store == nil || registry == nil {
+		return
+	}
+
+	cellRunning, err := store.ListSandboxesByWorkerStatus(ctx, workerID, "running")
+	if err != nil {
+		log.Printf("controlplane: reverse-reconcile %s: list running sessions failed: %v", workerID, err)
+		return
+	}
+	if len(cellRunning) == 0 {
+		return
+	}
+
+	client, err := registry.GetWorkerClient(workerID)
+	if err != nil {
+		log.Printf("controlplane: reverse-reconcile %s: GetWorkerClient failed: %v", workerID, err)
+		return
+	}
+
+	rpcCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	resp, err := client.ListSandboxes(rpcCtx, &pb.ListSandboxesRequest{})
+	cancel()
+	if err != nil {
+		log.Printf("controlplane: reverse-reconcile %s: ListSandboxes RPC failed: %v", workerID, err)
+		return
+	}
+
+	workerHas := make(map[string]struct{}, len(resp.Sandboxes))
+	for _, sb := range resp.Sandboxes {
+		workerHas[sb.SandboxId] = struct{}{}
+	}
+
+	log.Printf("controlplane: reverse-reconcile %s: cell-running=%d worker-has=%d", workerID, len(cellRunning), len(workerHas))
+
+	reason := "reverse_reconcile_worker_lost_session"
+	var closed, alive int
+	for _, ref := range cellRunning {
+		if _, has := workerHas[ref.SandboxID]; has {
+			alive++
+			continue
+		}
+		// Close the cell-side state. Order matters: status first (so future
+		// dashboard reads see the right thing immediately), then scale event
+		// (so usage-reporter stops billing), then the lifecycle event (so D1
+		// gets the same signal via events-ingest).
+		errMsg := reason
+		if err := store.UpdateSandboxSessionStatus(ctx, ref.SandboxID, "stopped", &errMsg); err != nil {
+			log.Printf("controlplane: reverse-reconcile %s: UpdateSandboxSessionStatus %s: %v", workerID, ref.SandboxID, err)
+			continue
+		}
+		if err := store.EndScaleEvent(ctx, ref.SandboxID); err != nil {
+			log.Printf("controlplane: reverse-reconcile %s: EndScaleEvent %s: %v", workerID, ref.SandboxID, err)
+			// Don't continue — the status update already happened, so emit
+			// the lifecycle event anyway. The scale event being orphaned is
+			// at worst a per-row leak the usage-reporter will eventually
+			// notice; the lifecycle event is what unblocks D1.
+		}
+		publishStoppedLifecycleEvent(ctx, registry.RedisClient(), cellID, ref.SandboxID, ref.OrgID.String(), workerID, reason)
+		closed++
+	}
+	log.Printf("controlplane: reverse-reconcile %s: closed=%d still-alive-on-worker=%d (of %d cell-running)", workerID, closed, alive, len(cellRunning))
+}
+
+// publishStoppedLifecycleEvent emits a `stopped` event onto this cell's events
+// stream so events-ingest mirrors it into D1 sandboxes_index. Mirrors the
+// shape of internal/api/checkpoint_events.go's publishSandboxLifecycleEvent
+// — extracted here so the reconcile (which lives in controlplane, doesn't
+// have an *api.Server handle) can call it directly.
+func publishStoppedLifecycleEvent(ctx context.Context, rdb *redis.Client, cellID, sandboxID, orgID, workerID, reason string) {
+	if rdb == nil || cellID == "" || sandboxID == "" {
+		return
+	}
+	envelope := map[string]any{
+		"id":         uuid.NewString(),
+		"type":       "stopped",
+		"sandbox_id": sandboxID,
+		"org_id":     orgID,
+		"worker_id":  workerID,
+		"cell_id":    cellID,
+		"payload":    map[string]any{"reason": reason},
+		"timestamp":  time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		log.Printf("controlplane: publishStoppedLifecycleEvent: marshal: %v", err)
+		return
+	}
+	streamKey := "events:" + cellID
+	xaddCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	if err := rdb.XAdd(xaddCtx, &redis.XAddArgs{
+		Stream: streamKey,
+		MaxLen: 100000,
+		Approx: true,
+		Values: map[string]any{"event": string(body)},
+	}).Err(); err != nil {
+		log.Printf("controlplane: publishStoppedLifecycleEvent: XADD %s: %v", sandboxID, err)
+	}
 }

--- a/internal/controlplane/reconcile.go
+++ b/internal/controlplane/reconcile.go
@@ -1,0 +1,97 @@
+package controlplane
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/opensandbox/opensandbox/internal/db"
+	pb "github.com/opensandbox/opensandbox/proto/worker"
+)
+
+// ReconcileStoppedOnWorker re-issues DestroySandbox for any sandbox the cell
+// believes is stopped on this worker but the worker may still be hosting.
+//
+// Why this exists:
+//   When the worker is unreachable, the customer's DELETE goes through the
+//   cell-side fallback at internal/api/sandbox.go's destroy handler — the
+//   cell marks the session stopped in PG and publishes a `stopped` lifecycle
+//   event "to close the drift" with D1. Worker never receives the gRPC
+//   Destroy. When the worker becomes reachable again, the cell already
+//   thinks the sandbox is dead, but the worker still has m.vms[id] alive,
+//   qemu still running, usage_ticker still emitting `usage_tick` events.
+//   That window has run for 74h+ in the wild before a worker restart finally
+//   cleared the m.vms map.
+//
+// This reconcile closes that gap: on worker rejoin (RedisWorkerRegistry's
+// OnWorkerRejoined callback), the cell sweeps every sandbox it has marked
+// stopped on that worker within the last 24h and re-issues DestroySandbox.
+// The RPC is idempotent — manager.Kill returns "sandbox not found" cleanly
+// for entries the worker doesn't have, so genuine first-seen workers (empty
+// m.vms) are a cheap no-op.
+//
+// Paired with: Fix A/B/C in internal/qemu/ghost_reaper.go which catches the
+// case where qemu died but m.vms wasn't cleaned. This function catches the
+// symmetric case where the cell already declared the sandbox dead but the
+// worker (with live qemu) doesn't know.
+func ReconcileStoppedOnWorker(ctx context.Context, registry *RedisWorkerRegistry, store *db.Store, workerID string) {
+	if store == nil || registry == nil {
+		return
+	}
+
+	ids, err := store.ListSandboxIDsByWorkerStatus(ctx, workerID, "stopped")
+	if err != nil {
+		log.Printf("controlplane: reconcile %s: list stopped sessions failed: %v", workerID, err)
+		return
+	}
+	if len(ids) == 0 {
+		return
+	}
+
+	client, err := registry.GetWorkerClient(workerID)
+	if err != nil {
+		// Worker was just added to the registry by handleHeartbeat; if the
+		// gRPC dial is still in flight (or just failed) we'll catch the
+		// next rejoin. Don't retry inline — that'd block other rejoins.
+		log.Printf("controlplane: reconcile %s: GetWorkerClient failed: %v", workerID, err)
+		return
+	}
+
+	log.Printf("controlplane: reconcile %s: sweeping %d cell-stopped sandboxes", workerID, len(ids))
+
+	var killed, notFound, errored int
+	for _, id := range ids {
+		rpcCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err := client.DestroySandbox(rpcCtx, &pb.DestroySandboxRequest{SandboxId: id})
+		cancel()
+		if err != nil {
+			// "sandbox not found" is the success-case: the worker didn't
+			// have it (either a genuine new worker or the entry was cleaned
+			// up another way). Only log+count non-not-found errors.
+			if isSandboxNotFound(err) {
+				notFound++
+			} else {
+				log.Printf("controlplane: reconcile %s: DestroySandbox %s failed: %v", workerID, id, err)
+				errored++
+			}
+			continue
+		}
+		killed++
+	}
+	log.Printf("controlplane: reconcile %s: done — killed=%d not_found=%d errored=%d (of %d cell-stopped within 24h)",
+		workerID, killed, notFound, errored, len(ids))
+}
+
+// isSandboxNotFound is a heuristic for the worker's "sandbox not found" error
+// surface — the qemu/firecracker managers both return `fmt.Errorf("sandbox %s
+// not found", id)` from Kill on unknown IDs, which propagates through the
+// gRPC layer as an Unknown error containing that string. We treat that as the
+// success case for reconcile: nothing to clean up.
+func isSandboxNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "sandbox not found") ||
+		strings.Contains(err.Error(), "not found")
+}

--- a/internal/controlplane/redis_registry.go
+++ b/internal/controlplane/redis_registry.go
@@ -96,6 +96,15 @@ type RedisWorkerRegistry struct {
 	rrCounter  uint64                        // round-robin counter for tie-breaking
 	stop       chan struct{}
 
+	// onWorkerRejoined fires when a worker registers — both genuinely new and
+	// after being pruned for missed heartbeats. Used by the reconcile-on-
+	// reconnect sweep to re-issue Destroy for sandboxes the cell already
+	// believes are stopped on this worker but the worker may still be hosting
+	// (e.g., the cell ran the "publish stopped fallback" path in
+	// internal/api/sandbox.go while this worker was unreachable). Fired in a
+	// goroutine; callback should be idempotent.
+	onWorkerRejoined func(workerID string)
+
 	// Per-sandbox stats indexed by sandboxID for O(1) autoscaler lookup. Updated
 	// from each worker heartbeat. Lock-protected separately from workers so the
 	// autoscaler doesn't contend with the routing path (which holds workersMu).
@@ -107,6 +116,17 @@ type RedisWorkerRegistry struct {
 // RedisClient returns the underlying Redis client (for health checks, shared state, etc.).
 func (r *RedisWorkerRegistry) RedisClient() *redis.Client {
 	return r.rdb
+}
+
+// OnWorkerRejoined registers a callback fired when a worker enters the
+// registry — both genuine first-seen and a rejoin after the worker was pruned
+// for missed heartbeats. Used by the reconcile-on-reconnect sweep (see
+// internal/controlplane/reconcile.go). Set this before Start(); callback runs
+// in its own goroutine.
+func (r *RedisWorkerRegistry) OnWorkerRejoined(fn func(workerID string)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.onWorkerRejoined = fn
 }
 
 // GetSandboxStats returns the latest cached stats for a sandbox along with
@@ -334,10 +354,22 @@ func (r *RedisWorkerRegistry) handleHeartbeat(entry WorkerEntry) {
 			existing.MachineID = entry.MachineID
 		}
 	} else {
-		// New worker
+		// New worker (genuine first-seen OR a rejoin after the worker was
+		// pruned for missing heartbeats). Both cases want reconcile-on-reconnect
+		// to fire: for genuine new workers the cell PG has no stopped sandboxes
+		// on that ID so it's a cheap no-op; for rejoins, this is where we
+		// re-issue Destroy for sandboxes the cell published "stopped" for
+		// during the unreachable window. See internal/controlplane/reconcile.go.
 		entry.Draining = drainOverride
 		r.workers[entry.ID] = &entry
 		log.Printf("redis_registry: new worker registered: %s (region=%s, grpc=%s, draining=%v)", entry.ID, entry.Region, entry.GRPCAddr, drainOverride)
+		if r.onWorkerRejoined != nil {
+			// Fire in a goroutine — reconcile may take a few seconds (DB query
+			// + a DestroySandbox RPC per stale entry) and we don't want
+			// subsequent heartbeats (which need r.mu) blocking on it.
+			workerID := entry.ID
+			go r.onWorkerRejoined(workerID)
+		}
 	}
 
 	// Per-sandbox stats indexing. Update fresh entries; prune sandboxes that

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -974,6 +974,41 @@ func (s *Store) ListSandboxSessions(ctx context.Context, orgID uuid.UUID, status
 	return sessions, nil
 }
 
+// ListSandboxIDsByWorkerStatus returns sandbox IDs (the public sb-... form,
+// not the row UUID) for sessions on a specific worker with a specific status.
+// Used by the reconcile-on-reconnect sweep: when a worker rejoins after being
+// pruned for missed heartbeats, the cell may have published "stopped"
+// lifecycle events during the unreachable window (internal/api/sandbox.go's
+// worker_unreachable fallback). This query identifies those entries so the
+// reconcile can re-issue Destroy and clean the worker's m.vms.
+//
+// Bounded to sessions whose stopped_at is within the last 24h — older entries
+// have presumably been cleaned by worker restarts or the ghost reaper, and
+// scanning them just wastes RPC round-trips.
+func (s *Store) ListSandboxIDsByWorkerStatus(ctx context.Context, workerID, status string) ([]string, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT sandbox_id FROM sandbox_sessions
+		 WHERE worker_id = $1 AND status = $2
+		   AND stopped_at IS NOT NULL
+		   AND stopped_at > NOW() - INTERVAL '24 hours'
+		 ORDER BY stopped_at DESC
+		 LIMIT 1000`,
+		workerID, status)
+	if err != nil {
+		return nil, fmt.Errorf("list sandboxes by worker+status: %w", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 func (s *Store) CountActiveSandboxes(ctx context.Context, orgID uuid.UUID) (int, error) {
 	var count int
 	err := s.pool.QueryRow(ctx,

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -974,6 +974,40 @@ func (s *Store) ListSandboxSessions(ctx context.Context, orgID uuid.UUID, status
 	return sessions, nil
 }
 
+// WorkerSandboxRef is the minimum (sandbox_id, org_id) tuple the reverse-direction
+// reconcile needs to close orphaned sessions and emit lifecycle events.
+type WorkerSandboxRef struct {
+	SandboxID string
+	OrgID     uuid.UUID
+}
+
+// ListSandboxesByWorkerStatus returns the (sandbox_id, org_id) pairs for sessions
+// on a worker with a given status. Used by the reverse-direction reconcile:
+// when a worker rejoins after a gap, we look up what cell PG thinks is *running*
+// on that worker, ask the worker what it actually has, and close any cell-PG row
+// the worker doesn't claim. Bounded to 1000 rows so a runaway query never blows.
+func (s *Store) ListSandboxesByWorkerStatus(ctx context.Context, workerID, status string) ([]WorkerSandboxRef, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT sandbox_id, org_id FROM sandbox_sessions
+		 WHERE worker_id = $1 AND status = $2
+		 ORDER BY started_at DESC
+		 LIMIT 1000`,
+		workerID, status)
+	if err != nil {
+		return nil, fmt.Errorf("list sandboxes by worker+status: %w", err)
+	}
+	defer rows.Close()
+	var refs []WorkerSandboxRef
+	for rows.Next() {
+		var r WorkerSandboxRef
+		if err := rows.Scan(&r.SandboxID, &r.OrgID); err != nil {
+			return nil, err
+		}
+		refs = append(refs, r)
+	}
+	return refs, rows.Err()
+}
+
 // ListSandboxIDsByWorkerStatus returns sandbox IDs (the public sb-... form,
 // not the row UUID) for sessions on a specific worker with a specific status.
 // Used by the reconcile-on-reconnect sweep: when a worker rejoins after being

--- a/internal/firecracker/manager.go
+++ b/internal/firecracker/manager.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -675,16 +676,44 @@ func (m *Manager) cleanupVM(netCfg *NetworkConfig, sandboxDir string) {
 	}
 }
 
-// List returns all running VMs.
+// List returns all running VMs. Skips ghost entries — see fcVMAlive.
 func (m *Manager) List(ctx context.Context) ([]types.Sandbox, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	result := make([]types.Sandbox, 0, len(m.vms))
 	for _, vm := range m.vms {
+		if !fcVMAlive(vm) {
+			continue
+		}
 		result = append(result, *vmToSandbox(vm))
 	}
 	return result, nil
+}
+
+// fcVMAlive — same signal-0 process probe as qemu's vmAlive (see
+// qemu/ghost_reaper.go). Firecracker VMInstance has the same cmd/pid shape
+// but is a distinct type, so the check is inlined here rather than abstracted.
+func fcVMAlive(vm *VMInstance) bool {
+	if vm == nil || vm.cmd == nil || vm.cmd.Process == nil {
+		return false
+	}
+	if vm.cmd.ProcessState != nil && vm.cmd.ProcessState.Exited() {
+		return false
+	}
+	return vm.cmd.Process.Signal(syscall.Signal(0)) == nil
+}
+
+// IsSandboxAlive — interface contract for Manager. (false, nil) on unknown id
+// OR known-but-dead. Usage_ticker treats both the same: skip the tick.
+func (m *Manager) IsSandboxAlive(ctx context.Context, id string) (bool, error) {
+	m.mu.RLock()
+	vm, ok := m.vms[id]
+	m.mu.RUnlock()
+	if !ok {
+		return false, nil
+	}
+	return fcVMAlive(vm), nil
 }
 
 // Count returns the number of running VMs.

--- a/internal/qemu/ghost_reaper.go
+++ b/internal/qemu/ghost_reaper.go
@@ -1,0 +1,126 @@
+package qemu
+
+import (
+	"context"
+	"log"
+	"syscall"
+	"time"
+)
+
+// Ghost VM reaper — defense for the case where a code path adds to m.vms,
+// later kills the qemu process (or qemu dies on its own), and never cleans the
+// map entry. Symptom in the wild: usage_ticker.tick() reads m.vms, finds the
+// ghost, emits usage_tick events every 20s — runs forever until the worker
+// process restarts and clears the map.
+//
+// Three layers, top-down (matches Fix A / B / C in the triage):
+//
+//   A. usage_ticker calls IsSandboxAlive(id) before LogEvent("usage_tick"). Even
+//      if List() returns a ghost, the ticker won't bill for it.
+//   B. List() filters m.vms entries whose qemu process is dead. + a reaper
+//      goroutine (started by NewManager, stopped by Close) walks m.vms every
+//      30s and prunes dead entries so they free memory + stop appearing in any
+//      consumer of m.vms — not just usage_ticker.
+//   C. Each m.vms add-site's failure paths are audited so the leak doesn't
+//      occur in the first place; the reaper is only the safety net.
+
+const reaperInterval = 30 * time.Second
+
+// vmAlive reports whether the qemu process backing this VM is still running.
+// Uses signal-0 ("does this process exist?") which is non-blocking and safe to
+// call on every tick. Survives transient QMP unresponsiveness (e.g. during a
+// savevm) because it checks the OS process, not the QMP socket.
+//
+// Returns false for: nil cmd, nil cmd.Process, or a reaped/exited process.
+func vmAlive(vm *VMInstance) bool {
+	if vm == nil || vm.cmd == nil || vm.cmd.Process == nil {
+		return false
+	}
+	// If cmd.Wait() already returned, ProcessState is non-nil and Exited() is true.
+	if vm.cmd.ProcessState != nil && vm.cmd.ProcessState.Exited() {
+		return false
+	}
+	// Signal(0) is the standard Unix "test process existence" probe. Returns
+	// nil if the process is still around, ESRCH/"already finished" otherwise.
+	return vm.cmd.Process.Signal(syscall.Signal(0)) == nil
+}
+
+// IsSandboxAlive returns true iff the manager has a tracked VM for this id AND
+// its qemu process is still running. Used by usage_ticker before emitting
+// billing events so a ghost m.vms entry can't drive billing on a dead sandbox.
+//
+// (false, nil) on unknown id (not in m.vms) OR known id whose process is dead.
+// Caller treats both the same: skip the tick.
+func (m *Manager) IsSandboxAlive(ctx context.Context, id string) (bool, error) {
+	m.mu.RLock()
+	vm, ok := m.vms[id]
+	m.mu.RUnlock()
+	if !ok {
+		return false, nil
+	}
+	return vmAlive(vm), nil
+}
+
+// startGhostReaper launches the reaper goroutine. Called once from NewManager.
+// Stop via m.stopGhostReaper() — Close() does that.
+func (m *Manager) startGhostReaper() {
+	m.reaperStop = make(chan struct{})
+	m.reaperDone = make(chan struct{})
+	go m.runGhostReaper()
+}
+
+// stopGhostReaper signals the reaper to exit and waits up to 2s for it to
+// drain. Idempotent — multiple Close() calls are safe.
+func (m *Manager) stopGhostReaper() {
+	m.reaperOnce.Do(func() {
+		if m.reaperStop != nil {
+			close(m.reaperStop)
+		}
+	})
+	if m.reaperDone == nil {
+		return
+	}
+	select {
+	case <-m.reaperDone:
+	case <-time.After(2 * time.Second):
+		log.Printf("qemu: ghost reaper did not exit within 2s; continuing close")
+	}
+}
+
+func (m *Manager) runGhostReaper() {
+	defer close(m.reaperDone)
+	t := time.NewTicker(reaperInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-m.reaperStop:
+			return
+		case <-t.C:
+			m.reapDeadVMs(context.Background())
+		}
+	}
+}
+
+// reapDeadVMs walks m.vms under the write lock and removes entries whose qemu
+// process has exited. Logs each removal — these are bugs upstream (a code path
+// that should have delete()'d on failure) and the log is the trail back to the
+// leaking path.
+//
+// Holds the write lock for the duration; the loop is short (one Signal(0)
+// syscall per VM) so this doesn't measurably contend with create/list/exec.
+func (m *Manager) reapDeadVMs(_ context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var reaped int
+	for id, vm := range m.vms {
+		if vmAlive(vm) {
+			continue
+		}
+		log.Printf("qemu: ghost-reaper: removing dead VM %s (pid=%d) from m.vms — qemu process is gone but entry was not cleaned up", id, vm.pid)
+		delete(m.vms, id)
+		reaped++
+	}
+	if reaped > 0 {
+		log.Printf("qemu: ghost-reaper: removed %d dead VM(s) from m.vms; %d alive remain", reaped, len(m.vms))
+	}
+}

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -348,6 +348,12 @@ type Manager struct {
 	// Per-sandbox stats cache populated by a background collector and read by
 	// the heartbeat path. See stats_collector.go.
 	statsCache *SandboxStatsCache
+
+	// Ghost-VM reaper: periodically prunes m.vms entries whose qemu process is
+	// dead but the map entry wasn't cleaned up. See ghost_reaper.go.
+	reaperStop chan struct{}
+	reaperDone chan struct{}
+	reaperOnce sync.Once
 }
 
 // NewManager creates a new QEMU-backed sandbox manager.
@@ -400,12 +406,17 @@ func NewManager(cfg Config) (*Manager, error) {
 		log.Printf("qemu: cleaned up stale archive-staging: %s", d)
 	}
 
-	return &Manager{
+	m := &Manager{
 		cfg:     cfg,
 		subnets: NewSubnetAllocator(),
 		vms:     make(map[string]*VMInstance),
 		nextCID: 3,
-	}, nil
+	}
+	// Start the ghost-VM reaper. Without it a code path that leaks an m.vms
+	// entry on failure (qemu dies but map entry stays) leads to usage_ticker
+	// emitting billing events forever — see ghost_reaper.go.
+	m.startGhostReaper()
+	return m, nil
 }
 
 // SetMetadataCallbacks registers callbacks that are invoked when sandboxes
@@ -2029,6 +2040,13 @@ func (m *Manager) List(ctx context.Context) ([]types.Sandbox, error) {
 
 	result := make([]types.Sandbox, 0, len(m.vms))
 	for _, vm := range m.vms {
+		// Filter ghost VMs: qemu died but the m.vms entry never got cleaned
+		// up. The reaper (ghost_reaper.go) eventually prunes these, but List
+		// callers — most importantly usage_ticker, which uses the list to
+		// drive billing — should never see them, even between reaper ticks.
+		if !vmAlive(vm) {
+			continue
+		}
 		result = append(result, *vmToSandbox(vm))
 	}
 	return result, nil
@@ -2043,6 +2061,8 @@ func (m *Manager) Count(ctx context.Context) (int, error) {
 
 // Close stops all VMs and cleans up.
 func (m *Manager) Close() {
+	m.stopGhostReaper()
+
 	m.mu.Lock()
 	vms := make([]*VMInstance, 0, len(m.vms))
 	for _, vm := range m.vms {
@@ -2666,6 +2686,17 @@ func (m *Manager) Hibernate(ctx context.Context, sandboxID string, checkpointSto
 
 	result, err := m.doHibernate(ctx, vm, checkpointStore)
 	if err != nil {
+		// Fix C: doHibernate may have killed qemu mid-flight (savevm path
+		// quits the VM) before bailing out. If qemu is dead, clean the
+		// m.vms entry now — otherwise it becomes a ghost that drives the
+		// usage_ticker until the next ghost-reaper tick (~30s). If qemu is
+		// still alive, leave it: the sandbox may still be recoverable.
+		if !vmAlive(vm) {
+			m.mu.Lock()
+			delete(m.vms, sandboxID)
+			m.mu.Unlock()
+			log.Printf("qemu: Hibernate %s failed (%v) AND qemu process is dead — cleaned m.vms entry inline", sandboxID, err)
+		}
 		return nil, err
 	}
 

--- a/internal/qemu/reset.go
+++ b/internal/qemu/reset.go
@@ -110,6 +110,26 @@ func (m *Manager) PowerCycleSandbox(ctx context.Context, sandboxID string) (host
 
 	t0 := time.Now()
 
+	// Fix C: once we kill the old qemu below, vm.cmd points to a reaped
+	// process until step 6 swaps in a new live cmd. Eight failure-returns
+	// live between the kill and the swap (drives missing, subnet alloc,
+	// TAP create, free port, DNAT, fresh qemu start, fresh QMP connect,
+	// fresh agent connect). Without this defer, any of them leaves m.vms
+	// holding a VMInstance whose vm.cmd refers to a reaped process — the
+	// ghost-VM shape that drove the billing leak. usage_ticker.IsSandboxAlive
+	// already skips these and the ghost-reaper drains them in ≤ 30s, but
+	// explicit local cleanup makes the failure semantics obvious here and
+	// matches the Hibernate failure-path fix.
+	var vmRestored bool
+	defer func() {
+		if err != nil && !vmRestored {
+			m.mu.Lock()
+			delete(m.vms, sandboxID)
+			m.mu.Unlock()
+			log.Printf("qemu: PowerCycleSandbox %s: failed before new qemu swap-in (%v) — cleaned m.vms entry", sandboxID, err)
+		}
+	}()
+
 	// Best-effort sync before we yank the rug. The QEMU drive is opened
 	// with cache=writethrough so the host always has a consistent view
 	// once the guest issues a write — but the guest kernel's own page
@@ -306,6 +326,9 @@ func (m *Manager) PowerCycleSandbox(ctx context.Context, sandboxID string) (host
 	vm.MemoryMB = finalMemMB
 	vm.baseMemoryMB = bootMemMB
 	vm.virtioMemRequestedMB = finalPlugMB
+	// Swap-in complete — the deferred cleanup at the top of this function
+	// will now no-op even if a future addition adds error returns below.
+	vmRestored = true
 
 	log.Printf("qemu: PowerCycleSandbox %s: complete (%dms, port=%d, tap=%s)",
 		sandboxID, time.Since(t0).Milliseconds(), freshPort, netCfg.TAPName)

--- a/internal/sandbox/interface.go
+++ b/internal/sandbox/interface.go
@@ -57,6 +57,12 @@ type Manager interface {
 	Kill(ctx context.Context, id string) error
 	List(ctx context.Context) ([]types.Sandbox, error)
 	Count(ctx context.Context) (int, error)
+	// IsSandboxAlive reports whether the manager has a tracked VM for id AND
+	// its backing process (qemu/firecracker) is still running. Used by the
+	// usage_ticker before emitting billing events so a stale in-memory entry
+	// (the "ghost VM" bug) can't drive billing on a dead sandbox.
+	// Returns (false, nil) for both "unknown id" and "known but dead".
+	IsSandboxAlive(ctx context.Context, id string) (bool, error)
 	Close()
 
 	// Execution

--- a/internal/worker/grpc_server.go
+++ b/internal/worker/grpc_server.go
@@ -756,13 +756,28 @@ func (s *GRPCServer) WakeSandbox(ctx context.Context, req *pb.WakeSandboxRequest
 		s.router.Register(sb.ID, time.Duration(timeout)*time.Second)
 	}
 
-	// Re-initialize per-sandbox SQLite
+	// Re-initialize the per-sandbox SQLite and emit a `woke` lifecycle event.
+	// The hibernate path called sandboxDBs.Remove(id) which deleted the
+	// on-disk SQLite + dir; Get() here recreates it via OpenSandboxDB →
+	// MkdirAll + schema apply. The fresh DB has no history (the previous
+	// "hibernated" event was already flushed by Hibernate's Remove hook), but
+	// new events (including this `woke`) flow normally through the event
+	// publisher poll loop.
+	//
+	// Previously this Get/LogEvent pair silently swallowed both errors, which
+	// hid the fact that `woke` events were getting lost in the wild — D1
+	// `events` shows ~10× more `hibernated` than `woke` across prod, and the
+	// missing transitions broke the phantom-tick auditor's post-hibernate
+	// classification (looked like post-hibernate phantoms instead of legit
+	// post-wake billing). Log loudly now.
 	if s.sandboxDBs != nil {
-		sdb, err := s.sandboxDBs.Get(sb.ID)
-		if err == nil {
-			_ = sdb.LogEvent("woke", map[string]string{
-				"sandbox_id": sb.ID,
-			})
+		sdb, getErr := s.sandboxDBs.Get(sb.ID)
+		if getErr != nil {
+			log.Printf("grpc: WakeSandbox %s: sandboxDBs.Get failed (woke event will not be emitted, downstream timeline will miss the wake transition): %v", sb.ID, getErr)
+		} else if logErr := sdb.LogEvent("woke", map[string]string{
+			"sandbox_id": sb.ID,
+		}); logErr != nil {
+			log.Printf("grpc: WakeSandbox %s: LogEvent(woke) failed: %v", sb.ID, logErr)
 		}
 	}
 

--- a/internal/worker/usage_ticker.go
+++ b/internal/worker/usage_ticker.go
@@ -108,7 +108,25 @@ func (t *UsageTicker) tick(ctx context.Context) {
 		return
 	}
 	emitted := 0
+	skippedDead := 0
 	for _, sb := range list {
+		// Defense in depth: even if manager.List() returns a ghost entry
+		// (m.vms entry whose qemu/firecracker process died but wasn't
+		// cleaned up), don't bill for it. The leak this guards against
+		// was a 70+ hour-per-sandbox billing bleed in prod where ghosts
+		// kept ticking until the worker process restarted and wiped m.vms.
+		// See internal/qemu/ghost_reaper.go for the boundary fix +
+		// reaper that drains the map.
+		alive, err := t.manager.IsSandboxAlive(ctx, sb.ID)
+		if err != nil {
+			log.Printf("usage_ticker: %s: IsSandboxAlive check failed: %v — skipping this tick", sb.ID, err)
+			continue
+		}
+		if !alive {
+			skippedDead++
+			log.Printf("usage_ticker: %s: not alive (ghost m.vms entry?) — skipping; reaper should drain it", sb.ID)
+			continue
+		}
 		sdb, err := t.sandboxDBs.Get(sb.ID)
 		if err != nil {
 			log.Printf("usage_ticker: %s: Get failed: %v", sb.ID, err)
@@ -124,5 +142,5 @@ func (t *UsageTicker) tick(ctx context.Context) {
 		}
 		emitted++
 	}
-	log.Printf("usage_ticker: tick: emitted %d usage_tick event(s) for %d running sandbox(es)", emitted, len(list))
+	log.Printf("usage_ticker: tick: emitted %d usage_tick event(s) for %d listed sandbox(es) (skipped %d as not-alive)", emitted, len(list), skippedDead)
 }


### PR DESCRIPTION
  ## Ghost-VM billing — every realistic path to this symptom

  **The bug shape:** an `m.vms` entry whose backing qemu is **dead**, OR an entry whose qemu is **alive** while the cell already published a `stopped` event. `usage_ticker`
  reads `manager.List()`, sees the entry, emits `usage_tick` every 20s. Worst observed: ~74h of phantom ticks per ghost on one worker, ending only at the next worker restart.

  Below: every realistic code path that produces this shape, grouped by trigger. "Status" shows what each shipped patch covers; **safe** = was already correct.

  ### Group A — manual stop / hibernate / delete failed mid-flight

  | # | Path | qemu | m.vms | Status |
  |---|---|---|---|---|
  | 1 | `Hibernate`: Quit OK, blob upload fails | dead | stayed | ✅ Fix C inline-clean + reaper |
  | 2 | `Hibernate`: savevm fails pre-Quit | alive | stayed | safe (alive = legit billing) |
  | 3 | `PowerCycle`: any of 8 paths between kill + swap | dead | stayed | ✅ Fix C defer covers all 8 |
  | 4 | `Kill`/`Delete`: cell-side kill succeeds | dead | deleted pre-`destroyVM` | safe |
  | 5 | `Kill`/`Delete`: worker unreachable → cell publishes `stopped` fallback | alive | stayed | ✅ Reconcile-on-reconnect (**new**) |
  | 6 | `Reboot`: agent reconnect timeout | alive | stayed | safe (alive, agent-wedged) |

  ### Group B — automatic ops (no human click triggered them)

  | # | Path | Trigger | Status |
  |---|---|---|---|
  | 7 | Auto-hibernate on idle timeout | `sandbox.timeout` fires in cell | safe — `router.onTimeout` falls back to `Kill` |
  | 8 | Scaler drain (`HibernateAll`) | worker rebalance | safe — per-sandbox `Hibernate` covered by Fix C |
  | 9 | `RecoverLocalSandboxes` on worker restart | worker startup | safe — read-only, never writes `m.vms` |

  ### Group C — out-of-band qemu death (no Go code path runs)

  | # | Path | What kills qemu | Status |
  |---|---|---|---|
  | 10 | OOM kill on worker VM | host memory pressure | ✅ ghost-reaper ≤30s |
  | 11 | qemu segfault | rare (virtio-mem unplug edges) | ✅ same |
  | 12 | cgroup OOM on the sandbox | host cgroup limit | ✅ same |
  | 13 | Kernel / hypervisor crash on worker | system failure | ✅ same |

  For (10)–(13) there's no Go code path to run cleanup — the reaper is the only safety net, and it's the case it was built for.

  ### Group D — looks similar but isn't (no `m.vms` leak)

  Listed for triage completeness. These cause UI/state mismatches but **don't** drive `usage_tick`:

  | # | Path | Symptom |
  |---|---|---|
  | 14 | `proxyToCellSDK` `waitUntil` D1 status update dropped | UI shows "running" briefly |
  | 15 | Cross-org Delete (org-id mismatch) | 404 silently, UI no-op |
  | 16 | Dashboard template Delete vs sandbox Delete | different endpoint, button no-ops |
  | 17 | Cell-PG ↔ D1 drift after a failed event-forwarder retry | UI mismatch, no billing impact |

  ### 🟡 Open separate concern (not addressed by this PR)

  **`PrepareIncomingMigration` stranded target.** `internal/qemu/migration.go:522` adds the migration target to `m.vms` with qemu in **incoming-migrate** mode (paused). If
  `CompleteIncomingMigration` never runs (source crash, cross-worker network blip), target sits with qemu **alive** — `vmAlive` returns true, ticker emits, reaper doesn't
  catch. Different shape (alive, not dead). Two clean fix shapes:
  
  - TTL via `time.AfterFunc(15*time.Minute)` to auto-kill if Complete doesn't promote
  - `migrationStatus` tag on `VMInstance`; `usage_ticker` skips entries in `IncomingPending`

  ### 👁 Observability fix in this PR — `woke` event drop visibility

  `WakeSandbox` previously swallowed both `sandboxDBs.Get` and `LogEvent("woke", …)` errors with `_ = err`. That hid the fact that D1 `events` shows ~10× more `hibernated` than
   `woke` across prod (e.g. one large pro org: 57 `hibernated` / 5 `woke` over 30 days). Narrower blast radius than first thought:

  | Surface | Affected by missed `woke`? | Why |
  |---|---|---|
  | Customer dashboard / D1 sandboxes_index | ✅ No | api-edge writes status='running' on POST /wake via `waitUntil` |
  | Cell PG `sandbox_sessions.status` | ✅ No | `UpdateSandboxSessionForWake` does `SET status='running'` |
  | Events table → events-ingest | ❌ Yes | Wake transition missing from stream |
  | Phantom-tick / refund audit | ❌ Yes | Over-counts `post_hibernate` (no wake to clear hibernated state) |

  This PR makes the failure visible by logging. If the logs reveal real silent drops post-deploy, the reliability follow-up is to call `OpenSandboxDB` eagerly inside
  `manager.Wake` so the per-sandbox SQLite is guaranteed to exist before WakeSandbox's emit.

  ### Defense layers shipped in this PR

  1. `usage_ticker.IsSandboxAlive` check before every `LogEvent("usage_tick", …)` — Fix A
  2. `Manager.List()` filters dead `m.vms` entries at the boundary — Fix B
  3. Ghost-reaper goroutine every 30s, `delete(m.vms, id)` when qemu is dead — Fix B
  4. `Hibernate` inline cleanup on failure when `!vmAlive(vm)` — Fix C
  5. `PowerCycle` defer-based cleanup covering all 8 between-kill-and-swap returns — Fix C
  6. **`ReconcileStoppedOnWorker`** — on worker rejoin (`RedisWorkerRegistry.OnWorkerRejoined`), the cell re-issues `DestroySandbox` for every sandbox it has marked stopped on
  that worker within the last 24h. Closes the "cell already declared stopped, qemu still alive" gap (Group A row 5)
  7. **`WakeSandbox` error logging** (observability) — surface dropped `woke` events so we can tell whether emit is failing or wakes are just rare; turns a silent bug into an
  actionable signal

  Worst-case latency between either drift class and clean state is the reaper's ≤30s tick interval **or** the next worker heartbeat (typically seconds), with the `usage_ticker`
   aliveness check ensuring **zero ticks emitted** even within that window.