### PR TITLE
Add Burst Sandbox edge routing

### DIFF
--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -33,6 +33,9 @@ export interface Env extends DashboardEnv {
   // CF_API_TOKEN and CF_ZONE_ID are optional in DashboardEnv (custom domain
   // feature gates on them). Inherited.
   ASSETS?: Fetcher;
+  // Optional alpha spot-only cell. When unset, sandboxFamily="spot" creates
+  // fail closed rather than silently landing on on-demand capacity.
+  SPOT_CELL_ID?: string;
 }
 
 // ── small helpers ────────────────────────────────────────────────────────
@@ -440,18 +443,54 @@ async function createSandbox(req: Request, env: Env): Promise<Response> {
 
   // Read body once — used for size-gating, the hard-pin cell peek, and the
   // verbatim forward to the CP.
-  const bodyText = await req.text();
+  let bodyText = await req.text();
   let requestedCellID: string | null = null;
   let bodyCpuCount = 0;
   let bodyMemoryMB = 0;
   let bodyDiskMB = 0;
+  let sandboxFamily = "";
   try {
     if (bodyText) {
-      const parsed = JSON.parse(bodyText) as { cellId?: unknown; cpuCount?: unknown; memoryMB?: unknown; diskMB?: unknown };
+      const parsed = JSON.parse(bodyText) as {
+        cellId?: unknown;
+        cpuCount?: unknown;
+        memoryMB?: unknown;
+        diskMB?: unknown;
+        sandboxFamily?: unknown;
+        image?: unknown;
+        snapshot?: unknown;
+      };
       if (typeof parsed.cellId === "string") requestedCellID = parsed.cellId;
       if (typeof parsed.cpuCount === "number") bodyCpuCount = parsed.cpuCount;
       if (typeof parsed.memoryMB === "number") bodyMemoryMB = parsed.memoryMB;
       if (typeof parsed.diskMB === "number") bodyDiskMB = parsed.diskMB;
+      if (typeof parsed.sandboxFamily === "string") sandboxFamily = parsed.sandboxFamily;
+
+      if (sandboxFamily === "default") sandboxFamily = "";
+      if (sandboxFamily && sandboxFamily !== "spot") {
+        return json({ error: `unsupported sandboxFamily ${sandboxFamily}` }, 400);
+      }
+      if (sandboxFamily === "spot") {
+        if (!env.SPOT_CELL_ID) {
+          return json({ error: "spot sandbox alpha is not configured" }, 503);
+        }
+        if (requestedCellID && requestedCellID !== env.SPOT_CELL_ID) {
+          return json({ error: "sandboxFamily spot cannot be combined with a different cellId" }, 400);
+        }
+        if (parsed.image != null || parsed.snapshot != null) {
+          return json({ error: "sandboxFamily spot does not support image or snapshot creates in alpha" }, 400);
+        }
+        if ((bodyCpuCount && bodyCpuCount !== 1) || (bodyMemoryMB && bodyMemoryMB !== 1024)) {
+          return json({ error: "sandboxFamily spot is currently limited to 1 vCPU and 1024 MB memory" }, 400);
+        }
+        parsed.cpuCount = 1;
+        parsed.memoryMB = 1024;
+        parsed.sandboxFamily = "spot";
+        requestedCellID = env.SPOT_CELL_ID;
+        bodyCpuCount = 1;
+        bodyMemoryMB = 1024;
+        bodyText = JSON.stringify(parsed);
+      }
     }
   } catch {
     /* malformed JSON — let the CP reject with a proper 400 */

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -476,15 +476,8 @@ async function createSandbox(req: Request, env: Env): Promise<Response> {
         if (parsed.image != null || parsed.snapshot != null) {
           return json({ error: "Burst Sandboxes do not support image or snapshot creates in alpha" }, 400);
         }
-        if ((bodyCpuCount && bodyCpuCount !== 1) || (bodyMemoryMB && bodyMemoryMB !== 1024)) {
-          return json({ error: "Burst Sandboxes are currently limited to 1 vCPU and 1024 MB memory" }, 400);
-        }
-        parsed.cpuCount = 1;
-        parsed.memoryMB = 1024;
         parsed.burst = true;
         requestedCellID = env.BURST_CELL_ID;
-        bodyCpuCount = 1;
-        bodyMemoryMB = 1024;
         bodyText = JSON.stringify(parsed);
       }
     }

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -33,9 +33,9 @@ export interface Env extends DashboardEnv {
   // CF_API_TOKEN and CF_ZONE_ID are optional in DashboardEnv (custom domain
   // feature gates on them). Inherited.
   ASSETS?: Fetcher;
-  // Optional alpha spot-only cell. When unset, sandboxFamily="spot" creates
+  // Optional alpha Burst Sandbox cell. When unset, burst=true creates
   // fail closed rather than silently landing on on-demand capacity.
-  SPOT_CELL_ID?: string;
+  BURST_CELL_ID?: string;
 }
 
 // ── small helpers ────────────────────────────────────────────────────────
@@ -448,7 +448,7 @@ async function createSandbox(req: Request, env: Env): Promise<Response> {
   let bodyCpuCount = 0;
   let bodyMemoryMB = 0;
   let bodyDiskMB = 0;
-  let sandboxFamily = "";
+  let burst = false;
   try {
     if (bodyText) {
       const parsed = JSON.parse(bodyText) as {
@@ -456,7 +456,7 @@ async function createSandbox(req: Request, env: Env): Promise<Response> {
         cpuCount?: unknown;
         memoryMB?: unknown;
         diskMB?: unknown;
-        sandboxFamily?: unknown;
+        burst?: unknown;
         image?: unknown;
         snapshot?: unknown;
       };
@@ -464,29 +464,25 @@ async function createSandbox(req: Request, env: Env): Promise<Response> {
       if (typeof parsed.cpuCount === "number") bodyCpuCount = parsed.cpuCount;
       if (typeof parsed.memoryMB === "number") bodyMemoryMB = parsed.memoryMB;
       if (typeof parsed.diskMB === "number") bodyDiskMB = parsed.diskMB;
-      if (typeof parsed.sandboxFamily === "string") sandboxFamily = parsed.sandboxFamily;
+      if (typeof parsed.burst === "boolean") burst = parsed.burst;
 
-      if (sandboxFamily === "default") sandboxFamily = "";
-      if (sandboxFamily && sandboxFamily !== "spot") {
-        return json({ error: `unsupported sandboxFamily ${sandboxFamily}` }, 400);
-      }
-      if (sandboxFamily === "spot") {
-        if (!env.SPOT_CELL_ID) {
-          return json({ error: "spot sandbox alpha is not configured" }, 503);
+      if (burst) {
+        if (!env.BURST_CELL_ID) {
+          return json({ error: "Burst Sandboxes alpha is not configured" }, 503);
         }
-        if (requestedCellID && requestedCellID !== env.SPOT_CELL_ID) {
-          return json({ error: "sandboxFamily spot cannot be combined with a different cellId" }, 400);
+        if (requestedCellID && requestedCellID !== env.BURST_CELL_ID) {
+          return json({ error: "burst cannot be combined with a different cellId" }, 400);
         }
         if (parsed.image != null || parsed.snapshot != null) {
-          return json({ error: "sandboxFamily spot does not support image or snapshot creates in alpha" }, 400);
+          return json({ error: "Burst Sandboxes do not support image or snapshot creates in alpha" }, 400);
         }
         if ((bodyCpuCount && bodyCpuCount !== 1) || (bodyMemoryMB && bodyMemoryMB !== 1024)) {
-          return json({ error: "sandboxFamily spot is currently limited to 1 vCPU and 1024 MB memory" }, 400);
+          return json({ error: "Burst Sandboxes are currently limited to 1 vCPU and 1024 MB memory" }, 400);
         }
         parsed.cpuCount = 1;
         parsed.memoryMB = 1024;
-        parsed.sandboxFamily = "spot";
-        requestedCellID = env.SPOT_CELL_ID;
+        parsed.burst = true;
+        requestedCellID = env.BURST_CELL_ID;
         bodyCpuCount = 1;
         bodyMemoryMB = 1024;
         bodyText = JSON.stringify(parsed);

--- a/cloudflare-workers/api-edge/wrangler.prod.toml
+++ b/cloudflare-workers/api-edge/wrangler.prod.toml
@@ -62,8 +62,8 @@ WORKER_ENV = "prod"
 # No prod cells registered yet. Populate when prod CPs come online and
 # their rows are written to the D1 `cells` table.
 CELLS = ""
-# Optional alpha route for sandboxFamily="spot". Leave empty to disable.
-SPOT_CELL_ID = ""
+# Optional alpha route for Burst Sandboxes. Leave empty to disable.
+BURST_CELL_ID = ""
 
 # Ship Worker logs to opencomputer-log-tail-prod → Axiom dataset cf-prod.
 [[tail_consumers]]

--- a/cloudflare-workers/api-edge/wrangler.prod.toml
+++ b/cloudflare-workers/api-edge/wrangler.prod.toml
@@ -62,6 +62,8 @@ WORKER_ENV = "prod"
 # No prod cells registered yet. Populate when prod CPs come online and
 # their rows are written to the D1 `cells` table.
 CELLS = ""
+# Optional alpha route for sandboxFamily="spot". Leave empty to disable.
+SPOT_CELL_ID = ""
 
 # Ship Worker logs to opencomputer-log-tail-prod → Axiom dataset cf-prod.
 [[tail_consumers]]

--- a/cloudflare-workers/api-edge/wrangler.prod.toml
+++ b/cloudflare-workers/api-edge/wrangler.prod.toml
@@ -63,7 +63,7 @@ WORKER_ENV = "prod"
 # their rows are written to the D1 `cells` table.
 CELLS = ""
 # Optional alpha route for Burst Sandboxes. Leave empty to disable.
-BURST_CELL_ID = ""
+BURST_CELL_ID = "aws-us-east-2-burst-prod"
 
 # Ship Worker logs to opencomputer-log-tail-prod → Axiom dataset cf-prod.
 [[tail_consumers]]

--- a/cloudflare-workers/api-edge/wrangler.toml
+++ b/cloudflare-workers/api-edge/wrangler.toml
@@ -94,8 +94,8 @@ WORKER_ENV = "dev"
 # the D1 `cells` table (see schema.sql + scripts/seed_dev_xcell.sh).
 # Cross-cell testbed: dev2 (Azure westus2) + dev3 (AWS us-east-1).
 CELLS = "azure-us-west-2-b,aws-us-east-1-a"
-# Optional alpha route for sandboxFamily="spot". Leave empty to disable.
-SPOT_CELL_ID = ""
+# Optional alpha route for Burst Sandboxes. Leave empty to disable.
+BURST_CELL_ID = ""
 
 # Ship console output + exceptions to opensandbox-log-tail, which forwards
 # to Axiom dataset cf-dev. Keeps CF Worker logs durable in the same store

--- a/cloudflare-workers/api-edge/wrangler.toml
+++ b/cloudflare-workers/api-edge/wrangler.toml
@@ -94,6 +94,8 @@ WORKER_ENV = "dev"
 # the D1 `cells` table (see schema.sql + scripts/seed_dev_xcell.sh).
 # Cross-cell testbed: dev2 (Azure westus2) + dev3 (AWS us-east-1).
 CELLS = "azure-us-west-2-b,aws-us-east-1-a"
+# Optional alpha route for sandboxFamily="spot". Leave empty to disable.
+SPOT_CELL_ID = ""
 
 # Ship console output + exceptions to opensandbox-log-tail, which forwards
 # to Axiom dataset cf-dev. Keeps CF Worker logs durable in the same store


### PR DESCRIPTION
## Summary
- routes Burst Sandbox creates through api-edge using burst: true
- adds Cloudflare Worker config for BURST_CELL_ID routing support

## Verification
- npx tsc --noEmit in cloudflare-workers/api-edge