### PR TITLE
Expose Burst Sandbox SDK options

### DIFF
--- a/sdks/python/opencomputer/__init__.py
+++ b/sdks/python/opencomputer/__init__.py
@@ -1,6 +1,6 @@
 """OpenComputer Python SDK - cloud sandbox platform."""
 
-from opencomputer.sandbox import Sandbox, ScalingLockedError, PlanLimitError
+from opencomputer.sandbox import Sandbox, ScalingLockedError, PlanLimitError, SandboxFamilyLimitError
 from opencomputer.agent import Agent, AgentEvent, AgentSession, AgentSessionInfo
 from opencomputer.filesystem import Filesystem
 from opencomputer.exec import Exec, ProcessResult, ExecSession, ExecSessionInfo
@@ -30,6 +30,7 @@ __all__ = [
     "Sandbox",
     "ScalingLockedError",
     "PlanLimitError",
+    "SandboxFamilyLimitError",
     "Agent",
     "AgentEvent",
     "AgentSession",

--- a/sdks/python/opencomputer/sandbox.py
+++ b/sdks/python/opencomputer/sandbox.py
@@ -34,6 +34,14 @@ class PlanLimitError(Exception):
     """
 
 
+class SandboxFamilyLimitError(Exception):
+    """Raised when a resource-changing call is blocked by a sandbox family.
+    Kept for compatibility with older API responses.
+    """
+
+    code = "sandbox_family_scale_disabled"
+
+
 def _raise_scaling_error(resp: httpx.Response, action: str) -> None:
     """Inspect a non-OK scaling response and raise the most specific error.
     Falls back to ``raise_for_status`` so callers still see HTTP details for
@@ -44,6 +52,8 @@ def _raise_scaling_error(resp: httpx.Response, action: str) -> None:
         body = {}
     if resp.status_code == 403 and isinstance(body, dict) and body.get("code") == "scaling_locked":
         raise ScalingLockedError(body.get("error", "scaling is locked on this sandbox"))
+    if resp.status_code == 403 and isinstance(body, dict) and body.get("code") == "sandbox_family_scale_disabled":
+        raise SandboxFamilyLimitError(body.get("error", "sandbox family does not allow scaling"))
     if resp.status_code == 402:
         msg = body.get("error", "plan limit exceeded") if isinstance(body, dict) else "plan limit exceeded"
         raise PlanLimitError(msg)
@@ -76,6 +86,8 @@ class Sandbox:
         api_url: str | None = None,
         envs: dict[str, str] | None = None,
         metadata: dict[str, str] | None = None,
+        resumable: bool | None = None,
+        sandbox_family: str | None = None,
         disk_mb: int | None = None,
         memory_mb: int | None = None,
         secret_store: str | None = None,
@@ -92,6 +104,10 @@ class Sandbox:
             api_url: API URL (or OPENCOMPUTER_API_URL env var).
             envs: Environment variables to inject. Overrides store secrets.
             metadata: Custom metadata key-value pairs.
+            resumable: Create a resumable sandbox. Disk is preserved across
+                infrastructure restarts; processes may restart.
+            sandbox_family: Internal/legacy placement family. Prefer
+                ``resumable=True`` for public API usage.
             disk_mb: Workspace disk size in MB (default 20480 = 20GB). Any
                 additional GB above 20GB is metered at a per-second rate
                 comparable to EBS gp3. Closed beta: requests above 20GB
@@ -135,6 +151,10 @@ class Sandbox:
             body["envs"] = envs
         if metadata:
             body["metadata"] = metadata
+        if resumable is not None:
+            body["resumable"] = resumable
+        if sandbox_family:
+            body["sandboxFamily"] = sandbox_family
         if disk_mb is not None:
             body["diskMB"] = disk_mb
         if memory_mb is not None:

--- a/sdks/python/opencomputer/sandbox.py
+++ b/sdks/python/opencomputer/sandbox.py
@@ -86,7 +86,7 @@ class Sandbox:
         api_url: str | None = None,
         envs: dict[str, str] | None = None,
         metadata: dict[str, str] | None = None,
-        resumable: bool | None = None,
+        burst: bool | None = None,
         sandbox_family: str | None = None,
         disk_mb: int | None = None,
         memory_mb: int | None = None,
@@ -104,10 +104,10 @@ class Sandbox:
             api_url: API URL (or OPENCOMPUTER_API_URL env var).
             envs: Environment variables to inject. Overrides store secrets.
             metadata: Custom metadata key-value pairs.
-            resumable: Create a resumable sandbox. Disk is preserved across
+            burst: Create a Burst Sandbox. Disk is preserved across
                 infrastructure restarts; processes may restart.
             sandbox_family: Internal/legacy placement family. Prefer
-                ``resumable=True`` for public API usage.
+                ``burst=True`` for public API usage.
             disk_mb: Workspace disk size in MB (default 20480 = 20GB). Any
                 additional GB above 20GB is metered at a per-second rate
                 comparable to EBS gp3. Closed beta: requests above 20GB
@@ -151,8 +151,8 @@ class Sandbox:
             body["envs"] = envs
         if metadata:
             body["metadata"] = metadata
-        if resumable is not None:
-            body["resumable"] = resumable
+        if burst is not None:
+            body["burst"] = burst
         if sandbox_family:
             body["sandboxFamily"] = sandbox_family
         if disk_mb is not None:

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opencomputer-sdk"
-version = "0.6.0"
+version = "0.6.1"
 description = "Python SDK for OpenComputer - cloud sandbox platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -2,6 +2,7 @@ export {
   Sandbox,
   ScalingLockedError,
   PlanLimitError,
+  SandboxFamilyLimitError,
   type SandboxOpts,
   type CheckpointInfo,
   type PatchInfo,

--- a/sdks/typescript/src/sandbox.ts
+++ b/sdks/typescript/src/sandbox.ts
@@ -14,9 +14,9 @@ function resolveApiUrl(url: string): string {
 
 export interface SandboxOpts {
   template?: string;
-  /** Create a resumable sandbox. Disk is preserved across infrastructure restarts; processes may restart. */
-  resumable?: boolean;
-  /** Internal/legacy placement family. Prefer `resumable: true` for public API usage. */
+  /** Create a Burst Sandbox. Disk is preserved across infrastructure restarts; processes may restart. */
+  burst?: boolean;
+  /** Internal/legacy placement family. Prefer `burst: true` for public API usage. */
   sandboxFamily?: "spot";
   /**
    * Idle timeout in seconds after which the sandbox auto-hibernates.
@@ -52,7 +52,7 @@ interface SandboxData {
   status: string;
   templateID?: string;
   sandboxFamily?: string;
-  resumable?: boolean;
+  burst?: boolean;
   connectURL?: string;
   token?: string;
   sandboxDomain?: string;
@@ -269,7 +269,7 @@ export class Sandbox {
     };
     if (opts.envs) body.envs = opts.envs;
     if (opts.metadata) body.metadata = opts.metadata;
-    if (opts.resumable != null) body.resumable = opts.resumable;
+    if (opts.burst != null) body.burst = opts.burst;
     if (opts.sandboxFamily) body.sandboxFamily = opts.sandboxFamily;
     if (opts.cpuCount != null) body.cpuCount = opts.cpuCount;
     if (opts.memoryMB != null) body.memoryMB = opts.memoryMB;

--- a/sdks/typescript/src/sandbox.ts
+++ b/sdks/typescript/src/sandbox.ts
@@ -14,6 +14,10 @@ function resolveApiUrl(url: string): string {
 
 export interface SandboxOpts {
   template?: string;
+  /** Create a resumable sandbox. Disk is preserved across infrastructure restarts; processes may restart. */
+  resumable?: boolean;
+  /** Internal/legacy placement family. Prefer `resumable: true` for public API usage. */
+  sandboxFamily?: "spot";
   /**
    * Idle timeout in seconds after which the sandbox auto-hibernates.
    * Default: `0` (persistent — never auto-hibernate).
@@ -47,6 +51,8 @@ interface SandboxData {
   sandboxID: string;
   status: string;
   templateID?: string;
+  sandboxFamily?: string;
+  resumable?: boolean;
   connectURL?: string;
   token?: string;
   sandboxDomain?: string;
@@ -119,6 +125,18 @@ export class PlanLimitError extends Error {
 }
 
 /**
+ * Thrown when a resource-changing call is blocked by the sandbox's family.
+ * Kept for compatibility with older API responses.
+ */
+export class SandboxFamilyLimitError extends Error {
+  readonly code = "sandbox_family_scale_disabled";
+  constructor(message?: string) {
+    super(message ?? "sandbox family does not allow scaling");
+    this.name = "SandboxFamilyLimitError";
+  }
+}
+
+/**
  * Inspect a non-OK response from a scaling endpoint and throw the most
  * specific error type. Falls back to a generic Error when the response
  * doesn't match a known shape so callers still see the status + body.
@@ -133,6 +151,9 @@ async function throwScalingError(resp: Response, action: string): Promise<never>
   }
   if (resp.status === 403 && body.code === "scaling_locked") {
     throw new ScalingLockedError(body.error);
+  }
+  if (resp.status === 403 && body.code === "sandbox_family_scale_disabled") {
+    throw new SandboxFamilyLimitError(body.error);
   }
   if (resp.status === 402) {
     throw new PlanLimitError(body.error);
@@ -248,6 +269,8 @@ export class Sandbox {
     };
     if (opts.envs) body.envs = opts.envs;
     if (opts.metadata) body.metadata = opts.metadata;
+    if (opts.resumable != null) body.resumable = opts.resumable;
+    if (opts.sandboxFamily) body.sandboxFamily = opts.sandboxFamily;
     if (opts.cpuCount != null) body.cpuCount = opts.cpuCount;
     if (opts.memoryMB != null) body.memoryMB = opts.memoryMB;
     if (opts.diskMB != null) body.diskMB = opts.diskMB;


### PR DESCRIPTION
## Summary
- exposes Burst Sandbox creation options in the TypeScript SDK via burst: true
- exposes Burst Sandbox creation options in the Python SDK via burst=True
- bumps npm and PyPI SDK versions to 0.6.1

## Verification
- npm run build in sdks/typescript
- python3 -m compileall -q sdks/python/opencomputer