### PR TITLE
Document Burst Sandboxes

### DIFF
--- a/docs/api-reference/sandboxes/create.mdx
+++ b/docs/api-reference/sandboxes/create.mdx
@@ -14,11 +14,15 @@ Create a new sandbox.
 </ParamField>
 
 <ParamField body="cpuCount" type="integer">
-  CPU cores. Must match an allowed tier: `1`, `2`, or `4`. If omitted but `memoryMB` is set, inferred automatically.
+  CPU cores. Must match an allowed tier: `1`, `2`, `4`, `8`, or `16`. If omitted but `memoryMB` is set, inferred automatically.
 </ParamField>
 
 <ParamField body="memoryMB" type="integer">
-  Memory in MB. Must match an allowed tier: `1024`, `4096`, `8192`, or `16384`. If omitted but `cpuCount` is set, inferred automatically.
+  Memory in MB. Must match an allowed tier: `1024`, `4096`, `8192`, `16384`, `32768`, or `65536`. If omitted but `cpuCount` is set, inferred automatically.
+</ParamField>
+
+<ParamField body="resumable" type="boolean">
+  Create a [resumable sandbox](/sandboxes/resumable-sandboxes). Disk is preserved across infrastructure restarts; processes may restart.
 </ParamField>
 
 The allowed CPU/memory combinations are:
@@ -29,6 +33,8 @@ The allowed CPU/memory combinations are:
 | 4096 MB (4 GB) | 1 |
 | 8192 MB (8 GB) | 2 |
 | 16384 MB (16 GB) | 4 |
+| 32768 MB (32 GB) | 8 |
+| 65536 MB (64 GB) | 16 |
 
 The 1 GB tier provides 1 vCPU on a best-effort basis. For guaranteed CPU allocation, use the 4 GB tier or above.
 

--- a/docs/api-reference/sandboxes/create.mdx
+++ b/docs/api-reference/sandboxes/create.mdx
@@ -21,8 +21,8 @@ Create a new sandbox.
   Memory in MB. Must match an allowed tier: `1024`, `4096`, `8192`, `16384`, `32768`, or `65536`. If omitted but `cpuCount` is set, inferred automatically.
 </ParamField>
 
-<ParamField body="resumable" type="boolean">
-  Create a [resumable sandbox](/sandboxes/resumable-sandboxes). Disk is preserved across infrastructure restarts; processes may restart.
+<ParamField body="burst" type="boolean">
+  Create a [Burst Sandbox](/sandboxes/burst-sandboxes). Disk is preserved across infrastructure restarts; processes may restart.
 </ParamField>
 
 The allowed CPU/memory combinations are:

--- a/docs/api-reference/sandboxes/create.mdx
+++ b/docs/api-reference/sandboxes/create.mdx
@@ -14,31 +14,20 @@ Create a new sandbox.
 </ParamField>
 
 <ParamField body="cpuCount" type="integer">
-  CPU cores. Must match an allowed tier: `1`, `2`, `4`, `8`, or `16`. If omitted but `memoryMB` is set, inferred automatically.
+  CPU cores. If omitted but `memoryMB` is set, inferred automatically.
 </ParamField>
 
 <ParamField body="memoryMB" type="integer">
-  Memory in MB. Must match an allowed tier: `1024`, `4096`, `8192`, `16384`, `32768`, or `65536`. If omitted but `cpuCount` is set, inferred automatically.
+  Memory in MB. If omitted but `cpuCount` is set, inferred automatically.
 </ParamField>
 
 <ParamField body="burst" type="boolean">
   Create a [Burst Sandbox](/sandboxes/burst-sandboxes). Disk is preserved across infrastructure restarts; processes may restart.
 </ParamField>
 
-The allowed CPU/memory combinations are:
-
-| Memory | vCPU |
-| --- | --- |
-| 1024 MB (1 GB) | 1 |
-| 4096 MB (4 GB) | 1 |
-| 8192 MB (8 GB) | 2 |
-| 16384 MB (16 GB) | 4 |
-| 32768 MB (32 GB) | 8 |
-| 65536 MB (64 GB) | 16 |
-
 The 1 GB tier provides 1 vCPU on a best-effort basis. For guaranteed CPU allocation, use the 4 GB tier or above.
 
-If both `cpuCount` and `memoryMB` are provided, they must match one of these tiers.
+If both `cpuCount` and `memoryMB` are provided, they must match a platform tier.
 
 <ParamField body="envs" type="object">
   Environment variables as key-value pairs

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -48,6 +48,13 @@
           "sandboxes/preview-urls",
           "sandboxes/elasticity",
           {
+            "group": "Resumable Sandboxes",
+            "tag": "Alpha",
+            "pages": [
+              "sandboxes/resumable-sandboxes"
+            ]
+          },
+          {
             "group": "Usage",
             "tag": "Preview",
             "expanded": true,

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -47,13 +47,7 @@
           "sandboxes/patches",
           "sandboxes/preview-urls",
           "sandboxes/elasticity",
-          {
-            "group": "Burst Sandboxes",
-            "tag": "Alpha",
-            "pages": [
-              "sandboxes/burst-sandboxes"
-            ]
-          },
+          "sandboxes/burst-sandboxes",
           {
             "group": "Usage",
             "tag": "Preview",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -48,10 +48,10 @@
           "sandboxes/preview-urls",
           "sandboxes/elasticity",
           {
-            "group": "Resumable Sandboxes",
+            "group": "Burst Sandboxes",
             "tag": "Alpha",
             "pages": [
-              "sandboxes/resumable-sandboxes"
+              "sandboxes/burst-sandboxes"
             ]
           },
           {

--- a/docs/reference/cli/scaling.mdx
+++ b/docs/reference/cli/scaling.mdx
@@ -11,7 +11,7 @@ The CLI groups three related actions for sizing a sandbox:
 | [`oc sandbox scale`](#oc-sandbox-scale-id-memory-mb) | Manually resize once |
 | [`oc sandbox lock`](#oc-sandbox-lock-id) / [`unlock`](#oc-sandbox-unlock-id) / [`lock-status`](#oc-sandbox-lock-status-id) | Freeze or unfreeze the current size |
 
-Memory tiers are fixed: `1024`, `4096`, `8192`, `16384`, `32768`, `65536` MB. CPU follows memory per the platform's tier table (e.g. 8 GB → 4 vCPU); you don't pick CPU separately.
+CPU follows memory per the platform's tier table; you don't pick CPU separately.
 
 For the underlying concepts and how these three modes interact, see the [Elasticity](/sandboxes/elasticity) guide.
 
@@ -53,8 +53,8 @@ The asymmetry is deliberate: rapid response when the user notices lag, conservat
 | --- | --- |
 | `--on` | Enable autoscale (requires `--min` and `--max`). |
 | `--off` | Disable autoscale. Mutually exclusive with `--on`. |
-| `--min N` | Minimum memory tier in MB. Must be an allowed tier. |
-| `--max N` | Maximum memory tier in MB. Must be an allowed tier and ≥ `--min`. |
+| `--min N` | Minimum memory in MB. |
+| `--max N` | Maximum memory in MB. Must be ≥ `--min`. |
 
 **Errors**
 

--- a/docs/reference/python-sdk/sandbox.mdx
+++ b/docs/reference/python-sdk/sandbox.mdx
@@ -33,8 +33,8 @@ Create a new sandbox. [HTTP API →](/api-reference/sandboxes/create)
   Arbitrary metadata
 </ParamField>
 
-<ParamField body="resumable" type="bool">
-  Create a [resumable sandbox](/sandboxes/resumable-sandboxes). Disk is preserved across infrastructure restarts; processes may restart.
+<ParamField body="burst" type="bool">
+  Create a [Burst Sandbox](/sandboxes/burst-sandboxes). Disk is preserved across infrastructure restarts; processes may restart.
 </ParamField>
 
 <ParamField body="image" type="Image">
@@ -55,17 +55,17 @@ Create a new sandbox. [HTTP API →](/api-reference/sandboxes/create)
 sandbox = await Sandbox.create(template="my-stack", timeout=600)
 ```
 
-Create a resumable sandbox:
+Create a Burst Sandbox:
 
 ```python
 sandbox = await Sandbox.create(
-    resumable=True,
+    burst=True,
     timeout=300,
 )
 ```
 
 <Note>
-  Resumable sandboxes are alpha. They preserve filesystem state across
+  Burst Sandboxes are alpha. They preserve filesystem state across
   infrastructure restarts, may restart running processes, and are priced roughly
   2x cheaper than on-demand sandboxes.
 </Note>

--- a/docs/reference/python-sdk/sandbox.mdx
+++ b/docs/reference/python-sdk/sandbox.mdx
@@ -33,6 +33,10 @@ Create a new sandbox. [HTTP API →](/api-reference/sandboxes/create)
   Arbitrary metadata
 </ParamField>
 
+<ParamField body="resumable" type="bool">
+  Create a [resumable sandbox](/sandboxes/resumable-sandboxes). Disk is preserved across infrastructure restarts; processes may restart.
+</ParamField>
+
 <ParamField body="image" type="Image">
   Declarative image definition (see [Image](/reference/python-sdk/image))
 </ParamField>
@@ -51,8 +55,19 @@ Create a new sandbox. [HTTP API →](/api-reference/sandboxes/create)
 sandbox = await Sandbox.create(template="my-stack", timeout=600)
 ```
 
+Create a resumable sandbox:
+
+```python
+sandbox = await Sandbox.create(
+    resumable=True,
+    timeout=300,
+)
+```
+
 <Note>
-  `cpuCount` and `memoryMB` are not available in the Python SDK. Use the [HTTP API](/api-reference/sandboxes/create) for custom resources.
+  Resumable sandboxes are alpha. They preserve filesystem state across
+  infrastructure restarts, may restart running processes, and are priced roughly
+  2x cheaper than on-demand sandboxes.
 </Note>
 
 ---

--- a/docs/reference/python-sdk/scaling.mdx
+++ b/docs/reference/python-sdk/scaling.mdx
@@ -11,7 +11,7 @@ OpenComputer sandboxes can change size at runtime. There are three knobs:
 | Track memory pressure automatically | [`set_autoscale()`](#sandbox-set-autoscale) |
 | Freeze the current size | [`set_scaling_lock()`](#sandbox-set-scaling-lock-locked) |
 
-Memory tiers are fixed: `1024`, `4096`, `8192`, `16384`, `32768`, `65536` MB. CPU follows memory per the platform's tier table (e.g. 8 GB → 4 vCPU). You don't pick CPU separately.
+CPU follows memory per the platform's tier table. You don't pick CPU separately.
 
 ## How the three interact
 
@@ -26,7 +26,7 @@ Memory tiers are fixed: `1024`, `4096`, `8192`, `16384`, `32768`, `65536` MB. CP
 Manually resize the sandbox. [HTTP API →](/api-reference/sandboxes/scale)
 
 <ParamField body="memory_mb" type="int" required>
-  Target memory tier in MB. Must be one of the allowed tiers.
+  Target memory in MB.
 </ParamField>
 
 **Returns:** `dict` with `sandboxID`, `memoryMB`, `cpuPercent`.
@@ -61,11 +61,11 @@ Enable or disable per-sandbox autoscale.
 </ParamField>
 
 <ParamField body="min_memory_mb" type="int">
-  Lower bound when `enabled=True`. Must be an allowed tier.
+  Lower bound when `enabled=True`.
 </ParamField>
 
 <ParamField body="max_memory_mb" type="int">
-  Upper bound when `enabled=True`. Must be an allowed tier and ≥ `min_memory_mb`.
+  Upper bound when `enabled=True`. Must be ≥ `min_memory_mb`.
 </ParamField>
 
 **Returns:** `dict` with `sandboxID`, `enabled`, `minMemoryMB`, `maxMemoryMB`.

--- a/docs/reference/typescript-sdk.mdx
+++ b/docs/reference/typescript-sdk.mdx
@@ -33,8 +33,8 @@ Create a new sandbox.
 | `apiUrl` | string | env var | API URL |
 | `envs` | Record\<string, string\> | — | Environment variables |
 | `metadata` | Record\<string, string\> | — | Arbitrary metadata |
-| `cpuCount` | number | — | CPU cores (1, 2, or 4) |
-| `memoryMB` | number | — | Memory in MB (1024, 4096, 8192, 16384, 32768, or 65536) |
+| `cpuCount` | number | — | CPU cores |
+| `memoryMB` | number | — | Memory in MB |
 | `image` | Image | — | Declarative image definition (see [Image](#image)) |
 | `snapshot` | string | — | Name of a pre-built snapshot |
 | `onBuildLog` | `(log: string) => void` | — | Build log callback (when using `image`) |

--- a/docs/reference/typescript-sdk/sandbox.mdx
+++ b/docs/reference/typescript-sdk/sandbox.mdx
@@ -33,6 +33,10 @@ Create a new sandbox. [HTTP API →](/api-reference/sandboxes/create)
   Arbitrary metadata
 </ParamField>
 
+<ParamField body="resumable" type="boolean">
+  Create a [resumable sandbox](/sandboxes/resumable-sandboxes). Disk is preserved across infrastructure restarts; processes may restart.
+</ParamField>
+
 <ParamField body="cpuCount" type="number">
   CPU cores
 </ParamField>
@@ -62,6 +66,21 @@ Create a new sandbox. [HTTP API →](/api-reference/sandboxes/create)
 ```typescript
 const sandbox = await Sandbox.create({ template: "my-stack", timeout: 600 });
 ```
+
+Create a resumable sandbox:
+
+```typescript
+const sandbox = await Sandbox.create({
+  resumable: true,
+  timeout: 300,
+});
+```
+
+<Note>
+  Resumable sandboxes are alpha. They preserve filesystem state across
+  infrastructure restarts, may restart running processes, and are priced roughly
+  2x cheaper than on-demand sandboxes.
+</Note>
 
 ---
 

--- a/docs/reference/typescript-sdk/sandbox.mdx
+++ b/docs/reference/typescript-sdk/sandbox.mdx
@@ -33,8 +33,8 @@ Create a new sandbox. [HTTP API →](/api-reference/sandboxes/create)
   Arbitrary metadata
 </ParamField>
 
-<ParamField body="resumable" type="boolean">
-  Create a [resumable sandbox](/sandboxes/resumable-sandboxes). Disk is preserved across infrastructure restarts; processes may restart.
+<ParamField body="burst" type="boolean">
+  Create a [Burst Sandbox](/sandboxes/burst-sandboxes). Disk is preserved across infrastructure restarts; processes may restart.
 </ParamField>
 
 <ParamField body="cpuCount" type="number">
@@ -67,17 +67,17 @@ Create a new sandbox. [HTTP API →](/api-reference/sandboxes/create)
 const sandbox = await Sandbox.create({ template: "my-stack", timeout: 600 });
 ```
 
-Create a resumable sandbox:
+Create a Burst Sandbox:
 
 ```typescript
 const sandbox = await Sandbox.create({
-  resumable: true,
+  burst: true,
   timeout: 300,
 });
 ```
 
 <Note>
-  Resumable sandboxes are alpha. They preserve filesystem state across
+  Burst Sandboxes are alpha. They preserve filesystem state across
   infrastructure restarts, may restart running processes, and are priced roughly
   2x cheaper than on-demand sandboxes.
 </Note>

--- a/docs/reference/typescript-sdk/scaling.mdx
+++ b/docs/reference/typescript-sdk/scaling.mdx
@@ -11,7 +11,7 @@ OpenComputer sandboxes can change size at runtime. There are three knobs:
 | Track memory pressure automatically | [`setAutoscale()`](#sandbox-setautoscale-opts) |
 | Freeze the current size | [`setScalingLock()`](#sandbox-setscalinglock-locked) |
 
-Memory tiers are fixed: `1024`, `4096`, `8192`, `16384`, `32768`, `65536` MB. CPU follows memory per the platform's tier table (e.g. 8 GB → 4 vCPU). You don't pick CPU separately.
+CPU follows memory per the platform's tier table. You don't pick CPU separately.
 
 ## How the three interact
 
@@ -26,7 +26,7 @@ Memory tiers are fixed: `1024`, `4096`, `8192`, `16384`, `32768`, `65536` MB. CP
 Manually resize the sandbox. [HTTP API →](/api-reference/sandboxes/scale)
 
 <ParamField body="memoryMB" type="number" required>
-  Target memory tier in MB. Must be one of the allowed tiers.
+  Target memory in MB.
 </ParamField>
 
 **Returns:** `Promise<{ sandboxID: string; memoryMB: number; cpuPercent: number }>`
@@ -66,11 +66,11 @@ Enable or disable per-sandbox autoscale.
 </ParamField>
 
 <ParamField body="minMemoryMB" type="number">
-  Lower bound when `enabled=true`. Must be an allowed tier.
+  Lower bound when `enabled=true`.
 </ParamField>
 
 <ParamField body="maxMemoryMB" type="number">
-  Upper bound when `enabled=true`. Must be an allowed tier and ≥ `minMemoryMB`.
+  Upper bound when `enabled=true`. Must be ≥ `minMemoryMB`.
 </ParamField>
 
 **Returns:** `Promise<{ sandboxID: string; enabled: boolean; minMemoryMB: number; maxMemoryMB: number }>`

--- a/docs/sandboxes/burst-sandboxes.mdx
+++ b/docs/sandboxes/burst-sandboxes.mdx
@@ -1,25 +1,25 @@
 ---
-title: "Resumable Sandboxes"
+title: "Burst Sandboxes"
 description: "Alpha lower-cost sandboxes that preserve disk across infrastructure restarts"
 ---
 
 <Warning>
-  Resumable sandboxes are in alpha. They preserve filesystem state across
+  Burst Sandboxes are in alpha. They preserve filesystem state across
   infrastructure restarts, but running processes, in-memory state, terminal
   sessions, and open network connections may restart.
 </Warning>
 
-Resumable sandboxes are lower-cost OpenComputer sandboxes designed for workloads that can recover from a process restart. They expose the same OpenComputer API for commands, files, PTY, preview URLs, images, snapshots, scaling, and lifecycle operations.
+Burst Sandboxes are lower-cost OpenComputer sandboxes designed for workloads that can recover from a process restart. They expose the same OpenComputer API for commands, files, PTY, preview URLs, images, snapshots, scaling, and lifecycle operations.
 
 If OpenComputer receives advance infrastructure interruption notice, the sandbox gets up to **25 seconds** to flush state before it restarts on healthy capacity. The sandbox's filesystem is preserved and made available after resume.
 
 ## Pricing
 
-Resumable sandboxes are priced roughly **2x cheaper than on-demand sandboxes**.
+Burst Sandboxes are priced roughly **2x cheaper than on-demand sandboxes**.
 
-## Create a Resumable Sandbox
+## Create a Burst Sandbox
 
-Set `resumable: true` when creating the sandbox.
+Set `burst: true` when creating the sandbox.
 
 <CodeGroup>
 
@@ -27,12 +27,12 @@ Set `resumable: true` when creating the sandbox.
 import { Sandbox } from "@opencomputer/sdk";
 
 const sandbox = await Sandbox.create({
-  resumable: true,
+  burst: true,
   memoryMB: 4096,
   timeout: 300,
 });
 
-const result = await sandbox.exec.run("echo hello from resumable");
+const result = await sandbox.exec.run("echo hello from burst");
 console.log(result.stdout);
 
 await sandbox.kill();
@@ -42,11 +42,11 @@ await sandbox.kill();
 from opencomputer import Sandbox
 
 async with await Sandbox.create(
-    resumable=True,
+    burst=True,
     memory_mb=4096,
     timeout=300,
 ) as sandbox:
-    result = await sandbox.exec.run("echo hello from resumable")
+    result = await sandbox.exec.run("echo hello from burst")
     print(result.stdout)
 ```
 
@@ -55,7 +55,7 @@ curl -X POST https://app.opencomputer.dev/api/sandboxes \
   -H "X-API-Key: $OPENCOMPUTER_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "resumable": true,
+    "burst": true,
     "memoryMB": 4096,
     "timeout": 300
   }'
@@ -65,7 +65,7 @@ curl -X POST https://app.opencomputer.dev/api/sandboxes \
 
 ## What Happens on Interruption
 
-Infrastructure capacity can be reclaimed or restarted by the cloud provider. When OpenComputer receives advance notice, it notifies the sandbox and starts the resumability flow.
+Infrastructure capacity can be reclaimed or restarted by the cloud provider. When OpenComputer receives advance notice, it notifies the sandbox and starts the burst restart flow.
 
 The sandbox receives these environment variables:
 
@@ -76,7 +76,7 @@ During the notice window, write important state to disk. After resume, restart y
 
 ## Good Fits
 
-Resumable sandboxes work well for cost-sensitive workloads that can restart from disk:
+Burst Sandboxes work well for cost-sensitive workloads that can restart from disk:
 
 - Batch code execution where failed jobs can be requeued.
 - CI-style checks, test runners, linters, and formatters.
@@ -96,15 +96,15 @@ Use on-demand sandboxes when process continuity is required:
 
 ## Alpha Limitations
 
-During alpha, resumable sandboxes have these restrictions:
+During alpha, Burst Sandboxes have these restrictions:
 
-| Capability | Resumable alpha behavior |
+| Capability | Burst alpha behavior |
 | --- | --- |
 | Process state | May restart |
-| Filesystem | Preserved across resumable restarts |
+| Filesystem | Preserved across burst restarts |
 | Notice window | Up to 25 seconds when advance notice is available |
 | Sudden host failure | May resume without advance notice |
-| Capacity | Best effort; create may fail or wait when resumable capacity is full |
+| Capacity | Best effort; create may fail or wait when burst capacity is full |
 
 ## Reliability Pattern
 
@@ -124,7 +124,7 @@ Example setup:
 import { Sandbox } from "@opencomputer/sdk";
 
 const sandbox = await Sandbox.create({
-  resumable: true,
+  burst: true,
   timeout: 0,
 });
 
@@ -173,7 +173,7 @@ await sandbox.exec.background("/home/sandbox/app/worker.sh", {
 ```python Python
 from opencomputer import Sandbox
 
-sandbox = await Sandbox.create(resumable=True, timeout=0)
+sandbox = await Sandbox.create(burst=True, timeout=0)
 
 await sandbox.exec.run("mkdir -p /home/sandbox/.opencomputer /home/sandbox/app")
 

--- a/docs/sandboxes/resumable-sandboxes.mdx
+++ b/docs/sandboxes/resumable-sandboxes.mdx
@@ -1,0 +1,234 @@
+---
+title: "Resumable Sandboxes"
+description: "Alpha lower-cost sandboxes that preserve disk across infrastructure restarts"
+---
+
+<Warning>
+  Resumable sandboxes are in alpha. They preserve filesystem state across
+  infrastructure restarts, but running processes, in-memory state, terminal
+  sessions, and open network connections may restart.
+</Warning>
+
+Resumable sandboxes are lower-cost OpenComputer sandboxes designed for workloads that can recover from a process restart. They expose the same OpenComputer API for commands, files, PTY, preview URLs, images, snapshots, scaling, and lifecycle operations.
+
+If OpenComputer receives advance infrastructure interruption notice, the sandbox gets up to **25 seconds** to flush state before it restarts on healthy capacity. The sandbox's filesystem is preserved and made available after resume.
+
+## Pricing
+
+Resumable sandboxes are priced roughly **2x cheaper than on-demand sandboxes**.
+
+## Create a Resumable Sandbox
+
+Set `resumable: true` when creating the sandbox.
+
+<CodeGroup>
+
+```typescript TypeScript
+import { Sandbox } from "@opencomputer/sdk";
+
+const sandbox = await Sandbox.create({
+  resumable: true,
+  memoryMB: 4096,
+  timeout: 300,
+});
+
+const result = await sandbox.exec.run("echo hello from resumable");
+console.log(result.stdout);
+
+await sandbox.kill();
+```
+
+```python Python
+from opencomputer import Sandbox
+
+async with await Sandbox.create(
+    resumable=True,
+    memory_mb=4096,
+    timeout=300,
+) as sandbox:
+    result = await sandbox.exec.run("echo hello from resumable")
+    print(result.stdout)
+```
+
+```bash HTTP
+curl -X POST https://app.opencomputer.dev/api/sandboxes \
+  -H "X-API-Key: $OPENCOMPUTER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "resumable": true,
+    "memoryMB": 4096,
+    "timeout": 300
+  }'
+```
+
+</CodeGroup>
+
+## What Happens on Interruption
+
+Infrastructure capacity can be reclaimed or restarted by the cloud provider. When OpenComputer receives advance notice, it notifies the sandbox and starts the resumability flow.
+
+The sandbox receives these environment variables:
+
+- `OPENSANDBOX_RESUMABLE=true`
+- `OPENSANDBOX_RESUME_NOTICE_SECONDS=25`
+
+During the notice window, write important state to disk. After resume, restart your process from durable state.
+
+## Good Fits
+
+Resumable sandboxes work well for cost-sensitive workloads that can restart from disk:
+
+- Batch code execution where failed jobs can be requeued.
+- CI-style checks, test runners, linters, and formatters.
+- AI agent tool calls with durable task state outside the sandbox.
+- Parallel exploration jobs where one attempt can restart.
+- Development, previews, and experiments where cost matters more than availability.
+
+## Poor Fits
+
+Use on-demand sandboxes when process continuity is required:
+
+- User-facing interactive sessions where a rare disconnect is still disruptive.
+- Long-running stateful services that keep important state only in RAM.
+- Databases, queues, or coordinators running inside the sandbox.
+- Workloads with strict deadlines and no retry budget.
+- Any task that cannot safely restart after a partial command failure.
+
+## Alpha Limitations
+
+During alpha, resumable sandboxes have these restrictions:
+
+| Capability | Resumable alpha behavior |
+| --- | --- |
+| Process state | May restart |
+| Filesystem | Preserved across resumable restarts |
+| Notice window | Up to 25 seconds when advance notice is available |
+| Sudden host failure | May resume without advance notice |
+| Capacity | Best effort; create may fail or wait when resumable capacity is full |
+
+## Reliability Pattern
+
+For agent or batch systems, run your work from a small process wrapper and install a restart-notice hook.
+
+1. Store task state on disk or outside the sandbox.
+2. Write outputs to durable storage as the task progresses.
+3. Install `/home/sandbox/.opencomputer/on-restart-notice` to flush or checkpoint before restart.
+4. Make your startup command resume from the last durable state.
+5. Use on-demand sandboxes for workloads with no process restart budget.
+
+Example setup:
+
+<CodeGroup>
+
+```typescript TypeScript
+import { Sandbox } from "@opencomputer/sdk";
+
+const sandbox = await Sandbox.create({
+  resumable: true,
+  timeout: 0,
+});
+
+await sandbox.exec.run("mkdir -p /home/sandbox/.opencomputer /home/sandbox/app");
+
+await sandbox.files.write(
+  "/home/sandbox/.opencomputer/on-restart-notice",
+  `#!/bin/sh
+set -eu
+echo "restart notice: ${1:-25}s" >> /home/sandbox/app/events.log
+touch /home/sandbox/app/restarting
+sync
+`,
+);
+
+await sandbox.exec.run("chmod +x /home/sandbox/.opencomputer/on-restart-notice");
+
+await sandbox.files.write(
+  "/home/sandbox/app/worker.sh",
+  `#!/bin/sh
+set -eu
+cd /home/sandbox/app
+if [ -f restarting ]; then
+  echo "resumed after restart" >> events.log
+  rm -f restarting
+else
+  echo "started" >> events.log
+fi
+
+i=$(cat counter 2>/dev/null || echo 0)
+while true; do
+  i=$((i + 1))
+  echo "$i" > counter
+  sync
+  sleep 5
+done
+`,
+);
+
+await sandbox.exec.run("chmod +x /home/sandbox/app/worker.sh");
+await sandbox.exec.background("/home/sandbox/app/worker.sh", {
+  maxRunAfterDisconnect: 0,
+});
+```
+
+```python Python
+from opencomputer import Sandbox
+
+sandbox = await Sandbox.create(resumable=True, timeout=0)
+
+await sandbox.exec.run("mkdir -p /home/sandbox/.opencomputer /home/sandbox/app")
+
+await sandbox.files.write(
+    "/home/sandbox/.opencomputer/on-restart-notice",
+    """#!/bin/sh
+set -eu
+echo "restart notice: ${1:-25}s" >> /home/sandbox/app/events.log
+touch /home/sandbox/app/restarting
+sync
+""",
+)
+
+await sandbox.exec.run("chmod +x /home/sandbox/.opencomputer/on-restart-notice")
+
+await sandbox.files.write(
+    "/home/sandbox/app/worker.sh",
+    """#!/bin/sh
+set -eu
+cd /home/sandbox/app
+if [ -f restarting ]; then
+  echo "resumed after restart" >> events.log
+  rm -f restarting
+else
+  echo "started" >> events.log
+fi
+
+i=$(cat counter 2>/dev/null || echo 0)
+while true; do
+  i=$((i + 1))
+  echo "$i" > counter
+  sync
+  sleep 5
+done
+""",
+)
+
+await sandbox.exec.run("chmod +x /home/sandbox/app/worker.sh")
+await sandbox.exec.background(
+    "/home/sandbox/app/worker.sh",
+    max_run_after_disconnect=0,
+)
+```
+
+</CodeGroup>
+
+When OpenComputer receives notice, it runs the hook with the notice window in seconds. If the sandbox resumes on another worker, start your process again and read the state you wrote under `/home/sandbox/app`.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Elasticity" href="/sandboxes/elasticity">
+    Resource tiers and autoscaling
+  </Card>
+  <Card title="Checkpoints" href="/sandboxes/checkpoints">
+    Save and resume sandbox state
+  </Card>
+</CardGroup>

--- a/docs/sandboxes/templates.mdx
+++ b/docs/sandboxes/templates.mdx
@@ -195,7 +195,7 @@ curl -X POST https://app.opencomputer.dev/api/sandboxes \
 `memoryMB` is clamped to a valid range, and the response's `memoryMB` reports the effective value:
 
 - **Floor — the snapshot's own memory.** A smaller request is ignored; a fork can't start smaller than the snapshot it restores. A 4 GB snapshot forked with `memoryMB: 1024` still boots at ~4 GB.
-- **Ceiling — 16 GB.** Larger requests are capped (`32768` → `16384`).
+- **Ceiling.** Larger requests are capped to the maximum platform tier.
 
 The same `memoryMB` field works when [forking from a checkpoint](/api-reference/checkpoints/fork).
 


### PR DESCRIPTION
## Summary
- adds the Burst Sandboxes docs page
- wires it into docs navigation
- documents API and SDK parameters using burst

## Verification
- python3 -m json.tool docs/docs.json