### PR TITLE
docs: separate Agent SDK from Hosted Agents in the nav

### DIFF
--- a/docs/agents-api/overview.mdx
+++ b/docs/agents-api/overview.mdx
@@ -6,7 +6,7 @@ description: "Run AI agents on OpenComputer — pick a core, connect channels, i
 A managed agent on OpenComputer is a **core** plus the **channels** and **packages** you bolt onto it. Pick a runtime, connect the messaging platforms you want, install the capabilities you need.
 
 <Info>
-  **There are two ways to run agents on OpenComputer.** This page covers **hosted agents** — long-lived, deployed, and exposed over channels or a public API. If you just want to run Claude inside a sandbox for a single task and drive it yourself with the SDK, see the [Agent SDK](/agents/overview).
+  **There are two ways to run agents on OpenComputer.** This page covers **hosted agents** — platform-managed agent definitions you reach through persistent instances or ephemeral sessions, and connect to messaging channels or a public API. If you'd rather create a sandbox yourself and drive a Claude session inside it directly with the SDK, see the [Agent SDK](/agents/overview).
 </Info>
 
 ```

--- a/docs/agents-api/overview.mdx
+++ b/docs/agents-api/overview.mdx
@@ -5,6 +5,10 @@ description: "Run AI agents on OpenComputer — pick a core, connect channels, i
 
 A managed agent on OpenComputer is a **core** plus the **channels** and **packages** you bolt onto it. Pick a runtime, connect the messaging platforms you want, install the capabilities you need.
 
+<Info>
+  **There are two ways to run agents on OpenComputer.** This page covers **hosted agents** — long-lived, deployed, and exposed over channels or a public API. If you just want to run Claude inside a sandbox for a single task and drive it yourself with the SDK, see the [Agent SDK](/agents/overview).
+</Info>
+
 ```
 ManagedAgent = Core + Channels + Packages + Secrets
 ```

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -7,7 +7,7 @@ description: "Run Claude inside a sandbox you control, with the SDK"
 An agent session is a Claude Agent SDK instance running inside a [sandbox](/sandboxes/overview). You send a prompt, the agent works autonomously — writing files, running commands, iterating on errors — and streams events back to your code. You own the sandbox and drive the loop directly: no deploy step, no hosting.
 
 <Info>
-  **There are two ways to run agents on OpenComputer.** This is the **SDK** path — you create a sandbox and run Claude inside it for the lifetime of a single task. If you instead want a long-lived agent the platform *hosts* and exposes over messaging channels or a public API, see [Hosted Agents](/agents-api/overview) (Hermes, OpenClaw).
+  **There are two ways to run agents on OpenComputer.** This is the **SDK** path — you create a sandbox yourself and drive a Claude session inside it directly, owning the sandbox and the loop. If you'd instead like the platform to manage an agent *definition* for you — reached through persistent instances or ephemeral sessions, and connectable to messaging channels or a public API — see [Hosted Agents](/agents-api/overview) (Hermes, OpenClaw).
 </Info>
 
 <CodeGroup>

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -1,9 +1,14 @@
 ---
-title: "Agents"
-description: "Run Claude inside sandboxes"
+title: "Run an agent in a sandbox"
+sidebarTitle: "Overview"
+description: "Run Claude inside a sandbox you control, with the SDK"
 ---
 
-An agent session is a Claude Agent SDK instance running inside a sandbox. You send a prompt, the agent works autonomously — writing files, running commands, iterating on errors — and streams events back to your code.
+An agent session is a Claude Agent SDK instance running inside a [sandbox](/sandboxes/overview). You send a prompt, the agent works autonomously — writing files, running commands, iterating on errors — and streams events back to your code. You own the sandbox and drive the loop directly: no deploy step, no hosting.
+
+<Info>
+  **There are two ways to run agents on OpenComputer.** This is the **SDK** path — you create a sandbox and run Claude inside it for the lifetime of a single task. If you instead want a long-lived agent the platform *hosts* and exposes over messaging channels or a public API, see [Hosted Agents](/agents-api/overview) (Hermes, OpenClaw).
+</Info>
 
 <CodeGroup>
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -69,7 +69,16 @@
         ]
       },
       {
-        "group": "Agents",
+        "group": "Agent SDK",
+        "pages": [
+          "agents/overview",
+          "agents/tools",
+          "agents/events",
+          "agents/multi-turn"
+        ]
+      },
+      {
+        "group": "Hosted Agents",
         "pages": [
           "agents-api/overview",
           {


### PR DESCRIPTION
## What

The docs for the **in-sandbox agent API** (`sandbox.agent.start` from `@opencomputer/sdk`) already exist — `agents/overview`, `agents/tools`, `agents/events`, `agents/multi-turn` — but they were **orphaned**: not referenced anywhere in `docs.json`, so unreachable from the sidebar. A reader landing on "Agents" only saw the hosted world (Cores/Hermes/OpenClaw, Channels, REST) and would conclude that's the only way to run an agent.

This surfaced while building the `demo-agent-triage` demo, which is built entirely on `sandbox.agent.start` and couldn't find supporting docs.

## Changes

- **`docs.json`** — split the single "Agents" nav group into two top-level groups:
  - **Agent SDK** *(new)* — `agents/overview`, `agents/tools`, `agents/events`, `agents/multi-turn` (the in-sandbox agent API)
  - **Hosted Agents** *(renamed from "Agents")* — agents-api overview, Cores, Packages, Channels, REST, CLI
- **`agents/overview.mdx`** — retitled (H1 "Run an agent in a sandbox", sidebar "Overview"); added a callout distinguishing the SDK path from Hosted Agents, with a cross-link.
- **`agents-api/overview.mdx`** — mirror callout linking back to the Agent SDK.

No content was deleted; existing pages are just regrouped and cross-linked.

## Notes

- Branched off `main`; contains only these 3 doc files.
- The "Agent SDK" group name sits near "TypeScript SDK"/"Python SDK" in the sidebar — open to "Sandbox Agents" instead if reviewers prefer less collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)