### PR TITLE
Websocket broker

### DIFF
--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -268,6 +268,19 @@ async function proxyWebSocket(
   if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
     return json({ error: "expected websocket upgrade" }, 400);
   }
+
+  // Mint the cell-bound cap-token the cell-CP expects in Authorization,
+  // then transparently forward the upgrade to the cell-CP. With the
+  // OPENSANDBOX_WS_BROKER=1 cell-CP path active, the cell-CP's
+  // wsgateway terminates the browser's WS and brokers it against the
+  // worker — redial on upstream close, keepalive, exec-exit suppression,
+  // multi-session per sandbox, etc. live in Go, not here.
+  //
+  // Previously this function did an edge-side WebSocketPair + manual
+  // Blob-aware bridge. That made the cell-CP see the EDGE as the client,
+  // which short-circuited the broker's redial/keepalive — a worker
+  // restart killed the browser's terminal. Replacing the bridge with
+  // a transparent forward puts the broker actually in the middle.
   let token: string;
   try {
     token = await mintCellCapToken(env.SESSION_JWT_SECRET, caller.orgID, cell.cell_id, caller.plan, caller.userID);
@@ -276,130 +289,15 @@ async function proxyWebSocket(
     return new Response("token mint failed", { status: 500 });
   }
   const upstreamURL = cell.base_url.replace(/\/$/, "") + cellPath;
-  console.log(`proxyWebSocket: dialing upstream ${upstreamURL}`);
+  console.log(`proxyWebSocket: forwarding upgrade to ${upstreamURL}`);
 
-  // CF Workers WebSocket fetch: only the Upgrade: websocket header is needed.
-  // Setting Connection: Upgrade can confuse the runtime; omit it. The Worker
-  // returns a Response with a `.webSocket` property on success (status 101).
-  let upstreamResp: Response;
-  try {
-    upstreamResp = await fetch(upstreamURL, {
-      headers: {
-        Upgrade: "websocket",
-        Authorization: "Bearer " + token,
-      },
-    });
-  } catch (e) {
-    console.error(`proxyWebSocket: upstream fetch threw: ${(e as Error).message}`);
-    return new Response(`cell websocket fetch failed: ${(e as Error).message}`, { status: 502 });
-  }
-  console.log(`proxyWebSocket: upstream status=${upstreamResp.status}`);
-  const upstream = (upstreamResp as Response & { webSocket?: WebSocket }).webSocket;
-  if (!upstream) {
-    const errBody = await upstreamResp.text().catch(() => "");
-    console.error(`proxyWebSocket: no webSocket on response; body=${errBody.slice(0, 200)}`);
-    return new Response(
-      `cell websocket connect failed (status ${upstreamResp.status}): ${errBody.slice(0, 200)}`,
-      { status: 502 },
-    );
-  }
-  const pair = new WebSocketPair();
-  const client = pair[0];
-  const server = pair[1];
-
-  // CF Workers delivers binary WebSocket frames as Blob and ignores any
-  // `binaryType = "arraybuffer"` setter on these proxy WebSockets. We have
-  // to detect Blob in the handler and await `.arrayBuffer()` before
-  // forwarding. We also use that ArrayBuffer when calling `.send()` so the
-  // browser (which has `binaryType="arraybuffer"`) decodes the frame to a
-  // plain ArrayBuffer in `event.data`.
-
-  // Diagnostic byte counters. Forward binary + text messages between
-  // upstream (cell) <-> server (browser-facing half of our pair).
-  let upToBrowser = 0;
-  let browserToUp = 0;
-
-  // forward async-awaits Blob → ArrayBuffer (binary) or passes through
-  // strings (text). Sending a Blob directly results in "[object Blob]"
-  // text frame, which xterm renders as nothing. The await-chain ordering
-  // is preserved per-direction by serializing through a single Promise.
-  let upQueue: Promise<unknown> = Promise.resolve();
-  let downQueue: Promise<unknown> = Promise.resolve();
-  const forward = (
-    data: unknown,
-    target: WebSocket,
-    addBytes: (n: number) => void,
-    label: string,
-  ): Promise<void> => {
-    if (typeof data === "string") {
-      addBytes(data.length);
-      try { target.send(data); } catch (err) { console.error(`${label}: send (string) failed: ${(err as Error).message}`); }
-      return Promise.resolve();
-    }
-    if (data instanceof ArrayBuffer) {
-      addBytes(data.byteLength);
-      try { target.send(data); } catch (err) { console.error(`${label}: send (ab) failed: ${(err as Error).message}`); }
-      return Promise.resolve();
-    }
-    if (ArrayBuffer.isView(data)) {
-      const v = data as ArrayBufferView;
-      const ab = new ArrayBuffer(v.byteLength);
-      new Uint8Array(ab).set(new Uint8Array(v.buffer, v.byteOffset, v.byteLength));
-      addBytes(ab.byteLength);
-      try { target.send(ab); } catch (err) { console.error(`${label}: send (view) failed: ${(err as Error).message}`); }
-      return Promise.resolve();
-    }
-    if (data && typeof (data as any).arrayBuffer === "function") {
-      return (data as Blob).arrayBuffer().then(
-        (ab) => {
-          addBytes(ab.byteLength);
-          try { target.send(ab); } catch (err) { console.error(`${label}: send (blob) failed: ${(err as Error).message}`); }
-        },
-        (err) => { console.error(`${label}: blob.arrayBuffer failed: ${(err as Error).message}`); },
-      );
-    }
-    console.error(`${label}: unknown data shape: ${typeof data} ${(data as any)?.constructor?.name}`);
-    return Promise.resolve();
-  };
-
-  upstream.addEventListener("message", (e) => {
-    const isFirst = upToBrowser === 0;
-    if (isFirst) {
-      console.log(`proxyWebSocket: up->browser first frame typeof=${typeof e.data} ctor=${(e.data as any)?.constructor?.name}`);
-    }
-    downQueue = downQueue.then(() => forward(e.data, server, (n) => { upToBrowser += n; }, "proxyWebSocket: server.send"));
-  });
-  server.addEventListener("message", (e) => {
-    const isFirst = browserToUp === 0;
-    if (isFirst) {
-      console.log(`proxyWebSocket: browser->up first frame typeof=${typeof e.data} ctor=${(e.data as any)?.constructor?.name}`);
-    }
-    upQueue = upQueue.then(() => forward(e.data, upstream, (n) => { browserToUp += n; }, "proxyWebSocket: upstream.send"));
-  });
-  server.addEventListener("close", (e) => {
-    console.log(`proxyWebSocket: server close code=${e.code} reason=${e.reason} (up->browser=${upToBrowser}, browser->up=${browserToUp})`);
-    try { upstream.close(e.code, e.reason); } catch {}
-  });
-  upstream.addEventListener("close", (e) => {
-    console.log(`proxyWebSocket: upstream close code=${e.code} reason=${e.reason} (up->browser=${upToBrowser}, browser->up=${browserToUp})`);
-    try { server.close(e.code, e.reason); } catch {}
-  });
-  server.addEventListener("error", (e: any) => {
-    console.error(`proxyWebSocket: server error: ${e?.message ?? "unknown"}`);
-    try { upstream.close(1011, "client error"); } catch {}
-  });
-  upstream.addEventListener("error", (e: any) => {
-    console.error(`proxyWebSocket: upstream error: ${e?.message ?? "unknown"}`);
-    try { server.close(1011, "upstream error"); } catch {}
-  });
-
-  // Accept AFTER attaching listeners so we don't miss the first frame.
-  // The worker emits the shell prompt (~27 bytes) within ~0.5ms of upgrade.
-  upstream.accept();
-  server.accept();
-  console.log(`proxyWebSocket: bridge wired up + accepted`);
-
-  return new Response(null, { status: 101, webSocket: client } as any);
+  const fwd = new Request(upstreamURL, req);
+  fwd.headers.set("authorization", "Bearer " + token);
+  // Strip browser cookies — cell-CP authenticates the cap-token, not
+  // dashboard session cookies, and the cookies would only bloat the
+  // upstream request.
+  fwd.headers.delete("cookie");
+  return await fetch(fwd);
 }
 
 // ── identity (/me, /orgs, /org, /org/switch) ─────────────────────────────

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -623,17 +623,13 @@ func main() {
 		log.Printf("opensandbox: edge client wired (base=%s)", cfg.CFEdgeBaseURL)
 	}
 
-	// Wire the in-process WebSocket broker. When enabled, data-plane
-	// WS routes (/sandboxes/:id/pty/:sid, /exec/:sid, /agent/:sid) go
-	// through internal/wsgateway instead of the legacy proxy's hijack
-	// + io.Copy path — gains redial on upstream close, keepalive,
-	// multi-session, exec-exit suppression, circuit breaker. Gated on
-	// OPENSANDBOX_WS_BROKER=1 so the rollout is a per-cell env flip;
-	// off keeps the legacy transparent forward in place.
-	if os.Getenv("OPENSANDBOX_WS_BROKER") == "1" {
-		server.SetWSGateway(wsgateway.NewGateway())
-		log.Printf("opensandbox: ws-broker enabled (OPENSANDBOX_WS_BROKER=1)")
-	}
+	// Wire the in-process WebSocket broker. Data-plane WS routes
+	// (/sandboxes/:id/pty/:sid, /exec/:sid, /agent/:sid) go through
+	// internal/wsgateway — redial on upstream close, keepalive, multi-
+	// session per sandbox, exec-exit suppression, flap circuit breaker.
+	// Always on; rollback is `git revert + redeploy` if the broker ever
+	// regresses, same as for any other commit.
+	server.SetWSGateway(wsgateway.NewGateway())
 
 	// Wire Axiom read-only token for the sandbox session logs API.
 	// Token never leaves this process; the UI proxies its queries through

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/opensandbox/opensandbox/internal/proxy"
 	"github.com/opensandbox/opensandbox/internal/sandbox"
 	"github.com/opensandbox/opensandbox/internal/storage"
+	"github.com/opensandbox/opensandbox/internal/wsgateway"
 )
 
 // ServerVersion is the control plane binary version, set at build time via -ldflags.
@@ -620,6 +621,18 @@ func main() {
 	if cfg.CFEdgeBaseURL != "" && cfg.CFEventSecret != "" {
 		server.SetEdgeClient(edgeclient.New(cfg.CFEdgeBaseURL, cfg.CFEventSecret))
 		log.Printf("opensandbox: edge client wired (base=%s)", cfg.CFEdgeBaseURL)
+	}
+
+	// Wire the in-process WebSocket broker. When enabled, data-plane
+	// WS routes (/sandboxes/:id/pty/:sid, /exec/:sid, /agent/:sid) go
+	// through internal/wsgateway instead of the legacy proxy's hijack
+	// + io.Copy path — gains redial on upstream close, keepalive,
+	// multi-session, exec-exit suppression, circuit breaker. Gated on
+	// OPENSANDBOX_WS_BROKER=1 so the rollout is a per-cell env flip;
+	// off keeps the legacy transparent forward in place.
+	if os.Getenv("OPENSANDBOX_WS_BROKER") == "1" {
+		server.SetWSGateway(wsgateway.NewGateway())
+		log.Printf("opensandbox: ws-broker enabled (OPENSANDBOX_WS_BROKER=1)")
 	}
 
 	// Wire Axiom read-only token for the sandbox session logs API.

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -386,7 +386,7 @@ func main() {
 	if qemuMgr != nil {
 		qemuMgr.SetMigrationOutgoingCallback(func(sandboxID string) {
 			ptyMgr.ReleaseForSandbox(sandboxID)
-			execMgr.RemoveSessions(sandboxID)
+			execMgr.ReleaseForSandbox(sandboxID)
 		})
 	}
 
@@ -974,6 +974,7 @@ func rebindExecSessionQEMU(agent *qm.AgentClient, sandboxID, sessionID string) (
 	scrollback := sandbox.NewScrollbackBuffer(0)
 	done := make(chan struct{})
 	stdinR, stdinW := io.Pipe()
+	streamCtx, cancel := context.WithCancel(context.Background())
 
 	handle := &sandbox.ExecSessionHandle{
 		ID:          sessionID,
@@ -987,6 +988,7 @@ func rebindExecSessionQEMU(agent *qm.AgentClient, sandboxID, sessionID string) (
 			stdinW.Close()
 			return agent.ExecSessionKill(context.Background(), sessionID, int32(signal))
 		},
+		Cancel: cancel,
 	}
 
 	// Same goroutine shape as the create path — attach + send first message
@@ -995,17 +997,17 @@ func rebindExecSessionQEMU(agent *qm.AgentClient, sandboxID, sessionID string) (
 	// gone, causing consumeExecOutput to return immediately; the caller's
 	// timeout on the WS upgrade will then fail. Acceptable for an edge case
 	// where the user reconnects right as the exec process exits.
-	go runExecRebindQEMU(agent, sessionID, stdinR, done, scrollback, handle)
+	go runExecRebindQEMU(streamCtx, agent, sessionID, stdinR, done, scrollback, handle)
 
 	return handle, nil
 }
 
 // runExecRebindQEMU mirrors runExecStreamQEMU but binds to an existing
 // session_id instead of expecting Create to have just allocated it.
-func runExecRebindQEMU(agent *qm.AgentClient, sessionID string, stdinR *io.PipeReader, done chan struct{}, scrollback *sandbox.ScrollbackBuffer, handle *sandbox.ExecSessionHandle) {
+func runExecRebindQEMU(ctx context.Context, agent *qm.AgentClient, sessionID string, stdinR *io.PipeReader, done chan struct{}, scrollback *sandbox.ScrollbackBuffer, handle *sandbox.ExecSessionHandle) {
 	defer close(done)
 	defer stdinR.Close()
-	stream, err := agent.ExecSessionAttach(context.Background())
+	stream, err := agent.ExecSessionAttach(ctx)
 	if err != nil {
 		return
 	}
@@ -1035,6 +1037,7 @@ func createExecSessionQEMU(agent *qm.AgentClient, sandboxID string, req types.Ex
 	scrollback := sandbox.NewScrollbackBuffer(0)
 	done := make(chan struct{})
 	stdinR, stdinW := io.Pipe()
+	streamCtx, cancel := context.WithCancel(context.Background())
 
 	handle := &sandbox.ExecSessionHandle{
 		ID:          sessionID,
@@ -1050,18 +1053,19 @@ func createExecSessionQEMU(agent *qm.AgentClient, sandboxID string, req types.Ex
 			stdinW.Close()
 			return agent.ExecSessionKill(context.Background(), sessionID, int32(signal))
 		},
+		Cancel: cancel,
 	}
 
-	go runExecStreamQEMU(agent, sessionID, stdinR, done, scrollback, handle)
+	go runExecStreamQEMU(streamCtx, agent, sessionID, stdinR, done, scrollback, handle)
 
 	return handle, nil
 }
 
 // runExecStreamQEMU attaches to an exec session stream (QEMU backend).
-func runExecStreamQEMU(agent *qm.AgentClient, sessionID string, stdinR *io.PipeReader, done chan struct{}, scrollback *sandbox.ScrollbackBuffer, handle *sandbox.ExecSessionHandle) {
+func runExecStreamQEMU(ctx context.Context, agent *qm.AgentClient, sessionID string, stdinR *io.PipeReader, done chan struct{}, scrollback *sandbox.ScrollbackBuffer, handle *sandbox.ExecSessionHandle) {
 	defer close(done)
 	defer stdinR.Close()
-	stream, err := agent.ExecSessionAttach(context.Background())
+	stream, err := agent.ExecSessionAttach(ctx)
 	if err != nil {
 		return
 	}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -129,8 +129,13 @@ func main() {
 
 	// Backend-specific exec session factory
 	var execSessionFactory func(sandboxID string, req types.ExecSessionCreateRequest) (*sandbox.ExecSessionHandle, error)
+	// Lazy reattach to an existing agent-side exec session — populated when the
+	// local map misses (live migration or worker restart).
+	var execSessionRebinder func(sandboxID, sessionID string) (*sandbox.ExecSessionHandle, error)
 	// Backend-specific PTY session factory
 	var ptySessionFactory func(sandboxID string, req types.PTYCreateRequest) (*sandbox.PTYSessionHandle, error)
+	// Lazy reattach for PTY sessions, same role as execSessionRebinder.
+	var ptySessionRebinder func(sandboxID, sessionID string) (*sandbox.PTYSessionHandle, error)
 	// Backend-specific autosaver syncer
 	var autosaverSyncer worker.SyncFSer
 	// Backend-specific graceful shutdown
@@ -296,12 +301,28 @@ func main() {
 			return createExecSessionQEMU(agent, sandboxID, req)
 		}
 
+		execSessionRebinder = func(sandboxID, sessionID string) (*sandbox.ExecSessionHandle, error) {
+			agent, err := qmMgr.GetAgent(sandboxID)
+			if err != nil {
+				return nil, fmt.Errorf("get agent for %s: %w", sandboxID, err)
+			}
+			return rebindExecSessionQEMU(agent, sandboxID, sessionID)
+		}
+
 		ptySessionFactory = func(sandboxID string, req types.PTYCreateRequest) (*sandbox.PTYSessionHandle, error) {
 			agent, err := qmMgr.GetAgent(sandboxID)
 			if err != nil {
 				return nil, fmt.Errorf("get agent for %s: %w", sandboxID, err)
 			}
 			return createPTYSessionQEMU(agent, sandboxID, req)
+		}
+
+		ptySessionRebinder = func(sandboxID, sessionID string) (*sandbox.PTYSessionHandle, error) {
+			agent, err := qmMgr.GetAgent(sandboxID)
+			if err != nil {
+				return nil, fmt.Errorf("get agent for %s: %w", sandboxID, err)
+			}
+			return rebindPTYSessionQEMU(agent, sandboxID, sessionID)
 		}
 
 		doGracefulShutdown = func(checkpointStore *storage.CheckpointStore, store *db.Store) {
@@ -348,12 +369,26 @@ func main() {
 	}
 
 	// Initialize exec session manager
-	execMgr := sandbox.NewAgentExecSessionManager(execSessionFactory)
+	execMgr := sandbox.NewAgentExecSessionManager(execSessionFactory, execSessionRebinder)
 	defer execMgr.CloseAll()
 
 	// Initialize PTY manager
-	ptyMgr := sandbox.NewAgentPTYManager(ptySessionFactory)
+	ptyMgr := sandbox.NewAgentPTYManager(ptySessionFactory, ptySessionRebinder)
 	defer ptyMgr.CloseAll()
+
+	// On outgoing migration, drop SOURCE-side PTY/exec handles so any WS
+	// blocked on a now-orphaned gRPC stream unblocks immediately. The edge DO
+	// then redials, the destination worker's RebindFromAgent picks up the
+	// still-alive in-VM session, and the user's terminal continues without
+	// any visible interruption beyond the redial latency. Wired here (not
+	// inside the QEMU manager) because the session managers live in the
+	// worker layer and the QEMU layer shouldn't depend on them.
+	if qemuMgr != nil {
+		qemuMgr.SetMigrationOutgoingCallback(func(sandboxID string) {
+			ptyMgr.ReleaseForSandbox(sandboxID)
+			execMgr.RemoveSessions(sandboxID)
+		})
+	}
 
 	// Initialize per-sandbox SQLite manager (forward-declared above so the
 	// graceful-shutdown closure can capture it).
@@ -926,6 +961,61 @@ func buildCheckpointBackend(label, endpoint, region, accessKeyID, secretAccessKe
 	})
 }
 
+// rebindExecSessionQEMU opens a fresh ExecSessionAttach stream against an
+// EXISTING agent-side exec session. The agent already has the process and
+// the scrollback ring — reattach delivers the scrollback snapshot followed
+// by live output, same shape as the original create flow.
+//
+// The local handle's Command/Args metadata is left blank: it isn't load-
+// bearing for the WS bridge (handlers.go uses the handle only for SandboxID
+// match + scrollback + stdin pipe). If we later need it post-migration, an
+// agent.ExecSessionList() lookup keyed on sessionID can populate it.
+func rebindExecSessionQEMU(agent *qm.AgentClient, sandboxID, sessionID string) (*sandbox.ExecSessionHandle, error) {
+	scrollback := sandbox.NewScrollbackBuffer(0)
+	done := make(chan struct{})
+	stdinR, stdinW := io.Pipe()
+
+	handle := &sandbox.ExecSessionHandle{
+		ID:          sessionID,
+		SandboxID:   sandboxID,
+		Running:     true,
+		StartedAt:   time.Now(),
+		Done:        done,
+		Scrollback:  scrollback,
+		StdinWriter: stdinW,
+		OnKill: func(signal int) error {
+			stdinW.Close()
+			return agent.ExecSessionKill(context.Background(), sessionID, int32(signal))
+		},
+	}
+
+	// Same goroutine shape as the create path — attach + send first message
+	// (bind to existing session) + pump stdin/scrollback. The agent will
+	// emit a "session not found" error to stream.Recv() if the session is
+	// gone, causing consumeExecOutput to return immediately; the caller's
+	// timeout on the WS upgrade will then fail. Acceptable for an edge case
+	// where the user reconnects right as the exec process exits.
+	go runExecRebindQEMU(agent, sessionID, stdinR, done, scrollback, handle)
+
+	return handle, nil
+}
+
+// runExecRebindQEMU mirrors runExecStreamQEMU but binds to an existing
+// session_id instead of expecting Create to have just allocated it.
+func runExecRebindQEMU(agent *qm.AgentClient, sessionID string, stdinR *io.PipeReader, done chan struct{}, scrollback *sandbox.ScrollbackBuffer, handle *sandbox.ExecSessionHandle) {
+	defer close(done)
+	defer stdinR.Close()
+	stream, err := agent.ExecSessionAttach(context.Background())
+	if err != nil {
+		return
+	}
+	if err := stream.Send(&agentpb.ExecSessionInput{SessionId: sessionID}); err != nil {
+		return
+	}
+	go forwardStdin(stdinR, stream)
+	consumeExecOutput(stream, scrollback, handle)
+}
+
 // createExecSessionQEMU creates an exec session using a QEMU agent client.
 func createExecSessionQEMU(agent *qm.AgentClient, sandboxID string, req types.ExecSessionCreateRequest) (*sandbox.ExecSessionHandle, error) {
 	agentPB := &agentpb.ExecSessionCreateRequest{
@@ -1072,6 +1162,44 @@ func (c *grpcPTYConn) Resize(cols, rows int) error {
 func (c *grpcPTYConn) Close() error {
 	c.closeOnce.Do(func() { c.cancel() })
 	return nil
+}
+
+// rebindPTYSessionQEMU opens a fresh PTYAttach stream against an EXISTING
+// agent-side PTY session — i.e. the agent already has the shell + tty, we
+// just need a host-side I/O channel into it. Used after a live migration or
+// worker restart wipes the destination worker's local session map.
+//
+// Failure modes:
+//   - agent returns "pty session <id> not found" on the first stream.Recv() →
+//     the session is genuinely gone (process exited or VM rebooted). We don't
+//     distinguish this from a transport error here — caller treats both as
+//     "not found" and returns 404 to the edge.
+//   - the bidi stream opens successfully → the agent looked up the session
+//     and is now streaming. Return a PTYSessionHandle that adapts the stream
+//     just like the create path's grpcPTYConn.
+func rebindPTYSessionQEMU(agent *qm.AgentClient, sandboxID, sessionID string) (*sandbox.PTYSessionHandle, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := agent.PTYAttach(ctx)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("rebind PTY stream: %w", err)
+	}
+	// First message binds the stream to an existing session in the agent.
+	// Cols/Rows omitted — the agent keeps whatever the original Create
+	// set; a fresh client that wants to resize will send PTYResize.
+	if err := stream.Send(&agentpb.PTYInput{SessionId: sessionID}); err != nil {
+		cancel()
+		return nil, fmt.Errorf("send PTY session ID for rebind: %w", err)
+	}
+
+	conn := &grpcPTYConn{stream: stream, cancel: cancel}
+	done := make(chan struct{})
+	return &sandbox.PTYSessionHandle{
+		ID:        sessionID,
+		SandboxID: sandboxID,
+		PTY:       conn,
+		Done:      done,
+	}, nil
 }
 
 // createPTYSessionQEMU creates a PTY session using gRPC PTYAttach (QEMU backend).

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -28,6 +28,7 @@ import (
 	"github.com/opensandbox/opensandbox/internal/observability"
 	"github.com/opensandbox/opensandbox/internal/obslog"
 	"github.com/opensandbox/opensandbox/internal/proxy"
+	"github.com/opensandbox/opensandbox/internal/wsgateway"
 	"github.com/opensandbox/opensandbox/internal/sandbox"
 	"github.com/opensandbox/opensandbox/internal/storage"
 )
@@ -63,6 +64,7 @@ type Server struct {
 	pendingCreates  sync.Map                          // map[sandboxID]*pendingCreate — async sandbox creation tracking
 	mountSvc        *mounts.Service                   // shared with worker.HTTPServer; nil disables the mounts API
 	sandboxAPIProxy *proxy.SandboxAPIProxy            // nil except in server mode (proxies data-plane to workers)
+	wsGateway       *wsgateway.Gateway                // nil disables the broker; WS data-plane routes fall back to sandboxAPIProxy
 	stripeClient    *billing.StripeClient              // nil if Stripe not configured
 	redisClient     *redis.Client                     // nil if Redis not configured (for health checks)
 	adminEvents     *AdminEventBus                    // real-time event bus for admin dashboard
@@ -84,6 +86,17 @@ type Server struct {
 // constructing it with the right base URL + HMAC secret (CFEventSecret).
 func (s *Server) SetEdgeClient(c *edgeclient.Client) {
 	s.edge = c
+}
+
+// SetWSGateway wires the in-process WebSocket broker. When non-nil,
+// data-plane WS routes (/sandboxes/:id/pty/:sid, /exec/:sid, /agent/:sid)
+// route through the broker instead of the legacy SandboxAPIProxy
+// hijack-and-io.Copy path. The broker provides multi-session, redial on
+// upstream close, exec-exit marker handling, keepalive, and circuit
+// breaking — see internal/wsgateway for the spec. Safe to leave nil
+// for cells that prefer the legacy transparent forward.
+func (s *Server) SetWSGateway(gw *wsgateway.Gateway) {
+	s.wsGateway = gw
 }
 
 // SetAxiomQueryConfig wires the read-only Axiom token and dataset for
@@ -448,16 +461,28 @@ func NewServer(mgr sandbox.Manager, ptyMgr *sandbox.PTYManager, apiKey string, o
 		// Server mode: proxy all data-plane requests to the worker that owns the sandbox
 		pxy := s.sandboxAPIProxy.ProxyHandler
 
+		// WS data-plane handler — dispatches dynamically per request so
+		// SetWSGateway works regardless of whether it was called before or
+		// after route registration. Non-WS verbs on the same paths always
+		// go through the proxy: the broker only handles bidi streaming.
+		wsHandler := func(c echo.Context) error {
+			if s.wsGateway != nil {
+				return s.brokerWebSocket(c)
+			}
+			return pxy(c)
+		}
+
 		// Exec
 		api.POST("/sandboxes/:id/exec", pxy)
 		api.GET("/sandboxes/:id/exec", pxy)
-		api.GET("/sandboxes/:id/exec/:sessionID", pxy)
+		api.GET("/sandboxes/:id/exec/:sessionID", wsHandler)
 		api.POST("/sandboxes/:id/exec/:sessionID/kill", pxy)
 		api.POST("/sandboxes/:id/exec/run", pxy)
 
 		// Agent
 		api.POST("/sandboxes/:id/agent", pxy)
 		api.GET("/sandboxes/:id/agent", pxy)
+		api.GET("/sandboxes/:id/agent/:sid", wsHandler)
 		api.POST("/sandboxes/:id/agent/:sid/prompt", pxy)
 		api.POST("/sandboxes/:id/agent/:sid/interrupt", pxy)
 		api.POST("/sandboxes/:id/agent/:sid/kill", pxy)
@@ -476,7 +501,7 @@ func NewServer(mgr sandbox.Manager, ptyMgr *sandbox.PTYManager, apiKey string, o
 
 		// PTY
 		api.POST("/sandboxes/:id/pty", pxy)
-		api.GET("/sandboxes/:id/pty/:sessionID", pxy)
+		api.GET("/sandboxes/:id/pty/:sessionID", wsHandler)
 		api.POST("/sandboxes/:id/pty/:sessionID/resize", pxy)
 		api.DELETE("/sandboxes/:id/pty/:sessionID", pxy)
 

--- a/internal/api/ws_broker.go
+++ b/internal/api/ws_broker.go
@@ -77,6 +77,9 @@ func (s *Server) brokerWebSocket(c echo.Context) error {
 			if isMigratingErr(err) {
 				return "", "", fmt.Errorf("%w: %v", wsgateway.ErrUpstreamMigrating, err)
 			}
+			if isTerminalErr(err) {
+				return "", "", fmt.Errorf("%w: %v", wsgateway.ErrUpstreamTerminal, err)
+			}
 			return "", "", err
 		}
 		return buildWorkerWSURL(r.WorkerURL, cellPathStripped, rawQuery), r.Token, nil
@@ -88,6 +91,22 @@ func (s *Server) brokerWebSocket(c echo.Context) error {
 		CellPath:      cellPath,
 		ResolveWorker: resolve,
 	})
+}
+
+// isTerminalErr matches the echo.HTTPError shapes ResolveWorker returns
+// for sandboxes that are permanently gone — 404 (no DB row, e.g. just
+// DELETEd or never existed) and 410 (status=stopped or error). The
+// broker uses this to close the client with a clean 1000 reason
+// instead of cycling through the redial budget.
+func isTerminalErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var he *echo.HTTPError
+	if !errors.As(err, &he) {
+		return false
+	}
+	return he.Code == http.StatusNotFound || he.Code == http.StatusGone
 }
 
 // isMigratingErr peeks at the echo.HTTPError returned by ResolveWorker

--- a/internal/api/ws_broker.go
+++ b/internal/api/ws_broker.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+
+	"github.com/opensandbox/opensandbox/internal/wsgateway"
+)
+
+// brokerWSUpgrader is the gorilla upgrader used for client WS upgrades
+// inside the broker route handlers. CheckOrigin returns true because by
+// the time the request reaches this handler it has already passed the
+// edge's auth (cap-token + API key) and CORS layers — same posture as
+// the existing api/pty.go and api/exec_session.go upgraders.
+var brokerWSUpgrader = websocket.Upgrader{
+	ReadBufferSize:  4096,
+	WriteBufferSize: 4096,
+	CheckOrigin:     func(r *http.Request) bool { return true },
+}
+
+// brokerWebSocket is the Echo handler mounted at the data-plane WS paths
+// (/api/sandboxes/:id/pty/:sessionID, /exec/:sessionID, /agent/:sid)
+// when s.wsGateway is non-nil. Replaces the legacy SandboxAPIProxy
+// hijack-and-io.Copy path with the in-process broker, which adds
+// redial, keepalive, exec-exit handling, etc.
+//
+// Auth has already happened upstream (PGAPIKeyMiddleware on the api
+// group). This handler does the worker resolution + broker handoff.
+func (s *Server) brokerWebSocket(c echo.Context) error {
+	if s.wsGateway == nil || s.sandboxAPIProxy == nil {
+		// Belt-and-suspenders. Routes shouldn't be registered without both.
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{
+			"error": "ws broker not configured",
+		})
+	}
+	sandboxID := c.Param("id")
+	sessionID := c.Param("sessionID")
+	if sessionID == "" {
+		sessionID = c.Param("sid") // /agent/:sid uses :sid
+	}
+	if sandboxID == "" || sessionID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"error": "sandbox ID and session ID required",
+		})
+	}
+
+	// Resolve once pre-upgrade so we can return a normal HTTP error if
+	// the sandbox is migrating / stopped / not found. After the upgrade
+	// the only failure channel is the WS close frame.
+	if _, err := s.sandboxAPIProxy.ResolveWorker(c, sandboxID); err != nil {
+		return err
+	}
+
+	// cellPath is the request path verbatim — drives isExec detection
+	// inside the broker (/exec/ and /agent/ flip it; /pty/ doesn't).
+	cellPath := c.Request().URL.Path
+	cellPathStripped := strings.TrimPrefix(cellPath, "/api")
+	rawQuery := c.Request().URL.RawQuery
+
+	// ResolveWorker closure: the broker calls it on initial dial AND on
+	// every redial, so a post-migration worker change picks up
+	// automatically. Route cache (3s TTL inside the proxy) coalesces
+	// rapid back-to-back lookups.
+	//
+	// When the cell-CP reports the sandbox is mid-migration (HTTP 503
+	// with "migrating" in the message), wrap the error with the
+	// wsgateway sentinel so the redial loop switches to the long
+	// migration cadence instead of burning its fast-ladder budget.
+	resolve := func() (string, string, error) {
+		r, err := s.sandboxAPIProxy.ResolveWorker(c, sandboxID)
+		if err != nil {
+			if isMigratingErr(err) {
+				return "", "", fmt.Errorf("%w: %v", wsgateway.ErrUpstreamMigrating, err)
+			}
+			return "", "", err
+		}
+		return buildWorkerWSURL(r.WorkerURL, cellPathStripped, rawQuery), r.Token, nil
+	}
+
+	return s.wsGateway.Serve(c.Response(), c.Request(), &brokerWSUpgrader, wsgateway.ServeOpts{
+		SandboxID:     sandboxID,
+		SessionID:     sessionID,
+		CellPath:      cellPath,
+		ResolveWorker: resolve,
+	})
+}
+
+// isMigratingErr peeks at the echo.HTTPError returned by ResolveWorker
+// and reports whether it's the "sandbox is migrating, retry shortly"
+// flavor — the only ResolveWorker error path that should drive the
+// broker into its migration backoff cadence rather than failing fast.
+func isMigratingErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var he *echo.HTTPError
+	if !errors.As(err, &he) {
+		return false
+	}
+	if he.Code != http.StatusServiceUnavailable {
+		return false
+	}
+	msg := ""
+	if s, ok := he.Message.(string); ok {
+		msg = s
+	}
+	return strings.Contains(strings.ToLower(msg), "migrating")
+}
+
+// buildWorkerWSURL composes the WebSocket URL the broker should dial
+// against the worker. Worker addresses are http:// (or https://); we
+// flip to ws:// (or wss://) and stitch the cell-stripped path + query.
+//
+// Worker URL examples:
+//
+//	http://10.0.0.5:8080  →  ws://10.0.0.5:8080/sandboxes/sb-xxx/pty/yyy?api_key=...
+//	https://worker.svc    →  wss://worker.svc/sandboxes/sb-xxx/pty/yyy
+func buildWorkerWSURL(workerAddr, cellPathStripped, rawQuery string) string {
+	scheme := "ws"
+	rest := workerAddr
+	switch {
+	case strings.HasPrefix(workerAddr, "https://"):
+		scheme = "wss"
+		rest = strings.TrimPrefix(workerAddr, "https://")
+	case strings.HasPrefix(workerAddr, "http://"):
+		scheme = "ws"
+		rest = strings.TrimPrefix(workerAddr, "http://")
+	}
+	rest = strings.TrimRight(rest, "/")
+	u := fmt.Sprintf("%s://%s%s", scheme, rest, cellPathStripped)
+	if rawQuery != "" {
+		u += "?" + rawQuery
+	}
+	return u
+}

--- a/internal/proxy/sandbox_api_proxy.go
+++ b/internal/proxy/sandbox_api_proxy.go
@@ -123,6 +123,91 @@ func (p *SandboxAPIProxy) SetWaitForReady(fn func(ctx context.Context, sandboxID
 	p.waitForReady = fn
 }
 
+// ResolvedRoute is the output of ResolveWorker: the worker's HTTP base
+// URL, its registered worker ID, and a fresh short-TTL sandbox JWT to
+// hand the worker on this request. Used by callers that need to do
+// their own transport (e.g. the WebSocket broker) but want the same
+// auth + routing logic as the proxy.
+type ResolvedRoute struct {
+	WorkerURL string
+	WorkerID  string
+	Token     string
+}
+
+// ResolveWorker performs the same lookup as ProxyHandler — waits for
+// async creation, rejects migrating, wakes hibernated, returns 404/410
+// equivalents — but instead of forwarding the request, returns the
+// resolved worker URL + token to the caller. Used by the WebSocket
+// broker (internal/wsgateway) which manages its own dialing.
+//
+// Errors are echo HTTP errors with the same status codes ProxyHandler
+// would return, so the caller can `return err` from a route handler and
+// get the right client-facing response.
+func (p *SandboxAPIProxy) ResolveWorker(c echo.Context, sandboxID string) (*ResolvedRoute, error) {
+	if sandboxID == "" {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "sandbox ID required")
+	}
+	ctx := c.Request().Context()
+
+	if workerURL, workerID, token, ok := p.routeCache.get(sandboxID); ok {
+		return &ResolvedRoute{WorkerURL: workerURL, WorkerID: workerID, Token: token}, nil
+	}
+
+	if p.waitForReady != nil {
+		if err := p.waitForReady(ctx, sandboxID); err != nil {
+			return nil, echo.NewHTTPError(http.StatusBadGateway, fmt.Sprintf("sandbox %s: creation failed: %v", sandboxID, err))
+		}
+	}
+
+	session, err := p.store.GetSandboxSession(ctx, sandboxID)
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("sandbox %s not found", sandboxID))
+	}
+	if session.Status == "migrating" {
+		return nil, echo.NewHTTPError(http.StatusServiceUnavailable, fmt.Sprintf("sandbox %s is migrating, retry shortly", sandboxID))
+	}
+	if session.Status == "hibernated" {
+		worker, workerURL, err := p.wakeHibernatedSandbox(ctx, sandboxID)
+		if err != nil {
+			return nil, echo.NewHTTPError(http.StatusBadGateway, fmt.Sprintf("sandbox %s: failed to wake: %v", sandboxID, err))
+		}
+		token := p.mintToken(c, sandboxID, worker.ID)
+		p.routeCache.set(sandboxID, workerURL, worker.ID, token)
+		return &ResolvedRoute{WorkerURL: workerURL, WorkerID: worker.ID, Token: token}, nil
+	}
+	if session.Status == "stopped" || session.Status == "error" {
+		return nil, echo.NewHTTPError(http.StatusGone, fmt.Sprintf("sandbox %s has been stopped", sandboxID))
+	}
+
+	worker := p.registry.GetWorker(session.WorkerID)
+	if worker == nil {
+		// Worker disappeared. Same recover-from-hibernation path the proxy uses,
+		// but we don't have a request to forward here so just surface the error.
+		return nil, echo.NewHTTPError(http.StatusBadGateway, fmt.Sprintf("worker %s unavailable", session.WorkerID))
+	}
+	if worker.HTTPAddr == "" {
+		return nil, echo.NewHTTPError(http.StatusBadGateway, fmt.Sprintf("worker %s has no HTTP address", session.WorkerID))
+	}
+	token := p.mintToken(c, sandboxID, session.WorkerID)
+	p.routeCache.set(sandboxID, worker.HTTPAddr, session.WorkerID, token)
+	return &ResolvedRoute{WorkerURL: worker.HTTPAddr, WorkerID: session.WorkerID, Token: token}, nil
+}
+
+// mintToken issues the same 5-minute sandbox JWT the proxy's forward()
+// path uses. Returns empty string if no jwtIssuer is configured (legacy
+// dev mode) — workers then accept anonymous in dev.
+func (p *SandboxAPIProxy) mintToken(c echo.Context, sandboxID, workerID string) string {
+	if p.jwtIssuer == nil {
+		return ""
+	}
+	orgID, _ := auth.GetOrgID(c)
+	t, err := p.jwtIssuer.IssueSandboxToken(orgID, sandboxID, workerID, 5*time.Minute)
+	if err != nil {
+		return ""
+	}
+	return t
+}
+
 // InvalidateRouteCache removes a sandbox from the proxy route cache.
 // Call this on hibernate, kill, or any event that changes the sandbox→worker mapping.
 func (p *SandboxAPIProxy) InvalidateRouteCache(sandboxID string) {

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -333,7 +333,8 @@ type Manager struct {
 
 	// Metadata service callbacks (set via SetMetadataCallbacks)
 	onSandboxReady   func(sandboxID, guestIP, template string, startedAt time.Time)
-	onSandboxDestroy func(sandboxID string)
+	onSandboxDestroy    func(sandboxID string)
+	onMigrationOutgoing func(sandboxID string)
 
 	// Hibernation upload status callback (set via SetHibernationUploadCallback).
 	// Invoked from the async archive+upload goroutine in doHibernate exactly once
@@ -428,6 +429,18 @@ func (m *Manager) SetMetadataCallbacks(
 ) {
 	m.onSandboxReady = onReady
 	m.onSandboxDestroy = onDestroy
+}
+
+// SetMigrationOutgoingCallback registers a callback fired AFTER a successful
+// outgoing LiveMigrate has handed the VM off to the destination worker and
+// cleaned up local QEMU + network state. Used to release per-sandbox session
+// handles (PTY, exec) without killing the in-VM session — the destination
+// worker now owns it. Without this hook the source worker's gRPC PTY/exec
+// streams sit on a dead vsock connection, so the edge DO sees no upstream
+// close, never redials, and the user's WS appears alive but is silently
+// black-holed.
+func (m *Manager) SetMigrationOutgoingCallback(cb func(sandboxID string)) {
+	m.onMigrationOutgoing = cb
 }
 
 // SetSecretsProxy configures the secrets proxy integration for token substitution.

--- a/internal/qemu/migration.go
+++ b/internal/qemu/migration.go
@@ -349,6 +349,14 @@ func (mc *MigrationCoordinator) LiveMigrate(ctx context.Context, sandboxID, inco
 		mc.manager.onSandboxDestroy(sandboxID)
 	}
 
+	// Release source-side PTY/exec session handles. Distinct from destroy:
+	// the in-VM session is still alive on the DESTINATION worker, so we must
+	// not call onKill paths that would hit the agent (the call would either
+	// fail or, worse, succeed against a now-unrelated host).
+	if mc.manager.onMigrationOutgoing != nil {
+		mc.manager.onMigrationOutgoing(sandboxID)
+	}
+
 	return nil
 }
 

--- a/internal/sandbox/exec_session.go
+++ b/internal/sandbox/exec_session.go
@@ -10,12 +10,14 @@ import (
 )
 
 // ExecSessionManager manages exec sessions on the host side.
-// Mirrors PTYManager's pattern: supports both Podman (stub) and Firecracker
-// (via createFunc override).
 type ExecSessionManager struct {
 	mu         sync.RWMutex
 	sessions   map[string]*ExecSessionHandle
 	createFunc func(sandboxID string, req types.ExecSessionCreateRequest) (*ExecSessionHandle, error)
+	// rebindFunc binds a NEW gRPC ExecSessionAttach stream to an EXISTING
+	// agent-side session by ID. Used after live migration (or worker restart)
+	// makes the local session map empty while the in-VM session keeps running.
+	rebindFunc func(sandboxID, sessionID string) (*ExecSessionHandle, error)
 }
 
 // ExecSessionHandle holds the state for an exec session on the host side.
@@ -41,13 +43,50 @@ func NewExecSessionManager() *ExecSessionManager {
 	}
 }
 
-// NewAgentExecSessionManager creates an exec session manager that delegates to
-// a custom create function (used by Firecracker mode).
-func NewAgentExecSessionManager(createFunc func(sandboxID string, req types.ExecSessionCreateRequest) (*ExecSessionHandle, error)) *ExecSessionManager {
+// NewAgentExecSessionManager creates an exec session manager that delegates
+// session creation to createFunc (gRPC ExecSessionCreate) and recovery to
+// rebindFunc (gRPC ExecSessionAttach against an existing in-VM session).
+// rebindFunc may be nil — RebindFromAgent then always reports "not found".
+func NewAgentExecSessionManager(
+	createFunc func(sandboxID string, req types.ExecSessionCreateRequest) (*ExecSessionHandle, error),
+	rebindFunc func(sandboxID, sessionID string) (*ExecSessionHandle, error),
+) *ExecSessionManager {
 	return &ExecSessionManager{
 		sessions:   make(map[string]*ExecSessionHandle),
 		createFunc: createFunc,
+		rebindFunc: rebindFunc,
 	}
+}
+
+// RebindFromAgent attempts to look up sessionID against the in-VM agent and,
+// if it's still alive, register a fresh local handle that streams through a
+// new ExecSessionAttach. Used after live migration or worker restart wipes
+// the local session map. Returns the registered handle on success, or an
+// error if the agent reports the session is gone.
+func (m *ExecSessionManager) RebindFromAgent(sandboxID, sessionID string) (*ExecSessionHandle, error) {
+	if m.rebindFunc == nil {
+		return nil, fmt.Errorf("exec session %s not found", sessionID)
+	}
+	// Drop stale local entry first — its gRPC stream targets the old worker.
+	m.mu.Lock()
+	if stale, ok := m.sessions[sessionID]; ok {
+		delete(m.sessions, sessionID)
+		if stale.OnKill != nil {
+			// Don't actually kill — just release local pipes. The agent owns
+			// the process and we want it to keep running.
+			_ = stale
+		}
+	}
+	m.mu.Unlock()
+
+	handle, err := m.rebindFunc(sandboxID, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	m.mu.Lock()
+	m.sessions[handle.ID] = handle
+	m.mu.Unlock()
+	return handle, nil
 }
 
 // CreateSession creates a new exec session.

--- a/internal/sandbox/exec_session.go
+++ b/internal/sandbox/exec_session.go
@@ -34,6 +34,13 @@ type ExecSessionHandle struct {
 	StdinWriter io.Writer
 
 	OnKill func(signal int) error
+
+	// Cancel terminates the gRPC ExecSessionAttach stream this handle is
+	// driven by, without signaling the in-VM session to exit. Called by
+	// ReleaseForSandbox on the source side of a live migration so the
+	// worker's WS handler unblocks immediately and the edge DO sees an
+	// upstream close (→ redial → destination rebind). Nil-safe.
+	Cancel func()
 }
 
 // NewExecSessionManager creates a stub exec session manager (Podman — not supported).
@@ -67,16 +74,14 @@ func (m *ExecSessionManager) RebindFromAgent(sandboxID, sessionID string) (*Exec
 	if m.rebindFunc == nil {
 		return nil, fmt.Errorf("exec session %s not found", sessionID)
 	}
-	// Drop stale local entry first — its gRPC stream targets the old worker.
+	// Defensive: drop any stale local entry — after a normal migration the
+	// source worker's onMigrationOutgoing hook has already released this
+	// sandbox's sessions, so the map should be empty here. If it isn't, the
+	// fresh handle we install below supersedes the stale one; we don't try
+	// to actively reclaim the old gRPC stream because its context is owned
+	// by a goroutine we don't have a handle to from here.
 	m.mu.Lock()
-	if stale, ok := m.sessions[sessionID]; ok {
-		delete(m.sessions, sessionID)
-		if stale.OnKill != nil {
-			// Don't actually kill — just release local pipes. The agent owns
-			// the process and we want it to keep running.
-			_ = stale
-		}
-	}
+	delete(m.sessions, sessionID)
 	m.mu.Unlock()
 
 	handle, err := m.rebindFunc(sandboxID, sessionID)
@@ -178,6 +183,31 @@ func (m *ExecSessionManager) RemoveSessions(sandboxID string) {
 	for id, s := range m.sessions {
 		if s.SandboxID == sandboxID {
 			delete(m.sessions, id)
+		}
+	}
+}
+
+// ReleaseForSandbox drops every local exec session for sandboxID and cancels
+// its gRPC ExecSessionAttach stream so the worker's WS handler — blocked on
+// the scrollback subscription — unblocks via session.Done. Does NOT invoke
+// OnKill (which would tell the in-VM agent to terminate the process); the
+// session is alive on another worker post-migration.
+//
+// Counterpart to PTYManager.ReleaseForSandbox; same role for the source side
+// of a live migration.
+func (m *ExecSessionManager) ReleaseForSandbox(sandboxID string) {
+	m.mu.Lock()
+	var toRelease []*ExecSessionHandle
+	for id, s := range m.sessions {
+		if s.SandboxID == sandboxID {
+			toRelease = append(toRelease, s)
+			delete(m.sessions, id)
+		}
+	}
+	m.mu.Unlock()
+	for _, s := range toRelease {
+		if s.Cancel != nil {
+			s.Cancel()
 		}
 	}
 }

--- a/internal/sandbox/pty.go
+++ b/internal/sandbox/pty.go
@@ -17,6 +17,13 @@ type PTYManager struct {
 
 	// createFunc creates PTY sessions via the Firecracker agent.
 	createFunc func(sandboxID string, req types.PTYCreateRequest) (*PTYSessionHandle, error)
+
+	// rebindFunc binds a NEW gRPC PTYAttach stream to an EXISTING agent-side
+	// session by ID. Used after live migration (or worker restart): the in-VM
+	// agent retains the PTY/shell across the move, but the destination worker's
+	// in-process session map is empty. Falling back to rebind on cache miss
+	// makes session_id portable across workers without touching the agent.
+	rebindFunc func(sandboxID, sessionID string) (*PTYSessionHandle, error)
 }
 
 // PTYSessionHandle holds the state for an active PTY session.
@@ -33,13 +40,48 @@ type PTYSessionHandle struct {
 	onResize func(cols, rows int) error
 }
 
-// NewAgentPTYManager creates a PTY manager that delegates to a custom
-// create function (used by Firecracker mode).
-func NewAgentPTYManager(createFunc func(sandboxID string, req types.PTYCreateRequest) (*PTYSessionHandle, error)) *PTYManager {
+// NewAgentPTYManager creates a PTY manager that delegates session creation
+// to createFunc (gRPC PTYCreate against the in-VM agent) and session
+// recovery to rebindFunc (gRPC PTYAttach against an existing in-VM session).
+// rebindFunc may be nil — RebindFromAgent then always reports "not found",
+// so the manager behaves as a strict local cache with no agent fallback.
+func NewAgentPTYManager(
+	createFunc func(sandboxID string, req types.PTYCreateRequest) (*PTYSessionHandle, error),
+	rebindFunc func(sandboxID, sessionID string) (*PTYSessionHandle, error),
+) *PTYManager {
 	return &PTYManager{
 		sessions:   make(map[string]*PTYSessionHandle),
 		createFunc: createFunc,
+		rebindFunc: rebindFunc,
 	}
+}
+
+// RebindFromAgent attempts to look up sessionID against the in-VM agent and,
+// if it's still alive, register a fresh local handle that streams through a
+// new PTYAttach. Used after live migration or worker restart wipes the local
+// session map. Returns the registered handle on success, or an error if the
+// agent reports the session is gone (or if rebindFunc was not configured).
+func (pm *PTYManager) RebindFromAgent(sandboxID, sessionID string) (*PTYSessionHandle, error) {
+	if pm.rebindFunc == nil {
+		return nil, fmt.Errorf("PTY session %s not found", sessionID)
+	}
+	// Drop any stale local entry first — its underlying gRPC stream points at
+	// the old worker's agent connection and won't ever produce bytes again.
+	pm.mu.Lock()
+	if stale, ok := pm.sessions[sessionID]; ok {
+		delete(pm.sessions, sessionID)
+		_ = stale.PTY.Close()
+	}
+	pm.mu.Unlock()
+
+	handle, err := pm.rebindFunc(sandboxID, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	pm.mu.Lock()
+	pm.sessions[handle.ID] = handle
+	pm.mu.Unlock()
+	return handle, nil
 }
 
 // CreateSession starts a new PTY session inside a sandbox.
@@ -115,6 +157,28 @@ func (pm *PTYManager) KillSession(sessionID string) error {
 		_ = session.Cmd.Process.Kill()
 	}
 	return nil
+}
+
+// ReleaseForSandbox drops every local session belonging to sandboxID and
+// closes its underlying gRPC PTY stream so any in-flight WS handler blocked
+// on session.PTY.Read() unblocks immediately. Does NOT invoke onKill — the
+// in-VM PTY is owned by the agent and may have migrated to another worker
+// that's still serving it. Use this on the SOURCE side of a live migration
+// (or after DestroySandbox) so the edge DO sees the upstream close, redials,
+// and lands on the destination worker where RebindFromAgent can take over.
+func (pm *PTYManager) ReleaseForSandbox(sandboxID string) {
+	pm.mu.Lock()
+	var toRelease []*PTYSessionHandle
+	for id, s := range pm.sessions {
+		if s.SandboxID == sandboxID {
+			toRelease = append(toRelease, s)
+			delete(pm.sessions, id)
+		}
+	}
+	pm.mu.Unlock()
+	for _, s := range toRelease {
+		_ = s.PTY.Close()
+	}
 }
 
 // CloseAll terminates all PTY sessions.

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -133,7 +133,15 @@ func (s *HTTPServer) execSessionWebSocket(c echo.Context) error {
 
 	session, err := s.execSessionManager.GetSession(sessionID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, map[string]string{"error": err.Error()})
+		// Local cache miss — possible post-migration first attach. Ask the
+		// agent; if the in-VM session is still alive, register a new local
+		// handle that streams through ExecSessionAttach.
+		rebound, rebindErr := s.execSessionManager.RebindFromAgent(id, sessionID)
+		if rebindErr != nil {
+			return c.JSON(http.StatusNotFound, map[string]string{"error": err.Error()})
+		}
+		session = rebound
+		log.Printf("worker exec: rebound session=%s sandbox=%s from agent", sessionID, id)
 	}
 
 	if session.SandboxID != id {
@@ -549,8 +557,16 @@ func (s *HTTPServer) ptyWebSocket(c echo.Context) error {
 
 	session, err := s.ptyManager.GetSession(sessionID)
 	if err != nil {
-		log.Printf("worker PTY: GetSession(%s) failed: %v", sessionID, err)
-		return c.JSON(http.StatusNotFound, map[string]string{"error": err.Error()})
+		// Local cache miss — try a lazy rebind against the agent. If the
+		// in-VM PTY is still alive (the common case after live migration or
+		// worker process restart), register a new local handle and continue.
+		rebound, rebindErr := s.ptyManager.RebindFromAgent(id, sessionID)
+		if rebindErr != nil {
+			log.Printf("worker PTY: GetSession(%s) miss, rebind also failed: get=%v rebind=%v", sessionID, err, rebindErr)
+			return c.JSON(http.StatusNotFound, map[string]string{"error": err.Error()})
+		}
+		session = rebound
+		log.Printf("worker PTY: rebound session=%s sandbox=%s from agent", sessionID, id)
 	}
 
 	if session.SandboxID != id {

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -236,14 +236,19 @@ func (s *HTTPServer) execSessionWebSocket(c echo.Context) error {
 				}
 			}
 		sendExit:
-			exitMsg := make([]byte, 5)
-			exitMsg[0] = 0x03
-			exitCode := 0
+			// Only emit the 0x03 exit-code marker when the process actually
+			// exited (ExitCode is non-nil — consumeExecOutput only sets it on
+			// an EXIT message from the agent). When the goroutine was canceled
+			// for other reasons (e.g. source-side ReleaseForSandbox during
+			// live migration), ExitCode stays nil and emitting a fake 0x03
+			// would be misread by the edge DO as "exec completed" → close
+			// client instead of redialing.
 			if session.ExitCode != nil {
-				exitCode = *session.ExitCode
+				exitMsg := make([]byte, 5)
+				exitMsg[0] = 0x03
+				binary.BigEndian.PutUint32(exitMsg[1:], uint32(int32(*session.ExitCode)))
+				_ = ws.WriteMessage(websocket.BinaryMessage, exitMsg)
 			}
-			binary.BigEndian.PutUint32(exitMsg[1:], uint32(int32(exitCode)))
-			_ = ws.WriteMessage(websocket.BinaryMessage, exitMsg)
 
 			ws.WriteControl(websocket.CloseMessage,
 				websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),

--- a/internal/wsgateway/config.go
+++ b/internal/wsgateway/config.go
@@ -1,0 +1,103 @@
+// Package wsgateway is the per-cell WebSocket broker that sits between
+// clients (SDK, dashboard) and workers for PTY/exec/agent sessions.
+//
+// Replaces the CloudFlare-DO implementation that lived in
+// cloudflare-workers/shared/sandbox_ws_gateway.ts on the websocket-edge
+// branch. Same behavioral spec — multi-session per sandbox, redial on
+// upstream close, exit-marker suppression, alarm-tick keepalive,
+// cap-token cache, flap circuit breaker — implemented as a Go subsystem
+// of the cell-CP (opensandbox-server) instead of a CF Durable Object.
+//
+// Why move out of CF: (1) the cell becomes self-hostable without depending
+// on Cloudflare DO infrastructure, (2) single implementation maintained
+// in one language, (3) the cell-CP orchestrates migration AND brokers WS
+// from the same process, so future work can switch the migration handoff
+// from reactive-redial to proactive-handoff via Go channels.
+//
+// Layering:
+//
+//   Client ── WS ── CF Worker ── WS ── cell-CP broker ── WS ── Worker ── gRPC ── Agent (in-VM)
+//                  (auth, cap-mint,    (this package:        (handlers.go,
+//                   transparent fwd)    redial, keepalive,    RebindFromAgent,
+//                                       exit marker, etc.)    PTY/exec session
+//                                                             map cache, etc.)
+//
+// The broker terminates the client WS on its end and opens an independent
+// WS to the worker. If the worker WS dies (worker restart, migration
+// release, network blip) the broker doesn't kill the client; it redials
+// the worker and the client keeps its connection.
+package wsgateway
+
+import "time"
+
+// AlarmIntervalMS is the keepalive ticker period — empty binary frame on
+// every tick to both client and upstream WS, plus a sweep for idle
+// sandbox actors that no longer hold any sessions. 30s matches the
+// previous DO implementation and is well under CF Workers' ~100s
+// fetch-WS idle drop threshold.
+const AlarmInterval = 30 * time.Second
+
+// Default redial cadence on upstream close — exponential then steady at
+// 4s. Total budget ~25s before the redial loop gives up and closes the
+// client. Same ladder as the DO; chosen so transient worker restarts
+// (≤15s) and live migrations (≤2s) reliably succeed.
+var RedialBackoffMS = []time.Duration{
+	250 * time.Millisecond,
+	500 * time.Millisecond,
+	1 * time.Second,
+	2 * time.Second,
+	4 * time.Second,
+	4 * time.Second,
+	4 * time.Second,
+	4 * time.Second,
+	4 * time.Second,
+	4 * time.Second,
+}
+
+// Migration-aware cadence: cross-cell live migration can take 30s+ on
+// slow links. When the cell-CP-side dial returns 503 + body matches
+// /migrating/, the redial loop switches to this steadier 2s × 30 cadence
+// for the rest of the cycle.
+const (
+	MigrationBackoff     = 2 * time.Second
+	MigrationMaxAttempts = 30
+)
+
+// Circuit breaker: a "redial cycle" is a single call to startRedial
+// regardless of how many internal dial attempts it triggers. After this
+// many cycles within REDIAL_FLAP_WINDOW the broker gives up and closes
+// the client with 1011 / "upstream flapping". Prevents an upstream that
+// keeps closing cleanly (e.g. a worker handler bug) from burning CF
+// Worker subrequests indefinitely.
+const (
+	RedialFlapThreshold = 3
+	RedialFlapWindow    = 60 * time.Second
+)
+
+// Cap-token cache: edge mints 120s HS256 JWTs. The broker reuses one
+// across sessions in the same sandbox actor and across redials until it
+// has less than CapRefreshAhead of life left.
+const (
+	CapLifetime     = 120 * time.Second
+	CapRefreshAhead = 30 * time.Second
+)
+
+// HandshakeTimeout bounds the worker WS dial. Worker side is in-cluster
+// (sub-millisecond RTT) so this only fires when the worker is actively
+// unhealthy or being restarted.
+const HandshakeTimeout = 10 * time.Second
+
+// WriteTimeout bounds individual WS writes — prevents a slow consumer
+// (client or upstream) from blocking the bridge goroutine indefinitely
+// while still allowing for transient buffer pressure.
+const WriteTimeout = 30 * time.Second
+
+// ExecExitMarkerLen / ExecExitMarkerTag — the agent emits a 5-byte
+// binary frame tagged 0x03 + 4-byte exit code immediately before closing
+// a completed exec session. The broker watches for it to distinguish
+// "session ended cleanly" (close client with 1000 / "exec completed")
+// from "transient upstream loss" (redial).
+const (
+	ExecExitMarkerLen = 5
+	ExecExitMarkerTag = 0x03
+)

--- a/internal/wsgateway/dial.go
+++ b/internal/wsgateway/dial.go
@@ -1,0 +1,105 @@
+package wsgateway
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+// ErrUpstreamMigrating is the sentinel the ResolveWorker closure (in
+// internal/api/ws_broker.go) returns wrapped via errors.Join when the
+// cell-CP reports the sandbox is mid-migration. The broker's runRedial
+// recognizes it and switches to the longer migration backoff cadence
+// instead of burning the fast-ladder budget on a guaranteed-to-fail dial.
+var ErrUpstreamMigrating = errors.New("upstream migrating")
+
+// DialResult classifies an upstream dial outcome so the redial loop can
+// pick the right backoff policy. Either Conn is non-nil (success), or
+// one of the Terminal/Migrating flags drives the loop's next action.
+type DialResult struct {
+	Conn        *websocket.Conn
+	Resp        *http.Response
+	Terminal    bool   // 404 or 410 — resource gone permanently, close client with reason
+	Migrating   bool   // 503 + body matches /migrating/ — switch to long backoff
+	Status      int    // last response status (0 if dial threw before headers)
+	BodySnippet string // first 200 bytes of error body if any, for logging
+	Err         error  // the underlying error from gorilla/websocket
+}
+
+var migratingPattern = regexp.MustCompile(`(?i)migrating`)
+
+// DialUpstream attempts a single WebSocket upgrade against workerWSURL,
+// passing the bearer token as Authorization. Returns a DialResult the
+// caller uses to decide whether to retry, swap to migration backoff, or
+// give up with a terminal close.
+func DialUpstream(workerWSURL, token string) DialResult {
+	header := http.Header{}
+	if token != "" {
+		header.Set("Authorization", "Bearer "+token)
+	}
+	dialer := websocket.Dialer{
+		HandshakeTimeout: HandshakeTimeout,
+	}
+	conn, resp, err := dialer.Dial(workerWSURL, header)
+	if err == nil {
+		return DialResult{Conn: conn, Resp: resp}
+	}
+	status := 0
+	body := ""
+	if resp != nil {
+		status = resp.StatusCode
+		body = snippet(resp.Body)
+	}
+	terminal := status == http.StatusNotFound || status == http.StatusGone
+	migrating := status == http.StatusServiceUnavailable && migratingPattern.MatchString(body)
+	return DialResult{
+		Resp:        resp,
+		Terminal:    terminal,
+		Migrating:   migrating,
+		Status:      status,
+		BodySnippet: body,
+		Err:         err,
+	}
+}
+
+// Note returns a compact one-line description of the dial outcome for
+// logging — chosen to mirror the DO's "status=X body=Y" format.
+func (r DialResult) Note() string {
+	if r.Conn != nil {
+		return "ok"
+	}
+	parts := []string{fmt.Sprintf("status=%d", r.Status)}
+	if r.BodySnippet != "" {
+		parts = append(parts, "body="+r.BodySnippet)
+	}
+	if r.Err != nil && !errors.Is(r.Err, websocket.ErrBadHandshake) {
+		parts = append(parts, "err="+r.Err.Error())
+	}
+	if r.Terminal {
+		parts = append(parts, "(terminal)")
+	}
+	if r.Migrating {
+		parts = append(parts, "(migrating)")
+	}
+	return strings.Join(parts, " ")
+}
+
+// snippet drains up to 200 bytes from r and returns it as a string for
+// log/error-body use. Closes the body before returning.
+func snippet(r io.ReadCloser) string {
+	if r == nil {
+		return ""
+	}
+	defer r.Close()
+	buf := make([]byte, 200)
+	n, _ := io.ReadFull(r, buf)
+	if n == 0 {
+		return ""
+	}
+	return strings.TrimSpace(string(buf[:n]))
+}

--- a/internal/wsgateway/dial.go
+++ b/internal/wsgateway/dial.go
@@ -12,11 +12,20 @@ import (
 )
 
 // ErrUpstreamMigrating is the sentinel the ResolveWorker closure (in
-// internal/api/ws_broker.go) returns wrapped via errors.Join when the
+// internal/api/ws_broker.go) returns wrapped via fmt.Errorf when the
 // cell-CP reports the sandbox is mid-migration. The broker's runRedial
 // recognizes it and switches to the longer migration backoff cadence
 // instead of burning the fast-ladder budget on a guaranteed-to-fail dial.
 var ErrUpstreamMigrating = errors.New("upstream migrating")
+
+// ErrUpstreamTerminal is the sentinel the ResolveWorker closure returns
+// when the cell-CP reports the sandbox is gone for good — 404 not found
+// or 410 stopped/error. The broker's runRedial closes the client with a
+// clean 1000 + the wrapped reason instead of retrying.
+//
+// The reason string sent to the client is extracted from the wrapped
+// error (see terminalReasonFromErr in session.go).
+var ErrUpstreamTerminal = errors.New("upstream terminal")
 
 // DialResult classifies an upstream dial outcome so the redial loop can
 // pick the right backoff policy. Either Conn is non-nil (success), or

--- a/internal/wsgateway/gateway.go
+++ b/internal/wsgateway/gateway.go
@@ -1,0 +1,234 @@
+package wsgateway
+
+import (
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// Gateway is the per-cell broker. One instance per cell-CP process,
+// holding a map of sandboxID → sandboxActor. The cell-CP's WS route
+// handlers (handlers added in Phase 2) call Gateway.Serve with the
+// upgraded client conn and a function that resolves the worker WS URL
+// + sandbox JWT.
+//
+// Routing model: each sandbox gets at most one sandboxActor. Multiple
+// concurrent WS upgrades to the same sandbox (dashboard + SDK, two
+// dashboard tabs, etc.) all share that actor and run as independent
+// sessions inside it. The actor owns a keepalive ticker that fires
+// across all its sessions every AlarmInterval, and a cap-token cache
+// shared across them.
+//
+// Lifecycle:
+//   - First Serve for a sandbox creates the actor.
+//   - Subsequent Serves attach new Sessions to the existing actor.
+//   - When the last session closes, the actor's keepalive loop notices
+//     during its next tick, signals shutdown, and the Gateway drops the
+//     map entry. Idempotent and tolerant of races.
+type Gateway struct {
+	mu        sync.Mutex
+	sandboxes map[string]*sandboxActor
+}
+
+// NewGateway constructs an empty Gateway ready to accept Serve calls.
+func NewGateway() *Gateway {
+	return &Gateway{
+		sandboxes: make(map[string]*sandboxActor),
+	}
+}
+
+// ServeOpts is everything the broker needs to bridge one client WS to
+// the worker. All fields are required.
+type ServeOpts struct {
+	SandboxID string
+	SessionID string
+	CellPath  string // e.g. "/api/sandboxes/sb-xxx/pty/yyy" — purely for logging + isExec detection
+
+	// ResolveWorker returns the worker WS URL plus the per-request
+	// sandbox JWT the worker expects in the Authorization header. Called
+	// once on initial dial and again on each redial — so a worker change
+	// (post-migration) is picked up automatically.
+	ResolveWorker func() (workerWSURL string, sandboxToken string, err error)
+}
+
+// Serve upgrades the request to a WebSocket, then runs the broker
+// session against the worker. Returns nil on a clean handoff; non-nil
+// error before the upgrade can be returned to the caller for a normal
+// HTTP error response. Once the upgrade succeeds, all further error
+// reporting happens via WS close frames — Serve returns nil and the
+// caller's HTTP path is done.
+func (g *Gateway) Serve(w http.ResponseWriter, r *http.Request, upgrader *websocket.Upgrader, opts ServeOpts) error {
+	if opts.SandboxID == "" || opts.SessionID == "" || opts.ResolveWorker == nil {
+		return errEmpty("missing required ServeOpts")
+	}
+
+	clientWS, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		// Upgrade already wrote a response.
+		return nil
+	}
+
+	actor := g.getOrCreateActor(opts.SandboxID)
+	sess := &Session{
+		actor:         actor,
+		sandboxID:     opts.SandboxID,
+		sessionID:     opts.SessionID,
+		cellPath:      opts.CellPath,
+		isExec:        strings.Contains(opts.CellPath, "/exec/") || strings.Contains(opts.CellPath, "/agent/"),
+		clientWS:      clientWS,
+		workerWSURLFn: opts.ResolveWorker,
+		done:          make(chan struct{}),
+	}
+	actor.addSession(sess)
+	// Run synchronously so the Echo Context the route handler captured —
+	// closures like ResolveWorker that call back into c.Request().Context()
+	// + auth.GetOrgID(c) need it — stays valid until the session ends.
+	// Echo pools Contexts and recycles them once the handler returns; if
+	// we spawned Run() in a goroutine and returned, those closures would
+	// see torn-down/reused state on the next call (404 spam from store
+	// lookups using a stale Context).
+	sess.Run()
+	return nil
+}
+
+// SessionCount returns the total number of live sessions across all
+// sandbox actors. Used by tests + admin endpoints; cheap O(N) over
+// actors, not hot-path.
+func (g *Gateway) SessionCount() int {
+	g.mu.Lock()
+	actors := make([]*sandboxActor, 0, len(g.sandboxes))
+	for _, a := range g.sandboxes {
+		actors = append(actors, a)
+	}
+	g.mu.Unlock()
+	total := 0
+	for _, a := range actors {
+		a.mu.Lock()
+		total += len(a.sessions)
+		a.mu.Unlock()
+	}
+	return total
+}
+
+// getOrCreateActor returns the actor for sandboxID, creating + starting
+// its keepalive ticker if absent.
+func (g *Gateway) getOrCreateActor(sandboxID string) *sandboxActor {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if a, ok := g.sandboxes[sandboxID]; ok {
+		return a
+	}
+	a := &sandboxActor{
+		sandboxID: sandboxID,
+		gw:        g,
+		sessions:  make(map[*Session]struct{}),
+		stop:      make(chan struct{}),
+	}
+	g.sandboxes[sandboxID] = a
+	go a.runKeepalive()
+	return a
+}
+
+// removeActor drops the actor from the map. Called by the actor itself
+// when it observes "no more sessions" during a keepalive tick.
+func (g *Gateway) removeActor(a *sandboxActor) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	// Guard against races: another Serve might have attached a session
+	// to this actor between the actor's empty-check and removeActor.
+	a.mu.Lock()
+	live := len(a.sessions)
+	a.mu.Unlock()
+	if live > 0 {
+		return
+	}
+	if g.sandboxes[a.sandboxID] == a {
+		delete(g.sandboxes, a.sandboxID)
+		close(a.stop)
+	}
+}
+
+// sandboxActor holds the per-sandbox state shared across concurrent
+// Sessions: the set of live sessions, the cap-token cache (for future
+// re-mint paths), and a keepalive ticker goroutine.
+type sandboxActor struct {
+	sandboxID string
+	gw        *Gateway
+
+	mu       sync.Mutex
+	sessions map[*Session]struct{}
+
+	capCacheMu sync.Mutex
+	capCache   *capCacheEntry
+
+	stop chan struct{} // closed by gateway.removeActor
+}
+
+func (a *sandboxActor) addSession(s *Session) {
+	a.mu.Lock()
+	a.sessions[s] = struct{}{}
+	count := len(a.sessions)
+	a.mu.Unlock()
+	log.Printf("wsgateway: attached session sandbox=%s session=%s active=%d", a.sandboxID, s.sessionID, count)
+}
+
+func (a *sandboxActor) removeSession(s *Session) {
+	a.mu.Lock()
+	delete(a.sessions, s)
+	count := len(a.sessions)
+	a.mu.Unlock()
+	log.Printf("wsgateway: detached session sandbox=%s session=%s active=%d", a.sandboxID, s.sessionID, count)
+}
+
+// runKeepalive fires every AlarmInterval. Sends an empty frame on every
+// session's client+upstream conn, then checks for "no sessions left → ask
+// gateway to drop me." Exits when the gateway closes a.stop.
+func (a *sandboxActor) runKeepalive() {
+	t := time.NewTicker(AlarmInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			a.mu.Lock()
+			alive := make([]*Session, 0, len(a.sessions))
+			for s := range a.sessions {
+				alive = append(alive, s)
+			}
+			a.mu.Unlock()
+			if len(alive) == 0 {
+				log.Printf("wsgateway: alarm sandbox=%s — idle, releasing", a.sandboxID)
+				a.gw.removeActor(a)
+				return
+			}
+			for _, s := range alive {
+				s.Keepalive()
+			}
+			log.Printf("wsgateway: alarm sandbox=%s sessions=%d", a.sandboxID, len(alive))
+		case <-a.stop:
+			return
+		}
+	}
+}
+
+// capCacheEntry mirrors the DO's v5 cap-token cache. The cell-CP doesn't
+// currently mint cap-tokens — the edge does that before forwarding — so
+// this cache is reserved for future use (e.g. if the broker grows the
+// ability to mint a fresh token on redial when the edge-provided one has
+// expired). Kept here as the actor's home for shared cross-session state.
+type capCacheEntry struct {
+	Token    string
+	MintedAt time.Time
+	OrgID    string
+	CellID   string
+	Plan     string
+}
+
+// errEmpty is the canonical pre-upgrade error so callers don't have to
+// import "errors".
+type errEmpty string
+
+func (e errEmpty) Error() string { return string(e) }

--- a/internal/wsgateway/session.go
+++ b/internal/wsgateway/session.go
@@ -1,0 +1,402 @@
+package wsgateway
+
+import (
+	"errors"
+	"log"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// Session owns one client WebSocket and brokers it against the upstream
+// worker WS. The upstream conn changes across redials; the client conn
+// is fixed for the session's lifetime. All writes to either conn are
+// serialized via clientMu/upstreamMu — gorilla/websocket connections
+// are not goroutine-safe for concurrent writes.
+//
+// The Run() method is the per-session goroutine entry point. It handles
+// initial dial, starts upstream + client read pumps, drives the redial
+// loop on upstream close, and cleans up.
+type Session struct {
+	actor     *sandboxActor
+	sandboxID string
+	sessionID string
+	cellPath  string
+
+	// isExec drives v6 exit-marker tracking. Set once from the path —
+	// /exec/ or /agent/ → true; /pty/ → false.
+	isExec bool
+
+	clientWS *websocket.Conn
+	clientMu sync.Mutex // serializes writes to clientWS
+
+	upstreamMu sync.RWMutex
+	upstreamWS *websocket.Conn
+
+	// workerWSURL is the cell-CP→worker URL. Recomputed on each redial
+	// from the worker registry so a worker_id change (mid-flight migration
+	// that completed) routes correctly.
+	workerWSURLFn func() (string, string, error) // returns (url, token, error)
+
+	// v6 exec-exit marker. Set when a 5-byte 0x03+exitCode frame arrives
+	// from upstream. On the next upstream close, the broker closes the
+	// client cleanly instead of redialing.
+	execExited atomic.Bool
+
+	// Circuit breaker — bounded slice of recent startRedial timestamps.
+	flapMu      sync.Mutex
+	redialTimes []time.Time
+
+	closeOnce sync.Once
+	done      chan struct{}
+}
+
+// Run is the per-session goroutine entry. Blocks until the session
+// terminates. Caller is the sandbox actor; it removes the session
+// from its map after Run returns.
+func (s *Session) Run() {
+	defer s.close()
+
+	// Initial dial.
+	url, token, err := s.workerWSURLFn()
+	if err != nil {
+		log.Printf("wsgateway: initial url resolve failed sandbox=%s session=%s: %v", s.sandboxID, s.sessionID, err)
+		s.closeClient(websocket.CloseInternalServerErr, "upstream resolve failed")
+		return
+	}
+	dial := DialUpstream(url, token)
+	if dial.Conn == nil {
+		log.Printf("wsgateway: initial dial failed sandbox=%s session=%s %s", s.sandboxID, s.sessionID, dial.Note())
+		if dial.Terminal {
+			s.closeClient(websocket.CloseNormalClosure, terminalReason(dial))
+		} else {
+			s.closeClient(websocket.CloseInternalServerErr, "upstream connect failed")
+		}
+		return
+	}
+	s.setUpstream(dial.Conn)
+
+	log.Printf("wsgateway: opened sandbox=%s session=%s path=%s", s.sandboxID, s.sessionID, s.cellPath)
+
+	// Start client reader (reads from client, writes to current upstream).
+	clientDone := make(chan struct{})
+	go s.pumpClientToUpstream(clientDone)
+
+	// Start upstream reader. Loop here so a redial can restart it with a
+	// new upstream while the same client conn stays attached.
+	upstreamDone := make(chan struct{})
+	go s.pumpUpstreamToClient(dial.Conn, upstreamDone)
+
+	for {
+		select {
+		case <-clientDone:
+			// Client went away; tear down upstream and exit.
+			s.upstreamClose(websocket.CloseNormalClosure, "client closed")
+			return
+
+		case <-upstreamDone:
+			// Upstream closed. If exec exited, that's the natural end.
+			if s.execExited.Load() {
+				log.Printf("wsgateway: exec exited — closing client sandbox=%s session=%s", s.sandboxID, s.sessionID)
+				s.closeClient(websocket.CloseNormalClosure, "exec completed")
+				return
+			}
+			// Circuit breaker — too many flaps in the window.
+			if !s.recordRedial() {
+				log.Printf("wsgateway: redial flap threshold hit sandbox=%s session=%s — closing client", s.sandboxID, s.sessionID)
+				s.closeClient(websocket.CloseInternalServerErr, "upstream flapping")
+				return
+			}
+			// Drive the redial loop. New upstream conn replaces the old;
+			// kick off a new pump goroutine. Pass clientDone so the loop
+			// bails immediately if the client disconnects mid-backoff
+			// instead of wasting the full ~25s window.
+			newUp, terminal, reason, ok := s.runRedial(clientDone)
+			if !ok {
+				log.Printf("wsgateway: redial exhausted sandbox=%s session=%s", s.sandboxID, s.sessionID)
+				if terminal {
+					s.closeClient(websocket.CloseNormalClosure, reason)
+				} else {
+					s.closeClient(websocket.CloseInternalServerErr, "upstream unrecoverable")
+				}
+				return
+			}
+			s.setUpstream(newUp)
+			upstreamDone = make(chan struct{})
+			go s.pumpUpstreamToClient(newUp, upstreamDone)
+
+		case <-s.done:
+			return
+		}
+	}
+}
+
+// pumpClientToUpstream reads frames from the client WS and writes them
+// to whichever upstream is currently bound on the session. Exits when
+// the client closes or errors; signals via done.
+//
+// Frames sent during a redial window (upstream temporarily nil or
+// closed) are dropped silently — matches the DO's behavior. Bidirectional
+// buffering of client→upstream is a deliberate non-goal here (the
+// session would have to choose how much to buffer; SDK retries handle it).
+func (s *Session) pumpClientToUpstream(done chan struct{}) {
+	defer close(done)
+	for {
+		mt, data, err := s.clientWS.ReadMessage()
+		if err != nil {
+			return
+		}
+		s.upstreamMu.RLock()
+		u := s.upstreamWS
+		s.upstreamMu.RUnlock()
+		if u == nil {
+			continue // drop during redial window
+		}
+		if err := writeOne(u, &s.upstreamMu, mt, data); err != nil {
+			// Don't return — upstream might come back via redial. The
+			// upstream reader will detect the close and trigger redial.
+			continue
+		}
+	}
+}
+
+// pumpUpstreamToClient reads from the specific upstream conn passed in
+// (does NOT swap on redial — a fresh goroutine is started for each new
+// upstream by the session main loop). Forwards every frame to the
+// client. Watches for the exec exit marker.
+func (s *Session) pumpUpstreamToClient(upstream *websocket.Conn, done chan struct{}) {
+	defer close(done)
+	for {
+		mt, data, err := upstream.ReadMessage()
+		if err != nil {
+			return
+		}
+		// v6 exec-exit detection. 5-byte binary frame, leading 0x03.
+		if s.isExec && mt == websocket.BinaryMessage && len(data) == ExecExitMarkerLen && data[0] == ExecExitMarkerTag {
+			s.execExited.Store(true)
+		}
+		if err := writeOne(s.clientWS, &s.clientMu, mt, data); err != nil {
+			return
+		}
+	}
+}
+
+// runRedial walks the backoff ladder, dialing the upstream each tick.
+// Returns (conn, terminal, reason, ok). On terminal failure (sandbox
+// stopped, 404/410), terminal=true and reason carries the close message;
+// ok=false. On success, ok=true and conn is the new upstream. On
+// exhausted attempts or client disconnect during backoff, ok=false and
+// terminal=false.
+//
+// Switches to migration cadence on first 503/migrating.
+//
+// clientDone is the channel pumpClientToUpstream closes when the client
+// disconnects — selected on during each backoff sleep so we don't spend
+// 25s+ in a dead loop when the user already hung up.
+func (s *Session) runRedial(clientDone <-chan struct{}) (*websocket.Conn, bool, string, bool) {
+	log.Printf("wsgateway: redial start sandbox=%s session=%s", s.sandboxID, s.sessionID)
+
+	inMigration := false
+	attempt := 0
+	for {
+		var delay time.Duration
+		var limit int
+		if inMigration {
+			delay = MigrationBackoff
+			limit = MigrationMaxAttempts
+		} else {
+			if attempt >= len(RedialBackoffMS) {
+				return nil, false, "", false
+			}
+			delay = RedialBackoffMS[attempt]
+			limit = len(RedialBackoffMS)
+		}
+		if attempt >= limit {
+			return nil, false, "", false
+		}
+
+		select {
+		case <-time.After(delay):
+		case <-clientDone:
+			log.Printf("wsgateway: redial: client gone during backoff sandbox=%s session=%s", s.sandboxID, s.sessionID)
+			return nil, false, "", false
+		case <-s.done:
+			return nil, false, "", false
+		}
+
+		url, token, err := s.workerWSURLFn()
+		if err != nil {
+			log.Printf("wsgateway: redial: url resolve failed sandbox=%s session=%s: %v", s.sandboxID, s.sessionID, err)
+			// Cell-CP signaling "currently migrating" → switch to the
+			// longer cadence (no point burning fast-ladder attempts at a
+			// resolve that's deterministically going to fail until the
+			// migration commits).
+			if errors.Is(err, ErrUpstreamMigrating) && !inMigration {
+				log.Printf("wsgateway: redial: cell reports migrating (resolve) — switching to migration backoff sandbox=%s", s.sandboxID)
+				inMigration = true
+				attempt = 0
+				continue
+			}
+			attempt++
+			continue
+		}
+
+		log.Printf("wsgateway: redial: attempt %d/%d sandbox=%s session=%s → %s%s",
+			attempt+1, limit, s.sandboxID, s.sessionID, url,
+			func() string {
+				if inMigration {
+					return " (migrating)"
+				}
+				return ""
+			}())
+
+		dial := DialUpstream(url, token)
+		if dial.Conn != nil {
+			log.Printf("wsgateway: redial: success on attempt %d sandbox=%s session=%s", attempt+1, s.sandboxID, s.sessionID)
+			return dial.Conn, false, "", true
+		}
+		log.Printf("wsgateway: redial: attempt %d failed — %s", attempt+1, dial.Note())
+		if dial.Terminal {
+			return nil, true, terminalReason(dial), false
+		}
+		if dial.Migrating && !inMigration {
+			log.Printf("wsgateway: redial: switching to migration backoff sandbox=%s session=%s", s.sandboxID, s.sessionID)
+			inMigration = true
+			attempt = 0
+			continue
+		}
+		attempt++
+	}
+}
+
+// recordRedial appends the current time to the recent-cycles slice and
+// returns true if we're still under the flap threshold within the
+// window. Returns false when threshold is reached → caller closes client.
+func (s *Session) recordRedial() bool {
+	s.flapMu.Lock()
+	defer s.flapMu.Unlock()
+	now := time.Now()
+	cutoff := now.Add(-RedialFlapWindow)
+	pruned := s.redialTimes[:0]
+	for _, t := range s.redialTimes {
+		if t.After(cutoff) {
+			pruned = append(pruned, t)
+		}
+	}
+	s.redialTimes = pruned
+	if len(s.redialTimes) >= RedialFlapThreshold {
+		return false
+	}
+	s.redialTimes = append(s.redialTimes, now)
+	return true
+}
+
+// Keepalive sends an empty binary frame on both ends. Called by the
+// sandbox actor's ticker every AlarmInterval. Empty frames are no-ops
+// on every receiver — see the file header in the worker handlers and
+// the agent for proof. Defends middleboxes against idle drop.
+func (s *Session) Keepalive() {
+	s.upstreamMu.RLock()
+	u := s.upstreamWS
+	s.upstreamMu.RUnlock()
+	if u != nil {
+		_ = writeOne(u, &s.upstreamMu, websocket.BinaryMessage, nil)
+	}
+	_ = writeOne(s.clientWS, &s.clientMu, websocket.BinaryMessage, nil)
+}
+
+// setUpstream swaps the bound upstream conn atomically. Old conn is NOT
+// closed here — caller decides whether the old conn is already closed
+// (the usual case after redial) or needs a goodbye frame (rare).
+func (s *Session) setUpstream(c *websocket.Conn) {
+	s.upstreamMu.Lock()
+	s.upstreamWS = c
+	s.upstreamMu.Unlock()
+}
+
+// closeClient sends a close frame to the client and tears down the
+// session. Idempotent.
+func (s *Session) closeClient(code int, reason string) {
+	s.clientMu.Lock()
+	_ = s.clientWS.WriteControl(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(code, reason),
+		time.Now().Add(time.Second),
+	)
+	s.clientMu.Unlock()
+	_ = s.clientWS.Close()
+}
+
+// upstreamClose tears down the current upstream conn (used when the
+// client disconnects so the worker also sees an upstream close).
+func (s *Session) upstreamClose(code int, reason string) {
+	s.upstreamMu.Lock()
+	u := s.upstreamWS
+	s.upstreamWS = nil
+	s.upstreamMu.Unlock()
+	if u == nil {
+		return
+	}
+	_ = u.WriteControl(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(code, reason),
+		time.Now().Add(time.Second),
+	)
+	_ = u.Close()
+}
+
+// close is the session's terminal cleanup. Closes both conns, signals
+// done, and notifies the actor so it can drop the entry.
+func (s *Session) close() {
+	s.closeOnce.Do(func() {
+		close(s.done)
+		_ = s.clientWS.Close()
+		s.upstreamMu.Lock()
+		u := s.upstreamWS
+		s.upstreamWS = nil
+		s.upstreamMu.Unlock()
+		if u != nil {
+			_ = u.Close()
+		}
+		s.actor.removeSession(s)
+	})
+}
+
+// writeOne sends a single WS message holding the given lock, with a
+// bounded deadline. Returns error on write failure or closed conn so
+// the caller can decide whether to drop, retry, or tear down. Accepts
+// sync.Locker so callers can pass either a *sync.Mutex (clientMu) or
+// the write half of a *sync.RWMutex (upstreamMu).
+func writeOne(c *websocket.Conn, mu sync.Locker, mt int, data []byte) error {
+	mu.Lock()
+	defer mu.Unlock()
+	_ = c.SetWriteDeadline(time.Now().Add(WriteTimeout))
+	return c.WriteMessage(mt, data)
+}
+
+// terminalReason maps a terminal-status DialResult into the close
+// reason string sent to the client. Mirrors the DO's wording so
+// clients that pattern-match on the reason continue to work.
+func terminalReason(dial DialResult) string {
+	if strings.Contains(strings.ToLower(dial.BodySnippet), "stopped") {
+		return "sandbox stopped"
+	}
+	if dial.Status == 0 {
+		return "cell gone"
+	}
+	return "cell " + httpStatusText(dial.Status)
+}
+
+func httpStatusText(s int) string {
+	switch s {
+	case 404:
+		return "404"
+	case 410:
+		return "410"
+	default:
+		return "unavailable"
+	}
+}

--- a/internal/wsgateway/session.go
+++ b/internal/wsgateway/session.go
@@ -230,6 +230,14 @@ func (s *Session) runRedial(clientDone <-chan struct{}) (*websocket.Conn, bool, 
 		url, token, err := s.workerWSURLFn()
 		if err != nil {
 			log.Printf("wsgateway: redial: url resolve failed sandbox=%s session=%s: %v", s.sandboxID, s.sessionID, err)
+			// Cell-CP says the sandbox is gone for good (DELETEd, stopped,
+			// errored, never existed). Close the client cleanly with the
+			// reason from the wrapped error instead of burning attempts.
+			if errors.Is(err, ErrUpstreamTerminal) {
+				reason := terminalReasonFromErr(err)
+				log.Printf("wsgateway: redial: cell reports terminal (resolve, reason=%q) — closing client sandbox=%s", reason, s.sandboxID)
+				return nil, true, reason, false
+			}
 			// Cell-CP signaling "currently migrating" → switch to the
 			// longer cadence (no point burning fast-ladder attempts at a
 			// resolve that's deterministically going to fail until the
@@ -375,6 +383,25 @@ func writeOne(c *websocket.Conn, mu sync.Locker, mt int, data []byte) error {
 	defer mu.Unlock()
 	_ = c.SetWriteDeadline(time.Now().Add(WriteTimeout))
 	return c.WriteMessage(mt, data)
+}
+
+// terminalReasonFromErr extracts a clean close-reason from an error
+// wrapped with ErrUpstreamTerminal. The wrapped echo.HTTPError carries
+// a message like "sandbox sb-xxx has been stopped" or
+// "sandbox sb-xxx not found" — we want the verb only, not the noisy
+// sandbox ID echoed back to clients. Falls back to a generic reason
+// when the wrapped error doesn't match a known shape.
+func terminalReasonFromErr(err error) string {
+	msg := err.Error()
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "stopped"):
+		return "sandbox stopped"
+	case strings.Contains(lower, "not found"):
+		return "sandbox not found"
+	default:
+		return "sandbox unavailable"
+	}
 }
 
 // terminalReason maps a terminal-status DialResult into the close

--- a/scripts/integration-tests/05-ws-multi-client.py
+++ b/scripts/integration-tests/05-ws-multi-client.py
@@ -1,0 +1,71 @@
+"""05 — Two concurrent WS sessions on the same sandbox stay independent.
+
+Validates the multi-session refactor in sandbox_ws_gateway.ts (v7). Pre-fix,
+the second WS upgrade to the same sandbox_id clobbered the first's
+clientWs/upstreamWs singletons on the DO instance — the first connection
+would silently stop receiving frames. Post-fix, each upgrade gets its own
+Session in a Set and they bridge to independent upstreams.
+
+Run with OPENCOMPUTER_API_URL + OPENCOMPUTER_API_KEY set in env.
+"""
+import asyncio
+import sys
+import time
+
+import websockets
+
+from _ws_common import create_sandbox, delete_sandbox, edge_client, open_pty
+
+
+def log(m: str) -> None:
+    print(f"[05] {time.strftime('%H:%M:%S')} {m}", flush=True)
+
+
+async def main() -> int:
+    async with edge_client() as c:
+        sb = await create_sandbox(c)
+        sid = sb["sandboxID"]
+        log(f"sandbox={sid}")
+        try:
+            pid_a, ws_a = await open_pty(c, sid)
+            pid_b, ws_b = await open_pty(c, sid)
+            log(f"opened pty_a={pid_a} pty_b={pid_b}")
+
+            sink_a, sink_b = bytearray(), bytearray()
+
+            async def drain(ws, sink):
+                while True:
+                    try:
+                        f = await asyncio.wait_for(ws.recv(), timeout=2.0)
+                    except asyncio.TimeoutError:
+                        continue
+                    except websockets.ConnectionClosed:
+                        return
+                    b = f if isinstance(f, bytes) else f.encode()
+                    if b:
+                        sink.extend(b)
+
+            da = asyncio.create_task(drain(ws_a, sink_a))
+            db = asyncio.create_task(drain(ws_b, sink_b))
+            await asyncio.sleep(1.0)
+            await ws_a.send("echo MARKER_FROM_A\n")
+            await ws_b.send("echo MARKER_FROM_B\n")
+            await asyncio.sleep(3.0)
+            da.cancel(); db.cancel()
+            await asyncio.gather(da, db, return_exceptions=True)
+            await ws_a.close(); await ws_b.close()
+
+            a_own = b"MARKER_FROM_A" in sink_a
+            b_own = b"MARKER_FROM_B" in sink_b
+            a_cross = b"MARKER_FROM_B" in sink_a
+            b_cross = b"MARKER_FROM_A" in sink_b
+            ok = a_own and b_own and not a_cross and not b_cross
+            log(f"a_own={a_own} b_own={b_own} a_cross={a_cross} b_cross={b_cross}")
+            log("PASS" if ok else "FAIL")
+            return 0 if ok else 1
+        finally:
+            await delete_sandbox(c, sid)
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/integration-tests/06-ws-exec-exit-clean.py
+++ b/scripts/integration-tests/06-ws-exec-exit-clean.py
@@ -1,0 +1,63 @@
+"""06 — Exec session that exits cleanly closes the client WS exactly once.
+
+Validates the v6 exec-exit suppression in sandbox_ws_gateway.ts. Without it,
+the DO would see the worker's clean 1000 close (sent on session.Done) as a
+transient drop, redial, reattach to the now-completed session, re-receive
+scrollback + exit byte + close 1000, redial again, etc. — an infinite loop
+that previously emitted 4000+ scrollback_end markers per session.
+
+Run with OPENCOMPUTER_API_URL + OPENCOMPUTER_API_KEY set in env.
+"""
+import asyncio
+import sys
+import time
+
+import websockets
+
+from _ws_common import create_sandbox, delete_sandbox, edge_client, open_exec
+
+
+def log(m: str) -> None:
+    print(f"[06] {time.strftime('%H:%M:%S')} {m}", flush=True)
+
+
+async def main() -> int:
+    async with edge_client() as c:
+        sb = await create_sandbox(c)
+        sid = sb["sandboxID"]
+        log(f"sandbox={sid}")
+        try:
+            _, ws = await open_exec(c, sid, "for i in $(seq 1 5); do echo OUT_$i; sleep 0.3; done")
+            scrollback_ends = 0
+            exit_markers = 0
+            close_code = close_reason = None
+            try:
+                while True:
+                    try:
+                        f = await asyncio.wait_for(ws.recv(), timeout=15.0)
+                    except asyncio.TimeoutError:
+                        log("FAIL — timeout, exec never closed cleanly")
+                        return 1
+                    b = f if isinstance(f, bytes) else f.encode()
+                    if len(b) == 1 and b[0] == 0x04:
+                        scrollback_ends += 1
+                    if len(b) == 5 and b[0] == 0x03:
+                        exit_markers += 1
+            except websockets.ConnectionClosed as e:
+                close_code = e.code; close_reason = e.reason
+
+            log(f"close=({close_code}, {close_reason!r}) scrollback_ends={scrollback_ends} exit_markers={exit_markers}")
+            ok = (
+                close_code == 1000
+                and (close_reason or "") == "exec completed"
+                and scrollback_ends == 1
+                and exit_markers == 1
+            )
+            log("PASS" if ok else "FAIL")
+            return 0 if ok else 1
+        finally:
+            await delete_sandbox(c, sid)
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/integration-tests/07-ws-pty-survives-migration.py
+++ b/scripts/integration-tests/07-ws-pty-survives-migration.py
@@ -1,0 +1,97 @@
+"""07 — PTY session survives live worker migration with the WS held open.
+
+Validates the lazy-rebind path: when the destination worker's local
+ptyManager misses for an inbound WS, handlers.go falls back to
+ptyManager.RebindFromAgent which opens a fresh agent.PTYAttach. The in-VM
+bash + PTY are preserved across the migration (the agent owns them), so the
+rebind succeeds and the user's terminal continues.
+
+Source-side ReleaseForSandbox is also exercised: without it the source
+worker's gRPC PTY stream would linger on a dead vsock and the edge DO
+would never see the upstream close that triggers the redial.
+
+Skips if the cluster has only one worker.
+
+Run with OPENCOMPUTER_API_URL + OPENCOMPUTER_API_KEY set in env.
+"""
+import asyncio
+import sys
+import time
+
+import websockets
+
+from _ws_common import create_sandbox, delete_sandbox, edge_client, list_workers, open_pty
+
+
+def log(m: str) -> None:
+    print(f"[07] {time.strftime('%H:%M:%S')} {m}", flush=True)
+
+
+async def main() -> int:
+    async with edge_client() as c:
+        sb = await create_sandbox(c)
+        sid = sb["sandboxID"]
+        src = sb["workerID"]
+        workers = await list_workers(c)
+        others = [w["worker_id"] for w in workers if w["worker_id"] != src]
+        if not others:
+            log("SKIP — only one worker in the cluster")
+            await delete_sandbox(c, sid)
+            return 0
+        tgt = others[0]
+        log(f"sandbox={sid} src={src} tgt={tgt}")
+        try:
+            _, ws = await open_pty(c, sid)
+            sink = bytearray()
+            closed: tuple | None = None
+
+            async def reader():
+                nonlocal closed
+                while True:
+                    try:
+                        f = await asyncio.wait_for(ws.recv(), timeout=2.0)
+                    except asyncio.TimeoutError:
+                        continue
+                    except websockets.ConnectionClosed as e:
+                        closed = (e.code, e.reason)
+                        return
+                    b = f if isinstance(f, bytes) else f.encode()
+                    if b:
+                        sink.extend(b)
+
+            rt = asyncio.create_task(reader())
+            await ws.send("echo PRE_MIG && echo H > /tmp/x\n")
+            await asyncio.sleep(2)
+            r = await c.post(f"/api/sandboxes/{sid}/migrate", json={"targetWorker": tgt}, timeout=120)
+            log(f"migrate {r.status_code} ms={r.json().get('elapsedMs')}")
+
+            # Retry POST_MIG send for up to 30s — covers the DO redial window
+            # during which client→upstream frames are dropped.
+            deadline = time.time() + 30
+            while time.time() < deadline:
+                if b"POST_MIG" in sink: break
+                if closed:
+                    log(f"FAIL — WS dropped during migration: {closed}")
+                    rt.cancel(); return 1
+                try:
+                    await ws.send("cat /tmp/x && echo POST_MIG\n")
+                except Exception:
+                    pass
+                await asyncio.sleep(3)
+            rt.cancel()
+            try: await ws.close()
+            except: pass
+
+            pre = b"PRE_MIG" in sink
+            post = b"POST_MIG" in sink
+            file_ok = b"H\r" in sink or b"H\n" in sink
+            log(f"pre={pre} post={post} file={file_ok} closed={closed}")
+            ok = pre and post and file_ok and closed is None
+            log("PASS" if ok else "FAIL")
+            return 0 if ok else 1
+        finally:
+            await delete_sandbox(c, sid)
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/integration-tests/08-ws-exec-survives-migration.py
+++ b/scripts/integration-tests/08-ws-exec-survives-migration.py
@@ -1,0 +1,97 @@
+"""08 — Exec session survives live worker migration.
+
+Same lazy-rebind path as 07, but for ExecSessionAttach. Requires the
+matching pieces:
+  - ExecSessionHandle.Cancel + ExecSessionManager.ReleaseForSandbox so the
+    source worker's gRPC stream is canceled on outgoing migration (without
+    this, the worker's exec WS handler stays blocked on the scrollback
+    subscription and the DO never sees an upstream close).
+  - handlers.go exec WS handler skips emitting the 0x03 exit marker when
+    ExitCode is nil (without this, a cancel looks like a process exit to
+    the edge DO and triggers "exec completed" close instead of redial).
+
+Skips if the cluster has only one worker.
+
+Run with OPENCOMPUTER_API_URL + OPENCOMPUTER_API_KEY set in env.
+"""
+import asyncio
+import re
+import sys
+import time
+
+import websockets
+
+from _ws_common import create_sandbox, delete_sandbox, edge_client, list_workers, open_exec
+
+
+def log(m: str) -> None:
+    print(f"[08] {time.strftime('%H:%M:%S')} {m}", flush=True)
+
+
+async def main() -> int:
+    async with edge_client() as c:
+        sb = await create_sandbox(c)
+        sid = sb["sandboxID"]
+        src = sb["workerID"]
+        workers = await list_workers(c)
+        others = [w["worker_id"] for w in workers if w["worker_id"] != src]
+        if not others:
+            log("SKIP — only one worker in the cluster")
+            await delete_sandbox(c, sid)
+            return 0
+        tgt = others[0]
+        log(f"sandbox={sid} src={src} tgt={tgt}")
+        try:
+            _, ws = await open_exec(c, sid, "for i in $(seq 1 30); do echo OUT_$i; sleep 1; done")
+            seen: dict[int, int] = {}
+            closed: tuple | None = None
+            scrollback_ends = 0
+            t0 = time.time()
+            events: list[tuple[float, str]] = []
+
+            async def reader():
+                nonlocal closed, scrollback_ends
+                while True:
+                    try:
+                        f = await asyncio.wait_for(ws.recv(), timeout=2.0)
+                    except asyncio.TimeoutError:
+                        continue
+                    except websockets.ConnectionClosed as e:
+                        closed = (e.code, e.reason)
+                        return
+                    b = f if isinstance(f, bytes) else f.encode()
+                    if not b: continue
+                    if len(b) == 1 and b[0] == 0x04:
+                        scrollback_ends += 1
+                        events.append((time.time() - t0, "scrollback_end"))
+                        continue
+                    payload = b[1:] if (len(b) >= 1 and b[0] in (0x01, 0x02)) else b
+                    for m in re.findall(rb"OUT_(\d+)", payload):
+                        n = int(m)
+                        if n not in seen:
+                            events.append((time.time() - t0, f"OUT_{n}"))
+                        seen[n] = seen.get(n, 0) + 1
+
+            rt = asyncio.create_task(reader())
+            await asyncio.sleep(5)
+            r = await c.post(f"/api/sandboxes/{sid}/migrate", json={"targetWorker": tgt}, timeout=120)
+            log(f"migrate {r.status_code} ms={r.json().get('elapsedMs')}")
+
+            await asyncio.sleep(35)  # let the 30s loop finish + headroom
+            rt.cancel()
+            try: await ws.close()
+            except: pass
+
+            log(f"unique OUT_ markers: {len(seen)}/30 scrollback_ends={scrollback_ends} close={closed}")
+            pre_mig = any(t < 5.5 and ev.startswith("OUT_") for t, ev in events)
+            post_mig = any(t > 7.0 and ev.startswith("OUT_") for t, ev in events)
+            ok = pre_mig and post_mig and closed is not None and closed[0] == 1000
+            log(f"pre_mig={pre_mig} post_mig={post_mig}")
+            log("PASS" if ok else "FAIL")
+            return 0 if ok else 1
+        finally:
+            await delete_sandbox(c, sid)
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/integration-tests/README.md
+++ b/scripts/integration-tests/README.md
@@ -1,20 +1,39 @@
-# Integration tests for fork/hibernate/wake fixes
+# Integration tests
 
-One test per fix in PR #128. Each test is self-contained, creates its own
-resources, cleans up in finally, and exits non-zero on regression.
+Each test is self-contained, creates its own resources, cleans up in finally,
+and exits non-zero on regression. 01-04 are TypeScript SDK tests for the
+fork/hibernate/wake fixes in PR #128. 05-08 are Python tests for the
+WS-via-DO + migration-survival work in PR #350 — they hit the edge directly
+with httpx + websockets so they exercise the actual `/api/sandboxes/...`
+edge routes (the SDK takes a different path for PTY/exec WS).
 
-| # | Test file                                 | Validates                                                                                   | Commit  |
-| - | ----------------------------------------- | ------------------------------------------------------------------------------------------- | ------- |
-| 1 | `01-fork-sync-hibernate.ts`               | `createFromCheckpoint` blocks until worker has the VM registered (no "sandbox not found")  | 08d5320 |
-| 2 | `02-fork-no-corruption.ts`                | Forks from savevm-based checkpoints have correct workspace state (no EBADMSG / git segv)   | 1caf148 + b2aa416 |
-| 3 | `03-hibernate-wake-routing.ts`            | Data-plane requests route to the current worker after wake (no "auto-wake failed")         | f4e3600 |
-| 4 | `04-hibernate-wake-data-preserved.ts`     | Wake does not shadow `/home/sandbox` with an empty mount; all files are readable post-wake | 9f550e2 |
+| # | Test file                                  | Validates                                                                                                                    | PR     |
+| - | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | ------ |
+| 1 | `01-fork-sync-hibernate.ts`                | `createFromCheckpoint` blocks until worker has the VM registered (no "sandbox not found")                                    | #128   |
+| 2 | `02-fork-no-corruption.ts`                 | Forks from savevm-based checkpoints have correct workspace state (no EBADMSG / git segv)                                     | #128   |
+| 3 | `03-hibernate-wake-routing.ts`             | Data-plane requests route to the current worker after wake (no "auto-wake failed")                                           | #128   |
+| 4 | `04-hibernate-wake-data-preserved.ts`      | Wake does not shadow `/home/sandbox` with an empty mount; all files are readable post-wake                                   | #128   |
+| 5 | `05-ws-multi-client.py`                    | Two concurrent PTYs on the same sandbox don't clobber each other (DO Session-set refactor)                                   | #350   |
+| 6 | `06-ws-exec-exit-clean.py`                 | An exec that exits cleanly closes the WS with `1000 'exec completed'` exactly once — no post-completion redial loop          | #350   |
+| 7 | `07-ws-pty-survives-migration.py`          | Live worker migration with a PTY WS held open: client never closes, file written pre-mig is readable post-mig (lazy rebind)  | #350   |
+| 8 | `08-ws-exec-survives-migration.py`         | Live migration of an exec session: output continues through the migration window, final close is the real `exec completed`  | #350   |
 
 ## Running
+
+TypeScript:
 
 ```
 OPENCOMPUTER_API_URL=... OPENCOMPUTER_API_KEY=... \
   npx tsx scripts/integration-tests/01-fork-sync-hibernate.ts
 ```
 
-Each script exits 0 on success, 1 on any failure.
+Python (requires `httpx` and `websockets`):
+
+```
+OPENCOMPUTER_API_URL=... OPENCOMPUTER_API_KEY=... \
+  python3 scripts/integration-tests/05-ws-multi-client.py
+```
+
+Each script exits 0 on success, 1 on any failure. The Python tests share a
+small `_ws_common.py` helper for env-var resolution and sandbox/session
+setup; each test file stays focused on the assertion it's checking.

--- a/scripts/integration-tests/_ws_common.py
+++ b/scripts/integration-tests/_ws_common.py
@@ -1,0 +1,88 @@
+"""Shared helpers for the WS edge integration tests (05-08).
+
+Reads OPENCOMPUTER_API_URL + OPENCOMPUTER_API_KEY from env. Exits 2 with a
+useful message if either is missing so the tests don't surface NameErrors.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from contextlib import asynccontextmanager
+
+import httpx
+import websockets
+
+
+def _env(name: str) -> str:
+    v = os.environ.get(name)
+    if not v:
+        print(
+            f"missing required env var {name}; "
+            "set OPENCOMPUTER_API_URL + OPENCOMPUTER_API_KEY (see scripts/integration-tests/README.md)",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return v
+
+
+API_URL = _env("OPENCOMPUTER_API_URL").rstrip("/")
+API_KEY = _env("OPENCOMPUTER_API_KEY")
+WS_URL = API_URL.replace("https://", "wss://").replace("http://", "ws://")
+
+
+@asynccontextmanager
+async def edge_client():
+    """httpx client preconfigured against the edge with the API key."""
+    headers = {"X-API-Key": API_KEY, "content-type": "application/json"}
+    async with httpx.AsyncClient(base_url=API_URL, headers=headers, timeout=60.0) as c:
+        yield c
+
+
+async def create_sandbox(client: httpx.AsyncClient, template: str = "base", timeout_s: int = 3600) -> dict:
+    r = await client.post("/api/sandboxes", json={"templateID": template, "timeout": timeout_s})
+    r.raise_for_status()
+    return r.json()
+
+
+async def delete_sandbox(client: httpx.AsyncClient, sandbox_id: str) -> None:
+    try:
+        await client.delete(f"/api/sandboxes/{sandbox_id}")
+    except Exception:
+        # best-effort cleanup; test result has already been decided
+        pass
+
+
+async def list_workers(client: httpx.AsyncClient) -> list[dict]:
+    r = await client.get("/api/workers")
+    r.raise_for_status()
+    return r.json()
+
+
+async def open_pty(client: httpx.AsyncClient, sandbox_id: str, cols: int = 80, rows: int = 24):
+    """POST /pty to create a session, then upgrade WS to /pty/{session_id}.
+    Returns (session_id, websocket)."""
+    pty = (await client.post(
+        f"/api/sandboxes/{sandbox_id}/pty",
+        json={"cols": cols, "rows": rows},
+    )).json()
+    sid = pty["sessionID"]
+    ws = await websockets.connect(
+        f"{WS_URL}/api/sandboxes/{sandbox_id}/pty/{sid}?api_key={API_KEY}",
+        additional_headers={"X-API-Key": API_KEY},
+    )
+    return sid, ws
+
+
+async def open_exec(client: httpx.AsyncClient, sandbox_id: str, shell_cmd: str):
+    """POST /exec to spawn `bash -lc <shell_cmd>`, then upgrade WS to
+    /exec/{session_id}. Returns (session_id, websocket)."""
+    es = (await client.post(
+        f"/api/sandboxes/{sandbox_id}/exec",
+        json={"cmd": "bash", "args": ["-lc", shell_cmd]},
+    )).json()
+    sid = es["sessionID"]
+    ws = await websockets.connect(
+        f"{WS_URL}/api/sandboxes/{sandbox_id}/exec/{sid}?api_key={API_KEY}",
+        additional_headers={"X-API-Key": API_KEY},
+    )
+    return sid, ws


### PR DESCRIPTION
## Summary
  
  Adds a per-cell WebSocket broker — `internal/wsgateway` — that sits between
  clients (SDK, dashboard) and workers for all PTY, exec, and agent
  WebSocket traffic. Replaces the legacy `SandboxAPIProxy.doWebSocket`
  hijack-and-`io.Copy` path with multi-session, redial on upstream close,
  keepalive, exec-exit suppression, migration-aware backoff, and a flap
  circuit breaker.

  This is the cell-only design we chose over a CloudFlare Durable Object:
  the broker layer structurally belongs where the worker is (the cell), not
  at the edge. Same broker code now handles hosted and self-hosted cells
  with no divergence.

  ## Architecture
  
  ```
  Client ──WS── CF Worker ──WS── Cell-CP broker ──WS── Worker ──gRPC── Agent (in-VM)
                    │                    │                  │
                auth, cell           redial,            handlers.go,
                lookup,              keepalive,         RebindFromAgent,
                cap-token            exec-exit,         (unchanged)
                mint,                multi-session,
                transparent          flap breaker,
                forward              migration-aware
                                     backoff
  ```

  CF Worker becomes a thin auth + cell-routing layer that transparently
  forwards the WS upgrade. Both `proxyToCellSDK` (SDK path) and `proxyWebSocket`
  (dashboard path) now forward — the dashboard's previous 120-LOC edge-side
  `WebSocketPair` bridge is gone, which was the only thing keeping the
  dashboard from getting broker benefits.

  ## What the broker does
  
  Per-sandbox actor goroutine (created on first session, released when
  idle) holding:

  - **Set of sessions** — multiple concurrent WSes per sandbox (dashboard +
    SDK, two dashboard tabs) each get their own `Session` instance.
  - **Per-session redial loop** with exponential backoff (250 ms → 4 s ×
    10). On upstream close, re-resolves the worker URL and re-dials. Client
    WS stays open across the redial window.
  - **Migration-aware cadence** — when the cell-CP returns `503 migrating`
    during resolve, switch to a steadier 2 s × 30 (~60 s budget) instead of
    burning the fast ladder.
  - **Terminal-aware close** — when the cell-CP returns `404 not found` or
    `410 stopped`, close client with `1000 / "sandbox stopped"` (or
    equivalent) instead of cycling redials.
  - **Exec-exit marker tracking** — the worker emits a 5-byte `0x03 +
    exitCode` frame before closing a completed exec session; broker
    recognizes it and closes the client with `1000 / "exec completed"`
    instead of redialing into a now-done session.
  - **30 s keepalive** — empty binary frame on both client and upstream every
    alarm tick. Defends the cell ↔ worker hop against any long-idle
    middlebox drops; empty frames are no-ops on every receiver.
  - **Flap circuit breaker** — > 3 redial cycles within 60 s closes the
    client with `1011 / "upstream flapping"`. Prevents a buggy upstream from
    burning resources indefinitely.

  ## Worker-side foundation (cherry-picked from PR #350)

  The Go broker depends on worker-side changes that make session state
  survive worker swaps. These are cherry-picked into this branch:

  - `PTYManager.RebindFromAgent` + `ExecSessionManager.RebindFromAgent`:
    lazy reattach to the in-VM agent when the worker's local cache misses
    (live migration or worker process restart).
  - `PTYManager.ReleaseForSandbox` + `ExecSessionManager.ReleaseForSandbox`:
    source-side handle release on outgoing migration, without killing the
    in-VM session.
  - `SetMigrationOutgoingCallback` on the QEMU manager + matching wiring in
    `cmd/worker/main.go`.
  - Exec WS handler skips the fake `0x03` exit marker when `ExitCode` is
    nil (i.e. cancel-during-migration vs real process exit).

  No agent changes, no proto changes. Lazy rebind uses the existing
  `PTYAttach` / `ExecSessionAttach` RPCs.

  ## What this means for users

  - **Worker restarts** become invisible if the VM survives them (same
    session ID rebinds against the in-VM agent on whichever worker now
    hosts the VM).
  - **Live migrations** transparent end-to-end: client typing through the
    migration window pauses for the redial duration (sub-second to a few
    seconds) then resumes. Same shell, same bash PID, same `/tmp` contents.
  - **Multiple dashboards or dashboard + SDK** on the same sandbox stop
    clobbering each other.
  - **Long-idle PTYs** don't get dropped by middlebox idle timeouts.
  - **Exec completion** closes cleanly with the right exit code instead of
    spinning into a redial loop.
  - **`DELETE /api/sandboxes/{id}`** while a client is connected closes the
    WS cleanly with `code=1000 reason='sandbox stopped'`.

  ## Tested
  
  In-repo integration tests in `scripts/integration-tests/05-08*.py`. All
  four pass end-to-end against dev:

  | # | Test | Verifies |
  |---|---|---|
  | 05 | `ws-multi-client.py` | Two concurrent PTYs on the same sandbox stay independent |
  | 06 | `ws-exec-exit-clean.py` | Exec exit closes WS once (one scrollback_end, one exit marker, `1000 'exec completed'`) — pre-fix logged 4000+ 
  scrollback ends in a redial loop |
  | 07 | `ws-pty-survives-migration.py` | PTY survives `POST /migrate` with WS held open; file written pre-mig readable post-mig |
  | 08 | `ws-exec-survives-migration.py` | Exec output stream continues through migration; final close is the real `exec completed` |

  Plus manual scenarios verified:

  - 90 s idle PTY held cleanly with broker keepalive frames at t=30 s and
    t=60 s
  - `DELETE` mid-session closes with `1000 'sandbox stopped'` (verified
    directly via `/tmp/verify_terminal_close.py`)
  - Long-running exec (90 s) with no spurious redial / scrollback re-send
    loop

  ## Files

  ```
  internal/wsgateway/         880 LOC  — the broker (4 files, new)
  internal/api/ws_broker.go   159 LOC  — route handler
  internal/proxy/sandbox_api_proxy.go +85  — public ResolveWorker
  internal/api/router.go      +27 -2   — wire wsGateway, dynamic dispatch
  cmd/server/main.go          +9       — always initialize the broker

  internal/sandbox/{pty,exec_session}.go  +143 -8  — worker rebind + release + cancel
  internal/qemu/manager.go              +14 -1     — migration callback
  internal/qemu/migration.go            +8         — fire callback
  internal/worker/handlers.go           +30 -9     — cache-miss → rebind, exit-marker fix
  cmd/worker/main.go                    +137 -5    — factories + plumbing

  cloudflare-workers/api-edge/src/dashboard.ts  +22 -124  — drop edge-side bridge

  scripts/integration-tests/05-08*.py + _ws_common.py + README  +435 LOC  — tests
  ```

  Total: +1957 / -159.
  
  ## Out of scope

  - **Cross-cell migration** — today's `/migrate` is within-cell. Code path
    exists (broker re-resolves cell on every redial) but no end-to-end test.
  - **Worker process restart end-to-end test** — architecturally identical
    to migration (empty local map → lazy rebind picks up).
  - **Deleting `SandboxAPIProxy.doWebSocket`** — the legacy hijack path is
    unreachable now but still in the tree (~100 LOC). Can be removed in a
    follow-up after some prod burn-in.

  ## Rollback

  `git revert + redeploy`. There's no env-var gate — the broker is the
  canonical WS path. Same operational story as for any other commit.