### PR TITLE
Close pending gap

### DIFF
--- a/cloudflare-workers/events-ingest/src/index.ts
+++ b/cloudflare-workers/events-ingest/src/index.ts
@@ -375,15 +375,15 @@ export default {
        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
        ON CONFLICT(id) DO NOTHING`,
     );
-    // Worker-validation guard. Drop a usage_tick if the emitting worker is NOT
-    // the sandbox's current owner in sandboxes_index, or the sandbox is already
-    // terminal there. This stops a zombie / migration-source / deregistered
-    // worker from billing a sandbox it no longer owns — the leak that silently
-    // 3×'d an org's edge usage when a stuck `-incoming` migration shell kept
-    // ticking after the sandbox had moved away. The cell never had this bug
-    // (scale_events are per-sandbox), but the edge inserted every tick blindly.
-    // Lookup failure → allow (degraded, no worse than before). A sandbox with no
-    // index row yet (create race) is allowed.
+    // Worker-validation guard. Edge usage is counted per-tick (one usage_sample
+    // per emitted tick), so a worker that is no longer the sandbox's owner — a
+    // migration source, a deregistered worker, or an abandoned `-incoming`
+    // receiver — must not contribute usage. Drop a usage_tick when the emitting
+    // worker is not the sandbox's current owner in sandboxes_index, or the
+    // sandbox is already terminal there. (The cell side needs no equivalent: its
+    // scale_events are keyed per-sandbox, not per-tick.) Lookup failure → allow
+    // (degraded, never blocks billing). A sandbox with no index row yet (create
+    // race) is allowed.
     const tickSandboxIds = [
       ...new Set(fresh.filter((e) => e.type === "usage_tick" && e.sandbox_id).map((e) => e.sandbox_id as string)),
     ];

--- a/cloudflare-workers/events-ingest/src/index.ts
+++ b/cloudflare-workers/events-ingest/src/index.ts
@@ -375,8 +375,37 @@ export default {
        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
        ON CONFLICT(id) DO NOTHING`,
     );
+    // Worker-validation guard. Drop a usage_tick if the emitting worker is NOT
+    // the sandbox's current owner in sandboxes_index, or the sandbox is already
+    // terminal there. This stops a zombie / migration-source / deregistered
+    // worker from billing a sandbox it no longer owns — the leak that silently
+    // 3×'d an org's edge usage when a stuck `-incoming` migration shell kept
+    // ticking after the sandbox had moved away. The cell never had this bug
+    // (scale_events are per-sandbox), but the edge inserted every tick blindly.
+    // Lookup failure → allow (degraded, no worse than before). A sandbox with no
+    // index row yet (create race) is allowed.
+    const tickSandboxIds = [
+      ...new Set(fresh.filter((e) => e.type === "usage_tick" && e.sandbox_id).map((e) => e.sandbox_id as string)),
+    ];
+    const owners = await resolveSandboxOwners(env, tickSandboxIds);
+    const TERMINAL_STATUSES = new Set(["stopped", "terminated", "failed", "error"]);
+    let droppedZombieTicks = 0;
+    const tickFromCurrentWorker = (e: SandboxEventEnvelope): boolean => {
+      if (!owners.ok) return true;
+      const row = e.sandbox_id ? owners.byId.get(e.sandbox_id) : undefined;
+      if (!row) return true; // no index row yet — don't drop a legit fresh create
+      if (TERMINAL_STATUSES.has(row.status)) {
+        droppedZombieTicks++;
+        return false;
+      }
+      if (row.worker_id && e.worker_id && row.worker_id !== e.worker_id) {
+        droppedZombieTicks++;
+        return false;
+      }
+      return true;
+    };
     const usageSampleBatches = fresh
-      .filter((e) => e.type === "usage_tick" && planFor(e) === "pro" && e.org_id && e.sandbox_id)
+      .filter((e) => e.type === "usage_tick" && planFor(e) === "pro" && e.org_id && e.sandbox_id && tickFromCurrentWorker(e))
       .map((e) => {
         const p = (e.payload ?? {}) as {
           memory_mb?: number;
@@ -394,6 +423,10 @@ export default {
           e.cell_id,
         );
       });
+
+    if (droppedZombieTicks > 0) {
+      console.warn(`events-ingest: dropped ${droppedZombieTicks} usage_tick(s) from non-owner/terminal sandboxes (zombie-tick guard)`);
+    }
 
     try {
       await env.OPENCOMPUTER_DB.batch([...batches, ...capacityBatches, ...lifecycleBatches, ...checkpointBatches, ...imageBatches, ...usageSampleBatches]);
@@ -471,6 +504,34 @@ async function fanoutDebits(env: Env, events: SandboxEventEnvelope[]): Promise<v
 // lookup fails, signalling callers to fall back to the envelope plan rather
 // than dropping billing entirely. Orgs absent from D1 (new-org race) are simply
 // missing from the map → treated as unknown plan → skipped, the safe default.
+// resolveSandboxOwners fetches each sandbox's current worker_id + status from
+// the D1 sandboxes_index, so the usage-tick guard can reject ticks from a worker
+// that no longer owns the sandbox (migration source / zombie) or for a sandbox
+// that's already terminal. Lookup failure returns ok:false so the caller allows
+// the ticks (degraded, never blocks billing on a transient D1 error).
+async function resolveSandboxOwners(
+  env: Env,
+  sandboxIds: string[],
+): Promise<{ ok: boolean; byId: Map<string, { worker_id: string; status: string }> }> {
+  const byId = new Map<string, { worker_id: string; status: string }>();
+  if (sandboxIds.length === 0) return { ok: true, byId };
+  const placeholders = sandboxIds.map((_, i) => `?${i + 1}`).join(",");
+  try {
+    const res = await env.OPENCOMPUTER_DB.prepare(
+      `SELECT id, worker_id, status FROM sandboxes_index WHERE id IN (${placeholders})`,
+    )
+      .bind(...sandboxIds)
+      .all<{ id: string; worker_id: string | null; status: string | null }>();
+    for (const r of res.results ?? []) {
+      byId.set(r.id, { worker_id: r.worker_id ?? "", status: r.status ?? "" });
+    }
+    return { ok: true, byId };
+  } catch (err) {
+    console.error("events-ingest: sandbox owner lookup failed — allowing ticks", err);
+    return { ok: false, byId };
+  }
+}
+
 async function resolvePlans(
   env: Env,
   orgIds: string[],

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -585,6 +585,21 @@ func main() {
 					log.Printf("maintenance: reverted %d stale migrations", recovered)
 				}
 
+				// Stale-pending reaper: a create stuck in 'pending' past the
+				// threshold (even on a still-live worker, which MarkOrphanedSandboxes
+				// below can't catch) is closed → 'failed', ending the open
+				// scale_event that would otherwise bill 1 GB forever. Publishes
+				// 'stopped' to the edge so D1 / usage_samples stop too.
+				if stale, err := opts.Store.ReapStalePendingSessions(ctx, 15*time.Minute); err != nil {
+					log.Printf("maintenance: stale-pending reap error: %v", err)
+					observability.CaptureError(err, "area", "maintenance", "op", "reap_stale_pending")
+				} else if len(stale) > 0 {
+					log.Printf("maintenance: reaped %d stale-pending sandboxes (failed → billing closed)", len(stale))
+					if redisRegistry.RedisClient() != nil && cfg.CellID != "" {
+						publishStoppedFromMaintenance(ctx, redisRegistry.RedisClient(), cfg.CellID, stale)
+					}
+				}
+
 				// DB/worker reconciliation: mark sandboxes on dead workers as error
 				liveWorkers := make(map[string]bool)
 				for _, w := range redisRegistry.GetAllWorkers() {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -587,9 +587,9 @@ func main() {
 
 				// Stale-pending reaper: a create stuck in 'pending' past the
 				// threshold (even on a still-live worker, which MarkOrphanedSandboxes
-				// below can't catch) is closed → 'failed', ending the open
-				// scale_event that would otherwise bill 1 GB forever. Publishes
-				// 'stopped' to the edge so D1 / usage_samples stop too.
+				// below does not cover) is closed → 'failed', ending the open
+				// scale_event that would otherwise keep billing. Publishes 'stopped'
+				// to the edge so D1 / usage_samples stop too.
 				if stale, err := opts.Store.ReapStalePendingSessions(ctx, 15*time.Minute); err != nil {
 					log.Printf("maintenance: stale-pending reap error: %v", err)
 					observability.CaptureError(err, "area", "maintenance", "op", "reap_stale_pending")
@@ -620,6 +620,28 @@ func main() {
 					if redisRegistry.RedisClient() != nil && cfg.CellID != "" {
 						publishStoppedFromMaintenance(ctx, redisRegistry.RedisClient(), cfg.CellID, orphans)
 					}
+				}
+			}
+		})
+	}
+
+	// Periodic reverse-reconcile. The rejoin-triggered ReconcileRunningOnWorker
+	// only fires when a worker reconnects; a worker that is deleted and never
+	// rejoins would leave its sandboxes 'running' (cell + edge sandboxes_index)
+	// with no event ever correcting them. Sweep every live worker every few
+	// minutes and close any sandbox the cell thinks is running that the worker no
+	// longer actually has (confirmed via the worker's ListSandboxes RPC, which
+	// publishes 'stopped' to the edge). This keeps the edge index — the post-
+	// cutover billing authority — accurate even when no 'stopped' event fired.
+	if opts.Store != nil && redisRegistry != nil {
+		observability.Go("periodic-running-reconcile", func() {
+			ticker := time.NewTicker(3 * time.Minute)
+			defer ticker.Stop()
+			for range ticker.C {
+				for _, w := range redisRegistry.GetAllWorkers() {
+					rctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+					controlplane.ReconcileRunningOnWorker(rctx, redisRegistry, opts.Store, cfg.CellID, w.ID)
+					cancel()
 				}
 			}
 		})

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -52,7 +52,10 @@ type TerminalHook func(sandboxID string, orgID uuid.UUID, status, reason string)
 // terminal status without classifying it here is the easy regression.
 func isTerminalSessionStatus(status string) bool {
 	switch status {
-	case "stopped", "error", "failed":
+	// `terminated` is a legacy status no current path writes, but classify it as
+	// terminal anyway: it keeps the cell consistent with the edge guard (which
+	// treats it as terminal) and ensures any future writer stops billing.
+	case "stopped", "error", "failed", "terminated":
 		return true
 	default:
 		return false
@@ -1015,11 +1018,11 @@ func (s *Store) RecoverStaleMigrations(ctx context.Context, maxAge time.Duration
 // loop's PG sweep would never reach D1 sandboxes_index, which is exactly
 // the post-cutover ghost-row bug.
 func (s *Store) MarkOrphanedSandboxes(ctx context.Context, liveWorkers map[string]bool) ([]OrphanedSandbox, error) {
-	// Include 'pending' as well as 'running': a sandbox whose create never
-	// reached running (stuck pending) on a worker that then disappeared used to
-	// slip through here — its scale_event stayed open and billed forever (the
-	// orphaned-pending leak). 'pending' on a *live* worker is left alone (it may
-	// still be mid-create); only pending rows on a dead worker are reaped.
+	// Include 'pending' as well as 'running': a create that never reached
+	// running (still 'pending') on a worker that has since disappeared must also
+	// be closed, since its scale_event is open and would keep billing. 'pending'
+	// on a *live* worker is left alone (it may still be mid-create); only pending
+	// rows on a dead worker are reaped.
 	rows, err := s.pool.Query(ctx,
 		`SELECT DISTINCT worker_id FROM sandbox_sessions WHERE status IN ('running', 'pending')`)
 	if err != nil {
@@ -1083,12 +1086,12 @@ func (s *Store) MarkOrphanedSandboxes(ctx context.Context, liveWorkers map[strin
 }
 
 // ReapStalePendingSessions terminates sandbox sessions stuck in 'pending' past
-// olderThan, closing their open scale_events. This is the backstop for the
-// orphaned-pending billing leak that MarkOrphanedSandboxes can't catch: a create
-// that hangs in 'pending' on a worker that is STILL alive (so it's never an
-// orphan) — without this it bills 1 GB forever. Returns the reaped rows so the
-// caller can publish 'stopped' to the edge. Marked 'failed' (the create never
-// succeeded) rather than 'error'; both are terminal and stop billing.
+// olderThan, closing their open scale_events. It complements MarkOrphanedSandboxes,
+// which only reaps sandboxes on dead workers: a create that hangs in 'pending' on
+// a worker that is STILL alive is never an orphan, so its open scale_event needs
+// this age-based backstop to stop billing. Returns the reaped rows so the caller
+// can publish 'stopped' to the edge. Marked 'failed' (the create never
+// succeeded), which is terminal and closes billing.
 func (s *Store) ReapStalePendingSessions(ctx context.Context, olderThan time.Duration) ([]OrphanedSandbox, error) {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1015,8 +1015,13 @@ func (s *Store) RecoverStaleMigrations(ctx context.Context, maxAge time.Duration
 // loop's PG sweep would never reach D1 sandboxes_index, which is exactly
 // the post-cutover ghost-row bug.
 func (s *Store) MarkOrphanedSandboxes(ctx context.Context, liveWorkers map[string]bool) ([]OrphanedSandbox, error) {
+	// Include 'pending' as well as 'running': a sandbox whose create never
+	// reached running (stuck pending) on a worker that then disappeared used to
+	// slip through here — its scale_event stayed open and billed forever (the
+	// orphaned-pending leak). 'pending' on a *live* worker is left alone (it may
+	// still be mid-create); only pending rows on a dead worker are reaped.
 	rows, err := s.pool.Query(ctx,
-		`SELECT DISTINCT worker_id FROM sandbox_sessions WHERE status = 'running'`)
+		`SELECT DISTINCT worker_id FROM sandbox_sessions WHERE status IN ('running', 'pending')`)
 	if err != nil {
 		return nil, err
 	}
@@ -1044,7 +1049,7 @@ func (s *Store) MarkOrphanedSandboxes(ctx context.Context, liveWorkers map[strin
 		}
 		upd, err := tx.Query(ctx,
 			`UPDATE sandbox_sessions SET status = 'error', error_msg = 'worker lost', stopped_at = now()
-			 WHERE worker_id = $1 AND status = 'running'
+			 WHERE worker_id = $1 AND status IN ('running', 'pending')
 			 RETURNING sandbox_id, org_id, worker_id`, workerID)
 		if err != nil {
 			tx.Rollback(ctx)
@@ -1075,6 +1080,52 @@ func (s *Store) MarkOrphanedSandboxes(ctx context.Context, liveWorkers map[strin
 		orphans = append(orphans, batchOrphans...)
 	}
 	return orphans, nil
+}
+
+// ReapStalePendingSessions terminates sandbox sessions stuck in 'pending' past
+// olderThan, closing their open scale_events. This is the backstop for the
+// orphaned-pending billing leak that MarkOrphanedSandboxes can't catch: a create
+// that hangs in 'pending' on a worker that is STILL alive (so it's never an
+// orphan) — without this it bills 1 GB forever. Returns the reaped rows so the
+// caller can publish 'stopped' to the edge. Marked 'failed' (the create never
+// succeeded) rather than 'error'; both are terminal and stop billing.
+func (s *Store) ReapStalePendingSessions(ctx context.Context, olderThan time.Duration) ([]OrphanedSandbox, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	upd, err := tx.Query(ctx,
+		`UPDATE sandbox_sessions SET status = 'failed', error_msg = 'stale_pending', stopped_at = now()
+		 WHERE status = 'pending' AND started_at < now() - $1::interval
+		 RETURNING sandbox_id, org_id, worker_id`,
+		fmt.Sprintf("%d seconds", int(olderThan.Seconds())))
+	if err != nil {
+		return nil, fmt.Errorf("reap stale pending: %w", err)
+	}
+	var reaped []OrphanedSandbox
+	for upd.Next() {
+		var o OrphanedSandbox
+		if err := upd.Scan(&o.SandboxID, &o.OrgID, &o.WorkerID); err == nil {
+			reaped = append(reaped, o)
+		}
+	}
+	upd.Close()
+	if len(reaped) == 0 {
+		return nil, tx.Commit(ctx)
+	}
+	ids := make([]string, len(reaped))
+	for i, o := range reaped {
+		ids[i] = o.SandboxID
+	}
+	if err := closeOpenScaleEventsForSandboxes(ctx, tx, ids); err != nil {
+		return nil, fmt.Errorf("reap stale pending: close scale events: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return reaped, nil
 }
 
 func (s *Store) GetSandboxSession(ctx context.Context, sandboxID string) (*SandboxSession, error) {

--- a/internal/db/terminal_status_test.go
+++ b/internal/db/terminal_status_test.go
@@ -9,7 +9,7 @@ import "testing"
 // "killed") without listing it here is the easy regression that would silently
 // leave it billing on the edge.
 func TestIsTerminalSessionStatus(t *testing.T) {
-	terminal := []string{"stopped", "error", "failed"}
+	terminal := []string{"stopped", "error", "failed", "terminated"}
 	notTerminal := []string{"running", "pending", "migrating", "hibernated", "woke", "", "unknown"}
 
 	for _, s := range terminal {

--- a/internal/qemu/ghost_reaper.go
+++ b/internal/qemu/ghost_reaper.go
@@ -37,9 +37,9 @@ const reaperInterval = 30 * time.Second
 // and the ghost-reaper can't drain the m.vms entry.
 //
 // Three checks in order:
-//   1. ProcessState — if cmd.Wait() returned, definitively dead.
-//   2. /proc/<pid>/stat — if state is Z (zombie) or X (dying), treat as dead.
-//   3. Signal(0) — fallback liveness probe; ESRCH means PID gone.
+//  1. ProcessState — if cmd.Wait() returned, definitively dead.
+//  2. /proc/<pid>/stat — if state is Z (zombie) or X (dying), treat as dead.
+//  3. Signal(0) — fallback liveness probe; ESRCH means PID gone.
 //
 // Returns false for: nil cmd, nil cmd.Process, reaped process, zombie, or
 // "no such process".
@@ -138,6 +138,37 @@ func (m *Manager) runGhostReaper() {
 			return
 		case <-t.C:
 			m.reapDeadVMs(context.Background())
+			m.reapStaleIncomingMigrations(context.Background())
+		}
+	}
+}
+
+// staleIncomingTimeout bounds how long a migration receiver may sit paused
+// (-incoming) before the reaper tears it down. A live migration loads in
+// seconds-to-minutes; anything still un-resumed past this never received its
+// source and is abandoned. Generous so a slow-but-real load is never killed.
+const staleIncomingTimeout = 10 * time.Minute
+
+// reapStaleIncomingMigrations destroys migration receivers whose migration never
+// completed. Such a receiver is a paused QEMU that passes vmAlive (the process
+// is up) but is not a running sandbox on this worker, so without this it would
+// be ticked indefinitely. The control-plane aborts receivers on an explicit
+// migration failure; this covers the abandoned case where no abort ever fires.
+// Identify under the lock (cheap timestamp check), tear down outside it.
+func (m *Manager) reapStaleIncomingMigrations(ctx context.Context) {
+	now := time.Now()
+	m.mu.Lock()
+	var stale []string
+	for id, vm := range m.vms {
+		if !vm.incomingMigrationAt.IsZero() && now.Sub(vm.incomingMigrationAt) > staleIncomingTimeout {
+			stale = append(stale, id)
+		}
+	}
+	m.mu.Unlock()
+	for _, id := range stale {
+		log.Printf("qemu: stale-incoming-reaper: destroying %s — migration receiver never resumed within %s", id, staleIncomingTimeout)
+		if err := m.Kill(ctx, id); err != nil {
+			log.Printf("qemu: stale-incoming-reaper: Kill %s failed: %v", id, err)
 		}
 	}
 }

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -242,6 +242,12 @@ type VMInstance struct {
 	baseMemoryMB         int           // initial memory passed to -m (before virtio-mem)
 	virtioMemRequestedMB int           // additional memory via virtio-mem (beyond base)
 	goldenVersion        string        // golden version this sandbox was created from (empty if cold-booted)
+	// Set when this VM is started as a migration receiver (paused, -incoming) and
+	// cleared once CompleteIncomingMigration resumes it. While set, the VM is a
+	// not-yet-completed receiver: it's alive (so it passes vmAlive and would be
+	// ticked) but doesn't represent a running sandbox here. The stale-incoming
+	// reaper destroys any whose migration never completes within the timeout.
+	incomingMigrationAt time.Time
 }
 
 // SandboxMeta is persisted to sandbox-meta.json for recovery after hard kills.

--- a/internal/qemu/migration.go
+++ b/internal/qemu/migration.go
@@ -284,7 +284,7 @@ func (mc *MigrationCoordinator) LiveMigrate(ctx context.Context, sandboxID, inco
 	// Set migration parameters for fast cutover
 	_ = vm.qmp.Execute("migrate-set-parameters", map[string]interface{}{
 		"max-bandwidth":  int64(1024 * 1024 * 1024), // 1 GB/s
-		"downtime-limit": int64(100),                 // 100ms max downtime
+		"downtime-limit": int64(100),                // 100ms max downtime
 	})
 
 	// Start live migration
@@ -470,12 +470,16 @@ func (m *Manager) PrepareIncomingMigration(ctx context.Context, sandboxID, rootf
 	cmd.Stderr = logFile
 	if err := cmd.Start(); err != nil {
 		logFile.Close()
-		if devNull != nil { devNull.Close() }
+		if devNull != nil {
+			devNull.Close()
+		}
 		m.cleanupVM(netCfg, sandboxDir)
 		return "", 0, fmt.Errorf("start qemu: %w", err)
 	}
 	logFile.Close()
-	if devNull != nil { devNull.Close() }
+	if devNull != nil {
+		devNull.Close()
+	}
 	log.Printf("qemu: migration-prepare %s: QEMU started (pid=%d), waiting for QMP", sandboxID, cmd.Process.Pid)
 
 	// Connect QMP — allow up to 60s for large-memory VMs (virtio-mem init takes time)
@@ -524,6 +528,11 @@ func (m *Manager) PrepareIncomingMigration(ctx context.Context, sandboxID, rootf
 		guestCID:      guestCID,
 		bootArgs:      bootArgs,
 		goldenVersion: m.GoldenVersion(),
+		// Marks this as an in-flight migration receiver until CompleteIncoming-
+		// Migration clears it. The reaper uses this to tear down receivers whose
+		// migration is abandoned (never completed), which otherwise stay alive
+		// and get ticked despite never becoming a running sandbox here.
+		incomingMigrationAt: time.Now(),
 	}
 
 	m.mu.Lock()
@@ -621,6 +630,13 @@ func (m *Manager) CompleteIncomingMigration(ctx context.Context, sandboxID strin
 	if m.onSandboxReady != nil {
 		m.onSandboxReady(sandboxID, vm.network.GuestIP, vm.Template, vm.StartedAt)
 	}
+
+	// Migration completed and the VM is resumed + agent-connected: it's now a
+	// normal running sandbox, so clear the receiver marker (the reaper must not
+	// touch it). Under the lock to pair with the reaper's read.
+	m.mu.Lock()
+	vm.incomingMigrationAt = time.Time{}
+	m.mu.Unlock()
 
 	log.Printf("qemu: incoming migration %s complete (port=%d, tap=%s)",
 		sandboxID, vm.HostPort, vm.network.TAPName)


### PR DESCRIPTION
  ## Harden sandbox billing cleanup (cell + edge) for the billing cutover

  ### Context                                                                                                                                                                               
  Compute billing is metered per sandbox: the cell keeps an open
  `sandbox_scale_events` row while a sandbox is live, and the edge records one
  `usage_samples` row per worker-emitted tick. After the cutover the edge becomes
  the billing authority, so any path that leaves a sandbox billing or ticking
  after it is actually gone is a correctness problem. This PR closes the remaining
  such paths across all three layers.

  ### Cell — close billing for sandboxes that never reach a clean terminal state
  - `MarkOrphanedSandboxes` now reaps `pending` as well as `running`. A create that
    never reached `running` on a worker that has since disappeared previously kept
    its scale_event open; it is now closed (and `stopped` published to the edge) on
    the next maintenance pass. `pending` on a live worker is left alone — it may
    still be mid-create.
  - New `ReapStalePendingSessions`: an age-based backstop for a create that hangs
    in `pending` on a worker that is still alive (so it is never an orphan).
    Anything `pending` past 15m → `failed`, scale_event closed, `stopped` published.
  - `terminated` is now classified as a terminal session status (consistent with
    the edge), so any writer of that status also stops billing.

  ### Edge — only count ticks from the sandbox's current worker
  - New worker-validation guard in `events-ingest`. Edge usage is counted per tick,
    so a worker that is no longer the sandbox's owner — a migration source, a
    deregistered worker, or an abandoned migration receiver — must not contribute
    usage. A `usage_tick` is dropped when the emitting worker is not the sandbox's
    current owner in `sandboxes_index`, or the sandbox is already terminal there.
    Lookup failure allows the tick (degraded, never blocks billing). The cell side
    needs no equivalent — its scale_events are keyed per sandbox, not per tick.

  ### Worker — reap abandoned migration receivers
  - A migration receiver is started paused (`-incoming`); if its migration never
    completes it stays alive (so it would be ticked) without being a running
    sandbox here. The control plane aborts receivers only on an explicit migration
    failure; the worker now tears down any receiver still un-resumed past 10m via
    the ghost-reaper. Marked at registration, cleared on successful completion.

  ### Control plane — periodic reverse-reconcile
  - The reverse-reconcile (ask the worker what it actually hosts; close and publish
    `stopped` for anything the cell thinks is running that the worker does not have)
    previously ran only on worker rejoin. It now runs every 3m for all live
    workers, so a worker that is deleted and never rejoins no longer leaves stale
    `running` rows on the edge index with nothing to correct them.

  ### Coverage
  | Way a sandbox could keep billing/ticking after it is gone | Closed by |
  |---|---|
  | Stuck `pending` on a dead worker | orphan reaper (extended to pending) |
  | Stuck `pending` on a live worker (hung create) | stale-pending age reaper |
  | Ticks from a migration-source / deregistered worker | edge tick guard |
  | Abandoned paused migration receiver | worker stale-incoming reaper |
  | Stale edge `running` row, no terminal event ever fired | periodic reverse-reconcile |