### PR TITLE
make a home cell/routing a d1 setting not cloudflare env

### DIFF
--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -26,7 +26,6 @@ export interface DashboardEnv {
   WORKOS_CLIENT_ID: string;
   STRIPE_API_KEY: string;
   WORKER_ENV: string;
-  CELLS: string;
   // CF Custom Hostnames API token + zone (for /org/custom-domain). Optional —
   // if unset the custom-domain endpoints return 503 (feature disabled).
   CF_API_TOKEN?: string;

--- a/cloudflare-workers/api-edge/src/index.test.ts
+++ b/cloudflare-workers/api-edge/src/index.test.ts
@@ -54,7 +54,6 @@ const env = {
   WORKOS_CLIENT_ID: "",
   STRIPE_API_KEY: "",
   WORKER_ENV: "test",
-  CELLS: cellID,
   CF_ADMIN_SECRET: "",
   STRIPE_WEBHOOK_SECRET: "",
   EVENT_SECRET: "",

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -1142,32 +1142,33 @@ async function authRefresh(req: Request, env: Env): Promise<Response> {
 }
 
 // pickHomeCell chooses a home cell for a brand-new org. Policy:
-//   1. If the request carries a `cf-ipcountry` header, map to a continent
-//      and prefer a cell whose region is on that continent.
-//   2. Otherwise pick the first cell from env.CELLS that's currently
-//      registered in D1 and healthy.
-//   3. Last-resort fallback: first entry in env.CELLS regardless of D1 state.
+//   1. If the request carries a `cf-ipcountry` header, map to a continent and
+//      prefer an onboarding-eligible cell whose region is on that continent.
+//   2. Otherwise the first onboarding-eligible cell (alphabetical → deterministic).
+//   3. None eligible → "" (downstream errors loudly).
 //
-// Geo lookup is intentionally coarse — continent-level is enough for
-// "don't put a UK user on a US cell" without an IP-to-region service.
+// "Onboarding-eligible" = status='active' AND accepts_new_orgs=1. That gate is a
+// property of the cell row itself — there's no separate env allowlist to keep in
+// sync, so it can't drift from the `cells` table (which is what previously left
+// new orgs with an empty home_cell). Opening a cell to new orgs is a D1 toggle,
+// not a deploy. Geo lookup is intentionally coarse — continent-level is enough.
 async function pickHomeCell(env: Env, req: Request): Promise<string> {
   const country = req.headers.get("cf-ipcountry") ?? "";
   const continent = COUNTRY_TO_CONTINENT[country.toUpperCase()] ?? "";
 
-  const configured = env.CELLS.split(",").map((c) => c.trim()).filter(Boolean);
-  if (configured.length === 0) return ""; // misconfigured — let downstream error
-
   const { results } = await env.OPENCOMPUTER_DB.prepare(
-    `SELECT cell_id, region, status FROM cells WHERE status = 'active'`,
-  ).all<{ cell_id: string; region: string; status: string }>();
-  const activeCells = (results ?? []).filter((c) => configured.includes(c.cell_id));
+    `SELECT cell_id, region FROM cells
+       WHERE status = 'active' AND accepts_new_orgs = 1
+       ORDER BY cell_id`,
+  ).all<{ cell_id: string; region: string }>();
+  const eligible = results ?? [];
+  if (eligible.length === 0) return ""; // none open for onboarding — downstream errors
 
-  if (continent && activeCells.length > 0) {
-    const onContinent = activeCells.find((c) => REGION_CONTINENT[c.region] === continent);
+  if (continent) {
+    const onContinent = eligible.find((c) => REGION_CONTINENT[c.region] === continent);
     if (onContinent) return onContinent.cell_id;
   }
-  if (activeCells.length > 0) return activeCells[0].cell_id;
-  return configured[0];
+  return eligible[0].cell_id;
 }
 
 // COUNTRY_TO_CONTINENT covers the countries we'd actually see on the
@@ -1451,7 +1452,7 @@ export default {
     }
 
     if (path === "/health") {
-      return json({ ok: true, env: env.WORKER_ENV, cells: env.CELLS.split(",") });
+      return json({ ok: true, env: env.WORKER_ENV });
     }
 
     if (path === "/internal/halt-list") {

--- a/cloudflare-workers/api-edge/wrangler.prod.toml
+++ b/cloudflare-workers/api-edge/wrangler.prod.toml
@@ -59,9 +59,9 @@ new_sqlite_classes = ["CreditAccount"]
 
 [vars]
 WORKER_ENV = "prod"
-# No prod cells registered yet. Populate when prod CPs come online and
-# their rows are written to the D1 `cells` table.
-CELLS = ""
+# Cells eligible for new-org home assignment live in the D1 `cells` table
+# (`accepts_new_orgs` column), not an env list — toggle a row to onboard a cell,
+# no deploy. See pickHomeCell in src/index.ts.
 # Optional alpha route for Burst Sandboxes. Leave empty to disable.
 BURST_CELL_ID = "aws-us-east-2-burst-prod"
 

--- a/cloudflare-workers/api-edge/wrangler.toml
+++ b/cloudflare-workers/api-edge/wrangler.toml
@@ -89,11 +89,9 @@ new_sqlite_classes = ["CreditAccount"]
 
 [vars]
 WORKER_ENV = "dev"
-# Cells available in this deployment — comma-separated cell_ids. The edge
-# validates cell selections against this list; each cell's base_url comes from
-# the D1 `cells` table (see schema.sql + scripts/seed_dev_xcell.sh).
-# Cross-cell testbed: dev2 (Azure westus2) + dev3 (AWS us-east-1).
-CELLS = "azure-us-west-2-b,aws-us-east-1-a"
+# Cells eligible for new-org home assignment are NOT configured here anymore —
+# it's the `accepts_new_orgs` column on the D1 `cells` table (single source of
+# truth, toggled per-row without a deploy). See pickHomeCell in src/index.ts.
 # Optional alpha route for Burst Sandboxes. Leave empty to disable.
 BURST_CELL_ID = ""
 

--- a/cloudflare-workers/schema.sql
+++ b/cloudflare-workers/schema.sql
@@ -111,6 +111,12 @@ CREATE TABLE IF NOT EXISTS cells (
   region      TEXT NOT NULL,
   base_url    TEXT NOT NULL,                     -- regional CP base URL (scheme+host[:port])
   status      TEXT NOT NULL DEFAULT 'active',    -- active | draining | down
+  -- New-org onboarding gate: pickHomeCell only assigns brand-new orgs to cells
+  -- with accepts_new_orgs=1. Distinct from `status` (which governs routing of
+  -- existing orgs / pins / failover) so a cell can be active+routable without
+  -- yet adopting new signups. Default 0 = a freshly-registered cell does NOT
+  -- onboard new orgs until explicitly opened (a D1 row toggle, no deploy).
+  accepts_new_orgs    INTEGER NOT NULL DEFAULT 0,
   -- Capacity-aware placement (updated by cell_capacity events; see
   -- internal/controlplane/capacity_reporter.go + events-ingest worker).
   -- The CP aggregates per-worker memory pressure from WorkerEntry. A cell is

--- a/cloudflare-workers/schema_phase5.sql
+++ b/cloudflare-workers/schema_phase5.sql
@@ -1,0 +1,37 @@
+-- Phase 5: home-cell onboarding gate moves from the edge `CELLS` env var to a
+-- column on the D1 `cells` table.
+--
+-- Why: `pickHomeCell` used a hardcoded, deploy-time `CELLS` allowlist that had
+-- to be kept in sync with the `cells` table by hand. It drifted — prod shipped
+-- `CELLS = ""`, so every new org since ~2026-05-27 got an empty `home_cell`.
+-- Making onboarding-eligibility a property of the cell row removes the second
+-- source of truth: it can't drift from `cells` because it IS `cells`, and
+-- opening a cell to new signups becomes a row toggle instead of a deploy.
+--
+-- Apply with:
+--   wrangler d1 execute opencomputer-dev --remote --file cloudflare-workers/schema_phase5.sql
+--
+-- SQLite/D1 has no `ADD COLUMN IF NOT EXISTS`, so this ALTER fails on re-run —
+-- one-shot, like the earlier phases.
+--
+-- ROLLOUT ORDER MATTERS. Run this migration AND open the onboarding cell(s)
+-- (step 2 below) BEFORE deploying the new api-edge code. The new pickHomeCell
+-- reads `accepts_new_orgs`; if you deploy code while every cell still has the
+-- default 0, new orgs get an empty home_cell during the gap.
+
+-- 1. Schema: the onboarding gate. Default 0 = a cell does NOT adopt new orgs
+--    until explicitly opened. Distinct from `status` (routing of existing
+--    orgs / pins / failover), so a cell can be active+routable without
+--    onboarding new signups (e.g. a brand-new cell still under validation).
+ALTER TABLE cells ADD COLUMN accepts_new_orgs INTEGER NOT NULL DEFAULT 0;
+
+-- 2. Open the cell(s) that SHOULD onboard new orgs. Run the line for your env;
+--    the other is a harmless no-op (cell_id won't match).
+--      prod:  UPDATE cells SET accepts_new_orgs = 1 WHERE cell_id = 'azure-us-east-2-a';
+--      dev:   UPDATE cells SET accepts_new_orgs = 1 WHERE cell_id = 'azure-westus2-cell-a';
+
+-- 3. Backfill orgs that were created with an empty home_cell during the drift
+--    window, pointing them at the de-facto cell (prod: azure-us-east-2-a).
+--    Run per env:
+--      UPDATE orgs SET home_cell = 'azure-us-east-2-a'
+--       WHERE home_cell IS NULL OR home_cell = '';


### PR DESCRIPTION
Noticed that a bunch of orgs didn't have home cells (will backfill). It was because we had some drift in the CELLS env at some point. Want to essentially remove that and have a accepts new orgs column in D1 so that we can still toggle on home cell routing separately from d1 registration but its more maintainable than having a long CELLS= somewhere (which in the future would be quite long, and difficult to maintain accurately). 