### PR TITLE
Fix/pin guest kernel

### DIFF
--- a/deploy/azure/setup-azure-host.sh
+++ b/deploy/azure/setup-azure-host.sh
@@ -45,17 +45,28 @@ export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
 echo "Go: $(/usr/local/go/bin/go version)"
 
 # --- Guest kernel for QEMU ---
-# Use the host's generic Ubuntu kernel (has VIRTIO_BLK=y, VIRTIO_NET=y, VIRTIO_PCI=y built-in).
+# Use a generic Ubuntu kernel (has VIRTIO_BLK=y, VIRTIO_NET=y, VIRTIO_PCI=y built-in).
 # We also need vsock and overlay as modules — those get baked into the rootfs image.
+#
+# The guest kernel is PINNED to an exact version. Hibernate/wake (savevm/loadvm)
+# correctness depends on guest kernel behavior, so kernel bumps must be
+# deliberate, validated changes — never whatever the Ubuntu archive happens to
+# serve on build day. To move the pin: bump GUEST_KVER_PIN, build the image, and
+# validate create → hibernate → wake → exec (plus e2fsck of the woken rootfs)
+# on dev before any prod roll.
 echo "Setting up guest kernel..."
 KERNEL_DIR="/opt/opensandbox"
 mkdir -p "$KERNEL_DIR"
 
-# Install generic kernel package (has virtio built-in, unlike the azure kernel)
-apt-get install -y -qq linux-image-generic
+GUEST_KVER_PIN="6.8.0-117"
 
-# Find the generic kernel and copy it
-GENERIC_VMLINUZ=$(ls -t /boot/vmlinuz-*-generic 2>/dev/null | head -1)
+# Install the exact pinned kernel (generic flavor: virtio built-in, unlike the
+# azure kernel). A missing package fails the build loudly — that's correct for
+# a pin; resolve by choosing and validating a new pin, not by unpinning.
+apt-get install -y -qq "linux-image-${GUEST_KVER_PIN}-generic"
+
+GENERIC_VMLINUZ="/boot/vmlinuz-${GUEST_KVER_PIN}-generic"
+[ -f "$GENERIC_VMLINUZ" ] || GENERIC_VMLINUZ=""
 if [ -n "$GENERIC_VMLINUZ" ]; then
     cp "$GENERIC_VMLINUZ" "$KERNEL_DIR/vmlinux"
     chmod 644 "$KERNEL_DIR/vmlinux"

--- a/deploy/packer/worker-ami.pkr.hcl
+++ b/deploy/packer/worker-ami.pkr.hcl
@@ -259,7 +259,11 @@ build {
       # Compute a stable hash over all rootfs inputs. Order must be
       # deterministic — use `sort` — so the same inputs always hash to the
       # same value regardless of filesystem enumeration order.
-      "INPUT_HASH=$({ sha256sum /usr/local/bin/osb-agent; find /tmp/rootfs-ctx -type f | sort | xargs sha256sum; sha256sum /opt/opensandbox/guest-modules/*.ko* 2>/dev/null; } | sha256sum | awk '{print $1}')",
+      # guest-kernel-version is a hash input: build-rootfs-docker.sh bakes the
+      # host's /lib/modules/<kver> tree into the ext4, so a kernel pin change
+      # MUST miss the cache — a cached rootfs carrying the old kernel's modules
+      # paired with the new vmlinux fails module loading (virtio_mem) at boot.
+      "INPUT_HASH=$({ sha256sum /usr/local/bin/osb-agent; find /tmp/rootfs-ctx -type f | sort | xargs sha256sum; sha256sum /opt/opensandbox/guest-modules/*.ko* 2>/dev/null; cat /opt/opensandbox/guest-kernel-version 2>/dev/null; } | sha256sum | awk '{print $1}')",
       "echo \"Rootfs input hash: $INPUT_HASH\"",
       "# Derive ext4 UUID from the hash (first 32 hex chars, dashed to UUID form).",
       "ROOTFS_UUID=$(echo \"$INPUT_HASH\" | head -c 32 | sed 's/\\(........\\)\\(....\\)\\(....\\)\\(....\\)\\(............\\)/\\1-\\2-\\3-\\4-\\5/')",


### PR DESCRIPTION
  ### Problem
  The worker image build installs the guest kernel with an unpinned `apt-get install linux-image-generic`, so every image build silently bakes in whatever Ubuntu kernel is current on
  build day. A routine image rebuild moved the guest kernel from 6.8.0-117 to 6.8.0-124, and under 6.8.0-124 hibernate/wake (savevm/loadvm) reliably breaks: woken sandboxes come back
  with the guest agent unresponsive or with persistent ext4 `metadata_csum` corruption in the rootfs (every `fork/exec` in the guest fails with EBADMSG). Workers on the 6.8.0-117 build
  wake cleanly with the same QEMU version and the same worker binary — verified by A/B repro across both kernel builds.
  
