### PR TITLE
reap terminal sandboxes

### DIFF
--- a/internal/controlplane/scaler.go
+++ b/internal/controlplane/scaler.go
@@ -1198,12 +1198,44 @@ func (s *Scaler) drainWorker(workerID, machineID, region string) {
 			return
 		}
 
-		// Count running sandboxes
+		// Count running sandboxes — but reap zombies instead of migrating them.
+		//
+		// The worker reports a VM as "running" whenever its qemu process is
+		// alive (vmAlive). That is NOT the same as the cell believing the
+		// sandbox is live: a sandbox can fail (session→failed, billing closed)
+		// while its qemu is never reaped, leaving a zombie the worker still
+		// lists as running. Migrating such a zombie relocates it onto a fresh
+		// worker, orphaned from the cell — it bills forever on the edge
+		// (D1=running, ticks flow) and is unroutable (cell session=failed →
+		// "Session not found"). This is exactly how sb-f62fc71d leaked during a
+		// rolling replace. Reap it on the source instead; only migrate VMs whose
+		// cell session is genuinely live.
+		//
+		// A VM with no cell session at all (lookup error) is left to migrate —
+		// it may be a brand-new create whose session row hasn't committed yet,
+		// and the worker-authoritative orphan reaper is the right place to
+		// handle truly session-less VMs.
 		var running []string
 		for _, sb := range listResp.Sandboxes {
-			if sb.Status == "running" {
-				running = append(running, sb.SandboxId)
+			if sb.Status != "running" {
+				continue
 			}
+			if s.store != nil {
+				if sess, err := s.store.GetSandboxSession(ctx, sb.SandboxId); err == nil && sess != nil && db.IsTerminalSessionStatus(sess.Status) {
+					log.Printf("scaler: drain: %s reports running on %s but cell session is %q — reaping zombie instead of migrating", sb.SandboxId, workerID, sess.Status)
+					reapCtx, reapCancel := context.WithTimeout(ctx, 10*time.Second)
+					if _, derr := sourceClient.DestroySandbox(reapCtx, &pb.DestroySandboxRequest{SandboxId: sb.SandboxId}); derr != nil {
+						log.Printf("scaler: drain: reap %s on %s failed: %v (ghost-reaper will retry)", sb.SandboxId, workerID, derr)
+					} else {
+						// Mirror reality to D1 so sandboxes_index stops showing
+						// running@worker and the edge stops metering the zombie.
+						s.publishStopped(context.Background(), sb.SandboxId, workerID, sess.OrgID, "drain_zombie_reap")
+					}
+					reapCancel()
+					continue
+				}
+			}
+			running = append(running, sb.SandboxId)
 		}
 		if len(running) == 0 {
 			log.Printf("scaler: drain: worker %s fully drained", workerID)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -62,6 +62,14 @@ func isTerminalSessionStatus(status string) bool {
 	}
 }
 
+// IsTerminalSessionStatus is the exported view of isTerminalSessionStatus, for
+// callers outside this package (e.g. the scaler's drain path, which reaps a
+// worker-reported-running VM whose cell session is already terminal instead of
+// migrating the zombie onto a fresh worker).
+func IsTerminalSessionStatus(status string) bool {
+	return isTerminalSessionStatus(status)
+}
+
 // SetEncryptor configures the encryption key for project secrets.
 func (s *Store) SetEncryptor(enc *crypto.Encryptor) {
 	s.encryptor = enc


### PR DESCRIPTION
## Drain: reap zombie sandboxes instead of migrating them

  ### Problem
  A draining worker chose which sandboxes to live-migrate purely from the
  worker's own `ListSandboxes` — i.e. "qemu process alive" == "running". That
  status is **not authoritative**: a sandbox can fail (cell session → `failed`,
  billing closed) while its qemu is never reaped, leaving a zombie the worker
  still reports as running. During a rolling replace, the drain then
  **live-migrated that zombie onto a fresh worker**, where it resumed orphaned
  from the cell.
  
  One bug, three symptoms:
  - **Phantom billing** — D1 says `running` and the worker keeps emitting
    `usage_tick`s, so the edge meters the dead sandbox indefinitely while the
    cell (authoritative) shows it stopped. Surfaced by the usage-parity check.
  - **"Session not found"** — D1 routes to the migrated VM, but the cell session
    is `failed` → customer-facing errors.
  - **Compute leak** — a real qemu burning CPU/RAM for a sandbox nobody can use.

  Observed in prod: a single such zombie survived a rolling replace and billed
  ~1 GB continuously for **90h+ / ~16k usage samples** (2+ days of CPU time) — it
  was the only genuine billing-parity drift across the entire fleet.

  ### Fix   
  Before migrating, consult the cell's authoritative session. If it's terminal
  (`stopped`/`error`/`failed`/`terminated`), **reap the VM on the source** via
  `DestroySandbox` + publish a `stopped` lifecycle event (so D1 and the edge
  meter follow reality) and exclude it from the migration batch. Only sandboxes
  with a genuinely live cell session get migrated.

  A VM with no cell session at all (lookup error) is still migrated — it may be a
  fresh create whose session row hasn't committed yet; truly session-less
  orphans are the worker-authoritative reaper's job (see follow-ups).

  ### Changes
  - `internal/controlplane/scaler.go` — `drainWorker` looks up
    `GetSandboxSession` per running VM and reaps terminal ones instead of
    migrating them.
  - `internal/db/store.go` — exported `IsTerminalSessionStatus` so the scaler
    (different package) can classify session status.

  ### Follow-ups (not in this PR)
  This closes the *creation* path — drain no longer propagates zombies onto fresh
  workers. Two related gaps let an already-orphaned VM survive once created, and
  are worth a separate change:  
  - both reconcilers are worker-keyed and forward-reconcile only sweeps
    `status='stopped'`, so a `failed` sandbox relocated by migration to a worker
    its session doesn't reference escapes both forward and reverse reconcile;
  - a **worker-authoritative orphan reaper** — kill any VM a worker actually runs
    that has no live cell session on *any* worker — would catch that class.

  ### Testing
  - Build + `go vet` clean; scaler/db tests pass (3 pre-existing timing-flaky
    failures unchanged with/without this diff).
  - Terminal-status classification covered by `TestIsTerminalSessionStatus`.
  - The drain guard is gated behind `s.store != nil`, so existing nil-store
    tests are unaffected. A full `drainWorker` unit test needs a store interface
    (the scaler holds a concrete `*db.Store`) — noted as a follow-up.
