### PR TITLE
Prevent agent clobbering, give better errors

### DIFF
--- a/deploy/ec2/build-rootfs-docker.sh
+++ b/deploy/ec2/build-rootfs-docker.sh
@@ -215,6 +215,18 @@ RUN useradd -m -u 1000 -s /bin/bash sandbox && \
     chown sandbox:sandbox /workspace 2>/dev/null || true
 COPY osb-agent /usr/local/bin/osb-agent
 RUN chmod +x /usr/local/bin/osb-agent
+# PID 1 is our custom init at /sbin/init (it execs osb-agent). That path is
+# normally owned by systemd-sysv, which ships /sbin/init as a symlink to
+# systemd. The base image has systemd-sysv removed so the path is ours — but a
+# user image build that runs `apt install` of anything pulling libpam-systemd
+# (cups, at-spi, many GUI/browser libs) drags systemd-sysv back in, and its
+# maintainer scripts reclaim /sbin/init -> /lib/systemd/systemd. The finalized
+# image then cold-boots systemd instead of osb-agent, the agent socket never
+# comes up, and the build fails at finalize with "agent not ready after 30s".
+# dpkg-divert redirects any future packaged /sbin/init to /sbin/init.distrib so
+# our init stays PID 1 no matter what the guest installs. Must run BEFORE we
+# place our init so the diversion is registered against the path first.
+RUN dpkg-divert --local --rename --divert /sbin/init.distrib /sbin/init
 COPY init /sbin/init
 RUN chmod +x /sbin/init
 RUN mkdir -p /mnt/data /mnt/overlay

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -1808,8 +1808,14 @@ func (m *Manager) Create(ctx context.Context, cfg types.SandboxConfig) (sb *type
 		goldenVersion: m.goldenVersion, // set even on cold boot — VM uses the same base image
 	}
 
-	// Wait for agent via Unix socket
-	agentClient, err := m.waitForAgentSocket(context.Background(), agentSockPath, 30*time.Second)
+	// Wait for agent via Unix socket. Default 30s; callers can extend it (the
+	// image-finalize cold boot does, since a heavy user-built rootfs can take
+	// longer to reach agent-ready than a stock base image).
+	agentReadyTimeout := 30 * time.Second
+	if cfg.AgentReadyTimeout > 0 {
+		agentReadyTimeout = cfg.AgentReadyTimeout
+	}
+	agentClient, err := m.waitForAgentSocket(context.Background(), agentSockPath, agentReadyTimeout)
 	if err != nil {
 		log.Printf("qemu: agent not ready for %s, killing VM: %v", id, err)
 		qmpClient.Close()
@@ -2884,6 +2890,18 @@ func (m *Manager) CreateCheckpointFinalized(ctx context.Context, buildSandboxID,
 		return "", "", 0, fmt.Errorf("finalize: build disks not found for %s", buildSandboxID)
 	}
 
+	// 1b. Pre-flight: verify the build steps didn't break PID 1 on the way the
+	//     finalize VM boots. The finalize cold-boots with init=/sbin/init; if a
+	//     build step replaced our custom init (most commonly `apt install`
+	//     pulling in systemd-sysv, which reclaims /sbin/init -> systemd) or
+	//     removed the agent binary, the finalize VM boots without the agent and
+	//     fails opaquely with "agent not ready after 30s". The build VM is still
+	//     running here with a working agent, so probe it and fail with a clear,
+	//     actionable error instead of a 30s timeout downstream.
+	if err := m.verifyBuildInitIntact(ctx, buildSandboxID); err != nil {
+		return "", "", 0, err
+	}
+
 	// 2. Cold-boot a fresh finalize VM from a copy of the build disks at the
 	//    target floor. Create() copies the disks (reflink) via TemplateRootfsKey
 	//    and cold-boots — no savevm restore, so no memory floor inherited.
@@ -2895,6 +2913,11 @@ func (m *Manager) CreateCheckpointFinalized(ctx context.Context, buildSandboxID,
 		NetworkEnabled:       &netEnabled,
 		TemplateRootfsKey:    "local://" + buildRootfs,
 		TemplateWorkspaceKey: "local://" + buildWorkspace,
+		// A heavy user-built rootfs (many apt/npm layers) can legitimately take
+		// longer than a stock base to reach agent-ready on cold boot. Give the
+		// finalize bring-up generous headroom so we don't fail a correct image
+		// on the default 30s wait.
+		AgentReadyTimeout: finalizeAgentReadyTimeout,
 	}
 	log.Printf("qemu: finalize: cold-booting %s from %s disks at %dMB", finalizeID, buildSandboxID, finalizeMemMB)
 	if _, err := m.Create(ctx, finCfg); err != nil {
@@ -2910,6 +2933,52 @@ func (m *Manager) CreateCheckpointFinalized(ctx context.Context, buildSandboxID,
 	// 3. Snapshot the finalize VM → the output checkpoint (floor = finalizeMemMB).
 	log.Printf("qemu: finalize %s → checkpoint %s (floor %dMB)", finalizeID, checkpointID, finalizeMemMB)
 	return m.CreateCheckpoint(ctx, finalizeID, checkpointID, checkpointStore, onReady)
+}
+
+// finalizeAgentReadyTimeout is how long the finalize cold-boot waits for the
+// guest agent. Larger than the default cold-boot wait because a heavy
+// user-built rootfs can legitimately take longer to reach agent-ready.
+const finalizeAgentReadyTimeout = 90 * time.Second
+
+// verifyBuildInitIntact probes the still-running build VM to confirm its rootfs
+// will cold-boot our agent at finalize time. The finalize VM boots
+// init=/sbin/init; a build step that replaced our custom busybox init (most
+// commonly `apt install` pulling in systemd-sysv, which repoints /sbin/init at
+// systemd) or removed the agent binary would otherwise fail downstream with an
+// opaque "agent not ready after 30s". Probing the live build agent lets us fail
+// with a clear, actionable error naming the cause.
+//
+// Best-effort: if there's no agent to probe with (or the probe itself errors),
+// we proceed — the cold boot still surfaces a failure if init is genuinely
+// broken; this check only upgrades the error message when it can.
+func (m *Manager) verifyBuildInitIntact(ctx context.Context, buildSandboxID string) error {
+	vm, err := m.getVM(buildSandboxID)
+	if err != nil || vm == nil || vm.agent == nil {
+		log.Printf("qemu: finalize %s: skipping init pre-flight (no live agent: %v)", buildSandboxID, err)
+		return nil
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	resp, err := vm.agent.Exec(probeCtx, &pb.ExecRequest{
+		Command:   "/bin/sh",
+		Args:      []string{"-c", `if [ ! -x /usr/local/bin/osb-agent ]; then echo AGENT_MISSING; elif [ -L /sbin/init ]; then echo "INIT_SYMLINK:$(readlink /sbin/init)"; else head -c 32 /sbin/init; fi`},
+		RunAsRoot: true,
+	})
+	if err != nil {
+		log.Printf("qemu: finalize %s: init pre-flight exec failed: %v (proceeding to cold boot)", buildSandboxID, err)
+		return nil
+	}
+	out := strings.TrimSpace(string(resp.Stdout))
+	switch {
+	case strings.Contains(out, "AGENT_MISSING"):
+		return fmt.Errorf("finalize: built image is missing an executable /usr/local/bin/osb-agent — a build step removed or overwrote the sandbox agent")
+	case strings.HasPrefix(out, "INIT_SYMLINK:"):
+		target := strings.TrimPrefix(out, "INIT_SYMLINK:")
+		return fmt.Errorf("finalize: built image replaced /sbin/init (now a symlink to %q) — a build step clobbered PID 1 (commonly `apt install` pulling in systemd-sysv); the finalized image would boot systemd instead of the agent", target)
+	case !strings.HasPrefix(out, "#!"):
+		return fmt.Errorf("finalize: built image /sbin/init is not the expected init script (starts with %q) — a build step replaced PID 1", truncate(out, 16))
+	}
+	return nil
 }
 
 func (m *Manager) CreateCheckpoint(ctx context.Context, sandboxID, checkpointID string, checkpointStore *storage.CheckpointStore, onReady func()) (rootfsKey, workspaceKey string, sizeBytes int64, err error) {

--- a/pkg/types/sandbox.go
+++ b/pkg/types/sandbox.go
@@ -99,6 +99,11 @@ type SandboxConfig struct {
 	// SandboxID allows pre-determining the sandbox ID for async creation.
 	// If empty, a new ID is generated automatically.
 	SandboxID string `json:"-"`
+	// AgentReadyTimeout overrides how long Create waits for the guest agent
+	// socket after cold boot (zero = default 30s). Set larger for the
+	// image-finalize cold boot, where a heavy user-built rootfs can legitimately
+	// take longer to reach agent-ready. Internal-only (not part of the API).
+	AgentReadyTimeout time.Duration `json:"-"`
 	// CheckpointID is the source checkpoint for template/snapshot creates.
 	// Used by the worker to key per-template golden snapshots.
 	CheckpointID string `json:"-"`

--- a/scripts/build-rootfs.sh
+++ b/scripts/build-rootfs.sh
@@ -209,6 +209,10 @@ build_image() {
 # --- OpenSandbox agent injection ---
 COPY osb-agent /usr/local/bin/osb-agent
 RUN chmod +x /usr/local/bin/osb-agent
+# Divert /sbin/init so a guest `apt install` that pulls in systemd-sysv can't
+# reclaim PID 1 from our custom init (see deploy/ec2/build-rootfs-docker.sh for
+# the full rationale — keep these two builders in sync).
+RUN dpkg-divert --local --rename --divert /sbin/init.distrib /sbin/init
 COPY init /sbin/init
 RUN chmod +x /sbin/init
 RUN mkdir -p /mnt/data /mnt/overlay


### PR DESCRIPTION
## Stop guest `apt` from clobbering `/sbin/init` in image builds

  ### Problem
  Template/snapshot builds failed at the **finalize** step for any image whose
  build ran `apt install` of packages that pull in `libpam-systemd` — cups,
  at-spi, Pango/GTK, and most browser/Chromium libs. The build steps all
  completed, then finalize failed with:
  
  create checkpoint failed: finalize: cold-boot at 1024MB: agent not ready:
  agent not ready after 30s (3 attempts, 0 ping failures)

  Minimal builds finalized fine; only "heavy" builds failed — a confusing,
  opaque split.
  
  ### Root cause
  A sandbox's PID 1 is our custom busybox init at `/sbin/init` (it `exec`s
  `osb-agent`). That path is owned by `systemd-sysv`, which ships `/sbin/init`
  as a symlink to systemd. The base image has `systemd-sysv` removed so the path
  is ours — but a guest `apt install` that transitively pulls `systemd-sysv`
  back in runs its maintainer scripts, which reclaim `/sbin/init` →
  `/lib/systemd/systemd`. The build VM survives (already running in memory), but
  **finalize cold-boots the modified disk** → it boots systemd to a login prompt
  instead of the agent → the agent socket never comes up → 30s timeout.
  
  Confirmed in a chroot against the exact failing apt set: before, `/sbin/init`
  is `#!/bin/busybox sh`; after, it's a symlink to systemd.

  ### Fix
  1. **`dpkg-divert /sbin/init` before installing our init** (in both rootfs
     builders). Any future packaged `/sbin/init` is redirected to
     `/sbin/init.distrib`, so our init stays PID 1 no matter what the guest
     installs. Package-agnostic — also covers `sysvinit-core`, `upstart`, etc.
  2. **Finalize pre-flight check** (`verifyBuildInitIntact`): before the finalize
     cold-boot, probe the still-running build VM and fail fast with an
     actionable error if `/sbin/init` was replaced or `osb-agent` was removed —
     instead of an opaque 30s timeout downstream. Best-effort: if there's no
     agent to probe, it proceeds (only ever upgrades the error message).
  3. **Generous finalize agent-wait** (90s, plumbed via a new internal-only
     `SandboxConfig.AgentReadyTimeout`): a heavy user-built rootfs can
     legitimately take longer than a stock base to reach agent-ready. Normal
     creates are unchanged (still 30s).
  
  ### Verification (dev, end-to-end)
  - Reproduced the heavy-build finalize failure, then confirmed the divert makes
    the identical build finalize cleanly.
  - chroot: divert holds — `/sbin/init` survives the clobbering apt; systemd
    lands harmlessly at `/sbin/init.distrib`.
  - Deployed the worker binary and exercised the pre-flight error paths:
    - build that does `ln -sf systemd /sbin/init` → fails in **12s** with
      *"replaced /sbin/init (symlink to /lib/systemd/systemd) — clobbered PID 1"*
    - build that does `rm /usr/local/bin/osb-agent` → fails in **12s** with
      *"missing an executable /usr/local/bin/osb-agent"*
    - clean heavy build (apt + systemd deps) → succeeds, no false positive.
