### PR TITLE
fix: expose sandbox id aliases in SDKs

### DIFF
--- a/sdks/python/opencomputer/__init__.py
+++ b/sdks/python/opencomputer/__init__.py
@@ -65,4 +65,4 @@ __all__ = [
     "TagKeyInfo",
 ]
 
-__version__ = "0.6.0"
+__version__ = "0.6.3"

--- a/sdks/python/opencomputer/sandbox.py
+++ b/sdks/python/opencomputer/sandbox.py
@@ -83,6 +83,10 @@ class Sandbox:
     _client: httpx.AsyncClient = field(default=None, repr=False)
     _data_client: httpx.AsyncClient = field(default=None, repr=False)
 
+    @property
+    def id(self) -> str:
+        return self.sandbox_id
+
     @classmethod
     async def create(
         cls,

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opencomputer-sdk"
-version = "0.6.2"
+version = "0.6.3"
 description = "Python SDK for OpenComputer - cloud sandbox platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/sandbox.ts
+++ b/sdks/typescript/src/sandbox.ts
@@ -227,6 +227,7 @@ export interface AllowedHostsInfo {
 
 export class Sandbox {
   readonly sandboxId: string;
+  readonly id: string;
   readonly agent: Agent;
   readonly files: Filesystem;
   readonly exec: Exec;
@@ -257,6 +258,7 @@ export class Sandbox {
 
   private constructor(data: SandboxData, apiUrl: string, apiKey: string) {
     this.sandboxId = data.sandboxID;
+    this.id = this.sandboxId;
     this._status = data.status;
     this.apiUrl = apiUrl;
     this.apiKey = apiKey;


### PR DESCRIPTION
## Summary
- expose `sandbox.id` as an alias for `sandbox.sandboxId` in the TypeScript SDK
- expose `sandbox.id` as an alias for `sandbox.sandbox_id` in the Python SDK
- bump TypeScript and Python SDK package versions to `0.6.3`

## Tests
- `npm --prefix ../../opencomputer/sdks/typescript run lint`
- `PYTHONPYCACHEPREFIX=/private/tmp/opencomputer-pycache python3 -m py_compile ../../opencomputer/sdks/python/opencomputer/sandbox.py ../../opencomputer/sdks/python/opencomputer/__init__.py`
