### PR TITLE
fix: index streamed sandbox creates inline

### DIFF
--- a/cloudflare-workers/api-edge/src/index.test.ts
+++ b/cloudflare-workers/api-edge/src/index.test.ts
@@ -5,10 +5,15 @@ const orgID = "org-1";
 const userID = "user-1";
 const cellID = "azure-us-east-2-a";
 
+const sandboxIndexInserts: unknown[][] = [];
+
 class FakeStatement {
   constructor(private sql: string) {}
 
-  bind(..._args: unknown[]) {
+  private args: unknown[] = [];
+
+  bind(...args: unknown[]) {
+    this.args = args;
     return this;
   }
 
@@ -33,10 +38,44 @@ class FakeStatement {
     if (this.sql.includes("SELECT plan FROM orgs")) {
       return { plan: "pro" } as T;
     }
+    if (this.sql.includes("SELECT home_cell, plan, is_halted")) {
+      return {
+        home_cell: cellID,
+        plan: "pro",
+        is_halted: 0,
+        max_concurrent_sandboxes: 10,
+        max_disk_mb: 262144,
+      } as T;
+    }
+    if (this.sql.includes("COUNT(*) AS n FROM sandboxes_index")) {
+      return { n: 0 } as T;
+    }
     return null;
   }
 
+  async all<T>() {
+    if (this.sql.includes("FROM cells WHERE status = 'active'")) {
+      return {
+        results: [
+          {
+            cell_id: cellID,
+            cloud: "azure",
+            region: "us-east-2",
+            base_url: "https://cp-us-east-2.opencomputer.dev",
+            status: "active",
+            available_workers: 1,
+            capacity_updated_at: Math.floor(Date.now() / 1000),
+          },
+        ],
+      } as { results: T[] };
+    }
+    return { results: [] as T[] };
+  }
+
   async run() {
+    if (this.sql.includes("INSERT OR REPLACE INTO sandboxes_index")) {
+      sandboxIndexInserts.push(this.args);
+    }
     return {};
   }
 }
@@ -68,6 +107,7 @@ const ctx = {
 describe("api-edge WebSocket auth", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    sandboxIndexInserts.length = 0;
   });
 
   it("accepts api_key query auth for sandbox WebSocket proxy requests", async () => {
@@ -166,5 +206,59 @@ describe("api-edge WebSocket auth", () => {
     expect(resp.status).toBe(401);
     expect(await resp.json()).toEqual({ error: "missing or invalid API key" });
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("api-edge sandbox create", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    sandboxIndexInserts.length = 0;
+  });
+
+  it("indexes SSE snapshot creates before the streamed response completes", async () => {
+    const fetchSpy = vi.fn(async (_url: string, _init?: RequestInit) => {
+      const body = [
+        "event: build_log",
+        'data: {"message":"creating"}',
+        "",
+        "event: result",
+        'data: {"sandboxID":"sb-sse1234","workerID":"worker-1","status":"running","memoryMB":2048}',
+        "",
+      ].join("\n");
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const resp = await worker.fetch(
+      new Request("https://app.opencomputer.dev/api/sandboxes", {
+        method: "POST",
+        headers: {
+          "X-API-Key": "osb_test",
+          "Content-Type": "application/json",
+          Accept: "text/event-stream",
+        },
+        body: JSON.stringify({ snapshot: "snapshot-1", memoryMB: 1024 }),
+      }),
+      env,
+      ctx,
+    );
+
+    expect(resp.status).toBe(200);
+    expect(await resp.text()).toContain("event: result");
+    expect(sandboxIndexInserts).toHaveLength(1);
+    expect(sandboxIndexInserts[0]).toEqual([
+      "sb-sse1234",
+      orgID,
+      userID,
+      cellID,
+      "worker-1",
+      "running",
+      0,
+      2048,
+      expect.any(Number),
+    ]);
   });
 });

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -102,6 +102,13 @@ interface Caller {
   userID: string | null;
 }
 
+interface SandboxCreateResult {
+  sandboxID?: string;
+  workerID?: string;
+  status?: string;
+  memoryMB?: number;
+}
+
 function isWebSocketUpgrade(req: Request): boolean {
   return req.headers.get("upgrade")?.toLowerCase() === "websocket";
 }
@@ -433,6 +440,107 @@ async function enforceCreatePolicy(
   return null;
 }
 
+async function insertSandboxIndex(
+  env: Env,
+  caller: Caller,
+  cellID: string,
+  parsed: SandboxCreateResult,
+  fallbackCpuCount: number,
+  fallbackMemoryMB: number,
+): Promise<void> {
+  if (!parsed.sandboxID) return;
+  await env.OPENCOMPUTER_DB.prepare(
+    `INSERT OR REPLACE INTO sandboxes_index
+       (id, org_id, user_id, cell_id, worker_id, status, cpu_count, memory_mb, created_at, last_event_at)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9)`,
+  )
+    .bind(
+      parsed.sandboxID,
+      caller.orgID,
+      caller.userID,
+      cellID,
+      parsed.workerID ?? null,
+      parsed.status ?? "running",
+      fallbackCpuCount,
+      parsed.memoryMB ?? fallbackMemoryMB,
+      Math.floor(Date.now() / 1000),
+    )
+    .run();
+}
+
+function indexSandboxFromSSE(
+  resp: Response,
+  env: Env,
+  caller: Caller,
+  cellID: string,
+  fallbackCpuCount: number,
+  fallbackMemoryMB: number,
+): Response {
+  if (!resp.ok || !resp.body) return resp;
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let eventName = "message";
+  let dataLines: string[] = [];
+  let indexed = false;
+
+  const handleEvent = async () => {
+    if (eventName !== "result" || dataLines.length === 0 || indexed) {
+      eventName = "message";
+      dataLines = [];
+      return;
+    }
+
+    indexed = true;
+    const data = dataLines.join("\n");
+    eventName = "message";
+    dataLines = [];
+
+    try {
+      const parsed = JSON.parse(data) as SandboxCreateResult;
+      await insertSandboxIndex(env, caller, cellID, parsed, fallbackCpuCount, fallbackMemoryMB);
+    } catch (e) {
+      console.error("sandboxes_index SSE create insert failed:", e);
+    }
+  };
+
+  const processLine = async (line: string) => {
+    if (line === "") {
+      await handleEvent();
+      return;
+    }
+    if (line.startsWith(":")) return;
+    const colon = line.indexOf(":");
+    const field = colon === -1 ? line : line.slice(0, colon);
+    const value = colon === -1 ? "" : line.slice(colon + (line[colon + 1] === " " ? 2 : 1));
+    if (field === "event") {
+      eventName = value;
+    } else if (field === "data") {
+      dataLines.push(value);
+    }
+  };
+
+  const stream = new TransformStream<Uint8Array, Uint8Array>({
+    async transform(chunk, controller) {
+      buffer += decoder.decode(chunk, { stream: true });
+      const lines = buffer.split(/\r\n|\r|\n/);
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        await processLine(line);
+      }
+      controller.enqueue(chunk);
+    },
+    async flush() {
+      const tail = decoder.decode();
+      if (tail) buffer += tail;
+      if (buffer) await processLine(buffer);
+      await handleEvent();
+    },
+  });
+
+  return new Response(resp.body.pipeThrough(stream), resp);
+}
+
 async function createSandbox(req: Request, env: Env): Promise<Response> {
   const caller = await authenticate(req, env);
   if (!caller) return json({ error: "missing or invalid API key" }, 401);
@@ -509,21 +617,18 @@ async function createSandbox(req: Request, env: Env): Promise<Response> {
   const capToken = await mintCapToken(env.SESSION_JWT_SECRET, caller.orgID, cell.cell_id, plan, caller.userID);
 
   // SSE build streaming: image/snapshot creates can take minutes (apt installs,
-  // etc.). When the client asks for an event stream, forward the Accept header
-  // and stream the cell's SSE response straight through — build logs reach the
-  // client live and the final `result` event is delivered intact. Buffering
-  // with .text() (the non-SSE path below) collapsed the stream to one blob,
-  // which broke the Python SDK ("No result received from build stream"). The
-  // sandboxes_index row is populated by the cell's `created` event via the
-  // events pipeline, so we don't need the inline INSERT on this path.
+  // etc.). Preserve live streaming, but index the final `result` event inline
+  // before the stream closes. Relying only on async lifecycle events leaves a
+  // race where immediate GET/DELETE after create sees no sandboxes_index row.
   const wantsSSE = req.headers.get("accept") === "text/event-stream";
   if (wantsSSE) {
     try {
-      return await fetch(cell.base_url.replace(/\/$/, "") + "/internal/sandboxes/create", {
+      const cpResp = await fetch(cell.base_url.replace(/\/$/, "") + "/internal/sandboxes/create", {
         method: "POST",
         headers: { authorization: "Bearer " + capToken, "content-type": "application/json", accept: "text/event-stream" },
         body: bodyText || "{}",
       });
+      return indexSandboxFromSSE(cpResp, env, caller, cell.cell_id, bodyCpuCount, bodyMemoryMB);
     } catch (e) {
       return json({ error: `cell ${cell.cell_id} unreachable: ${(e as Error).message}` }, 502);
     }
@@ -542,31 +647,13 @@ async function createSandbox(req: Request, env: Env): Promise<Response> {
 
   const cpText = await cpResp.text();
   if (cpResp.status >= 200 && cpResp.status < 300) {
-    let parsed: { sandboxID?: string; workerID?: string; status?: string; memoryMB?: number } = {};
+    let parsed: SandboxCreateResult = {};
     try {
       parsed = JSON.parse(cpText);
     } catch {
       /* leave parsed empty — still record what we can */
     }
-    if (parsed.sandboxID) {
-      await env.OPENCOMPUTER_DB.prepare(
-        `INSERT OR REPLACE INTO sandboxes_index
-           (id, org_id, user_id, cell_id, worker_id, status, cpu_count, memory_mb, created_at, last_event_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9)`,
-      )
-        .bind(
-          parsed.sandboxID,
-          caller.orgID,
-          caller.userID,
-          cell.cell_id,
-          parsed.workerID ?? null,
-          parsed.status ?? "running",
-          bodyCpuCount,
-          parsed.memoryMB ?? bodyMemoryMB,
-          Math.floor(Date.now() / 1000),
-        )
-        .run();
-    }
+    await insertSandboxIndex(env, caller, cell.cell_id, parsed, bodyCpuCount, bodyMemoryMB);
   }
   // Pass the CP's response through verbatim (status + body).
   return new Response(cpText, {


### PR DESCRIPTION
## Summary
- index streamed image/snapshot sandbox creates from the SSE `result` event
- reuse the same `sandboxes_index` insert helper for JSON and SSE create paths
- add a regression test covering SSE snapshot create indexing

## Why
The SSE create path streamed the cell response directly and relied on the async lifecycle event pipeline to populate `sandboxes_index`. That left a race where the SDK could receive a sandbox ID and an immediate `GET`/`DELETE` returned `404 {"error":"sandbox not found"}` before D1 was updated.

## Manual Reproduction
Save this as `repro-sse-create-kill-404.mjs` and run it against an environment with a ready snapshot:

```js
#!/usr/bin/env node

const apiKey = process.env.OPENCOMPUTER_API_KEY;
const apiUrl = resolveApiUrl(process.env.OPENCOMPUTER_API_URL || "https://app.opencomputer.dev");
const snapshot = process.env.OPENCOMPUTER_SNAPSHOT || "deputies-opencomputer-base-bridge";
const memoryMB = Number(process.env.OPENCOMPUTER_MEMORY_MB || 1024);
const iterations = Number(process.env.ITERATIONS || 1);
const killDelayMs = Number(process.env.KILL_DELAY_MS || 0);

if (!apiKey) throw new Error("Set OPENCOMPUTER_API_KEY");

for (let i = 1; i <= iterations; i += 1) {
  let sandboxID;
  console.log(`\niteration ${i}/${iterations}`);
  try {
    const started = Date.now();
    const created = await createSandboxFromSnapshot();
    sandboxID = created.sandboxID;
    console.log("created", JSON.stringify({
      id: sandboxID,
      status: created.status,
      createMs: Date.now() - started,
    }, null, 2));

    const before = await raw("GET", `/sandboxes/${sandboxID}`);
    console.log("get before kill", JSON.stringify(before, null, 2));

    if (killDelayMs > 0) {
      console.log(`waiting ${killDelayMs}ms before kill`);
      await new Promise((resolve) => setTimeout(resolve, killDelayMs));
    }

    const killed = await raw("DELETE", `/sandboxes/${sandboxID}`);
    console.log("delete", JSON.stringify(killed, null, 2));

    const after = await raw("GET", `/sandboxes/${sandboxID}`);
    console.log("get after kill", JSON.stringify(after, null, 2));

    if (before.status === 404 || killed.status === 404) {
      process.exitCode = 1;
      break;
    }
  } catch (error) {
    console.error("repro failed", {
      sandboxID,
      message: String(error?.message || error),
    });
    process.exitCode = 1;
    break;
  }
}

function resolveApiUrl(url) {
  const base = url.replace(/\/+$/, "");
  return base.endsWith("/api") ? base : `${base}/api`;
}

async function createSandboxFromSnapshot() {
  const response = await fetch(`${apiUrl}/sandboxes`, {
    method: "POST",
    headers: {
      "Accept": "text/event-stream",
      "Content-Type": "application/json",
      "X-API-Key": apiKey,
    },
    body: JSON.stringify({
      snapshot,
      memoryMB,
      timeout: 60,
      metadata: { repro: "sse-create-kill-404", createdAt: new Date().toISOString() },
    }),
  });

  if (!response.ok) {
    throw new Error(`create failed: ${response.status} ${await response.text()}`);
  }
  if (!(response.headers.get("content-type") || "").includes("text/event-stream")) {
    return await response.json();
  }
  return await readSSEResult(response);
}

async function readSSEResult(response) {
  const reader = response.body?.getReader();
  if (!reader) throw new Error("create response did not include a readable SSE body");

  const decoder = new TextDecoder();
  let buffer = "";
  let result;

  while (true) {
    const { done, value } = await reader.read();
    if (done) break;
    buffer += decoder.decode(value, { stream: true });
    const events = buffer.split("\n\n");
    buffer = events.pop() || "";
    for (const event of events) {
      const parsed = parseSSEEvent(event);
      if (parsed.type === "error") throw new Error(`create stream error: ${parsed.data}`);
      if (parsed.type === "result") result = JSON.parse(parsed.data);
    }
  }

  const tail = decoder.decode();
  if (tail) buffer += tail;
  if (buffer.trim()) {
    const parsed = parseSSEEvent(buffer);
    if (parsed.type === "error") throw new Error(`create stream error: ${parsed.data}`);
    if (parsed.type === "result") result = JSON.parse(parsed.data);
  }
  if (!result?.sandboxID) throw new Error("create stream ended without a sandbox result");
  return result;
}

function parseSSEEvent(event) {
  let type = "message";
  const data = [];
  for (const rawLine of event.split(/\r?\n/)) {
    const line = rawLine.trimEnd();
    if (!line || line.startsWith(":")) continue;
    if (line.startsWith("event:")) type = line.slice("event:".length).trimStart();
    if (line.startsWith("data:")) data.push(line.slice("data:".length).trimStart());
  }
  return { type, data: data.join("\n") };
}

async function raw(method, path) {
  const started = Date.now();
  const response = await fetch(`${apiUrl}${path}`, {
    method,
    headers: { "X-API-Key": apiKey },
  });
  const body = await response.text();
  return { method, path, status: response.status, ms: Date.now() - started, body };
}
```

Example prod command:

```sh
OPENCOMPUTER_API_KEY='<key>' \
OPENCOMPUTER_API_URL='https://app.opencomputer.dev/api' \
OPENCOMPUTER_SNAPSHOT='deputies-opencomputer-base-bridge' \
ITERATIONS=1 \
node repro-sse-create-kill-404.mjs
```

Observed on prod before this edge fix:

```text
created sb-b50a1971
GET /sandboxes/sb-b50a1971    -> 404 {"error":"sandbox not found"}
DELETE /sandboxes/sb-b50a1971 -> 404 {"error":"sandbox not found"}

5 seconds later:
GET /sandboxes/sb-b50a1971    -> 200 status=running
DELETE /sandboxes/sb-b50a1971 -> 204
GET /sandboxes/sb-b50a1971    -> 200 status=stopped
```

Observed on the `mo-oc-dev.com` test cell after deploying this PR branch:

```sh
OPENCOMPUTER_API_KEY='<key>' \
OPENCOMPUTER_API_URL='https://mo-oc-dev.com/api' \
OPENCOMPUTER_SNAPSHOT='repro-kill-404-minimal-dev' \
ITERATIONS=5 \
node repro-sse-create-kill-404.mjs
```

All 5 iterations returned:

```text
GET before kill -> 200
DELETE          -> 204
GET after kill  -> 200 status=stopped
```

## Tests
- `npm --prefix ../../opencomputer/cloudflare-workers/api-edge test -- --run`
- `../../opencomputer/cloudflare-workers/api-edge/node_modules/.bin/tsc -p ../../opencomputer/cloudflare-workers/api-edge/tsconfig.json --noEmit`
