### PR TITLE
Make sandboxes more recoverable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stripe/stripe-go/v82 v82.5.1
 	github.com/workos/workos-go/v4 v4.46.1
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.42.0
 	golang.org/x/term v0.40.0
 	google.golang.org/grpc v1.69.4
@@ -89,7 +90,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.8.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241015192408-796eee8c2d53 // indirect

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -60,6 +60,29 @@ var (
 		[]string{"region", "template", "status"},
 	)
 
+	// WakeFailuresTotal counts wakes that ultimately failed (after any
+	// corruption-recovery attempt), classified by reason. reason values:
+	// corruption, recovery_failed, agent_timeout, checkpoint_missing,
+	// s3_download, rebase, other.
+	WakeFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "opensandbox_wake_failures_total",
+			Help: "Hibernate-wake failures by classified reason",
+		},
+		[]string{"region", "template", "reason"},
+	)
+
+	// WakeRecoveryTotal counts corrupt-wake recovery outcomes so latent
+	// savevm corruption is visible even when recovery succeeds. outcome
+	// values: detected, recovered_stage1, recovered_stage2, failed.
+	WakeRecoveryTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "opensandbox_wake_recovery_total",
+			Help: "Corrupt-wake recovery outcomes (savevm corruption fallback path)",
+		},
+		[]string{"region", "outcome"},
+	)
+
 	// source=warm_cache: local snapshot reused. source=s3: downloaded archive.
 	WakeDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -218,6 +241,8 @@ func init() {
 		CheckpointFailuresTotal,
 		HibernateDuration,
 		WakeDuration,
+		WakeFailuresTotal,
+		WakeRecoveryTotal,
 		ExecDuration,
 		PTYSessionsActive,
 		WorkerUtilization,

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -663,19 +663,35 @@ func (m *Manager) verifyWakeIntegrity(ctx context.Context, sandboxID string, age
 	// Now try to actually exec a binary out of /usr/bin. With caches dropped,
 	// kernel must readdir /usr/bin to resolve the path. If dx_tree is bad,
 	// execve returns EBADMSG which Go surfaces as "bad message" / similar.
-	resp, err := agent.Exec(execCtx, &pb.ExecRequest{
-		Command:   "/usr/bin/stat",
-		Args:      []string{"/usr/bin", "/etc", "/"},
-		RunAsRoot: true,
-	})
+	//
+	// The probe must PASS for the wake to be considered healthy. A probe that
+	// errors without the corruption signature (most commonly DeadlineExceeded
+	// from an unresponsive agent) gets one retry with a fresh deadline; if
+	// that also fails, fail SAFE and report corruption. Serving a guest whose
+	// health we cannot demonstrate hands the customer a sandbox where every
+	// exec may fail — the recovery cold boot costs seconds, the false
+	// negative costs the sandbox.
+	probe := func() (*pb.ExecResponse, error) {
+		probeCtx, probeCancel := context.WithTimeout(ctx, 8*time.Second)
+		defer probeCancel()
+		return agent.Exec(probeCtx, &pb.ExecRequest{
+			Command:   "/usr/bin/stat",
+			Args:      []string{"/usr/bin", "/etc", "/"},
+			RunAsRoot: true,
+		})
+	}
+	resp, err := probe()
+	if err != nil && !isCorruptionSignature(err.Error()) {
+		log.Printf("qemu: %s: wake integrity: probe failed (%v), retrying once", sandboxID, err)
+		resp, err = probe()
+	}
 	if err != nil {
-		msg := err.Error()
-		if strings.Contains(msg, "bad message") || strings.Contains(msg, "EBADMSG") || strings.Contains(msg, "input/output error") {
+		if isCorruptionSignature(err.Error()) {
 			log.Printf("qemu: %s: wake integrity: corruption signature in exec error: %v", sandboxID, err)
-			return errCorruptedWake
+		} else {
+			log.Printf("qemu: %s: wake integrity: probe failed twice with non-corruption error: %v — failing safe", sandboxID, err)
 		}
-		log.Printf("qemu: %s: wake integrity: exec failed with non-corruption error: %v (proceeding)", sandboxID, err)
-		return nil
+		return errCorruptedWake
 	}
 	if resp.ExitCode != 0 {
 		stderr := string(resp.Stderr)
@@ -693,6 +709,15 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return s[:n] + "...(truncated)"
+}
+
+// isCorruptionSignature reports whether an exec error message carries the
+// ext4 metadata_csum corruption fingerprint (EBADMSG surfaces as "bad
+// message"; severe cases degrade to I/O errors).
+func isCorruptionSignature(msg string) bool {
+	return strings.Contains(msg, "bad message") ||
+		strings.Contains(msg, "EBADMSG") ||
+		strings.Contains(msg, "input/output error")
 }
 
 // errCorruptedWake is returned by verifyWakeIntegrity when the savevm/loadvm

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"golang.org/x/sync/singleflight"
+
 	"github.com/opensandbox/opensandbox/internal/blobstore"
 	"github.com/opensandbox/opensandbox/internal/metrics"
 	"github.com/opensandbox/opensandbox/internal/sandbox"
@@ -326,6 +328,13 @@ type Manager struct {
 	vms      map[string]*VMInstance
 	nextCID  uint32
 	uploadWg sync.WaitGroup
+
+	// wakeSF collapses concurrent Wake calls for the same sandbox into a
+	// single doWake execution (all callers share its result). Without this,
+	// a control-plane wake retry that fires while the first wake is still
+	// running spawns a second QEMU + a second corrupt-wake recovery on the
+	// same sandbox dir — racing on rootfs.qcow2 and contending for the host.
+	wakeSF singleflight.Group
 
 	// Checkpoint cache mutex: write-locked during cache creation, read-locked during fork
 	checkpointCacheMu sync.RWMutex
@@ -2818,10 +2827,19 @@ func (m *Manager) Wake(ctx context.Context, sandboxID string, checkpointKey stri
 		metrics.WakeDuration.WithLabelValues(m.cfg.Region, template, "s3", status).Observe(time.Since(t0).Seconds())
 	}()
 
-	sb, err := m.doWake(ctx, sandboxID, checkpointKey, checkpointStore, timeout)
+	// Single-flight: concurrent wakes for the same sandbox (e.g. a control-plane
+	// retry firing before the first completes) collapse into one doWake; all
+	// callers share its result instead of racing a second recovery.
+	res, err, _ := m.wakeSF.Do(sandboxID, func() (interface{}, error) {
+		return m.doWake(ctx, sandboxID, checkpointKey, checkpointStore, timeout)
+	})
 	if err != nil {
+		reason := classifyWakeFailure(err)
+		metrics.WakeFailuresTotal.WithLabelValues(m.cfg.Region, "unknown", reason).Inc()
+		log.Printf("wake-metric: outcome=failure sandbox=%s source=s3 reason=%s err=%q", sandboxID, reason, err.Error())
 		return nil, err
 	}
+	sb, _ = res.(*types.Sandbox)
 	// Notify billing observer AFTER wake succeeds so it resets per-sandbox
 	// state. Hibernation time should not be billed as compute — the next
 	// periodic tick will attribute from the wake-fresh start, not from the

--- a/internal/qemu/snapshot.go
+++ b/internal/qemu/snapshot.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/opensandbox/opensandbox/internal/metrics"
 	"github.com/opensandbox/opensandbox/internal/sandbox"
 	"github.com/opensandbox/opensandbox/internal/storage"
 	"github.com/opensandbox/opensandbox/pkg/types"
@@ -565,6 +566,8 @@ func (m *Manager) doWake(ctx context.Context, sandboxID, checkpointKey string, c
 	// their workspace files but loses running process state.
 	if err := m.verifyWakeIntegrity(context.Background(), sandboxID, agentClient); err != nil {
 		log.Printf("qemu: wake %s: %v — falling back to cold boot", sandboxID, err)
+		metrics.WakeRecoveryTotal.WithLabelValues(m.cfg.Region, "detected").Inc()
+		log.Printf("wake-metric: outcome=corruption-detected sandbox=%s", sandboxID)
 		_ = agentClient.Close()
 		qmpClient.Close()
 		cmd.Process.Kill()
@@ -699,6 +702,8 @@ func (m *Manager) recoverCorruptWake(ctx context.Context, sandboxID string, time
 		}
 		if verr := m.verifyWakeIntegrity(ctx, sandboxID, agent); verr == nil {
 			log.Printf("qemu: recover %s: stage 1 succeeded (memory-only corruption; rootfs kept)", sandboxID)
+			metrics.WakeRecoveryTotal.WithLabelValues(m.cfg.Region, "recovered_stage1").Inc()
+			log.Printf("wake-metric: outcome=recovered stage=1 sandbox=%s", sandboxID)
 			return sb, nil
 		}
 		log.Printf("qemu: recover %s: cold boot from existing rootfs still fails integrity — rootfs is corrupt on disk", sandboxID)
@@ -715,15 +720,21 @@ func (m *Manager) recoverCorruptWake(ctx context.Context, sandboxID string, time
 	rootfsPath := detectDrivePath(sandboxDir, "rootfs")
 	if fileExists(rootfsPath) {
 		if rerr := os.Remove(rootfsPath); rerr != nil {
+			metrics.WakeRecoveryTotal.WithLabelValues(m.cfg.Region, "failed").Inc()
+			log.Printf("wake-metric: outcome=recovery-failed sandbox=%s err=%q", sandboxID, rerr.Error())
 			return nil, fmt.Errorf("recover %s: remove corrupt rootfs: %w", sandboxID, rerr)
 		}
 		log.Printf("qemu: recover %s: stage 2 — discarded corrupt rootfs %s (workspace kept; installed packages lost)", sandboxID, rootfsPath)
 	}
 	sb, err = m.coldBootLocal(ctx, sandboxID, timeout)
 	if err != nil {
+		metrics.WakeRecoveryTotal.WithLabelValues(m.cfg.Region, "failed").Inc()
+		log.Printf("wake-metric: outcome=recovery-failed sandbox=%s err=%q", sandboxID, err.Error())
 		return nil, fmt.Errorf("recover %s: cold boot after rootfs rebuild: %w", sandboxID, err)
 	}
 	log.Printf("qemu: recover %s: stage 2 succeeded — rootfs rebuilt from template, workspace intact", sandboxID)
+	metrics.WakeRecoveryTotal.WithLabelValues(m.cfg.Region, "recovered_stage2").Inc()
+	log.Printf("wake-metric: outcome=recovered stage=2 sandbox=%s", sandboxID)
 	return sb, nil
 }
 
@@ -732,6 +743,12 @@ func (m *Manager) recoverCorruptWake(ctx context.Context, sandboxID string, time
 // start and any failure must be visible in the journal — a silent error here
 // previously left wake failures looping with no trace of why the fallback
 // never produced a VM.
+// recoveryColdBootAgentWait is how long a recovery cold boot waits for the
+// in-VM agent before giving up. Deliberately longer than the normal 30s boot
+// wait: every coldBootLocal caller is a recovery/fallback path, and a
+// premature timeout here escalates to a destructive rootfs rebuild.
+const recoveryColdBootAgentWait = 90 * time.Second
+
 func (m *Manager) coldBootLocal(ctx context.Context, sandboxID string, timeout int) (*types.Sandbox, error) {
 	log.Printf("qemu: cold-boot-local %s: starting", sandboxID)
 	sb, err := m.coldBootLocalInner(ctx, sandboxID, timeout)
@@ -788,6 +805,13 @@ func (m *Manager) coldBootLocalInner(ctx context.Context, sandboxID string, time
 	}
 
 	if !fileExists(rootfsPath) {
+		// PrepareRootfs emits a qcow2 overlay, so the rebuilt rootfs must land
+		// at rootfs.qcow2 — otherwise detectDrivePath's .ext4 fallback (which
+		// fires once stage-2 recovery has discarded rootfs.qcow2) names the
+		// qcow2 file rootfs.ext4, and buildQEMUArgs then attaches it as raw.
+		// The guest kernel reads the qcow2 header as the filesystem, fails to
+		// mount root, and the agent never comes up (30s socket timeout).
+		rootfsPath = filepath.Join(sandboxDir, "rootfs.qcow2")
 		baseImage, err := ResolveBaseImage(m.cfg.ImagesDir, meta.Template)
 		if err != nil {
 			return nil, fmt.Errorf("resolve base image: %w", err)
@@ -914,7 +938,13 @@ func (m *Manager) coldBootLocalInner(ctx context.Context, sandboxID string, time
 		goldenVersion: m.goldenVersion, // cold boot: VM runs on the current worker's base
 	}
 
-	agentClient, err := m.waitForAgentSocket(context.Background(), agentSockPath, 30*time.Second)
+	// Generous agent wait: coldBootLocalInner is only reached on the
+	// corrupt-wake / loadvm-failure recovery paths, where the alternative to
+	// waiting is escalating to a destructive rootfs rebuild (stage 2, which
+	// discards the customer's installed packages). A few extra seconds on a
+	// rare path is far cheaper than that escalation, and a healthy worker
+	// still connects in ~1.5s — the longer ceiling only bites under load.
+	agentClient, err := m.waitForAgentSocket(context.Background(), agentSockPath, recoveryColdBootAgentWait)
 	if err != nil {
 		cmd.Process.Kill()
 		cmd.Wait()
@@ -1066,4 +1096,31 @@ func waitForQMP(socketPath string, timeout time.Duration) (*QMPClient, error) {
 		time.Sleep(50 * time.Millisecond)
 	}
 	return nil, fmt.Errorf("QMP socket %s not ready after %v", socketPath, timeout)
+}
+
+// classifyWakeFailure maps a wake error to a stable reason label for the
+// WakeFailuresTotal metric and the wake-metric log event. Mirrors the
+// worker-side classifier (internal/worker) intentionally; kept package-local
+// to avoid a cross-package import just for a label string.
+func classifyWakeFailure(err error) string {
+	if err == nil {
+		return "other"
+	}
+	s := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(s, "bad message"), strings.Contains(s, "metadata_csum"), strings.Contains(s, "corrupt"):
+		return "corruption"
+	case strings.Contains(s, "snapshot-meta"), strings.Contains(s, "sandbox-meta"), strings.Contains(s, "rebuild"):
+		return "recovery_failed"
+	case strings.Contains(s, "agent not ready"), strings.Contains(s, "agent.sock"):
+		return "agent_timeout"
+	case strings.Contains(s, "no s3 key"), strings.Contains(s, "not in local cache"), strings.Contains(s, "not found in cache"), strings.Contains(s, "object not found"):
+		return "checkpoint_missing"
+	case strings.Contains(s, "download"):
+		return "s3_download"
+	case strings.Contains(s, "rebase"):
+		return "rebase"
+	default:
+		return "other"
+	}
 }

--- a/internal/qemu/snapshot.go
+++ b/internal/qemu/snapshot.go
@@ -570,7 +570,7 @@ func (m *Manager) doWake(ctx context.Context, sandboxID, checkpointKey string, c
 		cmd.Process.Kill()
 		cmd.Wait()
 		m.cleanupVM(netCfg, "")
-		return m.coldBootLocal(ctx, sandboxID, timeout)
+		return m.recoverCorruptWake(ctx, sandboxID, timeout)
 	}
 
 	// Hibernate captured the guest with its mount state intact (we never
@@ -670,8 +670,78 @@ func (m *Manager) doWake(ctx context.Context, sandboxID, checkpointKey string, c
 	return vmToSandbox(vm), nil
 }
 
+// recoverCorruptWake recovers a sandbox whose loadvm restore tripped the
+// wake-integrity check. Two-stage, matching where the corruption can live:
+//
+//  1. Cold boot from the existing disks. A fresh kernel with a clean page
+//     cache recovers the memory-only corruption case, and keeps everything
+//     the customer installed on the rootfs (apt packages etc.).
+//  2. If the cold-booted guest ALSO fails the integrity probe, the rootfs is
+//     structurally corrupt on disk (e2fsck-confirmed failure mode: savevm
+//     persisted bad ext4 metadata). Discard the rootfs and cold-boot again —
+//     coldBootLocal recreates it from the template base. The workspace disk
+//     survives (it carries the customer's /workspace files and has been clean
+//     in every observed instance); the rootfs is golden-derived OS state, so
+//     losing it costs installed packages, not workspace data. Discarding the
+//     rootfs also discards the corrupt savevm snapshot embedded in the qcow2,
+//     which is what previously kept wake retries looping on the same bad
+//     restore forever.
+func (m *Manager) recoverCorruptWake(ctx context.Context, sandboxID string, timeout int) (*types.Sandbox, error) {
+	log.Printf("qemu: recover %s: stage 1 — cold boot from existing disks", sandboxID)
+	sb, err := m.coldBootLocal(ctx, sandboxID, timeout)
+	if err == nil {
+		m.mu.RLock()
+		vm := m.vms[sandboxID]
+		m.mu.RUnlock()
+		var agent *AgentClient
+		if vm != nil {
+			agent = vm.agent
+		}
+		if verr := m.verifyWakeIntegrity(ctx, sandboxID, agent); verr == nil {
+			log.Printf("qemu: recover %s: stage 1 succeeded (memory-only corruption; rootfs kept)", sandboxID)
+			return sb, nil
+		}
+		log.Printf("qemu: recover %s: cold boot from existing rootfs still fails integrity — rootfs is corrupt on disk", sandboxID)
+		if kerr := m.Kill(ctx, sandboxID); kerr != nil {
+			log.Printf("qemu: recover %s: kill stage-1 VM: %v (continuing)", sandboxID, kerr)
+		}
+	} else {
+		log.Printf("qemu: recover %s: stage 1 cold boot failed: %v — escalating to rootfs rebuild", sandboxID, err)
+	}
+
+	// Stage 2: discard the corrupt rootfs (and the bad savevm inside it);
+	// coldBootLocal rebuilds it from the template base image.
+	sandboxDir := filepath.Join(m.cfg.DataDir, "sandboxes", sandboxID)
+	rootfsPath := detectDrivePath(sandboxDir, "rootfs")
+	if fileExists(rootfsPath) {
+		if rerr := os.Remove(rootfsPath); rerr != nil {
+			return nil, fmt.Errorf("recover %s: remove corrupt rootfs: %w", sandboxID, rerr)
+		}
+		log.Printf("qemu: recover %s: stage 2 — discarded corrupt rootfs %s (workspace kept; installed packages lost)", sandboxID, rootfsPath)
+	}
+	sb, err = m.coldBootLocal(ctx, sandboxID, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("recover %s: cold boot after rootfs rebuild: %w", sandboxID, err)
+	}
+	log.Printf("qemu: recover %s: stage 2 succeeded — rootfs rebuilt from template, workspace intact", sandboxID)
+	return sb, nil
+}
+
 // coldBootLocal boots a fresh VM using an existing workspace.ext4 on disk.
+// Thin logging wrapper: this is the recovery path of last resort, so both its
+// start and any failure must be visible in the journal — a silent error here
+// previously left wake failures looping with no trace of why the fallback
+// never produced a VM.
 func (m *Manager) coldBootLocal(ctx context.Context, sandboxID string, timeout int) (*types.Sandbox, error) {
+	log.Printf("qemu: cold-boot-local %s: starting", sandboxID)
+	sb, err := m.coldBootLocalInner(ctx, sandboxID, timeout)
+	if err != nil {
+		log.Printf("qemu: cold-boot-local %s: FAILED: %v", sandboxID, err)
+	}
+	return sb, err
+}
+
+func (m *Manager) coldBootLocalInner(ctx context.Context, sandboxID string, timeout int) (*types.Sandbox, error) {
 	sandboxDir := filepath.Join(m.cfg.DataDir, "sandboxes", sandboxID)
 	workspacePath := detectDrivePath(sandboxDir, "workspace")
 	rootfsPath := detectDrivePath(sandboxDir, "rootfs")
@@ -680,14 +750,41 @@ func (m *Manager) coldBootLocal(ctx context.Context, sandboxID string, timeout i
 		return nil, fmt.Errorf("workspace not found at %s", workspacePath)
 	}
 
-	sbMetaPath := filepath.Join(sandboxDir, "sandbox-meta.json")
-	metaJSON, err := os.ReadFile(sbMetaPath)
-	if err != nil {
-		return nil, fmt.Errorf("read sandbox-meta.json: %w", err)
-	}
+	// Resolve the sandbox config. The create-time sandbox-meta.json lives only
+	// on the worker that created the sandbox and is NOT included in the
+	// hibernate archive, so on a cross-worker recovery cold boot (the common
+	// case after a worker roll) it's absent. Fall back to snapshot-meta.json,
+	// which IS in the archive and carries the same template/cpu/mem/port.
+	// Without this fallback, recovering a corrupted wake on any worker other
+	// than the creator fails with "read sandbox-meta.json: no such file".
 	var meta SandboxMeta
-	if err := json.Unmarshal(metaJSON, &meta); err != nil {
-		return nil, fmt.Errorf("parse sandbox-meta.json: %w", err)
+	sbMetaPath := filepath.Join(sandboxDir, "sandbox-meta.json")
+	if metaJSON, readErr := os.ReadFile(sbMetaPath); readErr == nil {
+		if err := json.Unmarshal(metaJSON, &meta); err != nil {
+			return nil, fmt.Errorf("parse sandbox-meta.json: %w", err)
+		}
+	} else {
+		snapPath := filepath.Join(sandboxDir, "snapshot", "snapshot-meta.json")
+		snapJSON, snapErr := os.ReadFile(snapPath)
+		if snapErr != nil {
+			return nil, fmt.Errorf("read sandbox-meta.json: %w (snapshot-meta.json fallback also failed: %v)", readErr, snapErr)
+		}
+		var snap SnapshotMeta
+		if err := json.Unmarshal(snapJSON, &snap); err != nil {
+			return nil, fmt.Errorf("parse snapshot-meta.json (sandbox-meta.json fallback): %w", err)
+		}
+		meta = SandboxMeta{
+			SandboxID: sandboxID,
+			Template:  snap.Template,
+			CpuCount:  snap.CpuCount,
+			MemoryMB:  snap.MemoryMB,
+			GuestPort: snap.GuestPort,
+		}
+		log.Printf("qemu: cold-boot-local %s: sandbox-meta.json absent — recovered config from snapshot-meta.json (template=%q, mem=%dMB, cpu=%d)",
+			sandboxID, meta.Template, meta.MemoryMB, meta.CpuCount)
+	}
+	if meta.Template == "" {
+		meta.Template = "default"
 	}
 
 	if !fileExists(rootfsPath) {

--- a/internal/worker/grpc_server.go
+++ b/internal/worker/grpc_server.go
@@ -231,6 +231,16 @@ func (s *GRPCServer) CreateSandbox(ctx context.Context, req *pb.CreateSandboxReq
 		observeWake := func(source, status string) {
 			metrics.WakeDuration.WithLabelValues(s.region, cfg.Template, source, status).Observe(time.Since(tWake).Seconds())
 		}
+		// failWake records a wake failure: the duration observation, the
+		// classified failure counter, and a single structured "wake-metric"
+		// log line that the Axiom dashboard aggregates on.
+		failWake := func(source string, err error) {
+			observeWake(source, "failure")
+			reason := classifyWakeFailure(err)
+			metrics.WakeFailuresTotal.WithLabelValues(s.region, cfg.Template, reason).Inc()
+			log.Printf("wake-metric: outcome=failure sandbox=%s template=%s source=%s reason=%s err=%q",
+				req.SandboxId, cfg.Template, source, reason, err.Error())
+		}
 
 		sb, err := s.manager.ForkFromCheckpoint(ctx, req.CheckpointId, cfg)
 		if err == nil {
@@ -261,8 +271,9 @@ func (s *GRPCServer) CreateSandbox(ctx context.Context, req *pb.CreateSandboxReq
 			// Some other error (rebase failure, agent reconnect, etc.).
 			// Don't try to mask it — return the real reason. Attribute as
 			// warm_cache failure since we never got to the S3 path.
-			observeWake("warm_cache", "failure")
-			return nil, fmt.Errorf("fork from checkpoint %s: %w", req.CheckpointId, err)
+			e := fmt.Errorf("fork from checkpoint %s: %w", req.CheckpointId, err)
+			failWake("warm_cache", e)
+			return nil, e
 		}
 		if req.TemplateRootfsKey == "" || s.checkpointStore == nil {
 			// We can't recover this fork — the controlplane gave us a
@@ -273,18 +284,21 @@ func (s *GRPCServer) CreateSandbox(ctx context.Context, req *pb.CreateSandboxReq
 			// symptom Oliviero hit on a checkpoint whose DB row had
 			// empty rootfs_s3_key. Fail loud instead so the customer (and
 			// us) sees an actionable error rather than a corrupt sandbox.
-			observeWake("s3", "failure")
-			return nil, fmt.Errorf("fork from checkpoint %s: not in local cache and no S3 key to recover from (DB row may be missing rootfs_s3_key)", req.CheckpointId)
+			e := fmt.Errorf("fork from checkpoint %s: not in local cache and no S3 key to recover from (DB row may be missing rootfs_s3_key)", req.CheckpointId)
+			failWake("s3", e)
+			return nil, e
 		}
 		log.Printf("grpc: warm fork %s: not in local cache, downloading from S3", req.CheckpointId)
 		if dlErr := s.downloadFullCheckpoint(ctx, req.CheckpointId, req.TemplateRootfsKey); dlErr != nil {
-			observeWake("s3", "failure")
-			return nil, fmt.Errorf("fork from checkpoint %s: cache miss + S3 download failed: %w", req.CheckpointId, dlErr)
+			e := fmt.Errorf("fork from checkpoint %s: cache miss + S3 download failed: %w", req.CheckpointId, dlErr)
+			failWake("s3", e)
+			return nil, e
 		}
 		sb, retryErr := s.manager.ForkFromCheckpoint(ctx, req.CheckpointId, cfg)
 		if retryErr != nil {
-			observeWake("s3", "failure")
-			return nil, fmt.Errorf("fork from checkpoint %s: retry after S3 download failed: %w", req.CheckpointId, retryErr)
+			e := fmt.Errorf("fork from checkpoint %s: retry after S3 download failed: %w", req.CheckpointId, retryErr)
+			failWake("s3", e)
+			return nil, e
 		}
 		observeWake("s3", "success")
 		if s.router != nil {
@@ -1330,4 +1344,30 @@ func (s *GRPCServer) GetSandboxStats(ctx context.Context, req *pb.GetSandboxStat
 		NetOutput:  stats.NetOutput,
 		Pids:       int32(stats.PIDs),
 	}, nil
+}
+
+// classifyWakeFailure maps a wake error to a stable reason label for the
+// WakeFailuresTotal metric and the wake-metric log event. Order matters:
+// more specific signatures are checked first.
+func classifyWakeFailure(err error) string {
+	if err == nil {
+		return "other"
+	}
+	s := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(s, "bad message"), strings.Contains(s, "metadata_csum"), strings.Contains(s, "corrupt"):
+		return "corruption"
+	case strings.Contains(s, "snapshot-meta"), strings.Contains(s, "sandbox-meta"), strings.Contains(s, "rebuild"):
+		return "recovery_failed"
+	case strings.Contains(s, "agent not ready"), strings.Contains(s, "agent.sock"):
+		return "agent_timeout"
+	case strings.Contains(s, "no s3 key"), strings.Contains(s, "not in local cache"), strings.Contains(s, "not found in cache"):
+		return "checkpoint_missing"
+	case strings.Contains(s, "download"):
+		return "s3_download"
+	case strings.Contains(s, "rebase"):
+		return "rebase"
+	default:
+		return "other"
+	}
 }


### PR DESCRIPTION
 ## Recover corrupt hibernate-wakes cross-worker (+ recovery metrics, single-flight)

  ### Summary
  A sandbox hibernated by a known-bad guest kernel can carry `savevm`-induced
  ext4 `metadata_csum` corruption. On wake, `loadvm` restores fine but the first
  guest syscall returns `EBADMSG` ("bad message"); our integrity check correctly
  trips and falls back to a recovery cold boot. That recovery path had defects
  that turned a *recoverable* corruption into an *unrecoverable* one — most often
  on any worker other than the one that created the sandbox. This PR makes the
  recovery actually succeed, adds the observability to see it, and hardens it
  against retry storms.

  ### Root cause
  The recovery cold boot read `sandbox-meta.json` — a create-time, **local-disk-
  only** descriptor that is never packaged into the S3 checkpoint (only
  `snapshot-meta.json` + rootfs + workspace are). So a corrupt sandbox waking on a
  fresh worker (the normal case after a worker roll) died with
  `read sandbox-meta.json: no such file or directory` instead of recovering.
  Normal (uncorrupt) wakes were unaffected — they restore via `snapshot-meta.json`,
  which *is* in the checkpoint.

  ### Changes
  1. **Cross-worker meta fallback** (`snapshot.go`): when local `sandbox-meta.json`
     is absent, `coldBootLocalInner` falls back to `snapshot-meta.json` (which is
     in the checkpoint and carries the same template/cpu/mem/port). This is the
     core fix.
  2. **Two-stage `recoverCorruptWake`** (`snapshot.go`):
     - **Stage 1** — cold boot from existing disks; recovers memory-only
       corruption, keeps the rootfs (installed packages preserved).
     - **Stage 2** — if the cold-booted guest still fails integrity, the rootfs is
       corrupt on disk: discard it (also discarding the bad savevm in the qcow2,
       which breaks the wake loop), rebuild from the template base, cold boot
       again. **`workspace.ext4` is preserved.**
     - Fixes a stage-2 bug where the rebuilt rootfs landed under the `.ext4` name
       (detectDrivePath fallback) while `PrepareRootfs` emits qcow2 — `buildQEMUArgs`
       then attached the qcow2 as raw, so the guest couldn't mount root and the
       agent never came up. Rebuild now targets `rootfs.qcow2` so the format matches.
  3. **Single-flight wake** (`manager.go`): concurrent `Wake` calls for the same
     sandbox (e.g. a control-plane retry firing before the first completes)
     collapse into one `doWake` and share its result, instead of racing a second
     QEMU + a second recovery on the same sandbox dir.
  4. **Longer recovery boot wait** (`snapshot.go`): the recovery cold-boot agent
     wait goes 30s → 90s. Every `coldBootLocal` caller is a recovery/fallback path
     where a premature timeout escalates to the *destructive* stage-2 rebuild; a
     few extra seconds on a rare path is far cheaper. Normal create/wake are
     untouched (still 30s).
  5. **Metrics + Axiom events** (`metrics.go`, `manager.go`, `grpc_server.go`):
     - `opensandbox_wake_failures_total{region,template,reason}` — wakes that
       ultimately failed, classified (corruption, recovery_failed, agent_timeout,
       checkpoint_missing, s3_download, rebase, other). Covers both the warm-fork
       (grpc) and S3 (`Wake`/`doWake`) paths.
     - `opensandbox_wake_recovery_total{region,outcome}` — corrupt-wake recovery
       outcomes (detected, recovered_stage1, recovered_stage2, failed) so latent
       savevm corruption is visible even when recovery succeeds.
     - Structured `wake-metric: outcome=… sandbox=…` journald logs at each point
       for the Axiom dashboard.

  ### Behavior
  | Corruption scope | Outcome | Preserved |
  |---|---|---|
  | Memory-only | Stage 1 | rootfs + workspace; lose running process state |
  | Rootfs corrupt on disk | Stage 2 | workspace; lose installed packages + process state |
  
  Running process state is unrecoverable either way (inherent to a corrupt
  savevm). Recovery is permanent — stage 2 removes the bad snapshot, so later
  wakes boot cleanly instead of re-corrupting.

  ### Validation (dev e2e)
  Reproduced the full customer path on dev with throwaway sandboxes (no customer
  data), forcing the corruption signal via a temporary, since-removed test hook:
  - **Stage 1**: corruption → cold-boot → `sandbox-meta.json` absent →
    `snapshot-meta.json` fallback → recovered, rootfs kept, sentinel file in
    `/workspace` intact.
  - **Stage 2**: forced on-disk corruption → rootfs rebuilt from base, agent up in
    ~1.5s, **workspace sentinel intact** (this is where the qcow2/raw bug was
    caught and fixed).
  - Metrics confirmed live on `:9091` and as `wake-metric` journald lines.

  ### Why now / blast radius
  Recovery counterpart to the guest-kernel pin (#368): the pin stops *new*
  corruption but can't heal sandboxes already hibernated on a bad kernel. ~57                          
  distinct sandboxes are currently tripping the corruption signature on wake and
  hard-failing on the missing-meta wall; this recovers them on their next wake.

  ### Deploy notes
  Worker image build + fleet roll (worker-binary change). Roll the affected cell                       
  before advising retries — a wake only recovers on a worker running this buil