### PR TITLE
Avoid draining fresh virtio-serial agent handshakes

### DIFF
--- a/cmd/agent/listen_linux.go
+++ b/cmd/agent/listen_linux.go
@@ -116,9 +116,8 @@ func (l *virtioSerialListener) Accept() (net.Conn, error) {
 		// bytes (GOAWAY frames, partial HTTP/2 frames). If we hand these to
 		// the new gRPC session, it gets a protocol error and closes immediately.
 		if instrumentVirtioSerial {
-			log.Printf("virtio-serial: Accept iter: active=false, draining stale...")
+			log.Printf("virtio-serial: Accept iter: active=false, waiting for fresh data...")
 		}
-		drainStaleData(l.f)
 
 		// Wait for the host to connect (port becomes readable with fresh data)
 		if !waitForReadable(l.f, 500*time.Millisecond) {


### PR DESCRIPTION
## Summary
- stop discarding pending virtio-serial bytes immediately before accepting the next agent gRPC connection
- avoids dropping the fresh HTTP/2 client preface after QEMU golden restore

## Validation
- Reproduced failure with drain enabled on dev AWS QEMU golden restore: VM resumed in ~336ms, then agent ping timed out after 30s.
- Removed only the pre-accept drain call, rebuilt golden, and sandbox creation hot-booted successfully.
- Re-enabled drain only, rebuilt golden, and reproduced the 30s timeout again.
- Restored no-drain build, rebuilt golden, and verified sandbox creation succeeds again.
- Ran: GOOS=linux GOARCH=amd64 go test ./cmd/agent