### PR TITLE
Exec fixes

### DIFF
--- a/internal/agent/exec.go
+++ b/internal/agent/exec.go
@@ -70,13 +70,14 @@ func (s *Server) SetEnvs(ctx context.Context, req *pb.SetEnvsRequest) (*pb.SetEn
 
 // Exec runs a command synchronously and returns stdout/stderr/exit code.
 func (s *Server) Exec(ctx context.Context, req *pb.ExecRequest) (*pb.ExecResponse, error) {
-	timeout := time.Duration(req.TimeoutSeconds) * time.Second
-	if timeout <= 0 {
-		timeout = 60 * time.Second
+	// TimeoutSeconds == 0 means no timeout: the command runs unbounded, bounded
+	// only by the caller's context (the connection) and the sandbox lifetime.
+	// A positive value is enforced as a hard cap.
+	if req.TimeoutSeconds > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(req.TimeoutSeconds)*time.Second)
+		defer cancel()
 	}
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	cmd := exec.CommandContext(ctx, req.Command, req.Args...)
 
@@ -188,13 +189,13 @@ func isExitError(err error) bool {
 
 // ExecStream runs a command and streams stdout/stderr chunks.
 func (s *Server) ExecStream(req *pb.ExecRequest, stream pb.SandboxAgent_ExecStreamServer) error {
-	timeout := time.Duration(req.TimeoutSeconds) * time.Second
-	if timeout <= 0 {
-		timeout = 60 * time.Second
+	// TimeoutSeconds == 0 means no timeout (see Exec).
+	ctx := stream.Context()
+	if req.TimeoutSeconds > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(req.TimeoutSeconds)*time.Second)
+		defer cancel()
 	}
-
-	ctx, cancel := context.WithTimeout(stream.Context(), timeout)
-	defer cancel()
 
 	cmd := exec.CommandContext(ctx, req.Command, req.Args...)
 

--- a/internal/api/exec_heartbeat_test.go
+++ b/internal/api/exec_heartbeat_test.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/opensandbox/opensandbox/pkg/types"
+)
+
+// newExecCtx builds an echo context backed by a recorder for handler tests.
+func newExecCtx() (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/sandboxes/sb-x/exec/run", nil)
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec), rec
+}
+
+// Fast commands (under the grace window) keep the original status semantics
+// and a plain JSON body — no heartbeat bytes.
+func TestRespondExecWithHeartbeat_FastPath(t *testing.T) {
+	c, rec := newExecCtx()
+	want := &types.ProcessResult{ExitCode: 7, Stdout: "out", Stderr: "err"}
+	err := respondExecWithHeartbeat(c, func(ctx context.Context) (*types.ProcessResult, error) {
+		return want, nil
+	})
+	if err != nil {
+		t.Fatalf("handler returned err: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if strings.HasPrefix(rec.Body.String(), " ") {
+		t.Fatalf("fast path should not emit leading heartbeat whitespace, got %q", rec.Body.String())
+	}
+	var got types.ProcessResult
+	if e := json.Unmarshal(rec.Body.Bytes(), &got); e != nil {
+		t.Fatalf("decode: %v", e)
+	}
+	if got != *want {
+		t.Fatalf("result = %+v, want %+v", got, *want)
+	}
+}
+
+// Fast-path errors still surface as a 500 (unchanged behavior).
+func TestRespondExecWithHeartbeat_FastPathError(t *testing.T) {
+	c, rec := newExecCtx()
+	err := respondExecWithHeartbeat(c, func(ctx context.Context) (*types.ProcessResult, error) {
+		return nil, fmt.Errorf("boom")
+	})
+	if err != nil {
+		t.Fatalf("handler returned err: %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+// Long commands commit a 200 and emit whitespace heartbeats, but the body still
+// decodes as a ProcessResult (leading whitespace is valid JSON).
+func TestRespondExecWithHeartbeat_SlowPathStreamsValidJSON(t *testing.T) {
+	og, oi := execHeartbeatGrace, execHeartbeatInterval
+	execHeartbeatGrace, execHeartbeatInterval = 5*time.Millisecond, 5*time.Millisecond
+	defer func() { execHeartbeatGrace, execHeartbeatInterval = og, oi }()
+
+	c, rec := newExecCtx()
+	want := &types.ProcessResult{ExitCode: 0, Stdout: "hello", Stderr: ""}
+	err := respondExecWithHeartbeat(c, func(ctx context.Context) (*types.ProcessResult, error) {
+		time.Sleep(40 * time.Millisecond) // forces slow path + several heartbeats
+		return want, nil
+	})
+	if err != nil {
+		t.Fatalf("handler returned err: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.HasPrefix(body, " ") {
+		t.Fatalf("slow path should emit leading heartbeat whitespace, got %q", body)
+	}
+	var got types.ProcessResult
+	if e := json.Unmarshal(rec.Body.Bytes(), &got); e != nil {
+		t.Fatalf("heartbeat body must still decode as JSON: %v (body=%q)", e, body)
+	}
+	if got != *want {
+		t.Fatalf("decoded result = %+v, want %+v", got, *want)
+	}
+}
+
+// An error after commit is surfaced as a ProcessResult (ExitCode -1), since the
+// 200 status is already on the wire — strictly better than the 524 it replaces.
+func TestRespondExecWithHeartbeat_SlowPathErrorAsResult(t *testing.T) {
+	og := execHeartbeatGrace
+	execHeartbeatGrace = 5 * time.Millisecond
+	defer func() { execHeartbeatGrace = og }()
+
+	c, rec := newExecCtx()
+	err := respondExecWithHeartbeat(c, func(ctx context.Context) (*types.ProcessResult, error) {
+		time.Sleep(20 * time.Millisecond)
+		return nil, fmt.Errorf("agent unreachable")
+	})
+	if err != nil {
+		t.Fatalf("handler returned err: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (already committed)", rec.Code)
+	}
+	var got types.ProcessResult
+	if e := json.Unmarshal(rec.Body.Bytes(), &got); e != nil {
+		t.Fatalf("decode: %v", e)
+	}
+	if got.ExitCode != -1 || !strings.Contains(got.Stderr, "agent unreachable") {
+		t.Fatalf("error not surfaced as ProcessResult: %+v", got)
+	}
+}

--- a/internal/api/exec_session.go
+++ b/internal/api/exec_session.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -237,29 +238,95 @@ func (s *Server) execRun(c echo.Context) error {
 		return c.JSON(http.StatusServiceUnavailable, errSandboxNotAvailable)
 	}
 
-	var result *types.ProcessResult
+	return respondExecWithHeartbeat(c, func(ctx context.Context) (*types.ProcessResult, error) {
+		var result *types.ProcessResult
+		op := func(ctx context.Context) error {
+			var err error
+			result, err = s.manager.Exec(ctx, id, req)
+			return err
+		}
+		if s.router != nil {
+			if err := s.router.Route(ctx, id, "execRun", op); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := op(ctx); err != nil {
+				return nil, err
+			}
+		}
+		return result, nil
+	})
+}
 
-	routeOp := func(ctx context.Context) error {
-		var err error
-		result, err = s.manager.Exec(ctx, id, req)
-		return err
+// Heartbeat tunables (vars, not consts, so tests can shrink them).
+var (
+	// execHeartbeatGrace is how long we wait for a fast command before
+	// committing to a chunked, heartbeat-kept-alive response. The vast majority
+	// of commands finish within this window and return with normal status codes.
+	execHeartbeatGrace = 20 * time.Second
+	// execHeartbeatInterval must stay under Cloudflare's ~100s origin-idle
+	// ceiling (a 524 fires if the origin sends no bytes for that long).
+	execHeartbeatInterval = 25 * time.Second
+)
+
+// respondExecWithHeartbeat runs a synchronous exec and writes its ProcessResult,
+// but keeps the HTTP connection warm for long commands so Cloudflare's ~100s
+// origin-idle timeout (524) never fires. Fast commands (< execHeartbeatGrace)
+// return with normal status codes. For a long command it commits a chunked 200
+// and emits whitespace heartbeats every execHeartbeatInterval; leading
+// whitespace is valid JSON, so the ProcessResult still decodes unchanged on the
+// client. Once committed the status can't signal failure, so a work() error is
+// surfaced as a ProcessResult with ExitCode -1 — strictly better than the 524
+// it replaces. (The streaming/WebSocket exec session already has a 30s keepalive
+// ticker; this brings synchronous exec/run to parity.)
+func respondExecWithHeartbeat(c echo.Context, work func(context.Context) (*types.ProcessResult, error)) error {
+	type outcome struct {
+		res *types.ProcessResult
+		err error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		r, e := work(c.Request().Context())
+		done <- outcome{r, e}
+	}()
+
+	select {
+	case o := <-done:
+		if o.err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": o.err.Error()})
+		}
+		return c.JSON(http.StatusOK, o.res)
+	case <-time.After(execHeartbeatGrace):
 	}
 
-	if s.router != nil {
-		if err := s.router.Route(c.Request().Context(), id, "execRun", routeOp); err != nil {
-			return c.JSON(http.StatusInternalServerError, map[string]string{
-				"error": err.Error(),
-			})
-		}
-	} else {
-		if err := routeOp(c.Request().Context()); err != nil {
-			return c.JSON(http.StatusInternalServerError, map[string]string{
-				"error": err.Error(),
-			})
+	resp := c.Response()
+	resp.Header().Set("Content-Type", "application/json")
+	resp.WriteHeader(http.StatusOK)
+	resp.Flush()
+
+	ticker := time.NewTicker(execHeartbeatInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if _, err := resp.Write([]byte(" ")); err != nil {
+				return nil // client/edge went away — nothing more to do
+			}
+			resp.Flush()
+		case o := <-done:
+			res := o.res
+			if o.err != nil {
+				res = &types.ProcessResult{ExitCode: -1, Stderr: "exec error: " + o.err.Error()}
+			}
+			body, err := json.Marshal(res)
+			if err != nil {
+				body = []byte(`{"exitCode":-1,"stderr":"exec: result marshal failed"}`)
+			}
+			_, _ = resp.Write(body)
+			resp.Flush()
+			return nil
 		}
 	}
-
-	return c.JSON(http.StatusOK, result)
 }
 
 // execRunRemote routes an exec/run request to the worker via gRPC.
@@ -286,32 +353,35 @@ func (s *Server) execRunRemote(c echo.Context, sandboxID string, req types.Proce
 		})
 	}
 
+	// timeout == 0 means no timeout: the command runs unbounded (bounded only by
+	// the client connection / sandbox lifetime) and the heartbeat keeps the edge
+	// connection alive. An explicit positive timeout is still honored.
 	timeout := int32(req.Timeout)
-	if timeout <= 0 {
-		timeout = 30
-	}
 
-	grpcCtx, cancel := context.WithTimeout(c.Request().Context(), time.Duration(timeout+5)*time.Second)
-	defer cancel()
+	return respondExecWithHeartbeat(c, func(ctx context.Context) (*types.ProcessResult, error) {
+		grpcCtx := ctx
+		if timeout > 0 {
+			var cancel context.CancelFunc
+			grpcCtx, cancel = context.WithTimeout(ctx, time.Duration(timeout+5)*time.Second)
+			defer cancel()
+		}
 
-	resp, err := client.ExecCommand(grpcCtx, &pb.ExecCommandRequest{
-		SandboxId: sandboxID,
-		Command:   req.Command,
-		Args:      req.Args,
-		Envs:      req.Env,
-		Cwd:       req.Cwd,
-		Timeout:   timeout,
-	})
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{
-			"error": err.Error(),
+		resp, err := client.ExecCommand(grpcCtx, &pb.ExecCommandRequest{
+			SandboxId: sandboxID,
+			Command:   req.Command,
+			Args:      req.Args,
+			Envs:      req.Env,
+			Cwd:       req.Cwd,
+			Timeout:   timeout,
 		})
-	}
-
-	return c.JSON(http.StatusOK, &types.ProcessResult{
-		ExitCode: int(resp.ExitCode),
-		Stdout:   resp.Stdout,
-		Stderr:   resp.Stderr,
+		if err != nil {
+			return nil, err
+		}
+		return &types.ProcessResult{
+			ExitCode: int(resp.ExitCode),
+			Stdout:   resp.Stdout,
+			Stderr:   resp.Stderr,
+		}, nil
 	})
 }
 

--- a/internal/proxy/controlplane_proxy.go
+++ b/internal/proxy/controlplane_proxy.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -287,6 +289,11 @@ func (p *ControlPlaneProxy) doHTTP(c echo.Context, sandboxID, workerURL string, 
 
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.Transport = p.transport
+	// Stream the worker's response to the client as it arrives. Buffering the
+	// whole thing (the old behavior) made any response slower than Cloudflare's
+	// ~100s ceiling a 524 and broke streaming (SSE, chunked, long-poll).
+	// FlushInterval=-1 flushes chunks immediately.
+	proxy.FlushInterval = -1
 
 	var proxyErr error
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
@@ -302,32 +309,49 @@ func (p *ControlPlaneProxy) doHTTP(c echo.Context, sandboxID, workerURL string, 
 		r.Host = originalHost
 	}
 
-	rec := &responseRecorder{
-		header: make(http.Header),
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		// The outer CORS middleware sets these; forwarding the worker's copies
+		// would duplicate them.
+		for k := range resp.Header {
+			if strings.HasPrefix(strings.ToLower(k), "access-control-") {
+				resp.Header.Del(k)
+			}
+		}
+		// A 502 "not found" from the worker means the sandbox was lost (worker
+		// restart). Convert to a clean 410 and mark the session stopped. Only
+		// 502s are read here (error bodies are tiny) — normal responses stream
+		// straight through without buffering.
+		if resp.StatusCode == http.StatusBadGateway {
+			b, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if strings.Contains(string(b), "not found") || strings.Contains(string(b), "not available") {
+				log.Printf("cp-proxy: sandbox %s not found on worker, marking session stopped", sandboxID)
+				errMsg := "sandbox lost on worker"
+				_ = p.store.UpdateSandboxSessionStatus(c.Request().Context(), sandboxID, "stopped", &errMsg)
+				b = []byte(fmt.Sprintf(`{"error":"sandbox %s is no longer available"}`, sandboxID))
+				resp.StatusCode = http.StatusGone
+				resp.Status = "410 Gone"
+				resp.Header.Set("Content-Type", "application/json")
+			}
+			// Restore the (small) body so the proxy can stream it out.
+			resp.Body = io.NopCloser(bytes.NewReader(b))
+			resp.ContentLength = int64(len(b))
+			resp.Header.Set("Content-Length", strconv.Itoa(len(b)))
+		}
+		return nil
 	}
-	proxy.ServeHTTP(rec, c.Request())
+
+	proxy.ServeHTTP(c.Response(), c.Request())
 
 	if proxyErr != nil {
+		// Once bytes have reached the client we can't swap in an error page.
+		if c.Response().Committed {
+			log.Printf("cp-proxy: mid-stream error proxying sandbox %s to %s: %v", sandboxID, workerURL, proxyErr)
+			return nil
+		}
 		log.Printf("cp-proxy: error proxying sandbox %s to %s: %v", sandboxID, workerURL, proxyErr)
 		return serveUpstreamUnavailable(c, sandboxID, port)
 	}
-
-	// If the worker returned a 502 with "not found", the sandbox was lost
-	// (e.g., worker restarted). Mark the session as stopped so future
-	// requests get a clean 410 Gone instead of a confusing 502.
-	if rec.statusCode == http.StatusBadGateway {
-		body := rec.body.String()
-		if strings.Contains(body, "not found") || strings.Contains(body, "not available") {
-			log.Printf("cp-proxy: sandbox %s not found on worker, marking session stopped", sandboxID)
-			errMsg := "sandbox lost on worker"
-			_ = p.store.UpdateSandboxSessionStatus(c.Request().Context(), sandboxID, "stopped", &errMsg)
-			return c.JSON(http.StatusGone, map[string]string{
-				"error": fmt.Sprintf("sandbox %s is no longer available", sandboxID),
-			})
-		}
-	}
-
-	rec.writeTo(c.Response())
 	return nil
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -241,18 +241,29 @@ func (p *SandboxProxy) doHTTP(c echo.Context, sandboxID, addr string, hostPort i
 			c.Request().Body = io.NopCloser(bytes.NewReader(bodyBytes))
 		}
 
-		// Use a recorder to capture the proxy response so we can detect
-		// errors and retry without having already written to the client.
-		rec := &responseRecorder{
-			header: make(http.Header),
-		}
-
 		proxy := httputil.NewSingleHostReverseProxy(target)
+		// Stream the upstream response straight to the client as bytes arrive.
+		// The old path buffered the ENTIRE response in memory before sending a
+		// single byte, which (a) made any response slower than Cloudflare's
+		// ~100s ceiling a 524, and (b) broke streaming (SSE, chunked, long-poll).
+		// FlushInterval=-1 flushes each chunk immediately.
+		proxy.FlushInterval = -1
 		proxy.Transport = &http.Transport{
 			DialContext: (&net.Dialer{
 				Timeout: 2 * time.Second,
 			}).DialContext,
 			ResponseHeaderTimeout: 60 * time.Second,
+		}
+		// The outer server's CORS middleware sets Access-Control-* headers;
+		// forwarding the upstream's copies duplicates them. With buffering gone,
+		// strip them here (before headers reach the client).
+		proxy.ModifyResponse = func(resp *http.Response) error {
+			for k := range resp.Header {
+				if strings.HasPrefix(strings.ToLower(k), "access-control-") {
+					resp.Header.Del(k)
+				}
+			}
+			return nil
 		}
 
 		var proxyErr error
@@ -260,20 +271,25 @@ func (p *SandboxProxy) doHTTP(c echo.Context, sandboxID, addr string, hostPort i
 			proxyErr = err
 		}
 
-		proxy.ServeHTTP(rec, c.Request())
+		proxy.ServeHTTP(c.Response(), c.Request())
 
-		if proxyErr != nil {
-			if isRetryable(proxyErr) && attempt < maxRetries {
-				continue
-			}
-			log.Printf("proxy: error proxying to sandbox %s (port %d) after %d attempts: %v",
-				sandboxID, hostPort, attempt+1, proxyErr)
-			return serveUpstreamUnavailable(c, sandboxID, hostPort)
+		if proxyErr == nil {
+			return nil // streamed to completion
 		}
-
-		// Success — flush the recorded response to the real client.
-		rec.writeTo(c.Response())
-		return nil
+		// Once any byte has reached the client (response committed) we can't
+		// retry — a partial response is already on the wire. Only pre-header
+		// failures are recoverable, which is exactly the CRIU-restore
+		// stabilization window the retry exists for.
+		if c.Response().Committed {
+			log.Printf("proxy: mid-stream error to sandbox %s (port %d): %v", sandboxID, hostPort, proxyErr)
+			return nil
+		}
+		if isRetryable(proxyErr) && attempt < maxRetries {
+			continue
+		}
+		log.Printf("proxy: error proxying to sandbox %s (port %d) after %d attempts: %v",
+			sandboxID, hostPort, attempt+1, proxyErr)
+		return serveUpstreamUnavailable(c, sandboxID, hostPort)
 	}
 
 	// Should not reach here, but just in case.

--- a/internal/proxy/proxy_stream_test.go
+++ b/internal/proxy/proxy_stream_test.go
@@ -1,0 +1,80 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// The preview-port proxy must stream the upstream response to the client as
+// bytes arrive — not buffer the whole thing first (which produced Cloudflare
+// 524s on long responses and broke SSE/chunked/long-poll). This proves the
+// first chunk reaches the client while the upstream is still holding the
+// response open, and that upstream CORS headers are stripped.
+func TestDoHTTP_StreamsBeforeUpstreamCompletes(t *testing.T) {
+	release := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Test", "up")
+		w.Header().Set("Access-Control-Allow-Origin", "*") // must be stripped by the proxy
+		fl, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("upstream writer is not a Flusher")
+			return
+		}
+		_, _ = io.WriteString(w, "chunk1\n")
+		fl.Flush()
+		<-release // hold the response open until the test says go
+		_, _ = io.WriteString(w, "chunk2\n")
+		fl.Flush()
+	}))
+	defer upstream.Close()
+	addr := strings.TrimPrefix(upstream.URL, "http://")
+
+	p := &SandboxProxy{} // doHTTP takes addr directly; no manager needed
+	e := echo.New()
+	e.Any("/*", func(c echo.Context) error { return p.doHTTP(c, "sb-x", addr, 13000) })
+	front := httptest.NewServer(e)
+	defer front.Close()
+
+	resp, err := http.Get(front.URL + "/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// The first chunk must arrive WITHOUT releasing the upstream — if the proxy
+	// buffered, this read would block until the whole response completed.
+	buf := make([]byte, len("chunk1\n"))
+	readDone := make(chan string, 1)
+	go func() {
+		n, _ := io.ReadFull(resp.Body, buf)
+		readDone <- string(buf[:n])
+	}()
+	select {
+	case got := <-readDone:
+		if !strings.Contains(got, "chunk1") {
+			t.Fatalf("first read = %q, want chunk1", got)
+		}
+	case <-time.After(2 * time.Second):
+		close(release)
+		t.Fatal("first chunk did not arrive before upstream completed — proxy is buffering, not streaming")
+	}
+
+	close(release) // let the upstream finish
+	rest, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(rest), "chunk2") {
+		t.Fatalf("rest = %q, want chunk2", rest)
+	}
+
+	if resp.Header.Get("Access-Control-Allow-Origin") != "" {
+		t.Fatalf("upstream Access-Control-Allow-Origin should be stripped by the proxy")
+	}
+	if resp.Header.Get("X-Test") != "up" {
+		t.Fatalf("non-CORS upstream headers should pass through; X-Test=%q", resp.Header.Get("X-Test"))
+	}
+}

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -2217,15 +2217,27 @@ func (m *Manager) HibernateAll(ctx context.Context, checkpointStore *storage.Che
 }
 
 // Exec runs a command in the VM via the agent.
+// execNoTimeoutSeconds is the cap handed to the in-VM agent when the caller
+// asks for no timeout (cfg.Timeout <= 0). It's large enough to be unreachable
+// in practice (the sandbox hibernates first) while staying a positive value, so
+// older agents that floor 0→60s instead run effectively-unbounded.
+const execNoTimeoutSeconds = 7 * 24 * 3600 // 7 days
+
 func (m *Manager) Exec(ctx context.Context, sandboxID string, cfg types.ProcessConfig) (*types.ProcessResult, error) {
 	vm, err := m.getReadyVM(ctx, sandboxID)
 	if err != nil {
 		return nil, err
 	}
 
+	// timeout == 0 means "no timeout". We send an effectively-unbounded value
+	// rather than a literal 0 because OLDER in-VM agents floor 0 to 60s — so to
+	// give EXISTING sandboxes a true no-timeout we hand them a cap large enough
+	// that the sandbox hibernates long before it's reached (7 days). New agents
+	// treat 0 as unbounded natively; once the fleet has rolled past the old
+	// agent this can become a literal 0.
 	timeout := int32(cfg.Timeout)
 	if timeout <= 0 {
-		timeout = 60
+		timeout = execNoTimeoutSeconds
 	}
 
 	command := cfg.Command

--- a/internal/worker/exec_keepalive_test.go
+++ b/internal/worker/exec_keepalive_test.go
@@ -1,0 +1,114 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/opensandbox/opensandbox/pkg/types"
+)
+
+func newKeepaliveCtx() (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/sandboxes/sb-x/exec/run", nil)
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec), rec
+}
+
+// Fast commands return with normal status codes and no heartbeat bytes.
+func TestRespondExecKeepalive_FastPath(t *testing.T) {
+	c, rec := newKeepaliveCtx()
+	want := &types.ProcessResult{ExitCode: 3, Stdout: "ok"}
+	if err := respondExecKeepalive(c, func(ctx context.Context) (*types.ProcessResult, error) {
+		return want, nil
+	}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if strings.HasPrefix(rec.Body.String(), " ") {
+		t.Fatalf("fast path should not emit heartbeat whitespace: %q", rec.Body.String())
+	}
+	var got types.ProcessResult
+	if e := json.Unmarshal(rec.Body.Bytes(), &got); e != nil {
+		t.Fatalf("decode: %v", e)
+	}
+	if got != *want {
+		t.Fatalf("result = %+v, want %+v", got, *want)
+	}
+}
+
+// Fast-path errors keep their 500.
+func TestRespondExecKeepalive_FastPathError(t *testing.T) {
+	c, rec := newKeepaliveCtx()
+	if err := respondExecKeepalive(c, func(ctx context.Context) (*types.ProcessResult, error) {
+		return nil, fmt.Errorf("nope")
+	}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+// A long (effectively un-timed-out) command commits 200, heartbeats, and still
+// returns a decodable ProcessResult.
+func TestRespondExecKeepalive_SlowPathStreamsValidJSON(t *testing.T) {
+	og, oi := execKeepaliveGrace, execKeepaliveInterval
+	execKeepaliveGrace, execKeepaliveInterval = 5*time.Millisecond, 5*time.Millisecond
+	defer func() { execKeepaliveGrace, execKeepaliveInterval = og, oi }()
+
+	c, rec := newKeepaliveCtx()
+	want := &types.ProcessResult{ExitCode: 0, Stdout: "done"}
+	if err := respondExecKeepalive(c, func(ctx context.Context) (*types.ProcessResult, error) {
+		time.Sleep(40 * time.Millisecond)
+		return want, nil
+	}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.HasPrefix(rec.Body.String(), " ") {
+		t.Fatalf("slow path should emit heartbeat whitespace: %q", rec.Body.String())
+	}
+	var got types.ProcessResult
+	if e := json.Unmarshal(rec.Body.Bytes(), &got); e != nil {
+		t.Fatalf("heartbeat body must decode as JSON: %v (%q)", e, rec.Body.String())
+	}
+	if got != *want {
+		t.Fatalf("result = %+v, want %+v", got, *want)
+	}
+}
+
+// An error after commit is surfaced as a ProcessResult (ExitCode -1).
+func TestRespondExecKeepalive_SlowPathErrorAsResult(t *testing.T) {
+	og := execKeepaliveGrace
+	execKeepaliveGrace = 5 * time.Millisecond
+	defer func() { execKeepaliveGrace = og }()
+
+	c, rec := newKeepaliveCtx()
+	if err := respondExecKeepalive(c, func(ctx context.Context) (*types.ProcessResult, error) {
+		time.Sleep(20 * time.Millisecond)
+		return nil, fmt.Errorf("agent gone")
+	}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (committed)", rec.Code)
+	}
+	var got types.ProcessResult
+	if e := json.Unmarshal(rec.Body.Bytes(), &got); e != nil {
+		t.Fatalf("decode: %v", e)
+	}
+	if got.ExitCode != -1 || !strings.Contains(got.Stderr, "agent gone") {
+		t.Fatalf("error not surfaced: %+v", got)
+	}
+}

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -261,6 +261,16 @@ func (s *HTTPServer) execSessionWebSocket(c echo.Context) error {
 	}
 }
 
+// Keepalive tunables for synchronous exec/run (vars so tests can shrink them).
+var (
+	// execKeepaliveGrace is how long we wait for a fast command before
+	// committing to a chunked, heartbeat-kept-alive response.
+	execKeepaliveGrace = 20 * time.Second
+	// execKeepaliveInterval must stay under Cloudflare's ~100s origin-idle
+	// ceiling (a 524 fires if the origin sends no bytes for that long).
+	execKeepaliveInterval = 15 * time.Second
+)
+
 func (s *HTTPServer) execRun(c echo.Context) error {
 	id := c.Param("id")
 
@@ -272,71 +282,84 @@ func (s *HTTPServer) execRun(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "cmd is required"})
 	}
 
-	// For long-running commands (timeout > 30s), send response headers
-	// immediately and write periodic keepalive whitespace. This prevents
-	// Cloudflare (and other reverse proxies) from timing out:
-	//   - 524 first-byte timeout (~100s): solved by sending headers early
-	//   - Body idle timeout (~600s): solved by periodic space bytes
-	// JSON parsers ignore leading whitespace, so the final JSON body
-	// is parsed cleanly regardless of how many spaces precede it.
-	earlyFlush := req.Timeout > 30
-	var keepaliveDone chan struct{}
-	if earlyFlush {
-		c.Response().Header().Set("Content-Type", "application/json")
-		c.Response().WriteHeader(http.StatusOK)
-		flusher, _ := c.Response().Writer.(http.Flusher)
-		if flusher != nil {
-			flusher.Flush()
+	// No gate on req.Timeout — a command may run arbitrarily long (an unbounded
+	// timeout==0 request included). respondExecKeepalive keeps the edge
+	// connection warm so it never trips Cloudflare's ~100s origin-idle 524.
+	return respondExecKeepalive(c, func(ctx context.Context) (*types.ProcessResult, error) {
+		var result *types.ProcessResult
+		op := func(ctx context.Context) error {
+			var err error
+			result, err = s.manager.Exec(ctx, id, req)
+			return err
 		}
-
-		keepaliveDone = make(chan struct{})
-		go func() {
-			ticker := time.NewTicker(15 * time.Second)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ticker.C:
-					c.Response().Write([]byte(" "))
-					if flusher != nil {
-						flusher.Flush()
-					}
-				case <-keepaliveDone:
-					return
-				}
+		if s.router != nil {
+			if err := s.router.Route(ctx, id, "execRun", op); err != nil {
+				return nil, err
 			}
-		}()
-	}
-
-	var result *types.ProcessResult
-
-	routeOp := func(ctx context.Context) error {
-		var err error
-		result, err = s.manager.Exec(ctx, id, req)
-		return err
-	}
-
-	var execErr error
-	if s.router != nil {
-		execErr = s.router.Route(c.Request().Context(), id, "execRun", routeOp)
-	} else {
-		execErr = routeOp(c.Request().Context())
-	}
-
-	if keepaliveDone != nil {
-		close(keepaliveDone)
-	}
-
-	if execErr != nil {
-		if earlyFlush {
-			return json.NewEncoder(c.Response()).Encode(map[string]string{"error": execErr.Error()})
+		} else {
+			if err := op(ctx); err != nil {
+				return nil, err
+			}
 		}
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": execErr.Error()})
+		return result, nil
+	})
+}
+
+// respondExecKeepalive runs a synchronous exec and writes its ProcessResult,
+// keeping the HTTP connection warm for long commands so reverse proxies
+// (Cloudflare's ~100s origin-idle 524) don't drop it. Fast commands (under
+// execKeepaliveGrace) return with normal status codes. A long command commits
+// a chunked 200 and emits whitespace heartbeats (valid leading JSON whitespace,
+// so the result still decodes); an error after commit is surfaced as a
+// ProcessResult with ExitCode -1, since the 200 is already on the wire.
+func respondExecKeepalive(c echo.Context, work func(context.Context) (*types.ProcessResult, error)) error {
+	type execOutcome struct {
+		res *types.ProcessResult
+		err error
+	}
+	done := make(chan execOutcome, 1)
+	go func() {
+		r, e := work(c.Request().Context())
+		done <- execOutcome{r, e}
+	}()
+
+	select {
+	case o := <-done:
+		if o.err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": o.err.Error()})
+		}
+		return c.JSON(http.StatusOK, o.res)
+	case <-time.After(execKeepaliveGrace):
 	}
 
-	if earlyFlush {
-		return json.NewEncoder(c.Response()).Encode(result)
+	resp := c.Response()
+	resp.Header().Set("Content-Type", "application/json")
+	resp.WriteHeader(http.StatusOK)
+	resp.Flush()
+
+	ticker := time.NewTicker(execKeepaliveInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if _, err := resp.Write([]byte(" ")); err != nil {
+				return nil // client/edge went away
+			}
+			resp.Flush()
+		case o := <-done:
+			res := o.res
+			if o.err != nil {
+				res = &types.ProcessResult{ExitCode: -1, Stderr: "exec error: " + o.err.Error()}
+			}
+			body, err := json.Marshal(res)
+			if err != nil {
+				body = []byte(`{"exitCode":-1,"stderr":"exec: result marshal failed"}`)
+			}
+			_, _ = resp.Write(body)
+			resp.Flush()
+			return nil
+		}
 	}
-	return c.JSON(http.StatusOK, result)
 }
 
 func (s *HTTPServer) killExecSession(c echo.Context) error {

--- a/sdks/python/opencomputer/exec.py
+++ b/sdks/python/opencomputer/exec.py
@@ -101,7 +101,7 @@ class Exec:
     async def run(
         self,
         command: str,
-        timeout: int = 60,
+        timeout: int = 0,
         env: dict[str, str] | None = None,
         cwd: str | None = None,
     ) -> ProcessResult:
@@ -109,6 +109,10 @@ class Exec:
 
         The command is executed via `sh -c`, so shell features like pipes,
         redirects, and env var expansion work as expected.
+
+        timeout defaults to 0 (no timeout): the command runs until it completes
+        and the server keeps the connection alive with heartbeats. Pass a
+        positive number of seconds to opt into a hard cap.
         """
         body: dict[str, Any] = {"cmd": "sh", "args": ["-c", command], "timeout": timeout}
         if env:

--- a/sdks/typescript/src/exec.ts
+++ b/sdks/typescript/src/exec.ts
@@ -288,8 +288,11 @@ export class Exec {
     };
     if (opts.env) body.envs = opts.env;
     if (opts.cwd) body.cwd = opts.cwd;
+    // Default: no timeout (0). The command runs until it completes; the server
+    // keeps the connection alive with heartbeats. Pass an explicit `timeout`
+    // (seconds) to opt into a hard cap.
     if (opts.timeout != null) body.timeout = opts.timeout;
-    else body.timeout = 60;
+    else body.timeout = 0;
 
     const resp = await fetch(`${this.apiUrl}/sandboxes/${this.sandboxId}/exec/run`, {
       method: "POST",


### PR DESCRIPTION
## Stop Cloudflare 524s on long exec & HTTP-proxied requests; default exec to no timeout
  
  ### Problem
  Customers running long operations got Cloudflare **524s** (origin idle >100s) and a surprising **60s cap** on exec. Three distinct origins:
  1. **`exec/run`** is synchronous and buffered — a command sending no bytes for 100s trips CF's 524.
  2. **HTTP proxied to a sandbox** (preview-port `sb-{id}-p{port}` and the CP edge path) was **fully buffered** — the whole response was held in memory before a single byte went out, so any response >100s 524'd *and* streaming (SSE/chunked/long-poll) was silently broken.
  3. **`exec/run` was capped at 60s** — the SDKs default `timeout=60`, and the worker + agent floored `0→60` — so "run a long command" died with `Process timed out`.

  ### Changes
  **Exec keepalive (no 524 on long `exec/run`)**
  - `internal/worker/handlers.go`, `internal/api/exec_session.go`: a grace-based keepalive (no `timeout>30` gate). Fast commands keep normal status codes; a command outlasting the grace window commits a chunked `200` and emits whitespace heartbeats (valid leading JSON, so the `ProcessResult` still decodes). The streaming/WebSocket exec session already had a 30s keepalive; this brings synchronous `exec/run` to parity.

  **No exec timeout (opt-in cap)**
  - `internal/agent/exec.go` (`Exec` + `ExecStream`): `timeout==0` → unbounded instead of flooring to 60s.
  - `internal/qemu/manager.go` (`manager.Exec`): `timeout<=0` now maps to an effectively-unbounded cap (7d) rather than 60s. This lives in the **worker binary**, so it gives **existing** sandboxes (whose in-VM agent still floors `0→60`) no-timeout immediately; no recreate.
  - SDKs (`exec.ts`, `exec.py`): `run()` default `60 → 0`. An explicit `timeout` is still honored as a hard cap.

  **HTTP proxy streaming (no 524 on long responses + streaming restored)**
  - `internal/proxy/proxy.go` (worker preview-port) and `internal/proxy/controlplane_proxy.go` (CP edge path): stream the upstream response (`FlushInterval=-1`) instead of buffering it whole. Retry still covers the CRIU-restore window (pre-commit only); CORS-stripping and the `502 not-found → 410 + mark-stopped` behavior are preserved via `ModifyResponse`.

  ### Behavior notes / externalities
  - Mid-stream upstream failures now **truncate** instead of returning a clean error (inherent to streaming; rare). As a bonus this removes a latent **double-execution** bug— the old buffered retry could re-send a request that already partially ran.
  - Responses without a `Content-Length` now use chunked transfer-encoding.
  - Memory is now O(chunk), not O(response) — the old path buffered entire responses (a real OOM/DoS vector for large downloads).
  - `exec.run` with no explicit `timeout` now blocks until the command finishes (or the sandbox hibernates) — the intended "no timeout" semantics; pass `timeout=N` to opt out.

  ### Testing
  - Unit tests: exec keepalive (api + worker), proxy streaming (first chunk arrives before the upstream completes; CORS stripped).
  - **Dev e2e through Cloudflare**, full `exec/run` matrix: fast/error/exit-code cases unchanged; explicit `timeout=5` killed at 5s; `timeout=0` `sleep 90` ran the full 90s;  **`timeout=0` `sleep 130` returned HTTP 200 at 130s — past the 100s ceiling, no 524**. Verified on an old-agent sandbox, proving the `manager.Exec` bridge covers existing sandboxes.

  ### Deployment
  - **Worker image build** → keepalive + `manager.Exec` bridge + agent rootfs change + proxy streaming → existing *and* new sandboxes.
  - **Server deploy** → CP exec heartbeat + CP proxy streaming.
  - **SDK publish** (npm/pip) → `run()` default `0`.
