### PR TITLE
Add CLI shell hint to session detail

### DIFF
--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -184,44 +184,6 @@ export default function SessionDetail() {
             <div style={{ fontSize: 13, color: 'var(--text-tertiary)' }}>
               {session.template || 'base'} &middot; Started {timeAgo(session.startedAt)}
             </div>
-            {session.status === 'running' && (
-              <div style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 8,
-                marginTop: 12,
-                padding: '6px 8px',
-                background: 'var(--bg-deep)',
-                border: '1px solid var(--border-subtle)',
-                borderRadius: 'var(--radius-sm)',
-              }}>
-                <span style={{
-                  fontSize: 10,
-                  color: 'var(--text-tertiary)',
-                  fontWeight: 600,
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.05em',
-                }}>
-                  CLI
-                </span>
-                <code style={{
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 12,
-                  color: 'var(--text-accent)',
-                  background: 'transparent',
-                  padding: 0,
-                }}>
-                  {shellCommand}
-                </code>
-                <button
-                  onClick={() => copyShellCommand(shellCommand)}
-                  className="btn-ghost"
-                  style={{ padding: '3px 8px', fontSize: 11 }}
-                >
-                  {copiedShell ? 'Copied' : 'Copy'}
-                </button>
-              </div>
-            )}
           </div>
 
           {/* Actions */}
@@ -457,6 +419,14 @@ export default function SessionDetail() {
           <DetailRow label="CPUs" value={String(session.config?.cpuCount ?? 1)} />
           <DetailRow label="Memory" value={`${session.config?.memoryMB ?? 512} MB`} />
           <DetailRow label="Started" value={new Date(session.startedAt).toLocaleString()} />
+          {session.status === 'running' && (
+            <DetailCommandRow
+              label="CLI shell"
+              value={shellCommand}
+              copied={copiedShell}
+              onCopy={() => copyShellCommand(shellCommand)}
+            />
+          )}
           {session.stoppedAt && (
             <DetailRow label="Stopped" value={new Date(session.stoppedAt).toLocaleString()} />
           )}
@@ -493,6 +463,41 @@ function DetailRow({ label, value, isError }: { label: string; value: string; is
         wordBreak: 'break-all',
       }}>
         {value}
+      </div>
+    </div>
+  )
+}
+
+function DetailCommandRow({
+  label,
+  value,
+  copied,
+  onCopy,
+}: {
+  label: string
+  value: string
+  copied: boolean
+  onCopy: () => void
+}) {
+  return (
+    <div>
+      <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginBottom: 2 }}>{label}</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+        <code style={{
+          fontSize: 13,
+          fontFamily: 'var(--font-mono)',
+          color: 'var(--text-primary)',
+          wordBreak: 'break-all',
+        }}>
+          {value}
+        </code>
+        <button
+          className="btn-ghost"
+          onClick={onCopy}
+          style={{ padding: '2px 7px', fontSize: 11, flexShrink: 0 }}
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
       </div>
     </div>
   )

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -62,6 +62,7 @@ export default function SessionDetail() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null)
+  const [copiedShell, setCopiedShell] = useState(false)
   const [showTerminal, setShowTerminal] = useState(false)
   const [showLogs, setShowLogs] = useState(false)
   const [showInternal, setShowInternal] = useState(false)
@@ -129,6 +130,12 @@ export default function SessionDetail() {
     setTimeout(() => setCopiedUrl(null), 2000)
   }
 
+  const copyShellCommand = (command: string) => {
+    navigator.clipboard.writeText(command)
+    setCopiedShell(true)
+    setTimeout(() => setCopiedShell(false), 1500)
+  }
+
   if (isLoading) {
     return (
       <div style={{ display: 'flex', justifyContent: 'center', padding: 80 }}>
@@ -144,6 +151,8 @@ export default function SessionDetail() {
       </div>
     )
   }
+
+  const shellCommand = `oc shell ${session.sandboxId}`
 
   return (
     <div>
@@ -175,6 +184,44 @@ export default function SessionDetail() {
             <div style={{ fontSize: 13, color: 'var(--text-tertiary)' }}>
               {session.template || 'base'} &middot; Started {timeAgo(session.startedAt)}
             </div>
+            {session.status === 'running' && (
+              <div style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 8,
+                marginTop: 12,
+                padding: '6px 8px',
+                background: 'var(--bg-deep)',
+                border: '1px solid var(--border-subtle)',
+                borderRadius: 'var(--radius-sm)',
+              }}>
+                <span style={{
+                  fontSize: 10,
+                  color: 'var(--text-tertiary)',
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                }}>
+                  CLI
+                </span>
+                <code style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 12,
+                  color: 'var(--text-accent)',
+                  background: 'transparent',
+                  padding: 0,
+                }}>
+                  {shellCommand}
+                </code>
+                <button
+                  onClick={() => copyShellCommand(shellCommand)}
+                  className="btn-ghost"
+                  style={{ padding: '3px 8px', fontSize: 11 }}
+                >
+                  {copiedShell ? 'Copied' : 'Copy'}
+                </button>
+              </div>
+            )}
           </div>
 
           {/* Actions */}


### PR DESCRIPTION
hope it kinda makes sense in that position 
<img width="1448" height="541" alt="Screenshot 2026-06-17 at 6 53 57 PM" src="https://github.com/user-attachments/assets/024b6ec8-072d-48ca-9207-ac109c31a0bd" />

## Summary
- show a compact `oc shell <sandbox-id>` command chip on running session detail pages
- add copy support without adding another large terminal action or panel

## Validation
- npm run build