### PR TITLE
docs: agent-sessions API reference accuracy + Artifacts/previews (coming soon)

### DIFF
--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -16,17 +16,19 @@ Base URL `https://api.opencomputer.dev/v3`. Management calls authenticate with y
 | `POST /sessions/:id/cancel` | Cooperatively stop the active turn (no-op if not running). |
 | `GET /sessions/:id/result` | The result helper — `{ last_turn, result? }` (the resolved final event). |
 | `GET /sessions/:id/turns` · `GET …/turns/:turnId` | Per-turn history: timing, usage, error. |
-| `POST /sessions/:id/client-tokens` | Mint a client token. Body: `scopes?`, `ttl?`. |
+| `POST /sessions/:id/client-tokens` | Mint a client token. Body: `scopes?` (subset of `read`, `steer`), `ttl?` (seconds; clamped to 60–86400). |
 
 `agent` is **required** (create a saved [agent](#agents) first); a resolvable Anthropic [credential](#credentials) is also required (`422 no_credential` otherwise). `key` gives get-or-create (one session per key); a request-level `Idempotency-Key` header makes a keyless create retry-safe. `input` is the task — a string or a full [envelope](/agent-sessions/messaging#the-envelope) (structured context rides `input.refs`: `repo`/`branch`/`commit`/`issue`/…). `limits` `{ tokens, turn_seconds, turns }` are **non-monetary** — token budget, per-turn wall-clock, auto-run count; hitting one ends the turn with a matching `last_turn.yield_reason`. Destinations on an idempotent create-replay are ignored — manage them via the [destinations API](#destinations).
 
 ```
 Session = { id, status, head, input_cursor,
             agent_snapshot: { prompt_hash, model, runtime, revision },
-            credential_id,   // resolved + pinned at create
-            last_turn: { state, yield_reason?, turn_id, started_at, completed_at?, result_event_id?, error? },
-            usage: { active_seconds, tokens? },
-            limits: { tokens?, turn_seconds?, turns? }, key?, created_at }
+            agent_id, credential_id,   // resolved + pinned at create
+            last_turn: { id, state, yield_reason?, result_event_id? },
+            usage, limits: { tokens?, turn_seconds?, turns? }, key?, created_at }
+
+Turn = { id, state, yield_reason?, started_at?, completed_at?,    // from GET …/result and …/turns
+         result_event_id?, error?, active_seconds, usage }
 ```
 
 `yield_reason` (`completed | needs_input | error | budget_exceeded | deadline_exceeded | max_turns | canceled`; `requires_action` is reserved, not emitted yet) is the machine-readable "why the turn ended" — `needs_input` means the agent asked a question; answer it by [steering](#steer).
@@ -41,17 +43,18 @@ Session = { id, status, head, input_cursor,
 | `GET /sessions/:id/events/:eventId/content` | Fetch a blob-backed body (large outputs). |
 | `GET /sessions/:id/messages?after=<seq>&limit=<n>` | User-message history (alias for `level=user` + `type=*.message`). |
 
-`after` resumes from a `seq`; `level` is a **visibility threshold** — `user` returns only user-facing events, `progress` adds work updates, `internal` adds everything (see [levels](/agent-sessions/events#levels)). Switch on [`type`](/agent-sessions/events#event-shape), don't parse prose.
+`after` resumes from a `seq`; `level` is a **visibility threshold** — `user` returns only user-facing events, `progress` adds work updates, `internal` adds everything (see [levels](/agent-sessions/events#levels)). Omitting `level` defaults to `internal` (you get everything). Switch on [`type`](/agent-sessions/events#event-shape), don't parse prose.
 
 ```
-Event = { id, seq, ts, session, actor, type, level, body, refs }
+Event = { id, seq, ts, session, actor, type, level, body, refs, turn_id?,
+          content_ref?, body_truncated?, body_bytes? }   // content_ref + body_* present when the body spilled to a blob
 ```
 
 ## Steer
 
 | Method · Path | Purpose |
 | --- | --- |
-| `POST /sessions/:id/messages` | Append an input message; wakes the session. Body: `{ text, idempotency_key? }` or `{ envelope }`. `202` → `{ event: { id, seq }, session: { id, status, head } }`. |
+| `POST /sessions/:id/messages` | Append an input message; wakes the session. Body: `{ text, idempotency_key? }` or `{ envelope }`. `202` (or `200` on an idempotent replay) → `{ event: { id, seq }, session: { id, status, head } }`. |
 
 ## Destinations
 
@@ -73,8 +76,10 @@ Event = { id, seq, ts, session, actor, type, level, body, refs }
 See [Webhooks](/agent-sessions/webhooks#delivery-contract) for the signing and delivery contract.
 
 ```
-Destination = { id, url, level, types, include_raw, enabled, created_at }
-Delivery    = { id, destination_id, event_id, status, attempts, last_attempt_at, response_code?, error? }
+Destination = { id, session, kind, url, level, types, include_raw, enabled,
+                has_secret, created_after_seq, created_at, updated_at }   // secret never returned — has_secret signals it's set
+Delivery    = { id, session, destination, event_id, event_seq, status, attempts,
+                last_attempt_at, response_code?, error?, created_at, updated_at }
 ```
 
 ## Agents
@@ -91,15 +96,15 @@ Pass `key` **or** `credential` (or neither → org default). The agent's `limits
 
 | Method · Path | Purpose |
 | --- | --- |
-| `POST /credentials` | Add a provider key (Anthropic). Body: `provider`, `key`, `name?`. Key is write-only. **Required** — sessions run on your key (no platform billing yet). |
+| `POST /credentials` | Add a provider key (Anthropic). Body: `provider`, `key`, `name?`, `is_default?`. Key is write-only. **Required** — sessions run on your key (no platform billing yet). |
 | `GET /credentials` · `DELETE /credentials/:id` | List / remove. |
-| `PUT /credentials/default` | Set the org default for a provider. Body: `provider`, `credential`. |
+| `PUT /credentials/default` | Set the org default to a credential (its provider is derived). Body: `credential`. |
 
 ```
-Credential  = { id, provider, name?, last4, created_at }
+Credential  = { id, provider, name?, last4, is_default, created_at }
 ClientToken = { token, scopes, expires_at }
 ```
 
 ## Errors & rate limits
 
-Errors use one envelope: `{ "error": { "type", "message", "code", "param?", "request_id" } }`. Cross-owner resources return `404` (not `403`). Rate and concurrency limits are not enforced at launch; clients should still treat a `429` (with a `Retry-After` header, when present) as a signal to back off and retry, since limits may be introduced later.
+Errors use one envelope: `{ "error": { "type", "message" } }`. Cross-owner resources return `404` (not `403`). Rate and concurrency limits are not enforced at launch (a `429` with a `Retry-After` header may be introduced later).

--- a/docs/agent-sessions/artifacts.mdx
+++ b/docs/agent-sessions/artifacts.mdx
@@ -5,9 +5,9 @@ description: "A session's published outputs — live previews and durable files 
 
 <Note>**Coming soon.** This page is our current thinking, not a shipped contract — names and shapes may change. What works *today*: large event bodies already spill to a [`content_ref`](/agent-sessions/events) you can fetch, and events can carry forward [`refs.artifacts[]`](/agent-sessions/events). The first-class collection below is what comes next.</Note>
 
-A session does its work in a private scratch sandbox. **Artifacts** are the subset it deliberately *publishes* for you and your UI to consume — a durable, session-scoped collection that survives reconnects and page reloads, so a "preview" or "outputs" panel can be rebuilt at any time, not just caught live. A **preview** is one kind of artifact: a live URL to something the agent is running (a dev server, a built app).
+A session does its work in a private scratch sandbox. **Artifacts** are the subset it deliberately *publishes* for your UI to consume — a durable, session-scoped collection you can fetch on load and stream for updates, so a preview or outputs panel survives reconnects and reloads. A **preview** is one kind of artifact: a live URL to something the agent is running (a dev server, a built app).
 
-## Two kinds, two lifetimes
+## Durable vs live
 
 The split is what lets a panel survive a refresh:
 
@@ -21,7 +21,7 @@ The runtime would get two tools alongside `bash`/`read`/`write`:
 - `oc.preview(port)` — expose a port of the session's machine as a preview URL.
 - `oc.publish(path)` — snapshot a file as a durable artifact.
 
-Each publish appends a `user`-level event and upserts the artifact, so it reaches your UI the moment it happens — the agent builds, then *shows* you.
+Each publish appends a `user`-level event and upserts the artifact, so it reaches your UI as soon as it's produced.
 
 ## How your app would consume it
 

--- a/docs/agent-sessions/artifacts.mdx
+++ b/docs/agent-sessions/artifacts.mdx
@@ -1,0 +1,41 @@
+---
+title: "Artifacts & previews"
+description: "A session's published outputs — live previews and durable files (coming soon)"
+---
+
+<Note>**Coming soon.** This page is our current thinking, not a shipped contract — names and shapes may change. What works *today*: large event bodies already spill to a [`content_ref`](/agent-sessions/events) you can fetch, and events can carry forward [`refs.artifacts[]`](/agent-sessions/events). The first-class collection below is what comes next.</Note>
+
+A session does its work in a private scratch sandbox. **Artifacts** are the subset it deliberately *publishes* for you and your UI to consume — a durable, session-scoped collection that survives reconnects and page reloads, so a "preview" or "outputs" panel can be rebuilt at any time, not just caught live. A **preview** is one kind of artifact: a live URL to something the agent is running (a dev server, a built app).
+
+## Two kinds, two lifetimes
+
+The split is what lets a panel survive a refresh:
+
+- **`file` / `link` — durable.** Snapshotted to storage at publish; fetchable forever, even after the session's machine is gone. (Reports, build outputs, screenshots, diffs.)
+- **`preview` — live.** A URL into the running session machine. The *entry* is durable (you always get it back on reload), but the served app is bound to a warm machine, so it carries a `status` (`live` / `cold`) and can be resumed.
+
+## How the agent publishes
+
+The runtime would get two tools alongside `bash`/`read`/`write`:
+
+- `oc.preview(port)` — expose a port of the session's machine as a preview URL.
+- `oc.publish(path)` — snapshot a file as a durable artifact.
+
+Each publish appends a `user`-level event and upserts the artifact, so it reaches your UI the moment it happens — the agent builds, then *shows* you.
+
+## How your app would consume it
+
+The same snapshot-plus-stream pattern as [events](/agent-sessions/events): list on load, subscribe for changes.
+
+```
+GET /v3/sessions/:id/artifacts             → [Artifact]      # the panel on load (survives refresh)
+GET /v3/sessions/:id/artifacts/:key/content                  # durable file bytes
+events: artifact.published | artifact.updated | artifact.removed   (level: user)
+
+Artifact = { key, kind: "preview" | "file" | "link", title?, status?, url?,
+             content_type?, bytes?, created_at, updated_at }
+```
+
+A preview URL is a public capability — the browser loads it directly; a [client token](/agent-sessions/authentication#client-tokens) only gates *learning* the URL (via the user-level event), so you can stream the whole build *and* embed the running app from the same front-end.
+
+<Note>Actively being designed — if you have a shape in mind or want it sooner, tell us how you'd use it.</Note>

--- a/docs/agent-sessions/authentication.mdx
+++ b/docs/agent-sessions/authentication.mdx
@@ -55,7 +55,7 @@ curl https://api.opencomputer.dev/v3/credentials \
 # make it the default for this provider
 curl -X PUT https://api.opencomputer.dev/v3/credentials/default \
   -H "Authorization: Bearer $OPENCOMPUTER_API_KEY" \
-  -d '{ "provider": "anthropic", "credential": "cred_…" }'
+  -d '{ "credential": "cred_…" }'
 ```
 
 **Resolution** per session: the agent's credential → your org default for the provider. (No platform-billed fallback yet — bring a key.)

--- a/docs/agent-sessions/channels.mdx
+++ b/docs/agent-sessions/channels.mdx
@@ -1,0 +1,14 @@
+---
+title: "Channels"
+description: "Talk to a session where people already work — Slack, GitHub (coming soon)"
+---
+
+<Note>**Coming soon.** Current thinking, not a shipped contract. Today you converse with a session over the [API](/agent-sessions/messaging) — stream events out, post messages in — and deliver events out via [webhooks](/agent-sessions/webhooks). Channels connect that same session to a Slack thread or a GitHub PR.</Note>
+
+A **channel** binds a session's thread to a place people already work, so the same session is reachable from there. Slack is the first channel.
+
+- **Inbound.** A Slack `@mention` or thread reply is verified, de-duplicated, and appended to the session as a [steer](/agent-sessions/messaging) — the same inbound message you can post over the API.
+- **Outbound.** The platform projects the session's `user` and `progress` [events](/agent-sessions/events#levels) back to the thread. The agent never calls Slack itself — it appends events; the platform delivers them, durably and idempotently.
+- **Additive bindings.** A session has a set of bindings added over its life; it is never typed as "a Slack session" or "a GitHub session." A chat-born session that opens a PR gains a binding to that PR. Routing follows event level — conversation goes to conversation bindings, work product to delivery targets.
+
+A channel is one consumer of the same public API a custom UI uses: post messages in, render the [event stream](/agent-sessions/events) at the level you want, and optionally bind a thread so the platform projects for you.

--- a/docs/agent-sessions/custom-runtimes.mdx
+++ b/docs/agent-sessions/custom-runtimes.mdx
@@ -1,0 +1,30 @@
+---
+title: "Custom runtimes"
+description: "Package any agent harness as a runtime (coming soon)"
+---
+
+<Note>**Coming soon.** Current thinking, not a shipped contract. Today the only [runtime](/agent-sessions/runtimes) is `claude`; custom runtimes are the extensibility seam — `claude` itself is just the first runtime built on this contract.</Note>
+
+A runtime is a container image that implements the **runtime contract**. Any agent harness — your own, or a lab's — becomes a runtime by meeting it; you then select it per agent with `runtime: "<name>"`, and nothing else about the session changes.
+
+## The contract
+
+The platform invokes your image once per turn and passes it (via env) the session id, the read cursor, the events API URL, and a fenced **turn token**. Per turn the image:
+
+1. reads the new input from the [event log](/agent-sessions/events) at the cursor;
+2. drives its own agent loop;
+3. **streams events back** to the session over the authenticated events API — the turn token is fenced, so if the platform has superseded this instance its writes are rejected and a stale machine can't corrupt the log;
+4. performs all side effects through the **remote [sandbox tools](/agent-sessions/runtime-tools)** — it has no local disk or network of its own; the sandbox is the boundary;
+5. **exits 0 when it has nothing left to do** (yield, don't block). A non-zero exit is treated as a crash, and the platform restarts the turn in place.
+
+## State and recovery
+
+The image carries no durable state. The durable record is the event log plus the runtime's on-box **journal**. Keep your resumable state in the journal directory the platform provides and you inherit the same [durability](/agent-sessions/durability) as `claude`: a crash restarts from the journal, an idle session hibernates and is checkpointed, and a lost machine is recreated and restored.
+
+## Models
+
+The model is configuration, not part of the image. A runtime declares which providers it can drive; switching across providers needs an image that drives the target (the planned `opencode` aims to drive all).
+
+## Distribution
+
+You register a runtime with `oc runtime push <image>` and select it with `runtime: "<name>"`. Runtimes are versioned and a session pins the version it runs, so pushing a new build never affects in-flight sessions — the same mechanism behind the prebuilt `claude`, `codex`, and `opencode` images.

--- a/docs/agent-sessions/events.mdx
+++ b/docs/agent-sessions/events.mdx
@@ -14,6 +14,7 @@ Every step a session takes is an **event**, appended to the log in order. The lo
 ```
 
 - **`id`** — the event's own unique id (`evt_…`). The client idempotency key for steering is separate (deduped per session — see [steering](/agent-sessions/messaging)).
+- **`turn_id`** — the turn that produced the event, when applicable; filter a turn's output with `?turn_id=`.
 - **`type`** — the one discriminator: a namespaced string (`agent.message`, `turn.completed`, …). See below.
 - **`actor`** — who produced it: `{ id, display?, type: "human" | "agent" | "system" }`.
 - **`level`** — visibility; see below.

--- a/docs/agent-sessions/events.mdx
+++ b/docs/agent-sessions/events.mdx
@@ -40,7 +40,7 @@ The stable contract is the top-level **`type`** — **switch on it, don't parse 
 
 **Correlate a steer to its turn.** Steers coalesce — one turn can pick up several — so [`POST /messages`](/agent-sessions/messaging) returns the *event* `seq`, not a turn. The turn that consumes your steer emits `turn.started` with `input_from_seq ≤ your_seq ≤ input_to_seq`; await its `turn.completed`, then `GET …/events?turn_id=` for everything it produced.
 
-**Large output.** A large `body` is offloaded to a `content_ref`; fetch the bytes with `GET /sessions/:id/events/:eventId/content` (e.g. full `exec.completed` output). Richer **artifacts** (named files, diffs, screenshots, reports) ride a forward `refs.artifacts[]`, with a first-class artifacts API **coming soon**. `refs` also carries optional correlation/evidence keys (`trace_id`, `sources[]`).
+**Large output.** A large `body` is offloaded to a `content_ref`; fetch the bytes with `GET /sessions/:id/events/:eventId/content` (e.g. full `exec.completed` output). Richer **artifacts** (named files, diffs, screenshots, reports) ride a forward `refs.artifacts[]`, with a first-class [artifacts & previews API](/agent-sessions/artifacts) **coming soon**. `refs` also carries optional correlation/evidence keys (`trace_id`, `sources[]`).
 
 ## Levels
 

--- a/docs/agent-sessions/messaging.mdx
+++ b/docs/agent-sessions/messaging.mdx
@@ -44,4 +44,4 @@ Every inbound and outbound message normalizes to this shape. The core fields are
 
 To get a session's output **out**, register a webhook destination. Deliveries carry the full [Event](/agent-sessions/events) (a message event's `body` is this envelope) — see [Webhooks](/agent-sessions/webhooks).
 
-<Note>Inbound channels (Slack, GitHub, Jira, email) are coming soon — they map onto this same envelope; today you steer in via the API.</Note>
+<Note>[Inbound channels](/agent-sessions/channels) (Slack, GitHub, Jira, email) are coming soon — they map onto this same envelope; today you steer in via the API.</Note>

--- a/docs/agent-sessions/runtime-tools.mdx
+++ b/docs/agent-sessions/runtime-tools.mdx
@@ -13,7 +13,7 @@ When you write a prompt for the `claude` [runtime](/agent-sessions/runtimes), it
 | `read` | Read a file from the sandbox. |
 | `write` | Write a file to the sandbox. |
 | `ls` | List a directory in the sandbox. |
-| `use_repo` | Check out a **public** git repository into the workspace. (Private-repo access — connections, repo catalog, scoped tokens — is coming soon; for launch, point it at a public URL or `git clone` via `bash`.) |
+| `use_repo` | Check out a **public** git repository into the workspace. (Private-repo access and prepared [workspaces](/agent-sessions/workspaces) — connections, repo catalog, scoped tokens — are coming soon; for launch, point it at a public URL or `git clone` via `bash`.) |
 
 These map to events you can stream: a `bash` run surfaces as an [`exec.completed`](/agent-sessions/events#event-shape) event (`{ command, exit_code, summary }`), with large output available via `content_ref`.
 

--- a/docs/agent-sessions/runtimes.mdx
+++ b/docs/agent-sessions/runtimes.mdx
@@ -26,7 +26,7 @@ Each **turn is one bounded run**, invoke-style — it:
 2. drives the Claude Agent SDK loop,
 3. **streams every step back as events** over the authenticated events API,
 4. performs side effects only through the remote [sandbox tools](/agent-sessions/runtime-tools) (`bash` / `read` / `write` / `ls`, plus `say` / `ask`), and
-5. **exits when it has nothing left to do** — it yields rather than busy-waits (waiting on a person, a build, or the clock costs no compute).
+5. **exits when it has nothing left to do** — it yields rather than busy-waits, so time spent waiting costs no compute.
 
 Across turns it continues an on-box **journal**; the durable record is the event log *plus* that journal, which the platform checkpoints at each boundary and restores on recovery ([durability](/agent-sessions/durability)).
 
@@ -34,11 +34,11 @@ Across turns it continues an on-box **journal**; the durable record is the event
 
 A regional **supervisor** owns each running session and keeps the runtime healthy — you never restart anything:
 
-- **One driver at a time.** The supervisor holds a **fenced lease** on the session: exactly one runtime instance may write at a time, and the fence rejects a stale or zombie instance (e.g. a slow machine that returns after it was given up) — no split-brain, no double-writes.
+- **One driver at a time.** The supervisor holds a **fenced lease** on the session: exactly one runtime instance can write at a time, and the fence rejects writes from a stale instance (e.g. a slow machine that returns after it was given up), so a session never has two concurrent writers.
 - **Liveness.** The lease is renewed while a turn runs. If the runtime's machine dies, the lease lapses and the supervisor **re-claims the turn and continues it** from the journal.
 - **Crash / hang / lost machine.** A bad exit restarts the turn in place (bounded attempts, with crash-loop backoff); a hung turn is bounded by a **deadline** and ends `deadline_exceeded`; a lost machine is recreated and **restored from the last checkpoint**. Full matrix in [durability](/agent-sessions/durability#limits).
-- **Failures surface — never an eternal spinner.** If a turn can't even start (the model key can't be resolved, the runtime image can't be fetched), the turn ends with an **`error` event carrying the reason** and the session returns to idle, instead of hanging.
-- **Backstop reconciler.** A periodic sweep re-dispatches work whose wake-up was missed, re-claims turns whose lease expired, and resets sessions left `running` after a crash — so nothing strands silently.
+- **A turn that can't start fails cleanly.** If the model key can't be resolved or the runtime image can't be fetched, the turn ends with an **`error` event carrying the reason** and the session returns to idle, rather than hanging.
+- **Backstop reconciler.** A periodic sweep re-dispatches work whose wake-up was missed, re-claims turns whose lease expired, and resets sessions left `running` after a crash, so stranded work is picked up.
 - **Observable.** Every turn and machine transition — turn start / complete / error, sandbox create / provision / hibernate, lease renew / fence — is recorded, so the platform can show exactly where a session is and why a turn ended the way it did.
 
 ## Coming soon

--- a/docs/agent-sessions/runtimes.mdx
+++ b/docs/agent-sessions/runtimes.mdx
@@ -16,6 +16,31 @@ curl https://api.opencomputer.dev/v3/agents \
         "prompt": "You review code.", "runtime": "claude" }'
 ```
 
+### How it's structured
+
+The runtime runs the agent loop in its **own per-session sandbox** (the *brain*). The agent's file and shell tools don't run there — they run in a **separate sandbox** (the *hands*) that the brain drives through remote tools, so the model has no local disk or network of its own: the sandbox is the only surface it can act through. The brain carries the [sealed model key](/agent-sessions/authentication#model-credentials) (egress-allowlisted to the model API, swapped in by a host proxy so the key never enters the VM); the hands sandbox holds no secrets at all.
+
+Each **turn is one bounded run**, invoke-style — it:
+
+1. reads the new input from the [event log](/agent-sessions/events) at the cursor,
+2. drives the Claude Agent SDK loop,
+3. **streams every step back as events** over the authenticated events API,
+4. performs side effects only through the remote [sandbox tools](/agent-sessions/runtime-tools) (`bash` / `read` / `write` / `ls`, plus `say` / `ask`), and
+5. **exits when it has nothing left to do** — it yields rather than busy-waits (waiting on a person, a build, or the clock costs no compute).
+
+Across turns it continues an on-box **journal**; the durable record is the event log *plus* that journal, which the platform checkpoints at each boundary and restores on recovery ([durability](/agent-sessions/durability)).
+
+### Reliability & supervision
+
+A regional **supervisor** owns each running session and keeps the runtime healthy — you never restart anything:
+
+- **One driver at a time.** The supervisor holds a **fenced lease** on the session: exactly one runtime instance may write at a time, and the fence rejects a stale or zombie instance (e.g. a slow machine that returns after it was given up) — no split-brain, no double-writes.
+- **Liveness.** The lease is renewed while a turn runs. If the runtime's machine dies, the lease lapses and the supervisor **re-claims the turn and continues it** from the journal.
+- **Crash / hang / lost machine.** A bad exit restarts the turn in place (bounded attempts, with crash-loop backoff); a hung turn is bounded by a **deadline** and ends `deadline_exceeded`; a lost machine is recreated and **restored from the last checkpoint**. Full matrix in [durability](/agent-sessions/durability#limits).
+- **Failures surface — never an eternal spinner.** If a turn can't even start (the model key can't be resolved, the runtime image can't be fetched), the turn ends with an **`error` event carrying the reason** and the session returns to idle, instead of hanging.
+- **Backstop reconciler.** A periodic sweep re-dispatches work whose wake-up was missed, re-claims turns whose lease expired, and resets sessions left `running` after a crash — so nothing strands silently.
+- **Observable.** Every turn and machine transition — turn start / complete / error, sandbox create / provision / hibernate, lease renew / fence — is recorded, so the platform can show exactly where a session is and why a turn ended the way it did.
+
 ## Coming soon
 
 <Note>The runtimes below are not yet callable. When one is available, you select it by setting `runtime` to its name — nothing else changes.</Note>

--- a/docs/agent-sessions/runtimes.mdx
+++ b/docs/agent-sessions/runtimes.mdx
@@ -46,16 +46,4 @@ A regional **supervisor** owns each running session and keeps the runtime health
 <Note>The runtimes below are not yet callable. When one is available, you select it by setting `runtime` to its name — nothing else changes.</Note>
 
 - **`codex`, `opencode`** — prebuilt, multi-provider runtimes.
-- **Custom (bring your own image)** — package any harness — your own, or a lab's — as a runtime.
-
-### How custom runtimes will work
-
-A runtime is a container image implementing the **runtime contract**. On wake it:
-
-1. Reads the session's events from the cursor.
-2. Drives its own agent loop.
-3. **Streams events back** to the session over the authenticated events API.
-4. Performs all side effects through the **remote sandbox tools** (no local disk or network).
-5. Calls the model, and **exits 0 when it has nothing left to do** (yield, don't block).
-
-The **image** carries no durable state — the durable record is the session (event log) plus the runtime's session journal, which the platform checkpoints and restores for the instance ([durability](/agent-sessions/durability)). You'll register it with `oc runtime push <image>` and select it with `runtime: "<name>"`. This is the extensibility seam: any agent harness becomes a runtime.
+- **Custom (bring your own image)** — package any agent harness as a runtime. See [Custom runtimes](/agent-sessions/custom-runtimes) for the contract and our current thinking.

--- a/docs/agent-sessions/sessions.mdx
+++ b/docs/agent-sessions/sessions.mdx
@@ -25,7 +25,7 @@ A **session** is the durable unit of an [agent](/agent-sessions/agents) at work:
 | `failed` | The session errored out. |
 | `archived` | Closed; read-only. |
 
-A session also carries `last_turn = { state, yield_reason?, turn_id, started_at, completed_at?, result_event_id?, error? }` and `usage` (`active_seconds`, `tokens` — observed only). The **`yield_reason`** tells you *why* the last turn ended — `completed`, `needs_input` (the agent asked a question — the session is now `awaiting_input`; answer by [steering](/agent-sessions/messaging)), `budget_exceeded` / `deadline_exceeded` / `max_turns` (a [limit](#limits) tripped), or `canceled`.
+A session also carries `last_turn = { id, state, yield_reason?, result_event_id? }` and `usage`; the fuller turn record (`started_at`, `completed_at`, `error`, `active_seconds`, `usage`) comes from [`GET …/result`](/agent-sessions/api-reference) and `…/turns`. The **`yield_reason`** tells you *why* the last turn ended — `completed`, `needs_input` (the agent asked a question — the session is now `awaiting_input`; answer by [steering](/agent-sessions/messaging)), `budget_exceeded` / `deadline_exceeded` / `max_turns` (a [limit](#limits) tripped), or `canceled`.
 
 ## Get the result
 
@@ -34,7 +34,7 @@ Don't sniff prose for "is it done." Await the **`turn.completed`** event (on the
 ```bash
 curl https://api.opencomputer.dev/v3/sessions/$ID/result \
   -H "Authorization: Bearer $OPENCOMPUTER_API_KEY"
-# → { "last_turn": { "state": "ok", "yield_reason": "completed", "result_event_id": "evt_…" },
+# → { "last_turn": { "id": "trn_…", "state": "ok", "yield_reason": "completed", "result_event_id": "evt_…" },
 #     "result": { "type": "agent.message", "level": "user", "body": { "text": "…" } } }
 ```
 

--- a/docs/agent-sessions/triggers.mdx
+++ b/docs/agent-sessions/triggers.mdx
@@ -1,0 +1,28 @@
+---
+title: "Triggers"
+description: "Start and resume sessions from external events (coming soon)"
+---
+
+<Note>**Coming soon.** Current thinking, not a shipped contract. Today you start a session with [`POST /sessions`](/agent-sessions/api-reference) and steer it with [`POST /messages`](/agent-sessions/messaging); triggers add an event-driven way to do the same.</Note>
+
+Triggers let external events start and resume sessions without an API call. You declare them on an [agent](/agent-sessions/agents); the platform receives the events and routes them to the right session.
+
+```toml
+[[triggers]]
+type = "github"
+on   = "issue.labeled:agent"
+```
+
+- **Sources (planned):** GitHub (issue labeled, PR/issue comment) and a Slack `@mention`. `cron`, `http`, and email are further out.
+- **Routing:** a routing key groups events into sessions — by default one session per issue; a comment on a PR the agent opened resumes the session that opened it.
+- **Who can trigger:** restricted to members of your organization by default, configurable per agent.
+
+## Connections
+
+Triggers, and the deliveries that carry work back out, run through **connections** — integrations the platform operates, so the agent holds no tokens. Installing the OpenComputer GitHub App is the whole GitHub integration; a Slack connection powers the Slack [channel](/agent-sessions/channels). Model provider keys are connections too.
+
+## Deliveries
+
+To act back on a source — open or update a draft PR, post a comment — the agent requests a **delivery** and the platform performs it, as the org or (with a personal grant) as the triggering user. Today the generic outbound path is [webhooks](/agent-sessions/webhooks); first-class GitHub/Slack deliveries are part of this work.
+
+See [Channels](/agent-sessions/channels) for the two-way conversation model and [Workspaces](/agent-sessions/workspaces) for the repo a triggered session works in.

--- a/docs/agent-sessions/webhooks.mdx
+++ b/docs/agent-sessions/webhooks.mdx
@@ -40,7 +40,7 @@ Every send and its outcome — the data behind a deliveries dashboard.
 A delivery moves `pending → delivering → delivered`, or `failed` (retrying) → `dead_letter` after the max attempts.
 
 ```
-Delivery = { id, destination_id, event_id, status, attempts, last_attempt_at, response_code?, error? }
+Delivery = { id, session, destination, event_id, event_seq, status, attempts, last_attempt_at, response_code?, error?, created_at, updated_at }
 ```
 
 <Note>Coming soon: full request/response **body** capture in delivery detail (today records status, attempts, response code, and error); a **test-ping** for a destination; and **org/agent-scoped** destinations that persist across sessions.</Note>

--- a/docs/agent-sessions/workspaces.mdx
+++ b/docs/agent-sessions/workspaces.mdx
@@ -1,0 +1,21 @@
+---
+title: "Workspaces"
+description: "Prepared repo environments, rebuilt on push (coming soon)"
+---
+
+<Note>**Coming soon.** Current thinking, not a shipped contract. Today a session works in its [sandbox](/agent-sessions/runtime-tools) and clones a repo on demand; workspaces prepare that environment ahead of time.</Note>
+
+Cloning, installing, and building take minutes. A **workspace** does that work ahead of time — on every push — and snapshots the result, so a session boots into a ready machine in seconds. It is a first-class resource (not an agent attribute), shared by every session that lands on its repo(s).
+
+```bash
+oc workspace create web \
+  --repo github.com/acme/web \
+  --setup "pnpm i && pnpm build" \
+  --pool 1
+```
+
+- **Recipe.** One or more repos (each at an optional ref), a `setup` step, and an optional `warm` step to heat caches.
+- **Builds.** Rebuilt on every push (or on an interval) into an immutable lineage; a session boots from the latest successful build and pins it. `--pool N` keeps machines pre-booted.
+- **Resolution.** A session is not bound to a repo — it resolves which to work in from the triggering event, the conversation, an agent default, or by asking, via a `use_repo` tool. Resolution is lazy and re-resolvable: switch repos mid-session, or open several at once.
+
+Pairs with the scoped, tokenless private-repo access noted in [Runtime tools](/agent-sessions/runtime-tools).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -73,7 +73,6 @@
           "agent-sessions/webhooks",
           "agent-sessions/runtimes",
           "agent-sessions/runtime-tools",
-          "agent-sessions/artifacts",
           "agent-sessions/api-reference"
         ]
       },
@@ -272,6 +271,13 @@
         "group": "Resources",
         "pages": [
           "troubleshooting"
+        ]
+      },
+      {
+        "group": "Labs",
+        "tag": "Coming soon",
+        "pages": [
+          "agent-sessions/artifacts"
         ]
       }
     ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -79,6 +79,7 @@
             "tag": "Coming soon",
             "expanded": true,
             "pages": [
+              "agent-sessions/custom-runtimes",
               "agent-sessions/triggers",
               "agent-sessions/channels",
               "agent-sessions/workspaces",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -79,6 +79,9 @@
             "tag": "Coming soon",
             "expanded": true,
             "pages": [
+              "agent-sessions/triggers",
+              "agent-sessions/channels",
+              "agent-sessions/workspaces",
               "agent-sessions/artifacts"
             ]
           }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -73,7 +73,15 @@
           "agent-sessions/webhooks",
           "agent-sessions/runtimes",
           "agent-sessions/runtime-tools",
-          "agent-sessions/api-reference"
+          "agent-sessions/api-reference",
+          {
+            "group": "Labs",
+            "tag": "Coming soon",
+            "expanded": true,
+            "pages": [
+              "agent-sessions/artifacts"
+            ]
+          }
         ]
       },
       {
@@ -271,13 +279,6 @@
         "group": "Resources",
         "pages": [
           "troubleshooting"
-        ]
-      },
-      {
-        "group": "Labs",
-        "tag": "Coming soon",
-        "pages": [
-          "agent-sessions/artifacts"
         ]
       }
     ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -73,6 +73,7 @@
           "agent-sessions/webhooks",
           "agent-sessions/runtimes",
           "agent-sessions/runtime-tools",
+          "agent-sessions/artifacts",
           "agent-sessions/api-reference"
         ]
       },


### PR DESCRIPTION
Two docs changes for the Durable Agent Sessions section.

## 1. API reference ↔ implementation accuracy (docs-only)

Audited the published reference against the actual `/v3` serializers and fixed every drift:

- **Error envelope** → `{ type, message }` only (dropped `code`, `param`, `request_id`, which the API never returns).
- **`Session.last_turn`** → `{ id, state, yield_reason?, result_event_id? }` (was `turn_id` + `started_at`/`completed_at`/`error`, which only the full Turn carries); added `agent_id`; documented the **Turn** shape (`id, …, active_seconds, usage`) returned by `/result` + `/turns`.
- **`Event`** → added `turn_id`, `content_ref`, `body_truncated`, `body_bytes`.
- **`Destination`** → added `session`, `kind`, `has_secret`, `created_after_seq`, `updated_at`.
- **`Delivery`** → `destination_id` → `destination`; added `session`, `event_seq`, `created_at`, `updated_at`.
- **`Credential`** → added `is_default`.
- **`PUT /credentials/default`** → body is `{ credential }` (provider derived; was documented *and* ignored).
- **`POST /credentials`** → documented the `is_default?` input.
- **`POST /messages`** → `200` on idempotent replay (was `202`-only).
- **Events** → omitting `?level=` defaults to `internal`; `client-tokens` `ttl` clamped to 60–86400.

Cross-referenced against `sessions-api/src/v3` serializers + route handlers; no stale field names remain. (Internal turn-token routes — `POST /events`, `/sandbox/*` — remain intentionally undocumented.)

## 2. Coming-soon: Artifacts & previews page

New `agent-sessions/artifacts` page introducing terminology not yet in the docs — a published **artifacts** collection (durable `file`/`link`) and live **previews** (`oc.preview`/`oc.publish`), with the snapshot + `artifact.*` stream consumption pattern. Clearly labeled **coming soon** (current thinking, not a spec; distilled from the internal design sketch). Added to the nav and linked from the events "artifacts API coming soon" hint.

Other forward-looking items already carry inline coming-soon notes (model providers/hot-swap, inbound channels, private-repo access, blocking ask, hard delete/export, webhook backfill); the **Runtimes** page already lists the planned `codex`/`opencode`/custom runtimes. Happy to promote any of those to their own coming-soon page if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
