### PR TITLE
docs: link the example apps repo (oc-sessions-demos)

### DIFF
--- a/docs/agent-sessions/overview.mdx
+++ b/docs/agent-sessions/overview.mdx
@@ -63,4 +63,7 @@ Reach for sessions when you want a long-running or interactive agent and don't w
   <Card title="How sessions work" icon="book" href="/agent-sessions/sessions">
     How a session works — lifecycle and events.
   </Card>
+  <Card title="Example apps" icon="github" href="https://github.com/diggerhq/oc-sessions-demos">
+    Self-contained apps built on this API — clone and run.
+  </Card>
 </CardGroup>

--- a/docs/agent-sessions/overview.mdx
+++ b/docs/agent-sessions/overview.mdx
@@ -64,6 +64,6 @@ Reach for sessions when you want a long-running or interactive agent and don't w
     How a session works — lifecycle and events.
   </Card>
   <Card title="Example apps" icon="github" href="https://github.com/diggerhq/oc-sessions-demos">
-    Self-contained apps built on this API — clone and run.
+    A repo of examples built on this API.
   </Card>
 </CardGroup>

--- a/docs/agent-sessions/quickstart.mdx
+++ b/docs/agent-sessions/quickstart.mdx
@@ -90,4 +90,7 @@ Deliveries are signed ([Standard Webhooks](https://www.standardwebhooks.com)) an
   <Card title="Webhooks" icon="bell" href="/agent-sessions/webhooks">
     Deliver output reliably, and control deliveries.
   </Card>
+  <Card title="Example apps" icon="github" href="https://github.com/diggerhq/oc-sessions-demos">
+    Self-contained apps built on this API — clone and run.
+  </Card>
 </CardGroup>

--- a/docs/agent-sessions/quickstart.mdx
+++ b/docs/agent-sessions/quickstart.mdx
@@ -91,6 +91,6 @@ Deliveries are signed ([Standard Webhooks](https://www.standardwebhooks.com)) an
     Deliver output reliably, and control deliveries.
   </Card>
   <Card title="Example apps" icon="github" href="https://github.com/diggerhq/oc-sessions-demos">
-    Self-contained apps built on this API — clone and run.
+    A repo of examples built on this API.
   </Card>
 </CardGroup>


### PR DESCRIPTION
Adds an **Example apps** card linking [oc-sessions-demos](https://github.com/diggerhq/oc-sessions-demos) to the *Next steps* on the Durable Agent Sessions **overview** and **quickstart**, so developers can find complete, self-contained apps built on the API.

Independent of #386 (touches only `overview.mdx` + `quickstart.mdx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)