### PR TITLE
Surface checkpoint failure details in dashboard

### DIFF
--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -578,13 +578,14 @@ async function handleListCheckpoints(req: Request, env: DashboardEnv, caller: Ca
     const offset = (page - 1) * perPage;
 
     const { results } = await env.OPENCOMPUTER_DB.prepare(
-      `SELECT id, sandbox_id, owner_cell_id, s3_url, size_bytes, golden_hash, workspace_size, created_at, expires_at, name
+      `SELECT id, sandbox_id, owner_cell_id, s3_url, size_bytes, golden_hash, workspace_size, created_at, expires_at, name, status, error_msg, failed_at
          FROM checkpoints_index WHERE org_id = ?1 ORDER BY created_at DESC LIMIT ?2 OFFSET ?3`,
     ).bind(caller.orgID, perPage, offset).all<{
       id: string; sandbox_id: string; owner_cell_id: string; s3_url: string | null;
       size_bytes: number | null; golden_hash: string | null; workspace_size: number | null;
       created_at: number; expires_at: number | null;
       name: string | null;
+      status: string | null; error_msg: string | null; failed_at: number | null;
     }>();
     const totalRow = await env.OPENCOMPUTER_DB.prepare(`SELECT COUNT(*) AS c FROM checkpoints_index WHERE org_id = ?1`).bind(caller.orgID).first<{ c: number }>();
     return json({
@@ -597,11 +598,13 @@ async function handleListCheckpoints(req: Request, env: DashboardEnv, caller: Ca
         // the column was added + backfilled from cell PG sandbox_checkpoints
         // so this now surfaces what customers actually called the checkpoint.
         name: r.name && r.name.length > 0 ? r.name : r.id.slice(0, 8),
-        status: "ready",
+        status: r.status ?? "ready",
         sizeBytes: r.size_bytes ?? 0,
         activeForks: 0,
         totalForks: 0,
         createdAt: epochToISORequired(r.created_at),
+        errorMsg: r.error_msg ?? undefined,
+        failedAt: r.failed_at ? epochToISORequired(r.failed_at) : undefined,
         cellId: r.owner_cell_id ?? "",
         goldenHash: r.golden_hash ?? "",
       })),

--- a/cloudflare-workers/events-ingest/src/index.ts
+++ b/cloudflare-workers/events-ingest/src/index.ts
@@ -234,8 +234,9 @@ export default {
       });
 
     // Checkpoint lifecycle: keep D1 checkpoints_index in sync with cell PG
-    // sandbox_checkpoints. CP emits checkpoint_ready after SetCheckpointReady
-    // (UPSERT all fields) and checkpoint_deleted after DeleteCheckpoint. The
+    // sandbox_checkpoints. CP emits checkpoint_ready after SetCheckpointReady,
+    // checkpoint_failed after SetCheckpointFailed, and checkpoint_deleted after
+    // DeleteCheckpoint. The
     // dashboard cross-cell list + the edge's spawn-from-checkpoint routing
     // both depend on this table being populated. golden_hash is write-once:
     // it pins the checkpoint to its base golden, so the upsert fills a
@@ -250,14 +251,29 @@ export default {
          owner_cell_id = excluded.owner_cell_id,
          s3_url        = excluded.s3_url,
          size_bytes    = excluded.size_bytes,
+         status        = 'ready',
+         error_msg     = NULL,
+         failed_at     = NULL,
          golden_hash   = CASE WHEN checkpoints_index.golden_hash = '' THEN excluded.golden_hash ELSE checkpoints_index.golden_hash END,
+         name          = CASE WHEN excluded.name IS NULL OR excluded.name = '' THEN checkpoints_index.name ELSE excluded.name END`,
+    );
+    const checkpointFailedUpsert = env.OPENCOMPUTER_DB.prepare(
+      `INSERT INTO checkpoints_index
+         (id, sandbox_id, org_id, owner_cell_id, s3_url, size_bytes, golden_hash, workspace_size, created_at, name, status, error_msg, failed_at)
+       VALUES (?1, ?2, ?3, ?4, '', 0, '', NULL, ?5, ?6, 'failed', ?7, ?8)
+       ON CONFLICT(id) DO UPDATE SET
+         sandbox_id    = excluded.sandbox_id,
+         owner_cell_id = excluded.owner_cell_id,
+         status        = 'failed',
+         error_msg     = excluded.error_msg,
+         failed_at     = excluded.failed_at,
          name          = CASE WHEN excluded.name IS NULL OR excluded.name = '' THEN checkpoints_index.name ELSE excluded.name END`,
     );
     const checkpointDelete = env.OPENCOMPUTER_DB.prepare(
       `DELETE FROM checkpoints_index WHERE id = ?1`,
     );
     const checkpointBatches = fresh
-      .filter((e) => e.type === "checkpoint_ready" || e.type === "checkpoint_deleted")
+      .filter((e) => e.type === "checkpoint_ready" || e.type === "checkpoint_failed" || e.type === "checkpoint_deleted")
       .flatMap((e) => {
         const p = (e.payload ?? {}) as {
           checkpoint_id?: string;
@@ -266,17 +282,32 @@ export default {
           size_bytes?: number;
           golden_hash?: string;
           name?: string;
+          error_msg?: string;
         };
         if (!p.checkpoint_id) return [];
         if (e.type === "checkpoint_deleted") {
           return [checkpointDelete.bind(p.checkpoint_id)];
+        }
+        const tsSec = Math.floor((Date.parse(e.timestamp) || Date.now()) / 1000);
+        if (e.type === "checkpoint_failed") {
+          return [
+            checkpointFailedUpsert.bind(
+              p.checkpoint_id,
+              e.sandbox_id ?? "",
+              e.org_id ?? "",
+              e.cell_id,
+              tsSec,
+              p.name ?? null,
+              p.error_msg ?? "checkpoint failed",
+              tsSec,
+            ),
+          ];
         }
         // checkpoint_ready — use rootfs_s3_key as the canonical s3_url since
         // it's the rootfs delta the worker pulls at spawn time. The workspace
         // key is reachable from the rootfs metadata. `name` is the user-set
         // label; pre-fix the dashboard derived it from rootfs_s3_key, which
         // always ended in "rootfs.tar.zst".
-        const tsSec = Math.floor((Date.parse(e.timestamp) || Date.now()) / 1000);
         return [
           checkpointUpsert.bind(
             p.checkpoint_id,

--- a/cloudflare-workers/schema_phase2_d1.sql
+++ b/cloudflare-workers/schema_phase2_d1.sql
@@ -27,7 +27,11 @@ CREATE TABLE IF NOT EXISTS checkpoints_index (
   workspace_size   INTEGER,
   created_at       INTEGER NOT NULL,
   expires_at       INTEGER,
-  replicated_to    TEXT NOT NULL DEFAULT '[]'
+  replicated_to    TEXT NOT NULL DEFAULT '[]',
+  name             TEXT,
+  status           TEXT NOT NULL DEFAULT 'ready',
+  error_msg        TEXT,
+  failed_at        INTEGER
 );
 
 CREATE INDEX IF NOT EXISTS idx_checkpoints_org      ON checkpoints_index(org_id);

--- a/cloudflare-workers/schema_phase6.sql
+++ b/cloudflare-workers/schema_phase6.sql
@@ -1,0 +1,18 @@
+-- Phase 6: checkpoint failure details in the global D1 checkpoint index.
+--
+-- The edge dashboard reads /checkpoints from checkpoints_index, not from each
+-- cell's local Postgres. Before this phase, failed async checkpoints stayed in
+-- cell PG only, so the dashboard could show "No checkpoints yet" while
+-- `oc checkpoint list` showed a failed checkpoint with an error reason.
+--
+-- Apply before deploying api-edge/events-ingest/control-plane code that reads
+-- or writes these columns:
+--   wrangler d1 execute opencomputer-dev --remote --file cloudflare-workers/schema_phase6.sql
+--
+-- SQLite/D1 has no `ADD COLUMN IF NOT EXISTS`, so this ALTER fails on re-run —
+-- one-shot, like earlier phase files.
+
+ALTER TABLE checkpoints_index ADD COLUMN name TEXT;
+ALTER TABLE checkpoints_index ADD COLUMN status TEXT NOT NULL DEFAULT 'ready';
+ALTER TABLE checkpoints_index ADD COLUMN error_msg TEXT;
+ALTER TABLE checkpoints_index ADD COLUMN failed_at INTEGER;

--- a/internal/api/checkpoint_events.go
+++ b/internal/api/checkpoint_events.go
@@ -20,6 +20,7 @@ import (
 //
 // Event types:
 //   checkpoint_ready    — checkpoint upload finished; UPSERT row in D1
+//   checkpoint_failed   — async checkpoint failed; UPSERT failed row in D1
 //   checkpoint_deleted  — checkpoint dropped from cell PG; DELETE row in D1
 //
 // Best-effort: failure to XADD is logged but doesn't fail the caller. The

--- a/internal/api/sandbox.go
+++ b/internal/api/sandbox.go
@@ -2152,6 +2152,10 @@ func (s *Server) createCheckpoint(c echo.Context) error {
 				// error_msg/failed_at columns added in migration 039.
 				// Pre-fix the reason was silently discarded.
 				_ = s.store.SetCheckpointFailed(context.Background(), checkpointID, err.Error())
+				s.publishCheckpointEvent(context.Background(), "checkpoint_failed", checkpointID, sandboxID, orgID, session.WorkerID, map[string]any{
+					"name":      req.Name,
+					"error_msg": err.Error(),
+				})
 				return
 			}
 			// Persist the actual archive size from the worker's response.
@@ -2190,6 +2194,10 @@ func (s *Server) createCheckpoint(c echo.Context) error {
 			if err != nil {
 				log.Printf("api: async checkpoint %s failed: %v", checkpointID, err)
 				_ = s.store.SetCheckpointFailed(context.Background(), checkpointID, err.Error())
+				s.publishCheckpointEvent(context.Background(), "checkpoint_failed", checkpointID, sandboxID, orgID, session.WorkerID, map[string]any{
+					"name":      req.Name,
+					"error_msg": err.Error(),
+				})
 				return
 			}
 			_ = s.store.SetCheckpointReady(context.Background(), checkpointID, rootfsKey, workspaceKey, sizeBytes)

--- a/web/src/pages/Checkpoints.tsx
+++ b/web/src/pages/Checkpoints.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getCheckpoints, deleteCheckpointDashboard, type CheckpointItem } from '../api/client'
 
 export default function Checkpoints() {
   const queryClient = useQueryClient()
   const [page, setPage] = useState(1)
+  const [showFailed, setShowFailed] = useState(false)
   const perPage = 20
 
   const { data, isLoading } = useQuery({
@@ -20,6 +21,21 @@ export default function Checkpoints() {
   })
 
   const checkpoints = data?.checkpoints ?? []
+  const visibleCheckpoints = useMemo(() => {
+    if (!showFailed) {
+      return checkpoints.filter((cp) => cp.status !== 'failed')
+    }
+
+    return checkpoints
+      .map((cp, index) => ({ cp, index }))
+      .sort((a, b) => {
+        const aFailed = a.cp.status === 'failed'
+        const bFailed = b.cp.status === 'failed'
+        if (aFailed !== bFailed) return aFailed ? 1 : -1
+        return a.index - b.index
+      })
+      .map(({ cp }) => cp)
+  }, [checkpoints, showFailed])
   const total = data?.total ?? 0
   const totalPages = Math.ceil(total / perPage)
 
@@ -30,6 +46,25 @@ export default function Checkpoints() {
         <h1 className="page-title">Checkpoints</h1>
         <p className="page-subtitle">Sandbox snapshots across your organization</p>
       </div>
+
+      <label
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 8,
+          marginBottom: 12,
+          fontSize: 13,
+          color: 'var(--text-secondary)',
+          cursor: 'pointer',
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={showFailed}
+          onChange={(event) => setShowFailed(event.target.checked)}
+        />
+        Show failed checkpoints
+      </label>
 
       {/* Table */}
       {isLoading ? (
@@ -51,74 +86,99 @@ export default function Checkpoints() {
               </tr>
             </thead>
             <tbody>
-              {checkpoints.map((cp: CheckpointItem) => (
-                <tr key={cp.id}>
-                  <td style={{ fontWeight: 500, color: 'var(--text-primary)' }}>{cp.name}</td>
-                  <td>
-                    <code style={{ fontSize: 12 }}>{cp.sandboxId}</code>
-                  </td>
-                  <td>
-                    <span
-                      style={{
-                        fontSize: 11,
-                        fontWeight: 600,
-                        padding: '2px 8px',
-                        borderRadius: 10,
-                        background: cp.status === 'ready'
-                          ? 'rgba(34, 197, 94, 0.08)'
-                          : cp.status === 'failed'
-                            ? 'rgba(251, 113, 133, 0.08)'
-                            : 'rgba(234, 179, 8, 0.08)',
-                        color: cp.status === 'ready'
-                          ? 'var(--accent-green)'
-                          : cp.status === 'failed'
-                            ? 'var(--accent-rose)'
-                            : '#eab308',
-                        border: `1px solid ${
-                          cp.status === 'ready'
-                            ? 'rgba(34, 197, 94, 0.15)'
+              {visibleCheckpoints.map((cp: CheckpointItem) => (
+                <Fragment key={cp.id}>
+                  <tr>
+                    <td style={{ fontWeight: 500, color: 'var(--text-primary)' }}>{cp.name}</td>
+                    <td>
+                      <code style={{ fontSize: 12 }}>{cp.sandboxId}</code>
+                    </td>
+                    <td>
+                      <span
+                        style={{
+                          fontSize: 11,
+                          fontWeight: 600,
+                          padding: '2px 8px',
+                          borderRadius: 10,
+                          background: cp.status === 'ready'
+                            ? 'rgba(34, 197, 94, 0.08)'
                             : cp.status === 'failed'
-                              ? 'rgba(251, 113, 133, 0.15)'
-                              : 'rgba(234, 179, 8, 0.15)'
-                        }`,
-                        cursor: cp.status === 'failed' && cp.errorMsg ? 'help' : 'default',
-                      }}
-                      title={cp.status === 'failed' && cp.errorMsg ? cp.errorMsg : undefined}
-                    >
-                      {cp.status === 'ready' ? 'Ready' : cp.status === 'failed' ? 'Failed' : 'Processing'}
-                    </span>
-                  </td>
-                  <td style={{ textAlign: 'right', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
-                    {cp.activeForks > 0 ? (
-                      <span style={{ color: 'var(--accent-emerald)' }}>{cp.activeForks}</span>
-                    ) : (
-                      <span style={{ color: 'var(--text-tertiary)' }}>0</span>
-                    )}
-                  </td>
-                  <td style={{ textAlign: 'right', fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--text-secondary)' }}>
-                    {cp.totalForks}
-                  </td>
-                  <td style={{ fontFamily: 'var(--font-mono)', fontSize: 12 }}>
-                    {new Date(cp.createdAt).toLocaleString()}
-                  </td>
-                  <td>
-                    <button
-                      className="btn-danger"
-                      onClick={() => {
-                        if (confirm(`Delete checkpoint "${cp.name}"? Active forks will not be affected.`)) {
-                          deleteMutation.mutate(cp.id)
-                        }
-                      }}
-                    >
-                      Delete
-                    </button>
-                  </td>
-                </tr>
+                              ? 'rgba(251, 113, 133, 0.08)'
+                              : 'rgba(234, 179, 8, 0.08)',
+                          color: cp.status === 'ready'
+                            ? 'var(--accent-green)'
+                            : cp.status === 'failed'
+                              ? 'var(--accent-rose)'
+                              : '#eab308',
+                          border: `1px solid ${
+                            cp.status === 'ready'
+                              ? 'rgba(34, 197, 94, 0.15)'
+                              : cp.status === 'failed'
+                                ? 'rgba(251, 113, 133, 0.15)'
+                                : 'rgba(234, 179, 8, 0.15)'
+                          }`,
+                        }}
+                      >
+                        {cp.status === 'ready' ? 'Ready' : cp.status === 'failed' ? 'Failed' : 'Processing'}
+                      </span>
+                    </td>
+                    <td style={{ textAlign: 'right', fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+                      {cp.activeForks > 0 ? (
+                        <span style={{ color: 'var(--accent-emerald)' }}>{cp.activeForks}</span>
+                      ) : (
+                        <span style={{ color: 'var(--text-tertiary)' }}>0</span>
+                      )}
+                    </td>
+                    <td style={{ textAlign: 'right', fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--text-secondary)' }}>
+                      {cp.totalForks}
+                    </td>
+                    <td style={{ fontFamily: 'var(--font-mono)', fontSize: 12 }}>
+                      {new Date(cp.createdAt).toLocaleString()}
+                    </td>
+                    <td>
+                      <button
+                        className="btn-danger"
+                        onClick={() => {
+                          if (confirm(`Delete checkpoint "${cp.name}"? Active forks will not be affected.`)) {
+                            deleteMutation.mutate(cp.id)
+                          }
+                        }}
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                  {cp.status === 'failed' && cp.errorMsg && (
+                    <tr key={`${cp.id}-error`}>
+                      <td colSpan={7} style={{ paddingTop: 0 }}>
+                        <div
+                          style={{
+                            border: '1px solid rgba(251, 113, 133, 0.16)',
+                            borderRadius: 8,
+                            padding: '10px 12px',
+                            background: 'rgba(251, 113, 133, 0.06)',
+                            color: 'var(--accent-rose)',
+                            fontSize: 12,
+                            lineHeight: 1.45,
+                            overflowWrap: 'anywhere',
+                          }}
+                        >
+                          {cp.errorMsg}
+                          {cp.failedAt && (
+                            <div style={{ color: 'var(--text-tertiary)', marginTop: 4 }}>
+                              Failed {new Date(cp.failedAt).toLocaleString()}
+                            </div>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
               ))}
-              {checkpoints.length === 0 && (
+              {visibleCheckpoints.length === 0 && (
                 <tr>
                   <td colSpan={7} style={{ textAlign: 'center', padding: 32, color: 'var(--text-tertiary)' }}>
-                    No checkpoints yet
+                    {checkpoints.length === 0 ? 'No checkpoints yet' : 'No checkpoints to show'}
                   </td>
                 </tr>
               )}

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -184,44 +184,6 @@ export default function SessionDetail() {
             <div style={{ fontSize: 13, color: 'var(--text-tertiary)' }}>
               {session.template || 'base'} &middot; Started {timeAgo(session.startedAt)}
             </div>
-            {session.status === 'running' && (
-              <div style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 8,
-                marginTop: 12,
-                padding: '6px 8px',
-                background: 'var(--bg-deep)',
-                border: '1px solid var(--border-subtle)',
-                borderRadius: 'var(--radius-sm)',
-              }}>
-                <span style={{
-                  fontSize: 10,
-                  color: 'var(--text-tertiary)',
-                  fontWeight: 600,
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.05em',
-                }}>
-                  CLI
-                </span>
-                <code style={{
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 12,
-                  color: 'var(--text-accent)',
-                  background: 'transparent',
-                  padding: 0,
-                }}>
-                  {shellCommand}
-                </code>
-                <button
-                  onClick={() => copyShellCommand(shellCommand)}
-                  className="btn-ghost"
-                  style={{ padding: '3px 8px', fontSize: 11 }}
-                >
-                  {copiedShell ? 'Copied' : 'Copy'}
-                </button>
-              </div>
-            )}
           </div>
 
           {/* Actions */}
@@ -457,6 +419,14 @@ export default function SessionDetail() {
           <DetailRow label="CPUs" value={String(session.config?.cpuCount ?? 1)} />
           <DetailRow label="Memory" value={`${session.config?.memoryMB ?? 512} MB`} />
           <DetailRow label="Started" value={new Date(session.startedAt).toLocaleString()} />
+          {session.status === 'running' && (
+            <DetailCommandRow
+              label="CLI shell"
+              value={shellCommand}
+              copied={copiedShell}
+              onCopy={() => copyShellCommand(shellCommand)}
+            />
+          )}
           {session.stoppedAt && (
             <DetailRow label="Stopped" value={new Date(session.stoppedAt).toLocaleString()} />
           )}
@@ -493,6 +463,41 @@ function DetailRow({ label, value, isError }: { label: string; value: string; is
         wordBreak: 'break-all',
       }}>
         {value}
+      </div>
+    </div>
+  )
+}
+
+function DetailCommandRow({
+  label,
+  value,
+  copied,
+  onCopy,
+}: {
+  label: string
+  value: string
+  copied: boolean
+  onCopy: () => void
+}) {
+  return (
+    <div>
+      <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginBottom: 2 }}>{label}</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+        <code style={{
+          fontSize: 13,
+          fontFamily: 'var(--font-mono)',
+          color: 'var(--text-primary)',
+          wordBreak: 'break-all',
+        }}>
+          {value}
+        </code>
+        <button
+          className="btn-ghost"
+          onClick={onCopy}
+          style={{ padding: '2px 7px', fontSize: 11, flexShrink: 0 }}
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
       </div>
     </div>
   )

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -62,6 +62,7 @@ export default function SessionDetail() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null)
+  const [copiedShell, setCopiedShell] = useState(false)
   const [showTerminal, setShowTerminal] = useState(false)
   const [showLogs, setShowLogs] = useState(false)
   const [showInternal, setShowInternal] = useState(false)
@@ -129,6 +130,12 @@ export default function SessionDetail() {
     setTimeout(() => setCopiedUrl(null), 2000)
   }
 
+  const copyShellCommand = (command: string) => {
+    navigator.clipboard.writeText(command)
+    setCopiedShell(true)
+    setTimeout(() => setCopiedShell(false), 1500)
+  }
+
   if (isLoading) {
     return (
       <div style={{ display: 'flex', justifyContent: 'center', padding: 80 }}>
@@ -144,6 +151,8 @@ export default function SessionDetail() {
       </div>
     )
   }
+
+  const shellCommand = `oc shell ${session.sandboxId}`
 
   return (
     <div>
@@ -175,6 +184,44 @@ export default function SessionDetail() {
             <div style={{ fontSize: 13, color: 'var(--text-tertiary)' }}>
               {session.template || 'base'} &middot; Started {timeAgo(session.startedAt)}
             </div>
+            {session.status === 'running' && (
+              <div style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 8,
+                marginTop: 12,
+                padding: '6px 8px',
+                background: 'var(--bg-deep)',
+                border: '1px solid var(--border-subtle)',
+                borderRadius: 'var(--radius-sm)',
+              }}>
+                <span style={{
+                  fontSize: 10,
+                  color: 'var(--text-tertiary)',
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                }}>
+                  CLI
+                </span>
+                <code style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 12,
+                  color: 'var(--text-accent)',
+                  background: 'transparent',
+                  padding: 0,
+                }}>
+                  {shellCommand}
+                </code>
+                <button
+                  onClick={() => copyShellCommand(shellCommand)}
+                  className="btn-ghost"
+                  style={{ padding: '3px 8px', fontSize: 11 }}
+                >
+                  {copiedShell ? 'Copied' : 'Copy'}
+                </button>
+              </div>
+            )}
           </div>
 
           {/* Actions */}


### PR DESCRIPTION
<img width="1494" height="641" alt="Screenshot 2026-06-18 at 7 05 44 PM" src="https://github.com/user-attachments/assets/9e82a79d-1f69-4649-abe5-077dd1cd5ea4" />
## Summary
- emit checkpoint_failed lifecycle events when async checkpoint creation fails
- sync failed checkpoint rows into D1 checkpoints_index with status/error_msg/failed_at
- add schema_phase6.sql for the D1 checkpoint failure columns and update fresh phase-2 schema
- show failed checkpoint details in the dashboard behind a Show failed checkpoints toggle, sorted below ready checkpoints

## Rollout
1. Apply D1 schema before deploying Workers/CP:
   `wrangler d1 execute <db> --remote --file cloudflare-workers/schema_phase6.sql`
2. Deploy events-ingest so checkpoint_failed events can write D1.
3. Deploy api-edge/dashboard so failed rows can be listed/rendered.
4. Deploy control planes so they emit checkpoint_failed events.

## Tested
- `npm --prefix web run build`
- `npx tsc -p cloudflare-workers/api-edge/tsconfig.json --noEmit`
- `go test ./internal/api`
- Deployed to mo-dev and verified D1 contains failed checkpoint `482933e0-f2b4-4efe-a68e-5ea7bcb93bd8` with error_msg.
- Created ready checkpoints `8d09ed72-4973-458a-bad2-539b3683bbac` and `2353ac2d-1a93-42cd-86ca-b02e6284f4fc` for UI comparison.