### PR TITLE
Remove agents UI surfaces

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,8 +5,6 @@ import Layout from './components/Layout'
 import Login from './pages/Login'
 import Dashboard from './pages/Dashboard'
 import Sessions from './pages/Sessions'
-import Agents from './pages/Agents'
-import AgentDetail from './pages/AgentDetail'
 import APIKeys from './pages/APIKeys'
 import Checkpoints from './pages/Checkpoints'
 import Templates from './pages/Templates'
@@ -24,8 +22,6 @@ export default function App() {
             <Route index element={<Dashboard />} />
             <Route path="sessions" element={<Sessions />} />
             <Route path="sessions/:sandboxId" element={<SessionDetail />} />
-            <Route path="agents" element={<Agents />} />
-            <Route path="agents/:agentId" element={<AgentDetail />} />
             <Route path="checkpoints" element={<Checkpoints />} />
             <Route path="templates" element={<Templates />} />
             <Route path="api-keys" element={<APIKeys />} />

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -44,16 +44,6 @@ const icons = {
       <line x1="1" y1="10" x2="23" y2="10" />
     </svg>
   ),
-  bot: (
-    <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
-      <rect x="4" y="7" width="16" height="12" rx="2" />
-      <path d="M12 7V3" />
-      <circle cx="12" cy="3" r="1" />
-      <circle cx="9" cy="13" r="1" fill="currentColor" />
-      <circle cx="15" cy="13" r="1" fill="currentColor" />
-      <path d="M9 17h6" />
-    </svg>
-  ),
   gear: (
     <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
       <circle cx="12" cy="12" r="3" />
@@ -72,7 +62,6 @@ const icons = {
 const navItems = [
   { to: '/', label: 'Dashboard', end: true, icon: icons.grid },
   { to: '/sessions', label: 'Sessions', icon: icons.clock },
-  { to: '/agents', label: 'Agents', icon: icons.bot },
   { to: '/checkpoints', label: 'Checkpoints', icon: icons.layers },
   { to: '/templates', label: 'Templates', icon: icons.box },
   { to: '/api-keys', label: 'API Keys', icon: icons.key },

--- a/web/src/pages/Billing.tsx
+++ b/web/src/pages/Billing.tsx
@@ -1,13 +1,11 @@
-import { useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   getBilling, billingSetup, billingPortal, getBillingInvoices, redeemPromoCode,
-  listOrgAgentSubscriptions, listAgents, cancelAgentFeature,
-  type StripeInvoice, type OrgAgentSubscription, type Agent,
+  type StripeInvoice,
 } from '../api/client'
 
-type Tab = 'sandboxes' | 'agents' | 'invoices'
+type Tab = 'sandboxes' | 'invoices'
 
 export default function Billing() {
   const [tab, setTab] = useState<Tab>('sandboxes')
@@ -16,12 +14,12 @@ export default function Billing() {
     <div>
       <div style={{ marginBottom: 24 }}>
         <h1 className="page-title">Billing</h1>
-        <p className="page-subtitle">Manage your plan, per-agent subscriptions, and invoices</p>
+        <p className="page-subtitle">Manage your plan, payment method, and invoices</p>
       </div>
 
       {/* Tabs */}
       <div style={{ display: 'flex', borderBottom: '1px solid var(--border-subtle)', marginBottom: 18, gap: 4 }}>
-        {(['sandboxes', 'agents', 'invoices'] as Tab[]).map((t) => (
+        {(['sandboxes', 'invoices'] as Tab[]).map((t) => (
           <button
             key={t}
             onClick={() => setTab(t)}
@@ -44,7 +42,6 @@ export default function Billing() {
       </div>
 
       {tab === 'sandboxes' && <PlanTab />}
-      {tab === 'agents' && <AgentsTab />}
       {tab === 'invoices' && <InvoicesTab />}
     </div>
   )
@@ -256,212 +253,6 @@ function PlanTab() {
   )
 }
 
-// ───────────── Agents tab ─────────────
-
-function AgentsTab() {
-  const queryClient = useQueryClient()
-  const { data: subsData, isLoading: subsLoading } = useQuery({
-    queryKey: ['org-agent-subscriptions'],
-    queryFn: listOrgAgentSubscriptions,
-    refetchInterval: 30_000,
-  })
-  const { data: agentsData } = useQuery({
-    queryKey: ['agents'], queryFn: listAgents,
-  })
-
-  const cancelMutation = useMutation({
-    mutationFn: ({ agentId, feature }: { agentId: string; feature: string }) =>
-      cancelAgentFeature(agentId, feature),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['org-agent-subscriptions'] })
-    },
-  })
-
-  // Index agents by ID so we can show display names instead of raw IDs.
-  const agentsById = useMemo(() => {
-    const map: Record<string, Agent> = {}
-    for (const a of agentsData?.agents ?? []) map[a.id] = a
-    return map
-  }, [agentsData])
-
-  // De-duplicate to one row per (agent_id, feature). We sort by created_at
-  // desc so the freshest row wins — covers cases where a user canceled then
-  // re-subscribed.
-  const rows = useMemo(() => {
-    const seen = new Set<string>()
-    const sorted = [...(subsData?.subscriptions ?? [])].sort((a, b) =>
-      b.created_at.localeCompare(a.created_at),
-    )
-    const out: OrgAgentSubscription[] = []
-    for (const sub of sorted) {
-      const key = `${sub.agent_id}::${sub.feature}`
-      if (seen.has(key)) continue
-      seen.add(key)
-      out.push(sub)
-    }
-    return out
-  }, [subsData])
-
-  const activeRows = rows.filter(r => r.active)
-  const inactiveRows = rows.filter(r => !r.active)
-
-  const totalMonthlyCents = activeRows.reduce((sum, r) => sum + r.price_monthly_cents, 0)
-
-  if (subsLoading) {
-    return (
-      <div style={{ display: 'flex', justifyContent: 'center', padding: 80 }}>
-        <div className="loading-spinner" />
-      </div>
-    )
-  }
-
-  return (
-    <>
-      {/* Summary card */}
-      <div className="glass-card animate-in stagger-1" style={{ padding: 28, marginBottom: 14 }}>
-        <span className="section-title" style={{ marginBottom: 12, display: 'block' }}>
-          Per-agent features
-        </span>
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: 12, marginBottom: 6 }}>
-          <span className="metric-value" style={{ fontSize: 32, fontWeight: 700 }}>
-            ${(totalMonthlyCents / 100).toFixed(2)}
-          </span>
-          <span style={{ fontSize: 12, color: 'var(--text-tertiary)' }}>
-            /mo across {activeRows.length} active subscription{activeRows.length === 1 ? '' : 's'}
-          </span>
-        </div>
-        <p style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.5, marginTop: 6 }}>
-          Each connected channel (e.g. Telegram) is billed per-agent. Subscribe or cancel from each
-          agent's page.
-        </p>
-      </div>
-
-      {/* Active subscriptions */}
-      <div className="glass-card animate-in stagger-2" style={{ padding: '22px 24px', marginBottom: 14 }}>
-        <span className="section-title" style={{ marginBottom: 14, display: 'block' }}>
-          Active
-        </span>
-        {activeRows.length === 0 ? (
-          <div style={{ textAlign: 'center', padding: '32px 20px', color: 'var(--text-tertiary)', fontSize: 13 }}>
-            No active per-agent subscriptions yet.
-          </div>
-        ) : (
-          <table className="data-table">
-            <thead>
-              <tr>
-                <th>Agent</th>
-                <th>Feature</th>
-                <th>Status</th>
-                <th>Renews</th>
-                <th style={{ textAlign: 'right' }}>Price</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {activeRows.map((sub) => {
-                const agent = agentsById[sub.agent_id]
-                const label = agent?.display_name || sub.agent_id
-                const renewLabel = sub.cancel_at_period_end
-                  ? `Ends ${formatDate(sub.current_period_end)}`
-                  : sub.current_period_end
-                    ? formatDate(sub.current_period_end)
-                    : '—'
-                return (
-                  <tr key={sub.stripe_subscription_id}>
-                    <td>
-                      <Link to={`/agents/${encodeURIComponent(sub.agent_id)}`}
-                        style={{ color: 'var(--accent-indigo)', textDecoration: 'none', fontWeight: 600 }}>
-                        {label}
-                      </Link>
-                      {agent && (
-                        <div style={{ fontSize: 11, color: 'var(--text-tertiary)', fontFamily: 'var(--font-mono)' }}>
-                          {sub.agent_id}
-                        </div>
-                      )}
-                    </td>
-                    <td style={{ textTransform: 'capitalize', fontSize: 13 }}>{sub.feature}</td>
-                    <td><SubscriptionStatus status={sub.status} cancelAtPeriodEnd={sub.cancel_at_period_end} /></td>
-                    <td style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--text-secondary)' }}>
-                      {renewLabel}
-                    </td>
-                    <td style={{ fontFamily: 'var(--font-mono)', fontSize: 13, fontWeight: 600, textAlign: 'right' }}>
-                      ${(sub.price_monthly_cents / 100).toFixed(2)}/mo
-                    </td>
-                    <td style={{ textAlign: 'right' }}>
-                      {!sub.cancel_at_period_end && (
-                        <button
-                          onClick={() => {
-                            if (confirm(`Cancel ${sub.feature} for ${label} at end of billing period?`)) {
-                              cancelMutation.mutate({ agentId: sub.agent_id, feature: sub.feature })
-                            }
-                          }}
-                          disabled={cancelMutation.isPending}
-                          style={{
-                            background: 'none',
-                            border: '1px solid var(--border-subtle)',
-                            color: 'var(--text-secondary)',
-                            fontSize: 12,
-                            padding: '4px 10px',
-                            borderRadius: 'var(--radius-sm)',
-                            cursor: 'pointer',
-                            fontFamily: 'var(--font-body)',
-                          }}
-                        >
-                          Cancel
-                        </button>
-                      )}
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
-        )}
-      </div>
-
-      {/* Past subscriptions (collapsed-feeling) */}
-      {inactiveRows.length > 0 && (
-        <div className="glass-card animate-in stagger-3" style={{ padding: '22px 24px' }}>
-          <span className="section-title" style={{ marginBottom: 14, display: 'block' }}>
-            Past
-          </span>
-          <table className="data-table">
-            <thead>
-              <tr>
-                <th>Agent</th>
-                <th>Feature</th>
-                <th>Status</th>
-                <th>Ended</th>
-              </tr>
-            </thead>
-            <tbody>
-              {inactiveRows.map((sub) => {
-                const agent = agentsById[sub.agent_id]
-                const label = agent?.display_name || sub.agent_id
-                return (
-                  <tr key={sub.stripe_subscription_id}>
-                    <td>
-                      <Link to={`/agents/${encodeURIComponent(sub.agent_id)}`}
-                        style={{ color: 'var(--text-secondary)', textDecoration: 'none' }}>
-                        {label}
-                      </Link>
-                    </td>
-                    <td style={{ textTransform: 'capitalize', fontSize: 13 }}>{sub.feature}</td>
-                    <td><SubscriptionStatus status={sub.status} cancelAtPeriodEnd={false} /></td>
-                    <td style={{ fontFamily: 'var(--font-mono)', fontSize: 12, color: 'var(--text-tertiary)' }}>
-                      {formatDate(sub.canceled_at || sub.current_period_end)}
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </>
-  )
-}
-
 // ───────────── Invoices tab ─────────────
 
 function InvoicesTab() {
@@ -484,7 +275,7 @@ function InvoicesTab() {
     return (
       <div className="glass-card" style={{ padding: 28, textAlign: 'center' }}>
         <p style={{ fontSize: 14, color: 'var(--text-secondary)' }}>
-          Invoices appear here once you're on the Pro plan or have a per-agent subscription.
+          Invoices appear here once you're on the Pro plan.
         </p>
       </div>
     )
@@ -531,38 +322,6 @@ function InvoicesTab() {
 }
 
 // ───────────── Helpers ─────────────
-
-function formatDate(s?: string | null) {
-  if (!s) return '—'
-  const d = new Date(s)
-  if (isNaN(d.getTime())) return '—'
-  return d.toLocaleDateString()
-}
-
-function SubscriptionStatus({ status, cancelAtPeriodEnd }: { status: string; cancelAtPeriodEnd: boolean }) {
-  let color = 'var(--text-tertiary)'
-  let bg = 'rgba(255,255,255,0.04)'
-  let label = status
-
-  if (cancelAtPeriodEnd) {
-    color = 'var(--accent-amber, #f59e0b)'
-    bg = 'rgba(245,158,11,0.1)'
-    label = 'cancels'
-  } else if (status === 'active' || status === 'trialing') {
-    color = 'var(--accent-emerald)'; bg = 'rgba(52,211,153,0.1)'
-  } else if (status === 'past_due' || status === 'incomplete') {
-    color = 'var(--accent-amber, #f59e0b)'; bg = 'rgba(245,158,11,0.1)'
-  } else if (status === 'canceled' || status === 'unpaid' || status === 'incomplete_expired') {
-    color = 'var(--accent-rose)'; bg = 'rgba(244,63,94,0.1)'
-  }
-  return (
-    <span style={{
-      display: 'inline-block', padding: '2px 8px', borderRadius: 4,
-      fontSize: 11, fontWeight: 600, color, background: bg,
-      textTransform: 'uppercase', letterSpacing: '0.5px',
-    }}>{label}</span>
-  )
-}
 
 function InvoiceStatus({ status }: { status: string }) {
   let color = 'var(--text-tertiary)'

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -177,12 +177,10 @@ function GettingStarted() {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-      <DeployAgentBanner />
-
       <StepCard
         index={1}
         title="Install the OpenComputer skill"
-        description="Adds a skill to Claude Code (or any agent that supports the Agent Skills standard) so it can drive sandboxes for you."
+        description="Adds OpenComputer sandbox controls to Claude Code so you can create, inspect, and manage sandboxes from your terminal."
       >
         <CommandRow command={SKILL_INSTALL_CMD} copied={copied === 'install'} onCopy={() => copy(SKILL_INSTALL_CMD, 'install')} />
       </StepCard>
@@ -461,90 +459,4 @@ function formatDuration(session: Session): string {
   if (secs < 60) return `${secs}s`
   if (secs < 3600) return `${Math.round(secs / 60)}m`
   return `${Math.round(secs / 3600 * 10) / 10}h`
-}
-
-// Deploy-managed-agent banner shown above the getting-started checklist on
-// fresh signups. The Agents page has the same lobster mark in its empty
-// state; keeping the two consistent makes the OpenClaw / managed-agent
-// product visible from minute one without asking the user to navigate.
-function DeployAgentBanner() {
-  const navigate = useNavigate()
-  return (
-    <div
-      onClick={() => navigate('/agents')}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate('/agents') }
-      }}
-      role="button"
-      tabIndex={0}
-      style={{
-        display: 'flex', alignItems: 'center', gap: 18,
-        padding: '20px 24px',
-        border: '1px solid rgba(255,77,77,0.30)',
-        borderRadius: 14,
-        background:
-          'radial-gradient(ellipse at left, rgba(255,77,77,0.14), transparent 62%), rgba(255,77,77,0.04)',
-        cursor: 'pointer',
-        transition: 'background 0.12s ease, border-color 0.12s ease',
-      }}
-      onMouseEnter={(e) => { (e.currentTarget as HTMLDivElement).style.borderColor = 'rgba(255,77,77,0.55)' }}
-      onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.borderColor = 'rgba(255,77,77,0.30)' }}
-    >
-      <DashClawLogo />
-      <div style={{ flex: 1 }}>
-        <div style={{ fontSize: 16, fontWeight: 700, fontFamily: 'var(--font-display)', marginBottom: 4 }}>
-          Deploy an OpenClaw managed agent
-        </div>
-        <div style={{ fontSize: 13, color: 'var(--text-secondary)', lineHeight: 1.5 }}>
-          Spin up a managed agent runtime with built-in chat, Telegram, and gbrain memory.
-          We host the gateway and the model routing — you bring the prompt.
-        </div>
-      </div>
-      <div
-        style={{
-          padding: '9px 18px',
-          fontSize: 13, fontWeight: 600,
-          background: 'var(--accent-indigo)', color: '#fff',
-          borderRadius: 'var(--radius-sm)',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        Deploy →
-      </div>
-    </div>
-  )
-}
-
-// OpenClaw lobster mark — pulled directly from openclaw.ai/favicon.svg so the
-// dashboard banner uses the same brand asset as the marketing site. Inline so
-// it ships with the bundle (no extra HTTP fetch); gradient ID is scoped per
-// page (`dash-…`) to avoid collisions when multiple copies render at once.
-function DashClawLogo() {
-  return (
-    <svg
-      width="56"
-      height="56"
-      viewBox="0 0 120 120"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-      style={{ filter: 'drop-shadow(0 0 16px rgba(255,77,77,0.45))', flexShrink: 0 }}
-    >
-      <defs>
-        <linearGradient id="dash-lobster-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#ff4d4d" />
-          <stop offset="100%" stopColor="#991b1b" />
-        </linearGradient>
-      </defs>
-      <path d="M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z" fill="url(#dash-lobster-gradient)" />
-      <path d="M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z" fill="url(#dash-lobster-gradient)" />
-      <path d="M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z" fill="url(#dash-lobster-gradient)" />
-      <path d="M45 15 Q35 5 30 8" stroke="#ff4d4d" strokeWidth="3" strokeLinecap="round" />
-      <path d="M75 15 Q85 5 90 8" stroke="#ff4d4d" strokeWidth="3" strokeLinecap="round" />
-      <circle cx="45" cy="35" r="6" fill="#050810" />
-      <circle cx="75" cy="35" r="6" fill="#050810" />
-      <circle cx="46" cy="34" r="2.5" fill="#00e5cc" />
-      <circle cx="76" cy="34" r="2.5" fill="#00e5cc" />
-    </svg>
-  )
 }


### PR DESCRIPTION

<img width="1725" height="856" alt="Screenshot 2026-06-18 at 7 39 22 PM" src="https://github.com/user-attachments/assets/9ec13b98-52ec-495b-98f3-b738190db30f" />


## Summary
- remove the Agents routes and sidebar entry from the dashboard
- remove the managed-agent onboarding banner and agent wording from first-run onboarding
- remove the Agents tab and per-agent subscription UI from Billing

## Verification
- npm --prefix web run build
- deployed to mo-oc-dev.com via opencomputer-edge-mo-dev