### PR TITLE
SDK: managed Durable Agent Sessions in @opencomputer/sdk (0.7.0) + dual-surface docs

### DIFF
--- a/docs/agent-sessions/agents.mdx
+++ b/docs/agent-sessions/agents.mdx
@@ -7,7 +7,7 @@ An **agent** is reusable configuration: `name`, `prompt`, `model`, and [`runtime
 
 <CodeGroup>
 
-```ts TypeScript
+```ts TypeScript SDK
 import { OpenComputer } from "@opencomputer/sdk";
 
 const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
@@ -21,7 +21,7 @@ const agent = await oc.agents.create({
 });
 ```
 
-```http REST
+```http REST API
 POST https://api.opencomputer.dev/v3/agents
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json

--- a/docs/agent-sessions/agents.mdx
+++ b/docs/agent-sessions/agents.mdx
@@ -5,7 +5,23 @@ description: "Reusable agent configuration"
 
 An **agent** is reusable configuration: `name`, `prompt`, `model`, and [`runtime`](/agent-sessions/runtimes). Every [session](/agent-sessions/sessions) runs on an agent, so create one first, then start as many sessions on it as you like.
 
-```http
+<CodeGroup>
+
+```ts TypeScript
+import { OpenComputer } from "@opencomputer/sdk";
+
+const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
+
+const agent = await oc.agents.create({
+  name: "reviewer",
+  runtime: "claude",
+  model: "anthropic/claude-opus-4-8",
+  prompt: "Review the repo. Run tests. Summarize risks.",
+  key: "sk-ant-...",
+});
+```
+
+```http REST
 POST https://api.opencomputer.dev/v3/agents
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
@@ -18,6 +34,8 @@ Content-Type: application/json
   "key": "sk-ant-..."
 }
 ```
+
+</CodeGroup>
 
 Pass your Anthropic `key` inline and it's stored as a [credential](/agent-sessions/authentication#model-credentials) and attached to the agent — sessions run the model on it. Already have a credential? Reference it with `credential: "cred_…"` instead, or omit both to use your org default. Optionally set default [`limits`](/agent-sessions/sessions#limits) (`tokens`/`turn_seconds`/`turns`) too; sessions inherit them.
 

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -1,26 +1,61 @@
 ---
-title: "API reference"
-description: "Every endpoint in the Durable Agent Sessions API"
+title: "API / SDK reference"
+description: "Every endpoint in the Durable Agent Sessions API, with its TypeScript SDK call"
 ---
 
 Base URL `https://api.opencomputer.dev/v3`. Management calls authenticate with your **org API key**; stream and steer also accept a **[client token](/agent-sessions/authentication#client-tokens)**.
 
+Each section toggles between the **TypeScript** SDK (`@opencomputer/sdk`) and **REST** — pick one and the whole page follows. In the SDK calls, `oc` is the client and `session` is a handle:
+
+```ts
+import { OpenComputer, connectSession } from "@opencomputer/sdk";
+
+const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
+const session = await oc.sessions.get("sess_...");        // server, org key
+// or, in a browser:  await connectSession({ sessionId, clientToken })
+```
+
+<Note>The SDK returns the same objects with **camelCase** fields (`client_token` → `session.clientToken`, `created_at` → `createdAt`, `yield_reason` → `yieldReason`, …). The wire shapes below are the raw JSON.</Note>
+
 ## Sessions
+
+<Tabs>
+
+<Tab title="TypeScript SDK">
+
+| Call | Purpose |
+| --- | --- |
+| `oc.sessions.create(params)` | Start a session → a `Session` handle (carries `.clientToken`). |
+| `oc.sessions.get(id)` | Fetch a session. |
+| `oc.sessions.list(params)` | List sessions (filtered, paginated). |
+| `session.archive()` | Cancel any active turn, then close (read-only). |
+| `session.cancel()` | Cooperatively stop the active turn (no-op if not running). |
+| `session.result()` | `{ lastTurn, result? }` — the resolved final event. |
+| `session.turns()` · `session.turn(id)` | Per-turn history: timing, error. |
+| `session.mintClientToken(opts)` | Mint a client token. |
+
+</Tab>
+
+<Tab title="REST API">
 
 | Method · Path | Purpose |
 | --- | --- |
-| `POST /sessions` | Start a session. Returns `{ session, client_token }`. |
+| `POST /sessions` | Start a session → `{ session, client_token }`. |
 | `GET /sessions/:id` | Fetch a session. |
 | `GET /sessions?status=&agent=&key=&after=&before=&limit=` | List sessions (filtered, paginated). |
 | `POST /sessions/:id/archive` | Cancel any active turn, then close (read-only). |
 | `POST /sessions/:id/cancel` | Cooperatively stop the active turn (no-op if not running). |
-| `GET /sessions/:id/result` | The result helper — `{ last_turn, result? }` (the resolved final event). |
-| `GET /sessions/:id/turns` · `GET …/turns/:turnId` | Per-turn history: timing, error. |
+| `GET /sessions/:id/result` | The result helper — `{ last_turn, result? }`. |
+| `GET /sessions/:id/turns` · `…/turns/:turnId` | Per-turn history: timing, error. |
 | `POST /sessions/:id/client-tokens` | Mint a client token. |
+
+</Tab>
+
+</Tabs>
 
 `agent` is **required** (create a saved [agent](#agents) first); a resolvable Anthropic [credential](#credentials) is also required (`422 no_credential` otherwise). `key` gives get-or-create (one session per key); a request-level `Idempotency-Key` header makes a keyless create retry-safe. `input` is the task — a string or a full [envelope](/agent-sessions/messaging#message-envelope). For the managed `claude` runtime, put all task-critical context in the task text. `limits` `{ tokens, turn_seconds, turns }` are **non-monetary** — token budget, per-turn wall-clock, auto-run count; hitting one ends the turn with a matching `last_turn.yield_reason`. Destinations on an idempotent create-replay are ignored — manage them via the [destinations API](#destinations).
 
-Client tokens accept `scopes?` (subset of `read`, `steer`) and `ttl?` seconds, clamped to 60–86400.
+Client tokens accept `scopes?` (subset of `read`, `steer`) and `ttl?` seconds, clamped to 60–86400 (SDK: `ttlSeconds`).
 
 ```
 Session = { id, status, head, input_cursor,
@@ -39,15 +74,35 @@ Turn = {
 
 ## Events
 
+<Tabs>
+
+<Tab title="TypeScript SDK">
+
+| Call | Purpose |
+| --- | --- |
+| `session.listEvents(opts)` | Read events since a cursor. |
+| `session.events(opts)` | Live stream from a cursor — an async iterator that resumes itself. |
+| `session.event(id)` | Fetch one event (resolve `resultEventId`). |
+| `session.eventContent(id)` | Fetch a blob-backed body (large outputs). |
+| `session.messages(opts)` | User-message history. |
+
+</Tab>
+
+<Tab title="REST API">
+
 | Method · Path | Purpose |
 | --- | --- |
 | `GET /sessions/:id/events?after=<seq>&level=<lvl>` | Read events since a cursor. |
-| `GET /sessions/:id/events?after=<seq>&level=<lvl>&stream=sse` | Live SSE stream from a cursor. |
+| `GET /sessions/:id/events?…&stream=sse` | Live SSE stream from a cursor. |
 | `GET /sessions/:id/events/:eventId` | Fetch one event (resolve `result_event_id`). |
 | `GET /sessions/:id/events/:eventId/content` | Fetch a blob-backed body (large outputs). |
 | `GET /sessions/:id/messages` | User-message history. |
 
-Filter events by `type` (exact or `prefix.*`), `turn_id`, and `limit`. `GET …/messages` is an alias for `level=user` + `type=*.message`.
+</Tab>
+
+</Tabs>
+
+Filter events by `type` (exact or `prefix.*`), `turn_id`, and `limit`. `…/messages` is an alias for `level=user` + `type=*.message`.
 
 `after` resumes from a `seq`; `level` is a **visibility threshold** — `user` returns only user-facing events, `progress` adds work updates, `internal` adds everything (see [visibility levels](/agent-sessions/events#visibility-levels)). Omitting `level` defaults to `internal` (you get everything). Switch on [`type`](/agent-sessions/events#event-shape), don't parse prose.
 
@@ -60,30 +115,83 @@ Event = {
 
 ## Steer
 
+<Tabs>
+
+<Tab title="TypeScript SDK">
+
+| Call | Purpose |
+| --- | --- |
+| `session.steer(text, { idempotencyKey })` | Append an input message; wakes the session. |
+
+</Tab>
+
+<Tab title="REST API">
+
 | Method · Path | Purpose |
 | --- | --- |
 | `POST /sessions/:id/messages` | Append an input message; wakes the session. |
+
+</Tab>
+
+</Tabs>
 
 Body: `{ text, idempotency_key? }` or `{ envelope }`. Returns `202` (or `200` on idempotent replay) with `{ event: { id, seq }, session: { id, status, head } }`.
 
 ## Destinations
 
+<Tabs>
+
+<Tab title="TypeScript SDK">
+
+| Call | Purpose |
+| --- | --- |
+| `session.destinations.create(params)` | Register a webhook destination. |
+| `session.destinations.list()` · `.get(did)` | List / fetch. |
+| `session.destinations.update(did, params)` | Pause/resume (`enabled`), retune `level`/`types`, rotate `secret`. |
+| `session.destinations.delete(did)` | Remove. |
+
+</Tab>
+
+<Tab title="REST API">
+
 | Method · Path | Purpose |
 | --- | --- |
 | `POST /sessions/:id/destinations` | Register a webhook destination. |
-| `GET /sessions/:id/destinations` · `GET …/:did` | List / fetch. |
+| `GET /sessions/:id/destinations` · `…/:did` | List / fetch. |
 | `PATCH /sessions/:id/destinations/:did` | Pause/resume (`enabled`), retune `level`/`types`, rotate `secret`. |
 | `DELETE /sessions/:id/destinations/:did` | Remove. |
 
-Destination body: `url`, `secret?`, `level?` (`user`), `types?[]`, `include_raw?` (`false`), `enabled?` (`true`). `types` accepts exact event types or `prefix.*`.
+</Tab>
+
+</Tabs>
+
+Destination body: `url`, `secret?`, `level?` (`user`), `types?[]`, `include_raw?` (`false`, SDK: `includeRaw`), `enabled?` (`true`). `types` accepts exact event types or `prefix.*`.
 
 ## Deliveries
+
+<Tabs>
+
+<Tab title="TypeScript SDK">
+
+| Call | Purpose |
+| --- | --- |
+| `session.deliveries.list(opts)` | List deliveries — status, attempts, last response/error. |
+| `session.deliveries.get(id)` | One delivery, in detail. |
+| `session.deliveries.redeliver(id)` | Re-send any delivery (not just dead-lettered). |
+
+</Tab>
+
+<Tab title="REST API">
 
 | Method · Path | Purpose |
 | --- | --- |
 | `GET /sessions/:id/deliveries?destination=&status=` | List deliveries — status, attempts, last response/error. |
 | `GET /sessions/:id/deliveries/:id` | One delivery, in detail. |
 | `POST /sessions/:id/deliveries/:id/redeliver` | Re-send any delivery (not just dead-lettered). |
+
+</Tab>
+
+</Tabs>
 
 See [Webhooks](/agent-sessions/webhooks#signing-retries-and-dedupe) for signing, retries, and dedupe.
 
@@ -100,11 +208,29 @@ Delivery = {
 
 ## Agents
 
+<Tabs>
+
+<Tab title="TypeScript SDK">
+
+| Call | Purpose |
+| --- | --- |
+| `oc.agents.create(params)` | Create a reusable agent. |
+| `oc.agents.get(id)` · `oc.agents.list()` | Fetch / list. |
+| `oc.agents.update(id, params)` | Update the agent for future sessions. |
+
+</Tab>
+
+<Tab title="REST API">
+
 | Method · Path | Purpose |
 | --- | --- |
 | `POST /agents` | Create a reusable agent. |
 | `GET /agents/:id` · `GET /agents` | Fetch / list. |
 | `PATCH /agents/:id` | Update the agent for future sessions. |
+
+</Tab>
+
+</Tabs>
 
 Create body: `name`, `prompt`, `model`, `runtime?` (`claude`), `key?`, `credential?`, `limits?`. Patch accepts `prompt?`, `model?`, `key?`, `credential?`, and `limits?`.
 
@@ -112,11 +238,29 @@ Pass `key` **or** `credential` (or neither → org default). The agent's `limits
 
 ## Credentials
 
+<Tabs>
+
+<Tab title="TypeScript SDK">
+
+| Call | Purpose |
+| --- | --- |
+| `oc.credentials.create(params)` | Add a provider key. |
+| `oc.credentials.list()` · `oc.credentials.delete(id)` | List / remove. |
+| `oc.credentials.setDefault(params)` | Set the org default to a credential. |
+
+</Tab>
+
+<Tab title="REST API">
+
 | Method · Path | Purpose |
 | --- | --- |
 | `POST /credentials` | Add a provider key. |
 | `GET /credentials` · `DELETE /credentials/:id` | List / remove. |
-| `PUT /credentials/default` | Set the org default to a credential (its provider is derived). Body: `credential`. |
+| `PUT /credentials/default` | Set the org default to a credential (its provider is derived). |
+
+</Tab>
+
+</Tabs>
 
 Credential body: `provider`, `key`, `name?`, `is_default?`. Keys are write-only. A credential is **required**; sessions run on your key (no platform billing yet).
 
@@ -127,4 +271,4 @@ ClientToken = { token, scopes, expires_at }
 
 ## Errors & rate limits
 
-Errors use one envelope: `{ "error": { "type", "message" } }`. Cross-owner resources return `404` (not `403`). Rate and concurrency limits are not enforced at launch (a `429` with a `Retry-After` header may be introduced later).
+Errors use one envelope: `{ "error": { "type", "message" } }`; the SDK throws them as typed `OpenComputerError` subclasses (`AuthError`, `NotFoundError`, `ConflictError`, `ValidationError`, `RateLimitError`). Cross-owner resources return `404` (not `403`). Rate and concurrency limits are not enforced at launch (a `429` with a `Retry-After` header may be introduced later; the SDK retries it automatically).

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -15,7 +15,7 @@ Base URL `https://api.opencomputer.dev/v3`. Management calls authenticate with y
 | `POST /sessions/:id/archive` | Cancel any active turn, then close (read-only). |
 | `POST /sessions/:id/cancel` | Cooperatively stop the active turn (no-op if not running). |
 | `GET /sessions/:id/result` | The result helper — `{ last_turn, result? }` (the resolved final event). |
-| `GET /sessions/:id/turns` · `GET …/turns/:turnId` | Per-turn history: timing, usage, error. |
+| `GET /sessions/:id/turns` · `GET …/turns/:turnId` | Per-turn history: timing, error. |
 | `POST /sessions/:id/client-tokens` | Mint a client token. |
 
 `agent` is **required** (create a saved [agent](#agents) first); a resolvable Anthropic [credential](#credentials) is also required (`422 no_credential` otherwise). `key` gives get-or-create (one session per key); a request-level `Idempotency-Key` header makes a keyless create retry-safe. `input` is the task — a string or a full [envelope](/agent-sessions/messaging#message-envelope). For the managed `claude` runtime, put all task-critical context in the task text. `limits` `{ tokens, turn_seconds, turns }` are **non-monetary** — token budget, per-turn wall-clock, auto-run count; hitting one ends the turn with a matching `last_turn.yield_reason`. Destinations on an idempotent create-replay are ignored — manage them via the [destinations API](#destinations).
@@ -27,11 +27,11 @@ Session = { id, status, head, input_cursor,
             agent_snapshot: { prompt_hash, model, runtime, revision },
             agent_id, credential_id,   // resolved + pinned at create
             last_turn: { id, state, yield_reason?, result_event_id? },
-            usage, limits: { tokens?, turn_seconds?, turns? }, key?, created_at }
+            limits: { tokens?, turn_seconds?, turns? }, key?, created_at }
 
 Turn = {
   id, state, yield_reason?, result_event_id?, error?,
-  started_at?, completed_at?, active_seconds, usage
+  started_at?, completed_at?
 }
 ```
 

--- a/docs/agent-sessions/authentication.mdx
+++ b/docs/agent-sessions/authentication.mdx
@@ -11,7 +11,7 @@ Your account key. Use it server-side for all **management** calls — creating a
 
 <CodeGroup>
 
-```ts TypeScript
+```ts TypeScript SDK
 import { OpenComputer } from "@opencomputer/sdk";
 
 const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! }); // org key, server-side only
@@ -22,7 +22,7 @@ const session = await oc.sessions.create({
 });
 ```
 
-```http REST
+```http REST API
 POST https://api.opencomputer.dev/v3/sessions
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
@@ -42,7 +42,7 @@ You get one back from `POST /v3/sessions`, and can mint more:
 
 <CodeGroup>
 
-```ts TypeScript
+```ts TypeScript SDK
 const session = await oc.sessions.get("sess_...");
 
 const clientToken = await session.mintClientToken({
@@ -51,7 +51,7 @@ const clientToken = await session.mintClientToken({
 });
 ```
 
-```http REST
+```http REST API
 POST https://api.opencomputer.dev/v3/sessions/sess_.../client-tokens
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
@@ -82,7 +82,7 @@ The easiest way to add one is inline when you [create an agent](/agent-sessions/
 
 <CodeGroup>
 
-```ts TypeScript
+```ts TypeScript SDK
 await oc.credentials.create({
   provider: "anthropic",
   key: "sk-ant-...",
@@ -90,7 +90,7 @@ await oc.credentials.create({
 });
 ```
 
-```http REST
+```http REST API
 POST https://api.opencomputer.dev/v3/credentials
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
@@ -102,14 +102,14 @@ Content-Type: application/json
 
 <CodeGroup>
 
-```ts TypeScript
+```ts TypeScript SDK
 await oc.credentials.setDefault({
   provider: "anthropic",
   credential: "cred_...",
 });
 ```
 
-```http REST
+```http REST API
 PUT https://api.opencomputer.dev/v3/credentials/default
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json

--- a/docs/agent-sessions/authentication.mdx
+++ b/docs/agent-sessions/authentication.mdx
@@ -9,13 +9,28 @@ Durable Agent Sessions use three credential types.
 
 Your account key. Use it server-side for all **management** calls — creating agents, starting sessions, registering webhooks, managing credentials.
 
-```http
+<CodeGroup>
+
+```ts TypeScript
+import { OpenComputer } from "@opencomputer/sdk";
+
+const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! }); // org key, server-side only
+
+const session = await oc.sessions.create({
+  agent: "agt_...",
+  input: "Run the tests and summarize failures.",
+});
+```
+
+```http REST
 POST https://api.opencomputer.dev/v3/sessions
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
 
 { "agent": "agt_...", "input": "Run the tests and summarize failures." }
 ```
+
+</CodeGroup>
 
 <Warning>Never ship the org API key to a browser or mobile client — it can do anything on your account. Use a client token instead.</Warning>
 
@@ -25,13 +40,26 @@ A **session-scoped, short-lived** token with `read` + `steer` scope — safe to 
 
 You get one back from `POST /v3/sessions`, and can mint more:
 
-```http
+<CodeGroup>
+
+```ts TypeScript
+const session = await oc.sessions.get("sess_...");
+
+const clientToken = await session.mintClientToken({
+  scopes: ["read", "steer"],
+  ttlSeconds: 3600,
+});
+```
+
+```http REST
 POST https://api.opencomputer.dev/v3/sessions/sess_.../client-tokens
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
 
 { "scopes": ["read", "steer"], "ttl": 3600 }
 ```
+
+</CodeGroup>
 
 Browser pattern: your backend creates the session with the org key, then hands the `client_token` to the browser, which uses it directly for the SSE stream and steer calls.
 
@@ -52,7 +80,17 @@ Sessions run the model on **your own Anthropic key**. It's held in OpenComputer'
 
 The easiest way to add one is inline when you [create an agent](/agent-sessions/agents) (`"key": "sk-ant-…"`). The standalone resource below is for reusing one key across agents, setting an org default, and rotating/removing keys:
 
-```http
+<CodeGroup>
+
+```ts TypeScript
+await oc.credentials.create({
+  provider: "anthropic",
+  key: "sk-ant-...",
+  name: "prod",
+});
+```
+
+```http REST
 POST https://api.opencomputer.dev/v3/credentials
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
@@ -60,13 +98,26 @@ Content-Type: application/json
 { "provider": "anthropic", "key": "sk-ant-...", "name": "prod" }
 ```
 
-```http
+</CodeGroup>
+
+<CodeGroup>
+
+```ts TypeScript
+await oc.credentials.setDefault({
+  provider: "anthropic",
+  credential: "cred_...",
+});
+```
+
+```http REST
 PUT https://api.opencomputer.dev/v3/credentials/default
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
 
 { "credential": "cred_..." }
 ```
+
+</CodeGroup>
 
 **Resolution** per session: the agent's credential → your org default for the provider. (No platform-billed fallback yet — bring a key.)
 

--- a/docs/agent-sessions/durability.mdx
+++ b/docs/agent-sessions/durability.mdx
@@ -32,7 +32,7 @@ const res = await fetch(
 
 ## Hibernate & resume
 
-When a session has nothing to do it goes **idle** and its sandbox **hibernates** — the VM is snapshotted and stopped. You pay storage-only while idle; **active seconds only** show up in usage. The next message (a steer, or the next turn) wakes it, typically sub-second, and it continues with prior context.
+When a session has nothing to do it goes **idle** and its sandbox **hibernates** — the VM is snapshotted and stopped. You pay storage-only while idle. The next message (a steer, or the next turn) wakes it, typically sub-second, and it continues with prior context.
 
 <Note>This mirrors [sandbox hibernation](/sandboxes/timeout): idle ≈ free, fast wake. Sessions manage it for you — you don't set a timeout per turn. The runtime's state is also **checkpointed off-box** at each hibernate, so an idle session resumes even if its sandbox is reclaimed.</Note>
 

--- a/docs/agent-sessions/messaging.mdx
+++ b/docs/agent-sessions/messaging.mdx
@@ -9,7 +9,16 @@ description: "Steer a session, and the shared message envelope"
 
 Send a message to a running or idle session; it wakes and continues with its prior context. Minimal form is just text:
 
-```http
+<CodeGroup>
+
+```ts TypeScript
+import { connectSession } from "@opencomputer/sdk";
+
+const live = await connectSession({ sessionId, clientToken });
+await live.steer("also check the CI config", { idempotencyKey: "msg_01" });
+```
+
+```http REST
 POST https://api.opencomputer.dev/v3/sessions/sess_.../messages
 Authorization: Bearer $CLIENT_TOKEN
 Content-Type: application/json
@@ -19,6 +28,8 @@ Content-Type: application/json
   "idempotency_key": "msg_01"
 }
 ```
+
+</CodeGroup>
 
 Pass `idempotency_key` so retries (flaky network, double-click) are de-duplicated — applied at most once **per session**, so the same key is safe to reuse across different sessions.
 

--- a/docs/agent-sessions/messaging.mdx
+++ b/docs/agent-sessions/messaging.mdx
@@ -11,14 +11,14 @@ Send a message to a running or idle session; it wakes and continues with its pri
 
 <CodeGroup>
 
-```ts TypeScript
+```ts TypeScript SDK
 import { connectSession } from "@opencomputer/sdk";
 
 const live = await connectSession({ sessionId, clientToken });
 await live.steer("also check the CI config", { idempotencyKey: "msg_01" });
 ```
 
-```http REST
+```http REST API
 POST https://api.opencomputer.dev/v3/sessions/sess_.../messages
 Authorization: Bearer $CLIENT_TOKEN
 Content-Type: application/json

--- a/docs/agent-sessions/quickstart.mdx
+++ b/docs/agent-sessions/quickstart.mdx
@@ -29,7 +29,24 @@ ANTHROPIC_API_KEY=sk-ant-...
 
 An agent stores reusable configuration: name, runtime, model, prompt, and model credential.
 
-```http
+<CodeGroup>
+
+```ts TypeScript
+import { OpenComputer } from "@opencomputer/sdk";
+
+const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
+
+const agent = await oc.agents.create({
+  name: "quickstart-coder",
+  runtime: "claude",
+  model: "anthropic/claude-opus-4-8",
+  prompt: "Work in /workspace. Say progress. Ask only when blocked.",
+  key: process.env.ANTHROPIC_API_KEY,
+  limits: { turns: 4, turnSeconds: 600 },
+});
+```
+
+```http REST
 POST https://api.opencomputer.dev/v3/agents
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
@@ -44,6 +61,8 @@ Content-Type: application/json
 }
 ```
 
+</CodeGroup>
+
 Response:
 
 ```json
@@ -56,7 +75,18 @@ Response:
 
 A session starts work immediately and returns a browser-safe `client_token` for that one session.
 
-```http
+<CodeGroup>
+
+```ts TypeScript
+const session = await oc.sessions.create({
+  agent: agent.id,
+  input: "Create a todo app with local storage and a clean dark UI.",
+});
+
+// session.id + session.clientToken — hand the token to your frontend
+```
+
+```http REST
 POST https://api.opencomputer.dev/v3/sessions
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
@@ -66,6 +96,8 @@ Content-Type: application/json
   "input": "Create a todo app with local storage and a clean dark UI."
 }
 ```
+
+</CodeGroup>
 
 Response:
 
@@ -80,28 +112,28 @@ Response:
 
 Use the `client_token` in the browser. Ask for `progress` for a good activity feed, or `internal` for an operator/debug view.
 
-```http
-GET /v3/sessions/sess_.../events?stream=sse&level=progress&token=ct_...
-Host: api.opencomputer.dev
+<CodeGroup>
+
+```ts TypeScript
+import { connectSession } from "@opencomputer/sdk";
+
+// in your frontend, with the session's client token
+const live = await connectSession({ sessionId, clientToken });
+
+for await (const event of live.events({ level: "progress" })) {
+  render(event); // reconnects from the last seq automatically
+}
 ```
 
-In a browser:
-
-```js
+```js EventSource
 const url = new URL(`${OC}/v3/sessions/${sessionId}/events`);
-url.search = new URLSearchParams({
-  stream: "sse",
-  level: "progress",
-  token: clientToken,
-});
+url.search = new URLSearchParams({ stream: "sse", level: "progress", token: clientToken });
 
 const events = new EventSource(url.toString());
-
-events.onmessage = (message) => {
-  const event = JSON.parse(message.data);
-  render(event);
-};
+events.onmessage = (message) => render(JSON.parse(message.data));
 ```
+
+</CodeGroup>
 
 Each event's `seq` is sent as the SSE `id`, so `EventSource` resumes automatically with `Last-Event-ID` after a dropped connection.
 
@@ -131,7 +163,13 @@ Handle `turn.completed.body.yield_reason` explicitly:
 
 Post follow-up messages with the same `client_token`. An idle session wakes and continues with its prior context.
 
-```http
+<CodeGroup>
+
+```ts TypeScript
+await live.steer("Add a filter for completed tasks.", { idempotencyKey: "msg_01" });
+```
+
+```http REST
 POST https://api.opencomputer.dev/v3/sessions/sess_.../messages
 Authorization: Bearer $CLIENT_TOKEN
 Content-Type: application/json
@@ -141,6 +179,8 @@ Content-Type: application/json
   "idempotency_key": "msg_01"
 }
 ```
+
+</CodeGroup>
 
 Response:
 

--- a/docs/agent-sessions/quickstart.mdx
+++ b/docs/agent-sessions/quickstart.mdx
@@ -31,7 +31,7 @@ An agent stores reusable configuration: name, runtime, model, prompt, and model 
 
 <CodeGroup>
 
-```ts TypeScript
+```ts TypeScript SDK
 import { OpenComputer } from "@opencomputer/sdk";
 
 const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
@@ -46,7 +46,7 @@ const agent = await oc.agents.create({
 });
 ```
 
-```http REST
+```http REST API
 POST https://api.opencomputer.dev/v3/agents
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
@@ -77,7 +77,7 @@ A session starts work immediately and returns a browser-safe `client_token` for 
 
 <CodeGroup>
 
-```ts TypeScript
+```ts TypeScript SDK
 const session = await oc.sessions.create({
   agent: agent.id,
   input: "Create a todo app with local storage and a clean dark UI.",
@@ -86,7 +86,7 @@ const session = await oc.sessions.create({
 // session.id + session.clientToken — hand the token to your frontend
 ```
 
-```http REST
+```http REST API
 POST https://api.opencomputer.dev/v3/sessions
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
@@ -114,7 +114,7 @@ Use the `client_token` in the browser. Ask for `progress` for a good activity fe
 
 <CodeGroup>
 
-```ts TypeScript
+```ts TypeScript SDK
 import { connectSession } from "@opencomputer/sdk";
 
 // in your frontend, with the session's client token
@@ -165,11 +165,11 @@ Post follow-up messages with the same `client_token`. An idle session wakes and 
 
 <CodeGroup>
 
-```ts TypeScript
+```ts TypeScript SDK
 await live.steer("Add a filter for completed tasks.", { idempotencyKey: "msg_01" });
 ```
 
-```http REST
+```http REST API
 POST https://api.opencomputer.dev/v3/sessions/sess_.../messages
 Authorization: Bearer $CLIENT_TOKEN
 Content-Type: application/json

--- a/docs/agent-sessions/sessions.mdx
+++ b/docs/agent-sessions/sessions.mdx
@@ -31,10 +31,22 @@ A session also carries `last_turn = { id, state, yield_reason?, result_event_id?
 
 Do not infer completion from prose. Await the **`turn.completed`** event (on the [stream](/agent-sessions/events) or a [webhook](/agent-sessions/webhooks)), then fetch the answer:
 
-```http
+<CodeGroup>
+
+```ts TypeScript
+import { OpenComputer } from "@opencomputer/sdk";
+
+const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
+const session = await oc.sessions.get("sess_...");
+const { lastTurn, result } = await session.result();
+```
+
+```http REST
 GET https://api.opencomputer.dev/v3/sessions/sess_.../result
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 ```
+
+</CodeGroup>
 
 Response:
 

--- a/docs/agent-sessions/sessions.mdx
+++ b/docs/agent-sessions/sessions.mdx
@@ -25,7 +25,7 @@ A **session** is the durable unit of an [agent](/agent-sessions/agents) at work:
 | `failed` | The session errored out. |
 | `archived` | Closed; read-only. |
 
-A session also carries `last_turn = { id, state, yield_reason?, result_event_id? }` and `usage`; the fuller turn record (`started_at`, `completed_at`, `error`, `active_seconds`, `usage`) comes from [`GET …/result`](/agent-sessions/api-reference) and `…/turns`. The **`yield_reason`** tells you *why* the last turn ended — `completed`, `needs_input` (the agent asked a question — the session is now `awaiting_input`; answer by [steering](/agent-sessions/messaging)), `budget_exceeded` / `deadline_exceeded` / `max_turns` (a [limit](#limits) tripped), or `canceled`.
+A session also carries `last_turn = { id, state, yield_reason?, result_event_id? }`; the fuller turn record (`started_at`, `completed_at`, `error`) comes from [`GET …/result`](/agent-sessions/api-reference) and `…/turns`. The **`yield_reason`** tells you *why* the last turn ended — `completed`, `needs_input` (the agent asked a question — the session is now `awaiting_input`; answer by [steering](/agent-sessions/messaging)), `budget_exceeded` / `deadline_exceeded` / `max_turns` (a [limit](#limits) tripped), or `canceled`.
 
 ## Fetch the result
 
@@ -56,7 +56,7 @@ Response:
 
 ## Limits
 
-Cap a session at create (or default it on the [agent](/agent-sessions/agents)) with `limits: { tokens, turn_seconds, turns }` — a token budget, per-turn wall-clock, and auto-run count. These are **non-monetary** (no dollar caps — we don't bill model usage yet; you run on your own key). Hitting one ends the turn with the matching `yield_reason`. (`usage` is observed-only.)
+Cap a session at create (or default it on the [agent](/agent-sessions/agents)) with `limits: { tokens, turn_seconds, turns }` — a token budget, per-turn wall-clock, and auto-run count. These are **non-monetary** (no dollar caps — we don't bill model usage yet; you run on your own key). Hitting one ends the turn with the matching `yield_reason`.
 
 ## Stop a session
 

--- a/docs/agent-sessions/sessions.mdx
+++ b/docs/agent-sessions/sessions.mdx
@@ -33,7 +33,7 @@ Do not infer completion from prose. Await the **`turn.completed`** event (on the
 
 <CodeGroup>
 
-```ts TypeScript
+```ts TypeScript SDK
 import { OpenComputer } from "@opencomputer/sdk";
 
 const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
@@ -41,7 +41,7 @@ const session = await oc.sessions.get("sess_...");
 const { lastTurn, result } = await session.result();
 ```
 
-```http REST
+```http REST API
 GET https://api.opencomputer.dev/v3/sessions/sess_.../result
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 ```

--- a/docs/agent-sessions/webhooks.mdx
+++ b/docs/agent-sessions/webhooks.mdx
@@ -7,7 +7,23 @@ Register a **destination** and a session's [events](/agent-sessions/events) are 
 
 ## Destinations
 
-```http
+<CodeGroup>
+
+```ts TypeScript
+import { OpenComputer } from "@opencomputer/sdk";
+
+const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
+const session = await oc.sessions.get(sessionId);
+
+await session.destinations.create({
+  url: "https://your.app/oc-webhook",
+  secret: "whsec_...",
+  level: "user",
+  includeRaw: false,
+});
+```
+
+```http REST
 POST https://api.opencomputer.dev/v3/sessions/sess_.../destinations
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
@@ -19,6 +35,8 @@ Content-Type: application/json
   "include_raw": false
 }
 ```
+
+</CodeGroup>
 
 `level` is the visibility threshold (`user` default, or `progress`); `types` is an optional event-type allow-list (default: all — which **includes the terminal `turn.completed`**); `include_raw: false` strips `body.raw` from the delivered Event. To get only completions, set `types: ["turn.completed"]`.
 

--- a/docs/agent-sessions/webhooks.mdx
+++ b/docs/agent-sessions/webhooks.mdx
@@ -9,7 +9,7 @@ Register a **destination** and a session's [events](/agent-sessions/events) are 
 
 <CodeGroup>
 
-```ts TypeScript
+```ts TypeScript SDK
 import { OpenComputer } from "@opencomputer/sdk";
 
 const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
@@ -23,7 +23,7 @@ await session.destinations.create({
 });
 ```
 
-```http REST
+```http REST API
 POST https://api.opencomputer.dev/v3/sessions/sess_.../destinations
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json

--- a/docs/reference/typescript-sdk/agent.mdx
+++ b/docs/reference/typescript-sdk/agent.mdx
@@ -1,7 +1,14 @@
 ---
-title: "Agent"
-description: "Start and manage Claude agent sessions"
+title: "Sandbox agent"
+description: "Start and manage an agent session inside a sandbox (low-level)"
 ---
+
+<Warning>
+The in-sandbox agent (`sandbox.agent`, exported as `SandboxAgent`) is a low-level
+primitive and is **deprecated**. For most use cases prefer managed **[Durable Agent
+Sessions](/agent-sessions/overview)** — the `OpenComputer` client gives you durable,
+streamable, steerable sessions without managing the sandbox yourself.
+</Warning>
 
 Accessed via `sandbox.agent`.
 
@@ -45,7 +52,7 @@ Start an agent session. [HTTP API →](/api-reference/agent/create)
   Resume session ID
 </ParamField>
 
-<ParamField body="onEvent" type="(event: AgentEvent) => void">
+<ParamField body="onEvent" type="(event: SandboxAgentEvent) => void">
   Event callback
 </ParamField>
 
@@ -61,7 +68,7 @@ Start an agent session. [HTTP API →](/api-reference/agent/create)
   Scrollback done callback
 </ParamField>
 
-**Returns:** `Promise<AgentSession>`
+**Returns:** `Promise<SandboxAgentSession>`
 
 ```typescript
 const session = await sandbox.agent.start({
@@ -76,7 +83,7 @@ const session = await sandbox.agent.start({
 
 Reconnect to a running agent session. Accepts `onEvent`, `onError`, `onExit`, `onScrollbackEnd`.
 
-**Returns:** `Promise<AgentSession>`
+**Returns:** `Promise<SandboxAgentSession>`
 
 ---
 
@@ -84,11 +91,11 @@ Reconnect to a running agent session. Accepts `onEvent`, `onError`, `onExit`, `o
 
 List all agent sessions. [HTTP API →](/api-reference/agent/list)
 
-**Returns:** `Promise<AgentSessionInfo[]>`
+**Returns:** `Promise<SandboxAgentSessionInfo[]>`
 
 ---
 
-## AgentSession
+## SandboxAgentSession
 
 | Member | Type | Description |
 | --- | --- | --- |
@@ -104,9 +111,9 @@ List all agent sessions. [HTTP API →](/api-reference/agent/list)
 
 ## Types
 
-<Accordion title="AgentEvent">
+<Accordion title="SandboxAgentEvent">
 ```typescript
-interface AgentEvent {
+interface SandboxAgentEvent {
   type: string;
   [key: string]: unknown;
 }

--- a/docs/reference/typescript-sdk/overview.mdx
+++ b/docs/reference/typescript-sdk/overview.mdx
@@ -36,8 +36,8 @@ import { Image, Snapshots } from "@opencomputer/sdk/node";
   <Card title="Exec" icon="terminal" href="/reference/typescript-sdk/exec">
     Run commands and manage exec sessions
   </Card>
-  <Card title="Agent" icon="robot" href="/reference/typescript-sdk/agent">
-    Start and manage Claude agent sessions
+  <Card title="Sandbox agent" icon="robot" href="/reference/typescript-sdk/agent">
+    Start and manage an agent session inside a sandbox (low-level; deprecated)
   </Card>
   <Card title="Filesystem" icon="folder" href="/reference/typescript-sdk/filesystem">
     Read, write, and manage files

--- a/docs/reference/typescript-sdk/sandbox.mdx
+++ b/docs/reference/typescript-sdk/sandbox.mdx
@@ -357,8 +357,8 @@ The returned `AllowedHostsInfo`:
   Preview URL domain for port 80 (e.g., `sb-abc123-p80.workers.opencomputer.dev`). Returns empty string if sandbox domain is not configured.
 </ParamField>
 
-<ParamField body="agent" type="Agent">
-  [Agent sessions](/reference/typescript-sdk/agent)
+<ParamField body="agent" type="SandboxAgent">
+  [Sandbox agent sessions](/reference/typescript-sdk/agent)
 </ParamField>
 
 <ParamField body="exec" type="Exec">

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/agent.ts
+++ b/sdks/typescript/src/agent.ts
@@ -1,4 +1,4 @@
-export interface AgentEvent {
+export interface SandboxAgentEvent {
   type:
     | "ready"
     | "configured"
@@ -19,7 +19,7 @@ export interface McpServerConfig {
   env?: Record<string, string>;
 }
 
-export interface AgentConfig {
+export interface SandboxAgentConfig {
   model?: string;
   systemPrompt?: string;
   allowedTools?: string[];
@@ -30,25 +30,29 @@ export interface AgentConfig {
   resume?: string;
 }
 
-export interface AgentStartOpts extends AgentConfig {
+export interface SandboxAgentStartOpts extends SandboxAgentConfig {
   prompt?: string;
-  onEvent?: (event: AgentEvent) => void;
+  onEvent?: (event: SandboxAgentEvent) => void;
   onError?: (data: string) => void;
   onExit?: (exitCode: number) => void;
   onScrollbackEnd?: () => void;
 }
 
-export interface AgentSession {
+export interface SandboxAgentSession {
   sessionId: string;
   done: Promise<number>;
   sendPrompt(text: string): void;
   interrupt(): void;
-  configure(config: AgentConfig): void;
+  configure(config: SandboxAgentConfig): void;
   kill(signal?: number): Promise<void>;
   close(): void;
 }
 
-export class Agent {
+/**
+ * @deprecated The in-sandbox agent is a low-level primitive and is being phased out.
+ * Prefer managed agents via the `OpenComputer` client — durable, streamable sessions.
+ */
+export class SandboxAgent {
   constructor(
     private apiUrl: string,
     private apiKey: string,
@@ -66,7 +70,7 @@ export class Agent {
     return h;
   }
 
-  async start(opts: AgentStartOpts = {}): Promise<AgentSession> {
+  async start(opts: SandboxAgentStartOpts = {}): Promise<SandboxAgentSession> {
     const body: Record<string, unknown> = {};
     if (opts.prompt) body.prompt = opts.prompt;
     if (opts.model) body.model = opts.model;
@@ -95,7 +99,7 @@ export class Agent {
     return this.attach(sessionId, opts);
   }
 
-  async attach(sessionId: string, opts: Omit<AgentStartOpts, "prompt" | keyof AgentConfig> = {}): Promise<AgentSession> {
+  async attach(sessionId: string, opts: Omit<SandboxAgentStartOpts, "prompt" | keyof SandboxAgentConfig> = {}): Promise<SandboxAgentSession> {
     // Connect via the existing exec session WebSocket endpoint
     const wsUrl = this.apiUrl
       .replace("http://", "ws://")
@@ -126,7 +130,7 @@ export class Agent {
         const trimmed = line.trim();
         if (!trimmed) continue;
         try {
-          const event: AgentEvent = JSON.parse(trimmed);
+          const event: SandboxAgentEvent = JSON.parse(trimmed);
           opts.onEvent?.(event);
         } catch {
           // Not JSON — treat as raw output
@@ -173,7 +177,7 @@ export class Agent {
       // Flush remaining line buffer
       if (lineBuf.trim()) {
         try {
-          const event: AgentEvent = JSON.parse(lineBuf.trim());
+          const event: SandboxAgentEvent = JSON.parse(lineBuf.trim());
           opts.onEvent?.(event);
         } catch {
           opts.onError?.(`non-JSON stdout: ${lineBuf.trim()}`);
@@ -213,7 +217,7 @@ export class Agent {
       interrupt(): void {
         sendStdin(JSON.stringify({ type: "interrupt" }) + "\n");
       },
-      configure(config: AgentConfig): void {
+      configure(config: SandboxAgentConfig): void {
         sendStdin(JSON.stringify({ type: "configure", ...config }) + "\n");
       },
       async kill(signal?: number): Promise<void> {

--- a/sdks/typescript/src/agents/agents.ts
+++ b/sdks/typescript/src/agents/agents.ts
@@ -1,0 +1,41 @@
+import type { Http, Query } from "./http.js";
+import type { Agent, Limits } from "./types.js";
+
+export interface CreateAgentParams {
+  name: string;
+  prompt: string;
+  model: string;
+  runtime?: string;
+  /** Anthropic key, stored as a sealed credential. Or pass `credential`, or rely on the org default. */
+  key?: string;
+  credential?: string;
+  limits?: Limits;
+}
+
+export interface UpdateAgentParams {
+  prompt?: string;
+  model?: string;
+  key?: string;
+  credential?: string;
+  limits?: Limits;
+}
+
+export interface Page<T> { data: T[]; nextCursor?: string | null; }
+
+/** Reusable agents — the "what" a session runs. */
+export class Agents {
+  constructor(private readonly http: Http) {}
+
+  create(params: CreateAgentParams): Promise<Agent> {
+    return this.http.request("POST", "/agents", { body: params });
+  }
+  get(id: string): Promise<Agent> {
+    return this.http.request("GET", `/agents/${id}`);
+  }
+  update(id: string, params: UpdateAgentParams): Promise<Agent> {
+    return this.http.request("PATCH", `/agents/${id}`, { body: params });
+  }
+  list(params: { limit?: number; cursor?: string } = {}): Promise<Page<Agent>> {
+    return this.http.request("GET", "/agents", { query: params as Query });
+  }
+}

--- a/sdks/typescript/src/agents/client.ts
+++ b/sdks/typescript/src/agents/client.ts
@@ -1,0 +1,30 @@
+import { Http, type HttpOptions } from "./http.js";
+import { Agents } from "./agents.js";
+import { Sessions } from "./sessions.js";
+import { Credentials } from "./credentials.js";
+
+export interface OpenComputerOptions extends HttpOptions {
+  /** Your OpenComputer org API key (server-side only — never ship it to a browser). */
+  apiKey: string;
+}
+
+/**
+ * Server-side client for Durable Agent Sessions. Holds the org API key and exposes the
+ * management surface. For the browser, mint a client token and use `connectSession`.
+ *
+ *   const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
+ *   const agent   = await oc.agents.create({ name, prompt, model, key });
+ *   const session = await oc.sessions.create({ agent: agent.id, input });
+ */
+export class OpenComputer {
+  readonly agents: Agents;
+  readonly sessions: Sessions;
+  readonly credentials: Credentials;
+
+  constructor(opts: OpenComputerOptions) {
+    const http = new Http({ apiKey: opts.apiKey }, opts);
+    this.agents = new Agents(http);
+    this.sessions = new Sessions(http);
+    this.credentials = new Credentials(http);
+  }
+}

--- a/sdks/typescript/src/agents/connect.ts
+++ b/sdks/typescript/src/agents/connect.ts
@@ -1,0 +1,22 @@
+import { Http, type HttpOptions } from "./http.js";
+import { Session } from "./sessions.js";
+import type { SessionData } from "./types.js";
+
+export interface ConnectSessionOptions extends HttpOptions {
+  sessionId: string;
+  /** A session-scoped client token (read + steer). Safe in a browser; never the org key. */
+  clientToken: string;
+}
+
+/**
+ * Browser/edge entry point: connect to one session with a client token. Returns a
+ * `Session` handle that can stream and steer that session — and nothing else.
+ *
+ *   const session = await connectSession({ sessionId, clientToken });
+ *   for await (const ev of session.events()) render(ev);
+ */
+export async function connectSession(opts: ConnectSessionOptions): Promise<Session> {
+  const http = new Http({ token: opts.clientToken }, opts);
+  const data = await http.request<SessionData>("GET", `/sessions/${opts.sessionId}`);
+  return new Session(http, data, opts.clientToken);
+}

--- a/sdks/typescript/src/agents/credentials.ts
+++ b/sdks/typescript/src/agents/credentials.ts
@@ -1,0 +1,28 @@
+import type { Http } from "./http.js";
+import type { Credential } from "./types.js";
+
+export interface CreateCredentialParams {
+  provider: "anthropic" | (string & {});
+  /** Write-only — never returned by the API. */
+  key: string;
+  name?: string;
+}
+
+/** Provider keys (e.g. Anthropic), stored in the secret store; sessions run on them. */
+export class Credentials {
+  constructor(private readonly http: Http) {}
+
+  create(params: CreateCredentialParams): Promise<Credential> {
+    return this.http.request("POST", "/credentials", { body: params });
+  }
+  async list(): Promise<Credential[]> {
+    const r = await this.http.request<{ data?: Credential[] } | Credential[]>("GET", "/credentials");
+    return Array.isArray(r) ? r : r.data ?? [];
+  }
+  delete(id: string): Promise<void> {
+    return this.http.request("DELETE", `/credentials/${id}`);
+  }
+  setDefault(params: { provider: string; credential: string }): Promise<void> {
+    return this.http.request("PUT", "/credentials/default", { body: params });
+  }
+}

--- a/sdks/typescript/src/agents/destinations.ts
+++ b/sdks/typescript/src/agents/destinations.ts
@@ -1,0 +1,61 @@
+import type { Http, Query } from "./http.js";
+import type { Destination, Delivery, DeliveryStatus, Level } from "./types.js";
+
+export interface CreateDestinationParams {
+  url: string;
+  /** Signing secret (write-only). */
+  secret?: string;
+  level?: Level;
+  /** Event-type allow-list (exact or `prefix.*`); default all. */
+  types?: string[];
+  includeRaw?: boolean;
+  enabled?: boolean;
+}
+
+export interface UpdateDestinationParams {
+  enabled?: boolean;
+  level?: Level;
+  types?: string[];
+  secret?: string;
+}
+
+/** Webhook destinations for one session. Management — needs the org key. */
+export class Destinations {
+  constructor(private readonly http: Http, private readonly sessionId: string) {}
+
+  create(params: CreateDestinationParams): Promise<Destination> {
+    return this.http.request("POST", `/sessions/${this.sessionId}/destinations`, { body: params });
+  }
+  async list(): Promise<Destination[]> {
+    const r = await this.http.request<{ data?: Destination[] } | Destination[]>("GET", `/sessions/${this.sessionId}/destinations`);
+    return Array.isArray(r) ? r : r.data ?? [];
+  }
+  get(id: string): Promise<Destination> {
+    return this.http.request("GET", `/sessions/${this.sessionId}/destinations/${id}`);
+  }
+  update(id: string, params: UpdateDestinationParams): Promise<Destination> {
+    return this.http.request("PATCH", `/sessions/${this.sessionId}/destinations/${id}`, { body: params });
+  }
+  delete(id: string): Promise<void> {
+    return this.http.request("DELETE", `/sessions/${this.sessionId}/destinations/${id}`);
+  }
+}
+
+/** Delivery records (the deliveries control surface) for one session. Needs the org key. */
+export class Deliveries {
+  constructor(private readonly http: Http, private readonly sessionId: string) {}
+
+  async list(params: { destination?: string; status?: DeliveryStatus } = {}): Promise<Delivery[]> {
+    const r = await this.http.request<{ data?: Delivery[] } | Delivery[]>(
+      "GET", `/sessions/${this.sessionId}/deliveries`, { query: params as Query },
+    );
+    return Array.isArray(r) ? r : r.data ?? [];
+  }
+  get(id: string): Promise<Delivery> {
+    return this.http.request("GET", `/sessions/${this.sessionId}/deliveries/${id}`);
+  }
+  /** Re-send any delivery (not just dead-lettered). */
+  redeliver(id: string): Promise<void> {
+    return this.http.request("POST", `/sessions/${this.sessionId}/deliveries/${id}/redeliver`);
+  }
+}

--- a/sdks/typescript/src/agents/errors.ts
+++ b/sdks/typescript/src/agents/errors.ts
@@ -1,0 +1,59 @@
+/** The error envelope the API returns: `{ error: { type, message, code, param?, request_id } }`. */
+export interface ApiErrorBody {
+  type?: string;
+  message?: string;
+  code?: string;
+  param?: string;
+  request_id?: string;
+}
+
+/** Base error for every failed API call. Thrown (never returned). */
+export class OpenComputerError extends Error {
+  readonly status: number;
+  readonly code?: string;
+  readonly type?: string;
+  readonly param?: string;
+  readonly requestId?: string;
+
+  constructor(status: number, body: ApiErrorBody | undefined, fallback: string) {
+    super(body?.message || fallback);
+    this.name = "OpenComputerError";
+    this.status = status;
+    this.code = body?.code;
+    this.type = body?.type;
+    this.param = body?.param;
+    this.requestId = body?.request_id;
+  }
+}
+
+export class AuthError extends OpenComputerError { name = "AuthError"; }        // 401 / 403
+export class NotFoundError extends OpenComputerError { name = "NotFoundError"; } // 404
+export class ConflictError extends OpenComputerError { name = "ConflictError"; } // 409
+export class ValidationError extends OpenComputerError { name = "ValidationError"; } // 422
+
+export class RateLimitError extends OpenComputerError {
+  name = "RateLimitError";
+  /** Seconds to wait, from the `Retry-After` header, if present. */
+  readonly retryAfter?: number;
+  constructor(status: number, body: ApiErrorBody | undefined, fallback: string, retryAfter?: number) {
+    super(status, body, fallback);
+    this.retryAfter = retryAfter;
+  }
+}
+
+export function errorFromResponse(
+  status: number,
+  body: ApiErrorBody | undefined,
+  retryAfter?: number,
+): OpenComputerError {
+  const fallback = `OpenComputer request failed (${status})`;
+  switch (status) {
+    case 401:
+    case 403: return new AuthError(status, body, fallback);
+    case 404: return new NotFoundError(status, body, fallback);
+    case 409: return new ConflictError(status, body, fallback);
+    case 422: return new ValidationError(status, body, fallback);
+    case 429: return new RateLimitError(status, body, fallback, retryAfter);
+    default:  return new OpenComputerError(status, body, fallback);
+  }
+}

--- a/sdks/typescript/src/agents/http.ts
+++ b/sdks/typescript/src/agents/http.ts
@@ -1,5 +1,5 @@
 import { errorFromResponse } from "./errors.js";
-import { normalize } from "./normalize.js";
+import { normalize, serialize } from "./normalize.js";
 
 /** Either an org API key (server) or a session-scoped client token (browser/edge). */
 export type Auth = { apiKey: string } | { token: string };
@@ -14,7 +14,7 @@ export interface HttpOptions {
 }
 
 export type Query = Record<string, string | number | boolean | undefined | null>;
-interface RequestOptions { query?: Query; body?: unknown; idempotencyKey?: string; signal?: AbortSignal; }
+interface RequestOptions { query?: Query; body?: unknown; idempotencyKey?: string; signal?: AbortSignal; idempotent?: boolean; }
 
 const DEFAULT_BASE = "https://api.opencomputer.dev/v3";
 
@@ -40,7 +40,9 @@ export class Http {
 
   url(path: string, query?: Query): string {
     const u = new URL(this.base + path);
-    if (query) for (const [k, v] of Object.entries(query)) if (v !== undefined && v !== null) u.searchParams.set(k, String(v));
+    if (query) for (const [k, v] of Object.entries(query)) {
+      if (v !== undefined && v !== null) u.searchParams.set(k.replace(/[A-Z]/g, (c) => "_" + c.toLowerCase()), String(v));
+    }
     return u.toString();
   }
 
@@ -48,19 +50,24 @@ export class Http {
     const headers = this.headers(opts.body !== undefined ? { "Content-Type": "application/json" } : undefined);
     if (opts.idempotencyKey) headers["Idempotency-Key"] = opts.idempotencyKey;
     const init: RequestInit = { method, headers, signal: opts.signal };
-    if (opts.body !== undefined) init.body = JSON.stringify(opts.body);
+    // The SDK owns serialization both ways: camelCase → snake_case on the way out
+    // (the API reads turn_seconds, include_raw, idempotency_key, …), camelCase back in.
+    if (opts.body !== undefined) init.body = JSON.stringify(serialize(opts.body));
     const url = this.url(path, opts.query);
+    // Only retry when the call is safe to repeat: reads, or writes that carry an
+    // idempotency key. Otherwise a retried POST could duplicate work or messages.
+    const canRetry = method === "GET" || method === "HEAD" || opts.idempotent === true;
 
     for (let attempt = 0; ; attempt++) {
       let res: Response;
       try {
         res = await this.doFetch(url, init);
       } catch (e) {
-        if (attempt < this.maxRetries && !opts.signal?.aborted) { await sleep(backoff(attempt)); continue; }
+        if (canRetry && attempt < this.maxRetries && !opts.signal?.aborted) { await sleep(backoff(attempt)); continue; }
         throw e;
       }
       if (res.ok) return res.status === 204 ? (undefined as T) : normalize<T>(await res.json());
-      if ((res.status === 429 || res.status >= 500) && attempt < this.maxRetries) {
+      if (canRetry && (res.status === 429 || res.status >= 500) && attempt < this.maxRetries) {
         await sleep(retryAfterMs(res) ?? backoff(attempt));
         continue;
       }

--- a/sdks/typescript/src/agents/http.ts
+++ b/sdks/typescript/src/agents/http.ts
@@ -78,6 +78,13 @@ export class Http {
     if (!res.ok) throw errorFromResponse(res.status, (await safeJson(res))?.error, retryAfterSec(res));
     return res;
   }
+
+  /** Raw GET (no JSON parse) — e.g. blob-backed event content. Returns the checked Response. */
+  async raw(method: string, path: string, opts: { query?: Query; signal?: AbortSignal } = {}): Promise<Response> {
+    const res = await this.doFetch(this.url(path, opts.query), { method, headers: this.headers(), signal: opts.signal });
+    if (!res.ok) throw errorFromResponse(res.status, (await safeJson(res))?.error, retryAfterSec(res));
+    return res;
+  }
 }
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));

--- a/sdks/typescript/src/agents/http.ts
+++ b/sdks/typescript/src/agents/http.ts
@@ -1,0 +1,95 @@
+import { errorFromResponse } from "./errors.js";
+import { normalize } from "./normalize.js";
+
+/** Either an org API key (server) or a session-scoped client token (browser/edge). */
+export type Auth = { apiKey: string } | { token: string };
+
+export interface HttpOptions {
+  /** Defaults to https://api.opencomputer.dev/v3 */
+  baseUrl?: string;
+  /** Override fetch (for runtimes without a global, or for testing). */
+  fetch?: typeof fetch;
+  /** Retries on 429 / 5xx / network error. Default 2. */
+  maxRetries?: number;
+}
+
+export type Query = Record<string, string | number | boolean | undefined | null>;
+interface RequestOptions { query?: Query; body?: unknown; idempotencyKey?: string; signal?: AbortSignal; }
+
+const DEFAULT_BASE = "https://api.opencomputer.dev/v3";
+
+/** Tiny fetch wrapper: auth, JSON, normalization, typed errors, retry. The whole HTTP layer. */
+export class Http {
+  readonly base: string;
+  private readonly doFetch: typeof fetch;
+  private readonly maxRetries: number;
+  private readonly bearer: string;
+
+  constructor(auth: Auth, opts: HttpOptions = {}) {
+    this.bearer = "token" in auth ? auth.token : auth.apiKey;
+    this.base = (opts.baseUrl ?? DEFAULT_BASE).replace(/\/+$/, "");
+    const f = opts.fetch ?? (typeof fetch !== "undefined" ? fetch : undefined);
+    if (!f) throw new Error("global fetch is unavailable — pass { fetch } in the client options.");
+    this.doFetch = f.bind(globalThis) as typeof fetch;
+    this.maxRetries = opts.maxRetries ?? 2;
+  }
+
+  private headers(extra?: Record<string, string>): Record<string, string> {
+    return { Authorization: `Bearer ${this.bearer}`, ...extra };
+  }
+
+  url(path: string, query?: Query): string {
+    const u = new URL(this.base + path);
+    if (query) for (const [k, v] of Object.entries(query)) if (v !== undefined && v !== null) u.searchParams.set(k, String(v));
+    return u.toString();
+  }
+
+  async request<T>(method: string, path: string, opts: RequestOptions = {}): Promise<T> {
+    const headers = this.headers(opts.body !== undefined ? { "Content-Type": "application/json" } : undefined);
+    if (opts.idempotencyKey) headers["Idempotency-Key"] = opts.idempotencyKey;
+    const init: RequestInit = { method, headers, signal: opts.signal };
+    if (opts.body !== undefined) init.body = JSON.stringify(opts.body);
+    const url = this.url(path, opts.query);
+
+    for (let attempt = 0; ; attempt++) {
+      let res: Response;
+      try {
+        res = await this.doFetch(url, init);
+      } catch (e) {
+        if (attempt < this.maxRetries && !opts.signal?.aborted) { await sleep(backoff(attempt)); continue; }
+        throw e;
+      }
+      if (res.ok) return res.status === 204 ? (undefined as T) : normalize<T>(await res.json());
+      if ((res.status === 429 || res.status >= 500) && attempt < this.maxRetries) {
+        await sleep(retryAfterMs(res) ?? backoff(attempt));
+        continue;
+      }
+      throw errorFromResponse(res.status, (await safeJson(res))?.error, retryAfterSec(res));
+    }
+  }
+
+  /** Open an SSE stream (caller reads the body). Auth via the Authorization header. */
+  async stream(path: string, query?: Query, signal?: AbortSignal): Promise<Response> {
+    const res = await this.doFetch(this.url(path, query), {
+      method: "GET",
+      headers: this.headers({ Accept: "text/event-stream" }),
+      signal,
+    });
+    if (!res.ok) throw errorFromResponse(res.status, (await safeJson(res))?.error, retryAfterSec(res));
+    return res;
+  }
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+const backoff = (attempt: number) => Math.min(500 * 2 ** attempt, 8000);
+const retryAfterSec = (res: Response): number | undefined => {
+  const v = Number(res.headers.get("retry-after"));
+  return Number.isFinite(v) && v > 0 ? v : undefined;
+};
+const retryAfterMs = (res: Response): number | undefined => {
+  const s = retryAfterSec(res);
+  return s ? s * 1000 : undefined;
+};
+async function safeJson(res: Response): Promise<any> {
+  try { return await res.json(); } catch { return undefined; }
+}

--- a/sdks/typescript/src/agents/index.ts
+++ b/sdks/typescript/src/agents/index.ts
@@ -7,6 +7,8 @@ export { Agents } from "./agents.js";
 export type { CreateAgentParams, UpdateAgentParams, Page } from "./agents.js";
 export { Credentials } from "./credentials.js";
 export type { CreateCredentialParams } from "./credentials.js";
+export { Destinations, Deliveries } from "./destinations.js";
+export type { CreateDestinationParams, UpdateDestinationParams } from "./destinations.js";
 
 export * from "./types.js";
 export * from "./errors.js";

--- a/sdks/typescript/src/agents/index.ts
+++ b/sdks/typescript/src/agents/index.ts
@@ -1,0 +1,12 @@
+export { OpenComputer, type OpenComputerOptions } from "./client.js";
+export { connectSession, type ConnectSessionOptions } from "./connect.js";
+
+export { Sessions, Session } from "./sessions.js";
+export type { CreateSessionParams, StreamOptions, Envelope, ListPage } from "./sessions.js";
+export { Agents } from "./agents.js";
+export type { CreateAgentParams, UpdateAgentParams, Page } from "./agents.js";
+export { Credentials } from "./credentials.js";
+export type { CreateCredentialParams } from "./credentials.js";
+
+export * from "./types.js";
+export * from "./errors.js";

--- a/sdks/typescript/src/agents/normalize.ts
+++ b/sdks/typescript/src/agents/normalize.ts
@@ -1,0 +1,29 @@
+// Normalize API responses to idiomatic TS: snake_case keys → camelCase, and a known set
+// of numeric fields that the API serializes as strings (bigints) → numbers. Leaves the
+// opaque `raw` payload (source-specific adapter data) untouched.
+
+const NUMERIC = new Set([
+  "seq", "head", "inputCursor", "inputFromSeq", "inputToSeq", "exitCode", "bytes", "port",
+  "numTurns", "revision", "tokens", "turnSeconds", "turns", "activeSeconds", "usd",
+  "attempts", "responseCode",
+]);
+
+const camel = (k: string): string => k.replace(/_([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+
+export function normalize<T = any>(value: unknown): T {
+  if (Array.isArray(value)) return value.map((v) => normalize(v)) as T;
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      const ck = camel(k);
+      if (ck === "raw") { out[ck] = v; continue; }
+      let nv: unknown = normalize(v);
+      if (NUMERIC.has(ck) && typeof nv === "string" && nv !== "" && !Number.isNaN(Number(nv))) {
+        nv = Number(nv);
+      }
+      out[ck] = nv;
+    }
+    return out as T;
+  }
+  return value as T;
+}

--- a/sdks/typescript/src/agents/normalize.ts
+++ b/sdks/typescript/src/agents/normalize.ts
@@ -27,3 +27,20 @@ export function normalize<T = any>(value: unknown): T {
   }
   return value as T;
 }
+
+// Inverse of normalize: camelCase keys → snake_case for REQUEST bodies (the API reads
+// snake_case). Values are left untouched, and an opaque `raw` payload is not recursed into.
+const snakeKey = (k: string): string => k.replace(/[A-Z]/g, (c) => "_" + c.toLowerCase());
+
+export function serialize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((v) => serialize(v));
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      const sk = snakeKey(k);
+      out[sk] = sk === "raw" ? v : serialize(v);
+    }
+    return out;
+  }
+  return value;
+}

--- a/sdks/typescript/src/agents/normalize.ts
+++ b/sdks/typescript/src/agents/normalize.ts
@@ -4,7 +4,7 @@
 
 const NUMERIC = new Set([
   "seq", "head", "inputCursor", "inputFromSeq", "inputToSeq", "exitCode", "bytes", "port",
-  "numTurns", "revision", "tokens", "turnSeconds", "turns", "activeSeconds", "usd",
+  "numTurns", "revision", "tokens", "turnSeconds", "turns",
   "attempts", "responseCode",
 ]);
 

--- a/sdks/typescript/src/agents/sessions.ts
+++ b/sdks/typescript/src/agents/sessions.ts
@@ -1,0 +1,136 @@
+import type { Http, Query } from "./http.js";
+import type { Event, Level, Limits, LastTurn, SessionData, SessionStatus } from "./types.js";
+import { parseEventStream } from "./sse.js";
+
+export type Envelope = { text?: string; [k: string]: unknown };
+
+export interface CreateSessionParams {
+  agent: string;
+  input: string | Envelope;
+  /** get-or-create idempotency/routing key — one session per key. */
+  key?: string;
+  webhook?: string;
+  destinations?: Array<{ url: string; secret?: string; level?: Level }>;
+  limits?: Limits;
+}
+
+export interface StreamOptions {
+  /** Visibility threshold; default `internal` (the full build trace). */
+  level?: Level;
+  /** Filter by event type (exact or `prefix.*`). */
+  type?: string;
+  /** Resume from this seq (default 0 — replays the whole log). */
+  after?: number;
+  signal?: AbortSignal;
+}
+
+export interface ListPage<T> { data: T[]; nextCursor?: string | null; }
+
+/** Sessions — durable runs of an agent. */
+export class Sessions {
+  constructor(private readonly http: Http) {}
+
+  async create(params: CreateSessionParams): Promise<Session> {
+    const r = await this.http.request<{ session: SessionData; clientToken?: string }>(
+      "POST", "/sessions", { body: params },
+    );
+    return new Session(this.http, r.session, r.clientToken);
+  }
+  async get(id: string): Promise<Session> {
+    return new Session(this.http, await this.http.request<SessionData>("GET", `/sessions/${id}`));
+  }
+  list(params: { agent?: string; status?: SessionStatus; key?: string; limit?: number; cursor?: string } = {}): Promise<ListPage<SessionData>> {
+    return this.http.request("GET", "/sessions", { query: params as Query });
+  }
+}
+
+/**
+ * A handle to one session. Returned by `sessions.create`/`get` (org key) and by
+ * `connectSession` (browser, client token) — same type, both auth modes.
+ */
+export class Session {
+  /** Present after create / connectSession — safe to hand to a browser. */
+  readonly clientToken?: string;
+  private data: SessionData;
+
+  constructor(private readonly http: Http, data: SessionData, clientToken?: string) {
+    this.data = data;
+    this.clientToken = clientToken;
+  }
+
+  get id(): string { return this.data.id; }
+  get status(): SessionStatus { return this.data.status; }
+  get lastTurn(): LastTurn | undefined { return this.data.lastTurn; }
+  /** The latest fetched session record. */
+  get snapshot(): SessionData { return this.data; }
+
+  async refresh(): Promise<this> {
+    this.data = await this.http.request<SessionData>("GET", `/sessions/${this.id}`);
+    return this;
+  }
+
+  /**
+   * Stream events as an async iterator. Reconnects from the last seq on a dropped
+   * connection and keeps tailing until the `signal` aborts. Replays the log from `after`
+   * (default 0) on first connect, so opening a session shows its whole history.
+   *
+   *   for await (const ev of session.events({ signal })) { switch (ev.type) { … } }
+   */
+  async *events(opts: StreamOptions = {}): AsyncGenerator<Event> {
+    let after = opts.after ?? 0;
+    const base: Query = { stream: "sse", level: opts.level ?? "internal", type: opts.type };
+    for (;;) {
+      if (opts.signal?.aborted) return;
+      let res: Response;
+      try {
+        res = await this.http.stream(`/sessions/${this.id}/events`, { ...base, after }, opts.signal);
+      } catch (e) {
+        if (opts.signal?.aborted) return;
+        throw e; // auth/404/etc. — surface it
+      }
+      try {
+        for await (const ev of parseEventStream(res)) {
+          after = ev.seq;
+          yield ev;
+        }
+      } catch {
+        if (opts.signal?.aborted) return;
+        // network drop mid-stream — fall through and reconnect from `after`
+      }
+      if (opts.signal?.aborted) return;
+      await sleep(1000); // stream ended (caught up / closed) — pause before re-tailing
+    }
+  }
+
+  /** Read a page of events without streaming. */
+  listEvents(opts: { after?: number; level?: Level; type?: string; limit?: number } = {}): Promise<ListPage<Event>> {
+    return this.http.request("GET", `/sessions/${this.id}/events`, { query: opts as Query });
+  }
+
+  /** Send a message; wakes the session. */
+  async steer(text: string, opts: { idempotencyKey?: string } = {}): Promise<{ id: string; seq: number }> {
+    const r = await this.http.request<{ event: { id: string; seq: number } }>(
+      "POST", `/sessions/${this.id}/messages`,
+      { body: { text }, idempotencyKey: opts.idempotencyKey },
+    );
+    return r.event;
+  }
+
+  /** The resolved final result + last-turn summary. */
+  result(): Promise<{ lastTurn?: LastTurn; result?: Event }> {
+    return this.http.request("GET", `/sessions/${this.id}/result`);
+  }
+  cancel(): Promise<void> { return this.http.request("POST", `/sessions/${this.id}/cancel`); }
+  archive(): Promise<void> { return this.http.request("POST", `/sessions/${this.id}/archive`); }
+
+  /** Mint a browser-safe client token for this session (org key only). */
+  async mintClientToken(opts: { scopes?: Array<"read" | "steer">; ttlSeconds?: number } = {}): Promise<string> {
+    const r = await this.http.request<{ clientToken?: string; token?: string }>(
+      "POST", `/sessions/${this.id}/client-tokens`,
+      { body: { scopes: opts.scopes, ttl: opts.ttlSeconds } },
+    );
+    return (r.clientToken ?? r.token)!;
+  }
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));

--- a/sdks/typescript/src/agents/sessions.ts
+++ b/sdks/typescript/src/agents/sessions.ts
@@ -11,8 +11,10 @@ export interface CreateSessionParams {
   /** get-or-create idempotency/routing key — one session per key. */
   key?: string;
   webhook?: string;
-  destinations?: Array<{ url: string; secret?: string; level?: Level }>;
+  destinations?: Array<{ url: string; secret?: string; level?: Level; types?: string[]; includeRaw?: boolean; enabled?: boolean }>;
   limits?: Limits;
+  /** Makes a keyless create retry-safe (sent as the Idempotency-Key header). */
+  idempotencyKey?: string;
 }
 
 export interface StreamOptions {
@@ -32,15 +34,22 @@ export class Sessions {
   constructor(private readonly http: Http) {}
 
   async create(params: CreateSessionParams): Promise<Session> {
+    const { idempotencyKey, destinations, ...rest } = params;
+    const body = {
+      ...rest,
+      // inline destinations on create take `secret_ref`; the standalone API takes `secret`.
+      destinations: destinations?.map(({ secret, ...d }) => ({ ...d, secretRef: secret })),
+    };
     const r = await this.http.request<{ session: SessionData; clientToken?: string }>(
-      "POST", "/sessions", { body: params },
+      "POST", "/sessions",
+      { body, idempotencyKey, idempotent: Boolean(idempotencyKey || rest.key) },
     );
     return new Session(this.http, r.session, r.clientToken);
   }
   async get(id: string): Promise<Session> {
     return new Session(this.http, await this.http.request<SessionData>("GET", `/sessions/${id}`));
   }
-  list(params: { agent?: string; status?: SessionStatus; key?: string; limit?: number; cursor?: string } = {}): Promise<ListPage<SessionData>> {
+  list(params: { agent?: string; status?: SessionStatus; key?: string; after?: string; before?: string; limit?: number; cursor?: string } = {}): Promise<ListPage<SessionData>> {
     return this.http.request("GET", "/sessions", { query: params as Query });
   }
 }
@@ -109,7 +118,7 @@ export class Session {
   }
 
   /** Read a page of events without streaming. */
-  listEvents(opts: { after?: number; level?: Level; type?: string; limit?: number } = {}): Promise<ListPage<Event>> {
+  listEvents(opts: { after?: number; level?: Level; type?: string; turnId?: string; limit?: number } = {}): Promise<ListPage<Event>> {
     return this.http.request("GET", `/sessions/${this.id}/events`, { query: opts as Query });
   }
 
@@ -142,13 +151,13 @@ export class Session {
   async steer(text: string, opts: { idempotencyKey?: string } = {}): Promise<{ id: string; seq: number }> {
     const r = await this.http.request<{ event: { id: string; seq: number } }>(
       "POST", `/sessions/${this.id}/messages`,
-      { body: { text }, idempotencyKey: opts.idempotencyKey },
+      { body: { text, idempotencyKey: opts.idempotencyKey }, idempotent: Boolean(opts.idempotencyKey) },
     );
     return r.event;
   }
 
   /** The resolved final result + last-turn summary. */
-  result(): Promise<{ lastTurn?: LastTurn; result?: Event }> {
+  result(): Promise<{ lastTurn?: LastTurn | null; result?: Event | null }> {
     return this.http.request("GET", `/sessions/${this.id}/result`);
   }
   cancel(): Promise<void> { return this.http.request("POST", `/sessions/${this.id}/cancel`); }

--- a/sdks/typescript/src/agents/sessions.ts
+++ b/sdks/typescript/src/agents/sessions.ts
@@ -1,6 +1,7 @@
 import type { Http, Query } from "./http.js";
-import type { Event, Level, Limits, LastTurn, SessionData, SessionStatus } from "./types.js";
+import type { Event, Level, Limits, LastTurn, SessionData, SessionStatus, Turn } from "./types.js";
 import { parseEventStream } from "./sse.js";
+import { Destinations, Deliveries } from "./destinations.js";
 
 export type Envelope = { text?: string; [k: string]: unknown };
 
@@ -51,11 +52,16 @@ export class Sessions {
 export class Session {
   /** Present after create / connectSession — safe to hand to a browser. */
   readonly clientToken?: string;
+  /** Webhook destinations + delivery records for this session (management — need the org key). */
+  readonly destinations: Destinations;
+  readonly deliveries: Deliveries;
   private data: SessionData;
 
   constructor(private readonly http: Http, data: SessionData, clientToken?: string) {
     this.data = data;
     this.clientToken = clientToken;
+    this.destinations = new Destinations(http, data.id);
+    this.deliveries = new Deliveries(http, data.id);
   }
 
   get id(): string { return this.data.id; }
@@ -105,6 +111,31 @@ export class Session {
   /** Read a page of events without streaming. */
   listEvents(opts: { after?: number; level?: Level; type?: string; limit?: number } = {}): Promise<ListPage<Event>> {
     return this.http.request("GET", `/sessions/${this.id}/events`, { query: opts as Query });
+  }
+
+  /** Fetch a single event by id. */
+  event(eventId: string): Promise<Event> {
+    return this.http.request("GET", `/sessions/${this.id}/events/${eventId}`);
+  }
+
+  /** Fetch a blob-backed event body (large outputs) as text. */
+  async eventContent(eventId: string): Promise<string> {
+    return (await this.http.raw("GET", `/sessions/${this.id}/events/${eventId}/content`)).text();
+  }
+
+  /** User-message history (alias for level=user + type=*.message). */
+  messages(opts: { after?: number; limit?: number } = {}): Promise<ListPage<Event>> {
+    return this.http.request("GET", `/sessions/${this.id}/messages`, { query: opts as Query });
+  }
+
+  /** Per-turn history (timing + outcome). */
+  turns(): Promise<Turn[]> {
+    return this.http
+      .request<{ data?: Turn[] } | Turn[]>("GET", `/sessions/${this.id}/turns`)
+      .then((r) => (Array.isArray(r) ? r : r.data ?? []));
+  }
+  turn(turnId: string): Promise<Turn> {
+    return this.http.request("GET", `/sessions/${this.id}/turns/${turnId}`);
   }
 
   /** Send a message; wakes the session. */

--- a/sdks/typescript/src/agents/sse.ts
+++ b/sdks/typescript/src/agents/sse.ts
@@ -1,0 +1,38 @@
+import type { Event } from "./types.js";
+import { normalize } from "./normalize.js";
+
+// Parse a `text/event-stream` Response body into normalized events. Web-standard only
+// (ReadableStream + TextDecoder) — works in Node 18+, browsers, Workers, and Deno. No
+// EventSource (can't set auth headers) and no dependencies.
+export async function* parseEventStream(res: Response): AsyncGenerator<Event> {
+  const body = res.body;
+  if (!body) return;
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let i: number;
+      while ((i = buf.indexOf("\n\n")) !== -1) {
+        const frame = buf.slice(0, i);
+        buf = buf.slice(i + 2);
+        const data = frameData(frame);
+        if (data) yield normalize<Event>(JSON.parse(data));
+      }
+    }
+  } finally {
+    try { await reader.cancel(); } catch { /* already closed */ }
+  }
+}
+
+function frameData(frame: string): string | null {
+  const data = frame
+    .split("\n")
+    .filter((l) => l.startsWith("data:"))
+    .map((l) => l.slice(5).replace(/^ /, ""))
+    .join("\n");
+  return data || null;
+}

--- a/sdks/typescript/src/agents/types.ts
+++ b/sdks/typescript/src/agents/types.ts
@@ -38,8 +38,6 @@ export interface LastTurn {
   error?: unknown;
 }
 
-export interface SessionUsage { activeSeconds?: number; usd?: number; tokens?: number; }
-
 export interface SessionData {
   id: string;
   status: SessionStatus;
@@ -48,7 +46,6 @@ export interface SessionData {
   agentSnapshot?: { promptHash?: string; model?: string; runtime?: string; revision?: number };
   credentialId?: string;
   lastTurn?: LastTurn;
-  usage?: SessionUsage;
   limits?: Limits;
   key?: string;
   createdAt?: string;

--- a/sdks/typescript/src/agents/types.ts
+++ b/sdks/typescript/src/agents/types.ts
@@ -1,7 +1,7 @@
 // Domain types for the Durable Agent Sessions API (v3). Field names are camelCase —
 // the client normalizes the API's snake_case at the boundary.
 
-export type SessionStatus = "queued" | "running" | "idle" | "failed" | "archived";
+export type SessionStatus = "queued" | "running" | "awaiting_input" | "idle" | "failed" | "archived";
 export type Level = "user" | "progress" | "internal";
 export type YieldReason =
   | "completed" | "needs_input" | "error"
@@ -29,7 +29,7 @@ export interface Agent {
 }
 
 export interface LastTurn {
-  state?: "queued" | "running" | "ok" | "error";
+  state?: "queued" | "accepted" | "running" | "ok" | "error";
   yieldReason?: YieldReason;
   turnId?: string;
   startedAt?: string;
@@ -40,7 +40,7 @@ export interface LastTurn {
 
 export interface Turn {
   id: string;
-  state?: "queued" | "running" | "ok" | "error";
+  state?: "queued" | "accepted" | "running" | "ok" | "error";
   yieldReason?: YieldReason;
   resultEventId?: string;
   error?: unknown;
@@ -54,6 +54,7 @@ export interface SessionData {
   head?: number;
   inputCursor?: number;
   agentSnapshot?: { promptHash?: string; model?: string; runtime?: string; revision?: number };
+  agentId?: string;
   credentialId?: string;
   lastTurn?: LastTurn;
   limits?: Limits;
@@ -71,25 +72,34 @@ export interface Credential {
 
 export interface Destination {
   id: string;
+  session: string;
+  kind: string;
   url: string;
   level: Level;
-  types?: string[];
+  types?: string[] | null;
   includeRaw: boolean;
   enabled: boolean;
+  hasSecret: boolean;
+  createdAfterSeq?: number;
   createdAt?: string;
+  updatedAt?: string;
 }
 
 export type DeliveryStatus = "pending" | "delivering" | "delivered" | "failed" | "dead_letter";
 
 export interface Delivery {
   id: string;
-  destinationId: string;
+  session: string;
+  destination: string;
   eventId: string;
+  eventSeq?: number;
   status: DeliveryStatus;
   attempts: number;
   lastAttemptAt?: string;
   responseCode?: number;
   error?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 // ── Events ─────────────────────────────────────────────────────────────────────
@@ -103,6 +113,10 @@ export interface EventBase {
   session: string;
   actor: Actor;
   level: Level;
+  turnId?: string;
+  contentRef?: string;
+  bodyTruncated?: boolean;
+  bodyBytes?: number;
   refs: Record<string, unknown>;
 }
 

--- a/sdks/typescript/src/agents/types.ts
+++ b/sdks/typescript/src/agents/types.ts
@@ -38,6 +38,16 @@ export interface LastTurn {
   error?: unknown;
 }
 
+export interface Turn {
+  id: string;
+  state?: "queued" | "running" | "ok" | "error";
+  yieldReason?: YieldReason;
+  resultEventId?: string;
+  error?: unknown;
+  startedAt?: string;
+  completedAt?: string;
+}
+
 export interface SessionData {
   id: string;
   status: SessionStatus;
@@ -57,6 +67,29 @@ export interface Credential {
   name?: string;
   last4?: string;
   createdAt?: string;
+}
+
+export interface Destination {
+  id: string;
+  url: string;
+  level: Level;
+  types?: string[];
+  includeRaw: boolean;
+  enabled: boolean;
+  createdAt?: string;
+}
+
+export type DeliveryStatus = "pending" | "delivering" | "delivered" | "failed" | "dead_letter";
+
+export interface Delivery {
+  id: string;
+  destinationId: string;
+  eventId: string;
+  status: DeliveryStatus;
+  attempts: number;
+  lastAttemptAt?: string;
+  responseCode?: number;
+  error?: string;
 }
 
 // ── Events ─────────────────────────────────────────────────────────────────────

--- a/sdks/typescript/src/agents/types.ts
+++ b/sdks/typescript/src/agents/types.ts
@@ -1,0 +1,87 @@
+// Domain types for the Durable Agent Sessions API (v3). Field names are camelCase —
+// the client normalizes the API's snake_case at the boundary.
+
+export type SessionStatus = "queued" | "running" | "idle" | "failed" | "archived";
+export type Level = "user" | "progress" | "internal";
+export type YieldReason =
+  | "completed" | "needs_input" | "error"
+  | "budget_exceeded" | "deadline_exceeded" | "max_turns" | "canceled";
+
+export interface Limits { tokens?: number; turnSeconds?: number; turns?: number; }
+
+export interface Actor {
+  id?: string;
+  kind?: "human" | "agent" | "system" | (string & {});
+  display?: string;
+}
+
+export interface Agent {
+  id: string;
+  name: string;
+  promptHash?: string;
+  model: string;
+  runtime: string;
+  revision?: number;
+  credentialId?: string | null;
+  limits?: Limits;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface LastTurn {
+  state?: "queued" | "running" | "ok" | "error";
+  yieldReason?: YieldReason;
+  turnId?: string;
+  startedAt?: string;
+  completedAt?: string;
+  resultEventId?: string;
+  error?: unknown;
+}
+
+export interface SessionUsage { activeSeconds?: number; usd?: number; tokens?: number; }
+
+export interface SessionData {
+  id: string;
+  status: SessionStatus;
+  head?: number;
+  inputCursor?: number;
+  agentSnapshot?: { promptHash?: string; model?: string; runtime?: string; revision?: number };
+  credentialId?: string;
+  lastTurn?: LastTurn;
+  usage?: SessionUsage;
+  limits?: Limits;
+  key?: string;
+  createdAt?: string;
+}
+
+export interface Credential {
+  id: string;
+  provider: string;
+  name?: string;
+  last4?: string;
+  createdAt?: string;
+}
+
+// ── Events ─────────────────────────────────────────────────────────────────────
+// Discriminated on `type`. Switch on it; don't parse prose. Unknown types fall through
+// the open member and still carry `body.text`/`summary`, so new types are non-breaking.
+
+export interface EventBase {
+  id: string;
+  seq: number;
+  ts: string;
+  session: string;
+  actor: Actor;
+  level: Level;
+  refs: Record<string, unknown>;
+}
+
+export type Event =
+  | (EventBase & { type: "user.message";   body: { text: string } })
+  | (EventBase & { type: "agent.message";  body: { text: string } })
+  | (EventBase & { type: "turn.started";   body: { turnId: string; inputFromSeq?: number; inputToSeq?: number } })
+  | (EventBase & { type: "turn.completed"; body: { turnId: string; yieldReason: YieldReason; resultEventId?: string } })
+  | (EventBase & { type: "tool.call";      body: { tool: string; argsSummary?: string } })
+  | (EventBase & { type: "exec.completed"; body: { command: string; exitCode: number; summary?: string; contentRef?: string; bytes?: number } })
+  | (EventBase & { type: "preview.url";    body: { url: string; port?: number } })
+  | (EventBase & { type: string;           body: Record<string, any> }); // forward-compat catch-all

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -13,7 +13,9 @@ export {
   type ScalingLockStatus,
   type AllowedHostsInfo,
 } from "./sandbox.js";
-export { Agent, type AgentEvent, type AgentConfig, type AgentStartOpts, type AgentSession, type McpServerConfig } from "./agent.js";
+export { SandboxAgent, type SandboxAgentEvent, type SandboxAgentConfig, type SandboxAgentStartOpts, type SandboxAgentSession, type McpServerConfig } from "./agent.js";
+// Managed Durable Agent Sessions (the OpenComputer client + Session handle).
+export * from "./agents/index.js";
 export { Filesystem, type EntryInfo } from "./filesystem.js";
 export { Exec, type ProcessResult, type RunOpts, type ExecSession, type ExecSessionInfo, type ExecStartOpts, type ExecAttachOpts } from "./exec.js";
 export { Mounts, type AddMountOpts, type MountInfo, type MountBackend } from "./mounts.js";

--- a/sdks/typescript/src/sandbox.ts
+++ b/sdks/typescript/src/sandbox.ts
@@ -1,4 +1,4 @@
-import { Agent } from "./agent.js";
+import { SandboxAgent } from "./agent.js";
 import { Filesystem } from "./filesystem.js";
 import { Exec } from "./exec.js";
 import { Mounts } from "./mounts.js";
@@ -228,7 +228,8 @@ export interface AllowedHostsInfo {
 export class Sandbox {
   readonly sandboxId: string;
   readonly id: string;
-  readonly agent: Agent;
+  /** @deprecated The in-sandbox agent is legacy — prefer managed agents (the `OpenComputer` client). */
+  readonly agent: SandboxAgent;
   readonly files: Filesystem;
   readonly exec: Exec;
   readonly mounts: Mounts;
@@ -268,7 +269,7 @@ export class Sandbox {
     this._sandboxDomain = data.sandboxDomain || "";
 
     // Always route through the CP — it handles readiness waiting and proxies to workers.
-    this.agent = new Agent(apiUrl, apiKey, this.sandboxId, "");
+    this.agent = new SandboxAgent(apiUrl, apiKey, this.sandboxId, "");
     this.files = new Filesystem(apiUrl, apiKey, this.sandboxId, "");
     this.exec = new Exec(apiUrl, apiKey, this.sandboxId, "");
     this.commands = this.exec; // backwards-compatible alias
@@ -456,7 +457,7 @@ export class Sandbox {
     this.token = data.token || "";
 
     // Always route through the CP
-    (this as any).agent = new Agent(this.apiUrl, this.apiKey, this.sandboxId, "");
+    (this as any).agent = new SandboxAgent(this.apiUrl, this.apiKey, this.sandboxId, "");
     (this as any).files = new Filesystem(this.apiUrl, this.apiKey, this.sandboxId, "");
     (this as any).exec = new Exec(this.apiUrl, this.apiKey, this.sandboxId, "");
     (this as any).mounts = new Mounts(this.apiUrl, this.apiKey, this.sandboxId, "");
@@ -724,7 +725,7 @@ export class Sandbox {
     this.token = data.token || "";
 
     // Always route through the CP
-    (this as any).agent = new Agent(this.apiUrl, this.apiKey, this.sandboxId, "");
+    (this as any).agent = new SandboxAgent(this.apiUrl, this.apiKey, this.sandboxId, "");
     (this as any).files = new Filesystem(this.apiUrl, this.apiKey, this.sandboxId, "");
     (this as any).exec = new Exec(this.apiUrl, this.apiKey, this.sandboxId, "");
     (this as any).mounts = new Mounts(this.apiUrl, this.apiKey, this.sandboxId, "");


### PR DESCRIPTION
## Summary

Adds a first-class **managed Durable Agent Sessions** client to `@opencomputer/sdk` (0.7.0) and makes the docs dual-surface (TypeScript SDK + REST).

### SDK — `@opencomputer/sdk` 0.7.0
- **New managed surface** under `src/agents/` (re-exported from the package root), edge-first (zero runtime deps, `fetch` + web streams — Node 18+, browsers, Workers, Deno):
  - `OpenComputer` client → `agents`, `sessions`, `credentials`.
  - `Session` handle → `events()` (SSE async-iterator, reconnect-from-cursor, `AbortSignal`), `listEvents`/`event`/`eventContent`/`messages`, `steer`, `result`, `turns`/`turn`, `cancel`/`archive`, `mintClientToken`, and `destinations.*` / `deliveries.*`.
  - Browser `connectSession({ sessionId, clientToken })` — talks to OC directly, never the org key.
  - Discriminated `Event` union, snake_case→camelCase normalization, typed `OpenComputerError` hierarchy + 429/5xx retry.
- **1:1 with the public `/v3` API** — audited against the deployed routes; every public endpoint has a method and vice-versa. Internal turn-token/worker routes (`POST …/events` append, `/sandbox/*`, `/internal/*`) are excluded by design.
- **Renamed the in-sandbox agent**: `Agent*` → `Sandbox*`, marked `@deprecated` (frees the `Agent`/`Session` nouns for the managed client; the sandbox agent is a low-level primitive). Coexists with `Sandbox.create()`.

### Docs (`docs/agent-sessions/*`)
- Every call example is **dual-surface**: `<CodeGroup>` tabs on the walkthrough pages (**TypeScript SDK** default + **REST API** / **EventSource**), and a **page-wide synced toggle** on the renamed **API / SDK reference**.
- Removed the unimplemented per-session `usage` field from the v3 SDK + docs (backend doesn't populate it yet).

## Notes
- `tsc` clean; managed surface smoke-tested against live `api.opencomputer.dev/v3`.
- `usage` / token-budget enforcement is a known backend gap (turn usage isn't captured yet) — out of scope here.
- Old in-sandbox `Agent*` imports break (intentional, fine at 0.x); deprecation points users to the managed client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
