### PR TITLE
sdk: bump @opencomputer/sdk to 0.7.1 (publish #393 connectSession fix)

### DIFF
--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
#393 merged the connectSession client-token fix (drops the org-only `GET /sessions/:id` pre-fetch; browser client tokens can now stream + steer) but did not bump the version, so the publish workflow no-op'd against the existing 0.7.0. This bumps to **0.7.1** so the fix ships to npm.

Once published, the oc-sessions-demos example will depend on `^0.7.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)