### PR TITLE
docs: revert to default mint theme (preserve colors)

### DIFF
--- a/docs/agent-sessions/agents.mdx
+++ b/docs/agent-sessions/agents.mdx
@@ -1,4 +1,5 @@
 ---
+mode: "wide"
 title: "Agents"
 description: "Reusable agent configuration"
 ---

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -1,5 +1,4 @@
 ---
-mode: "wide"
 title: "API / SDK reference"
 description: "Every endpoint in the Durable Agent Sessions API, with its TypeScript SDK call"
 ---

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -1,4 +1,5 @@
 ---
+mode: "wide"
 title: "API / SDK reference"
 description: "Every endpoint in the Durable Agent Sessions API, with its TypeScript SDK call"
 ---

--- a/docs/agent-sessions/artifacts.mdx
+++ b/docs/agent-sessions/artifacts.mdx
@@ -1,4 +1,5 @@
 ---
+mode: "wide"
 title: "Artifacts & previews"
 description: "A session's published outputs — live previews and durable files (coming soon)"
 ---

--- a/docs/agent-sessions/authentication.mdx
+++ b/docs/agent-sessions/authentication.mdx
@@ -1,4 +1,5 @@
 ---
+mode: "wide"
 title: "Authentication"
 description: "Org keys, browser-safe client tokens, and bring-your-own model keys"
 ---

--- a/docs/agent-sessions/channels.mdx
+++ b/docs/agent-sessions/channels.mdx
@@ -1,4 +1,5 @@
 ---
+mode: "wide"
 title: "Channels"
 description: "Talk to a session where people already work — Slack, GitHub (coming soon)"
 ---
@@ -9,6 +10,6 @@ A **channel** binds a session's thread to a place people already work, so the sa
 
 - **Inbound.** A Slack `@mention` or thread reply is verified, de-duplicated, and appended to the session as a [steer](/agent-sessions/messaging) — the same inbound message you can post over the API.
 - **Outbound.** The platform projects the session's `user` and `progress` [events](/agent-sessions/events#visibility-levels) back to the thread. The agent never calls Slack itself — it appends events; the platform delivers them, durably and idempotently.
-- **Additive bindings.** A session has a set of bindings added over its life; it is never typed as "a Slack session" or "a GitHub session." A chat-born session that opens a PR gains a binding to that PR. Routing follows event level — conversation goes to conversation bindings, work product to delivery targets.
+- **Bindings accumulate.** A session gains bindings over its life; it is never typed as "a Slack session" or "a GitHub session." A chat-born session that opens a PR gains a binding to that PR. Routing follows event level — conversation goes to conversation bindings, work product to delivery targets.
 
 A channel is one consumer of the same public API a custom UI uses: post messages in, render the [event stream](/agent-sessions/events) at the level you want, and optionally bind a thread so the platform projects for you.

--- a/docs/agent-sessions/custom-runtimes.mdx
+++ b/docs/agent-sessions/custom-runtimes.mdx
@@ -1,4 +1,5 @@
 ---
+mode: "wide"
 title: "Custom runtimes"
 description: "Package any agent harness as a runtime (coming soon)"
 ---

--- a/docs/agent-sessions/events.mdx
+++ b/docs/agent-sessions/events.mdx
@@ -1,9 +1,25 @@
 ---
 title: "Events"
-description: "The append-only log: envelope, levels, cursors, and resume"
+description: "The append-only log: read, stream, filter by level, and resume"
 ---
 
-Every session step is an **event** appended in order. Read events, stream them live, or resume from any `seq`. Use the same stream for chat, activity feeds, notifications, and audit trails by filtering on **level**.
+A session is an **append-only log of events**: every step the agent takes is appended in order. You **read** it, **stream** it live, **filter** it by who should see each event (`level`), and **resume** from any point. Switch on the event **`type`**, don't parse prose.
+
+## Events in a turn
+
+When a turn runs it appends events in order — here, the agent runs the tests, sees them fail, and replies:
+
+```text
+turn.started
+  tool.call         npm test
+  exec.completed    exit 1
+  agent.message     "3 tests fail"   (level: user)
+turn.completed      needs_input
+```
+
+Everything between `turn.started` and `turn.completed` is that turn's work. **`turn.completed` is the "done" signal — await it** and read its `yield_reason` (here, `needs_input`). The `body` each type carries is in the table below.
+
+Each event is one envelope:
 
 ```json
 { "id": "evt_…", "seq": 12, "ts": "…", "session": "sess_…",
@@ -12,18 +28,11 @@ Every session step is an **event** appended in order. Read events, stream them l
   "body": { "text": "3 tests fail in auth.spec.ts" } }
 ```
 
-- **`id`** — the event's own unique id (`evt_…`). The client idempotency key for steering is separate (deduped per session — see [steering](/agent-sessions/messaging)).
-- **`turn_id`** — the turn that produced the event, when applicable; filter a turn's output with `?turn_id=`.
-- **`type`** — the one discriminator: a namespaced string (`agent.message`, `turn.completed`, …). See below.
-- **`actor`** — who produced it: `{ id, display?, type: "human" | "agent" | "system" }`.
-- **`level`** — visibility; see below.
-- **`body`** — the event payload.
+The two fields you act on are **`type`** (what happened — the discriminator) and **`level`** (who should see it). `seq` orders and resumes the log, `body` is the payload, and `actor` is who produced it (`{ id, display?, type: "human" | "agent" | "system" }`). The full field reference lives in the [API reference](/agent-sessions/api-reference); inbound and outbound messages share one [envelope](/agent-sessions/messaging#message-envelope) shape.
 
-Inbound and outbound messages share one [envelope](/agent-sessions/messaging#message-envelope) shape.
+## Event types
 
-## Event shape
-
-Treat the top-level **`type`** as the stable discriminator — **switch on it, don't parse prose.** Unknown types render fine from their `text`/`summary`, so new ones are additive. (There's no separate `kind`; coarse buckets are just `type` prefixes like `turn.*` or `agent.*`.)
+Treat **`type`** as the stable discriminator — switch on it, don't parse prose. Unknown types render fine from their `text`/`summary`, so new ones won't break your UI. Match a prefix like `turn.*` or `agent.*` for coarse buckets.
 
 | `type` | `body` shape | Use it for |
 | --- | --- | --- |
@@ -35,15 +44,11 @@ Treat the top-level **`type`** as the stable discriminator — **switch on it, d
 | `exec.completed` | `{ command, exit_code, summary, content_ref?, bytes? }` | a finished command |
 | `error.runtime` · `error.model` · `error.task` | `{ code, message, retriable? }` | a failure |
 
-**Coming soon** (already shaped, additive): `test.results`, `diff`/`patch`, `pr.result`, `preview.url`, `action.required` (agent needs an approval / tool result).
-
-**Correlate a steer to its turn.** Steers coalesce — one turn can pick up several — so [`POST /messages`](/agent-sessions/messaging) returns the *event* `seq`, not a turn. The turn that consumes your steer emits `turn.started` with `input_from_seq ≤ your_seq ≤ input_to_seq`; await its `turn.completed`, then `GET …/events?turn_id=` for everything it produced.
-
-**Large output.** A large `body` is offloaded to a `content_ref`; fetch the bytes with `GET /sessions/:id/events/:eventId/content` (e.g. full `exec.completed` output). Richer **artifacts** (named files, diffs, screenshots, reports) have a first-class [artifacts & previews API](/agent-sessions/artifacts) **coming soon**.
+**Coming soon**: `test.results`, `diff`/`patch`, `pr.result`, `preview.url`, `action.required` (agent needs an approval / tool result).
 
 ## Visibility levels
 
-Every event carries a `level`. Use it to choose how much detail each surface receives.
+Every event carries a `level` — use it to choose how much detail each surface receives.
 
 | Level | Contains | Use for |
 | --- | --- | --- |
@@ -51,20 +56,32 @@ Every event carries a `level`. Use it to choose how much detail each surface rec
 | `progress` | Plain-language work updates. | Activity feeds and status lines. |
 | `internal` | Tool calls and runtime detail. | Debug consoles and audit trails. |
 
-The model's private reasoning is never surfaced. Webhooks default to `user`.
-
 Filtering is **cumulative** — `user` is the narrowest, `internal` is everything:
 
 - `?level=user` → just `user`
 - `?level=progress` → `progress` + `user`
 - `?level=internal` → everything
 
-So a customer-facing chat asks for `user`; an agent-activity view asks for `progress`; debugging your agent asks for `internal`.
+So customer-facing chat asks for `user`, an agent-activity view for `progress`, and debugging for `internal`. The model's private reasoning is never surfaced; webhooks default to `user`.
 
-## Cursors
+## Cursors and resume
 
 - **`seq`** — a monotonic id assigned to each event.
 - **`head`** — the highest `seq` in the session.
-- **`input_cursor`** — how far the *runtime* has consumed (a session field). As a **reader** you don't track this — you just pass `after=<seq>`.
+- **`input_cursor`** — how far the *runtime* has consumed (a session field). As a **reader** you ignore it and just pass `after=<seq>`.
 
-Read or stream with `after=<seq>` and you get everything since that point. This is how **resume** works: reconnect with the last `seq` you saw — you miss nothing and get no duplicates. In the browser, native `EventSource` does this automatically — each event's `seq` is the SSE `id`, so it resumes via `Last-Event-ID` on reconnect (see the [quickstart](/agent-sessions/quickstart)).
+Read or stream with `after=<seq>` to get everything since that point — this is how **resume** works: reconnect with the last `seq` you saw and you miss nothing and get no duplicates. In the browser, native `EventSource` does this for you — each event's `seq` is the SSE `id`, so it resumes via `Last-Event-ID` on reconnect (see the [quickstart](/agent-sessions/quickstart)).
+
+## Details
+
+<AccordionGroup>
+  <Accordion title="Correlate a steer to its turn">
+    Steers coalesce — one turn can pick up several — so [`POST /messages`](/agent-sessions/messaging) returns the *event* `seq`, not a turn. The turn that consumes your steer emits `turn.started` with `input_from_seq ≤ your_seq ≤ input_to_seq`; await its `turn.completed`, then `GET …/events?turn_id=` for everything it produced.
+  </Accordion>
+  <Accordion title="Large output and artifacts">
+    A large `body` is offloaded to a `content_ref`; fetch the bytes with `GET /sessions/:id/events/:eventId/content` (e.g. full `exec.completed` output). Richer **artifacts** (named files, diffs, screenshots, reports) get a first-class [artifacts & previews API](/agent-sessions/artifacts) **coming soon**.
+  </Accordion>
+  <Accordion title="id, turn_id, and idempotency keys">
+    **`id`** is the event's own unique id (`evt_…`). **`turn_id`** is the turn that produced the event, when applicable — filter a turn's output with `?turn_id=`. The client idempotency key for steering is separate from both (deduped per session — see [steering](/agent-sessions/messaging)).
+  </Accordion>
+</AccordionGroup>

--- a/docs/agent-sessions/messaging.mdx
+++ b/docs/agent-sessions/messaging.mdx
@@ -1,4 +1,5 @@
 ---
+mode: "wide"
 title: "Messaging"
 description: "Steer a session, and the shared message envelope"
 ---

--- a/docs/agent-sessions/overview.mdx
+++ b/docs/agent-sessions/overview.mdx
@@ -1,4 +1,5 @@
 ---
+mode: "wide"
 title: "Durable Agent Sessions"
 description: "Define an agent, then run resumable, steerable sessions"
 ---

--- a/docs/agent-sessions/quickstart.mdx
+++ b/docs/agent-sessions/quickstart.mdx
@@ -1,18 +1,12 @@
 ---
+mode: "wide"
 title: "Quickstart"
 description: "Start a session, stream it live, and steer it"
 ---
 
 Build the smallest useful Durable Agent Sessions integration: define an agent, start a session, stream its event log, then send follow-up messages with a scoped client token.
 
-<CardGroup cols={2}>
-  <Card title="Complete example app" icon="github" href="https://github.com/diggerhq/oc-sessions-demos">
-    A Lovable-style app builder using the same API calls.
-  </Card>
-  <Card title="API reference" icon="code" href="/agent-sessions/api-reference">
-    Endpoint details and response shapes.
-  </Card>
-</CardGroup>
+For the finished version, see the [example app](https://github.com/diggerhq/oc-sessions-demos); for every endpoint, the [API / SDK reference](/agent-sessions/api-reference).
 
 ## Prerequisites
 
@@ -68,6 +62,8 @@ Response:
 ```json
 { "id": "agt_...", "name": "quickstart-coder", "revision": 1 }
 ```
+
+<Note>Your Anthropic `key` is held in OpenComputer's [secret store](/sandboxes/secrets) (encrypted, write-only) and **never enters the sandbox**. The agent runs with a placeholder; an **egress proxy substitutes the real key in-flight** on the outbound call to Anthropic — so neither the model nor your agent's code ever sees it. Reuse one key across agents via a [credential](/agent-sessions/authentication#model-credentials).</Note>
 
 <Tip>`POST /agents` is idempotent by agent name, so it is fine to call this during application startup.</Tip>
 
@@ -214,8 +210,5 @@ Response:
   </Card>
   <Card title="API reference" icon="code" href="/agent-sessions/api-reference">
     Endpoint details and response shapes.
-  </Card>
-  <Card title="Example apps" icon="github" href="https://github.com/diggerhq/oc-sessions-demos">
-    A repo of examples built on this API.
   </Card>
 </CardGroup>

--- a/docs/agent-sessions/runtime-tools.mdx
+++ b/docs/agent-sessions/runtime-tools.mdx
@@ -1,4 +1,5 @@
 ---
+mode: "wide"
 title: "Claude runtime tools"
 description: "The tools the claude runtime can use — what to rely on when you write prompts"
 ---

--- a/docs/agent-sessions/runtimes.mdx
+++ b/docs/agent-sessions/runtimes.mdx
@@ -1,4 +1,5 @@
 ---
+mode: "wide"
 title: "Runtimes"
 description: "The engine that runs your agent — claude today, more soon"
 ---
@@ -37,16 +38,16 @@ Each **turn is one bounded run**, invoke-style — it:
 
 Across turns it continues an on-box **journal**; the durable record is the event log *plus* that journal, which the platform checkpoints at each boundary and restores on recovery (see [Failure behavior](#failure-behavior)).
 
-### Supervision and recovery
+### Recovery
 
-A regional **supervisor** owns each running session and keeps the runtime healthy — you never restart anything:
+Sessions are fully managed — you never restart anything yourself:
 
-- **One driver at a time.** The supervisor holds a **fenced lease** on the session: exactly one runtime instance can write at a time, and the fence rejects writes from a stale instance (e.g. a slow machine that returns after it was given up), so a session never has two concurrent writers.
-- **Liveness.** The lease is renewed while a turn runs. If the runtime's machine dies, the lease lapses and the supervisor **re-claims the turn and continues it** from the journal.
-- **Crash / hang / lost machine.** A bad exit restarts the turn in place (bounded attempts, with crash-loop backoff); a hung turn is bounded by a **deadline** and ends `deadline_exceeded`; a lost machine is recreated and **restored from the last checkpoint**. Full matrix [below](#failure-behavior).
-- **A turn that can't start fails cleanly.** If the model key can't be resolved or the runtime image can't be fetched, the turn ends with an **`error` event carrying the reason** and the session returns to idle, rather than hanging.
-- **Backstop reconciler.** A periodic sweep re-dispatches work whose wake-up was missed, re-claims turns whose lease expired, and resets sessions left `running` after a crash, so stranded work is picked up.
-- **Observable.** Every turn and machine transition — turn start / complete / error, sandbox create / provision / hibernate, lease renew / fence — is recorded, so the platform can show exactly where a session is and why a turn ended the way it did.
+- **One writer at a time.** Only one runtime instance advances a session at any moment; a stale or slow instance that returns after it was replaced is rejected, so a session never has two concurrent writers and the log never forks.
+- **A lost machine is picked back up.** If the machine running a turn dies, the turn is continued from where it left off, not restarted from scratch.
+- **Crash, hang, lost machine.** A bad exit restarts the turn in place (bounded retries); a hung turn is cut off by a **deadline** and ends `deadline_exceeded`; a lost machine is recreated and **restored from its last checkpoint**. Full matrix [below](#failure-behavior).
+- **A turn that can't start fails cleanly.** If the model key can't be resolved or the runtime image can't be fetched, the turn ends with an **`error` event carrying the reason** and the session returns to idle — it doesn't hang.
+- **Nothing gets stranded.** A periodic safety sweep picks up any session whose work was missed or left mid-flight, so nothing stays stuck silently.
+- **Everything is recorded.** Every turn and sandbox transition is logged, so you can see where a session is and why a turn ended the way it did.
 
 ### Failure behavior
 

--- a/docs/agent-sessions/sessions.mdx
+++ b/docs/agent-sessions/sessions.mdx
@@ -1,4 +1,5 @@
 ---
+mode: "wide"
 title: "Sessions"
 description: "The durable, resumable unit of an agent's work"
 ---

--- a/docs/agent-sessions/triggers.mdx
+++ b/docs/agent-sessions/triggers.mdx
@@ -1,4 +1,5 @@
 ---
+mode: "wide"
 title: "Triggers"
 description: "Start and resume sessions from external events (coming soon)"
 ---

--- a/docs/agent-sessions/webhooks.mdx
+++ b/docs/agent-sessions/webhooks.mdx
@@ -1,4 +1,5 @@
 ---
+mode: "wide"
 title: "Webhooks"
 description: "Deliver a session's output, and control deliveries"
 ---
@@ -40,12 +41,33 @@ Content-Type: application/json
 
 `level` is the visibility threshold (`user` default, or `progress`); `types` is an optional event-type allow-list (default: all — which **includes the terminal `turn.completed`**); `include_raw: false` strips `body.raw` from the delivered Event. To get only completions, set `types: ["turn.completed"]`.
 
+<Tabs>
+
+<Tab title="TypeScript SDK">
+
+| Call | Purpose |
+| --- | --- |
+| `session.destinations.create(params)` | Register a destination. |
+| `session.destinations.list()` | List destinations. |
+| `session.destinations.get(did)` | Fetch one. |
+| `session.destinations.update(did, params)` | Pause or resume (`enabled`), retune `level`/`types`, or rotate `secret`. |
+| `session.destinations.delete(did)` | Remove. |
+
+</Tab>
+
+<Tab title="REST API">
+
 | Method · Path | Purpose |
 | --- | --- |
 | `POST /sessions/:id/destinations` | Register a destination. |
-| `GET /sessions/:id/destinations` · `GET …/:did` | List / fetch. |
+| `GET /sessions/:id/destinations` | List destinations. |
+| `GET /sessions/:id/destinations/:did` | Fetch one. |
 | `PATCH /sessions/:id/destinations/:did` | Pause or resume (`enabled`), retune `level`/`types`, or rotate `secret`. |
 | `DELETE /sessions/:id/destinations/:did` | Remove. |
+
+</Tab>
+
+</Tabs>
 
 A destination receives events appended **after** it's created. To capture a whole session, pass `webhook` in `POST /v3/sessions` so it's registered before the agent produces output. (Replaying earlier events with `backfill_from_seq` is coming soon.)
 
@@ -53,11 +75,29 @@ A destination receives events appended **after** it's created. To capture a whol
 
 Every send and its outcome — the data behind a deliveries dashboard.
 
+<Tabs>
+
+<Tab title="TypeScript SDK">
+
+| Call | Purpose |
+| --- | --- |
+| `session.deliveries.list(opts)` | List deliveries — status, attempts, last response/error. |
+| `session.deliveries.get(id)` | One delivery, in detail. |
+| `session.deliveries.redeliver(id)` | Re-send any delivery (not just dead-lettered). |
+
+</Tab>
+
+<Tab title="REST API">
+
 | Method · Path | Purpose |
 | --- | --- |
 | `GET /sessions/:id/deliveries?destination=&status=` | List deliveries — status, attempts, last response/error. |
 | `GET /sessions/:id/deliveries/:id` | One delivery, in detail. |
-| `POST /sessions/:id/deliveries/:id/redeliver` | Re-send — **any** delivery, not just dead-lettered. |
+| `POST /sessions/:id/deliveries/:id/redeliver` | Re-send any delivery (not just dead-lettered). |
+
+</Tab>
+
+</Tabs>
 
 A delivery moves `pending → delivering → delivered`, or `failed` (retrying) → `dead_letter` after the max attempts.
 
@@ -73,7 +113,7 @@ Delivery = {
 ## Signing, retries, and dedupe
 
 - **HTTPS only.** Private, loopback, link-local, and cloud-metadata addresses are refused.
-- **At-least-once.** Retried with exponential backoff; after the max attempts a delivery is **dead-lettered** (inspect and redeliver it above). A duplicate can still arrive — a send that succeeds as the worker dies, or a replayed turn — so **dedupe on `webhook-id`** (it equals the event id).
+- **At-least-once.** Retried with exponential backoff; after the max attempts a delivery is **dead-lettered** (inspect and redeliver it above). A duplicate can still arrive — a delivery interrupted after it reached you, or a replayed turn — so **dedupe on `webhook-id`** (it equals the event id).
 - **Signed with [Standard Webhooks](https://www.standardwebhooks.com).** Every request carries `webhook-id`, `webhook-timestamp`, and `webhook-signature` — so you can verify with an off-the-shelf library instead of hand-rolling. `webhook-signature` = `v1,<base64(HMAC-SHA256(secret, "{webhook-id}.{webhook-timestamp}.{rawBody}"))>`. Verify against the **raw request body, before parsing it**; `webhook-timestamp` guards replay; your `secret` (`whsec_…`) is write-only — set once, never returned. Plus `X-OC-Delivery-ID` and `X-OC-Session-ID` for correlation.
 - A delivery succeeds on HTTP `2xx`.
 

--- a/docs/agent-sessions/workspaces.mdx
+++ b/docs/agent-sessions/workspaces.mdx
@@ -1,4 +1,5 @@
 ---
+mode: "wide"
 title: "Workspaces"
 description: "Prepared repo environments, rebuilt on push (coming soon)"
 ---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "theme": "willow",
+  "theme": "mint",
   "name": "OpenComputer",
   "description": "Cloud sandboxes for running AI agents",
   "contextual": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -331,7 +331,7 @@
   "fonts": {
     "heading": {
       "family": "Newsreader",
-      "weight": 400
+      "weight": 600
     },
     "body": {
       "family": "Inter",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -89,6 +89,7 @@
       },
       {
         "group": "Reserved Capacity",
+        "tag": "Preview",
         "pages": [
           "reserved-capacity/overview",
           "reserved-capacity/concepts",

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -55,4 +55,5 @@ pre code {
 [data-component-part="card-title"] + .prose {
   font-size: 0.875rem;
   line-height: 1.5;
+  margin-top: 0.625rem; /* was mt-1 (4px) — too tight under the heading; give it air */
 }

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -79,3 +79,12 @@ pre code {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
+
+/* Sidebar item highlight — its own dial (independent of the surface radius above).
+   0 = square; bump to 0.125rem (2px) / 0.25rem (4px) for a little rounding. */
+:root {
+  --oc-sidebar-radius: 0;
+}
+#sidebar a {
+  border-radius: var(--oc-sidebar-radius);
+}

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -57,3 +57,16 @@ pre code {
   line-height: 1.5;
   margin-top: 0.625rem; /* was mt-1 (4px) — too tight under the heading; give it air */
 }
+
+/* Corner radius: OC's brand radius is 6px (the site's --radius). Mint already uses 6px for
+   small UI, but over-rounds the big surfaces to 16px (rounded-2xl). Bring code blocks,
+   callouts, and cards to the brand radius — crisper + consistent. Dial --oc-radius to taste
+   (0.25rem = crisper, 0 = terminal-sharp). Pills/badges (rounded-full) are left alone. */
+:root {
+  --oc-radius: 0.375rem;
+}
+[data-component-part="code-block-root"],
+[data-component-part="card"],
+.callout {
+  border-radius: var(--oc-radius);
+}

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -83,7 +83,7 @@ pre code {
 /* Sidebar item highlight — its own dial (independent of the surface radius above).
    0 = square; bump to 0.125rem (2px) / 0.25rem (4px) for a little rounding. */
 :root {
-  --oc-sidebar-radius: 0;
+  --oc-sidebar-radius: 0.125rem;
 }
 #sidebar a {
   border-radius: var(--oc-sidebar-radius);

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -58,15 +58,16 @@ pre code {
   margin-top: 0.625rem; /* was mt-1 (4px) — too tight under the heading; give it air */
 }
 
-/* Corner radius: OC's brand radius is 6px (the site's --radius). Mint already uses 6px for
-   small UI, but over-rounds the big surfaces to 16px (rounded-2xl). Bring code blocks,
-   callouts, and cards to the brand radius — crisper + consistent. Dial --oc-radius to taste
-   (0.25rem = crisper, 0 = terminal-sharp). Pills/badges (rounded-full) are left alone. */
+/* Corner radius: OC's brand radius is 6px (the site's --radius). Mint wires each rounded-*
+   utility to a --rounded-* variable (defaulting the big steps to 12–16px), so redefine those
+   at the source. This tightens code blocks (incl. nested/tabbed pieces), cards, callouts, and
+   sidebar items consistently — and avoids the corner/border mismatch a single-element override
+   caused. Pills (rounded-full) and the small step (rounded-md = 6px) are left as-is.
+   Dial --oc-radius: 0.25rem = crisper, 0 = terminal-sharp. */
 :root {
   --oc-radius: 0.375rem;
-}
-[data-component-part="code-block-root"],
-[data-component-part="card"],
-.callout {
-  border-radius: var(--oc-radius);
+  --rounded-lg: var(--oc-radius);
+  --rounded-xl: var(--oc-radius);
+  --rounded-2xl: var(--oc-radius);
+  --rounded-3xl: var(--oc-radius);
 }

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -44,3 +44,15 @@ pre code {
   background: #dfdfdf;
   color: #0f0f0f;
 }
+
+/* Cards read "off" because the title and body are both text-base (16px) — a flat 1:1 scale,
+   so the title never leads as a heading. Two fixes: give the title the UI sans (the inherited
+   display serif looks mis-sized at a 16px semibold label), and step the body down to 14px so
+   the title clearly leads. Title size/weight/color stay as Mintlify set them. */
+[data-component-part="card-title"] {
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+}
+[data-component-part="card-title"] + .prose {
+  font-size: 0.875rem;
+  line-height: 1.5;
+}

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500&display=swap');
 
 h5 {
   font-family: 'Inter', sans-serif;
@@ -21,4 +21,26 @@ h5 {
 }
 .dark #navbar a:has(.nav-logo)::after {
   color: #dfdfdf;
+}
+
+/* ── Subtle brand vibe — layered on mint, nothing structural ─────────────────── */
+
+/* Code is the brand's signature texture: Geist Mono (the site's monospace). Only the
+   typeface changes — Mintlify keeps its code-block chrome and syntax colors. */
+code,
+kbd,
+samp,
+pre,
+pre code {
+  font-family: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* Brand selection: ink-on-paper, inverted, matching opencomputer.dev's ::selection. */
+::selection {
+  background: #131311;
+  color: #f8f6f1;
+}
+.dark ::selection {
+  background: #dfdfdf;
+  color: #0f0f0f;
 }

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -88,3 +88,9 @@ pre code {
 #sidebar a {
   border-radius: var(--oc-sidebar-radius);
 }
+
+/* Nav tag pills (Preview / Coming soon) — 2px, matching the sidebar items.
+   Scoped to the tag only (not the shared rounded-md UI). */
+.nav-tag-pill-text[data-nav-tag] {
+  border-radius: var(--oc-sidebar-radius);
+}

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -71,3 +71,11 @@ pre code {
   --rounded-2xl: var(--oc-radius);
   --rounded-3xl: var(--oc-radius);
 }
+
+/* In a tabbed code group the content sits flush under the tab bar — square its top corners
+   so it reads as one unit (bottom corners keep the brand radius). */
+[data-component-part="code-group-tab-content"],
+[data-component-part="code-group-tab-content"] [data-component-part="code-block-root"] {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -1,3 +1,24 @@
+@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@500&display=swap');
+
 h5 {
   font-family: 'Inter', sans-serif;
+}
+
+/* Brand wordmark in the navbar — matches the marketing site (Geist Mono, medium, tight,
+   lowercase). Mintlify renders its logo as an <img>, which can't use a page web font, so
+   hide it and draw the wordmark. The :has(.nav-logo) selector targets the logo link by
+   structure, not a theme-specific class, so a theme change won't blank it. */
+#navbar .nav-logo {
+  display: none;
+}
+#navbar a:has(.nav-logo)::after {
+  content: "opencomputer";
+  font-family: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 500;
+  font-size: 1.125rem;
+  letter-spacing: -0.025em;
+  color: #131311;
+}
+.dark #navbar a:has(.nav-logo)::after {
+  color: #dfdfdf;
 }

--- a/docs/styles/custom.css
+++ b/docs/styles/custom.css
@@ -1,22 +1,3 @@
 h5 {
   font-family: 'Inter', sans-serif;
 }
-#navbar .nav-logo {
-  display: none;
-}
-#navbar a.select-none::before {
-  content: 'opencomputer';
-  font-family: 'Newsreader', serif;
-  font-size: 24px;
-  font-weight: 400;
-  letter-spacing: 0.01em;
-  transition: letter-spacing 0.3s ease;
-  color: #131311;
-}
-#navbar a:hover::before {
-  letter-spacing: 0.06em;
-}
-
-.dark #navbar a.select-none::before {
-  color: #dfdfdf;
-}


### PR DESCRIPTION
Prod was rendering the `willow` theme, which looked unpolished and differed from local dev (which shows the default look). Switch `theme` back to the default **`mint`**.

Colors are untouched — they're in the separate `colors` block (`#131311` etc.), independent of the theme.

Preview the Mintlify build on this PR before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)