### PR TITLE
docs(agent-sessions): session metadata + webhook delivery envelope

### DIFF
--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -53,7 +53,7 @@ const session = await oc.sessions.get("sess_...");        // server, org key
 
 </Tabs>
 
-`agent` is **required** (create a saved [agent](#agents) first); a resolvable Anthropic [credential](#credentials) is also required (`422 no_credential` otherwise). `key` gives get-or-create (one session per key); a request-level `Idempotency-Key` header makes a keyless create retry-safe. `input` is the task — a string or a full [envelope](/agent-sessions/messaging#message-envelope). For the managed `claude` runtime, put all task-critical context in the task text. `limits` `{ tokens, turn_seconds, turns }` are **non-monetary** — token budget, per-turn wall-clock, auto-run count; hitting one ends the turn with a matching `last_turn.yield_reason`. Destinations on an idempotent create-replay are ignored — manage them via the [destinations API](#destinations).
+`agent` is **required** (create a saved [agent](#agents) first); a resolvable Anthropic [credential](#credentials) is also required (`422 no_credential` otherwise). `key` gives get-or-create (one session per key); a request-level `Idempotency-Key` header makes a keyless create retry-safe. `metadata` is opaque **application routing state** — a JSON object (≤ 16 KB) stored on the session, returned by get/list, and delivered **verbatim in webhooks** so a callback handler can route to the right external record without a lookup; it is **never** shown to the model, **not** indexed/queryable, and distinct from `key` (get-or-create) and `Idempotency-Key` (dedupe). `input` is the task — a string or a full [envelope](/agent-sessions/messaging#message-envelope). For the managed `claude` runtime, put all task-critical context in the task text. `limits` `{ tokens, turn_seconds, turns }` are **non-monetary** — token budget, per-turn wall-clock, auto-run count; hitting one ends the turn with a matching `last_turn.yield_reason`. Destinations on an idempotent create-replay are ignored — manage them via the [destinations API](#destinations).
 
 Client tokens accept `scopes?` (subset of `read`, `steer`) and `ttl?` seconds, clamped to 60–86400 (SDK: `ttlSeconds`).
 
@@ -62,7 +62,9 @@ Session = { id, status, head, input_cursor,
             agent_snapshot: { prompt_hash, model, runtime, revision },
             agent_id, credential_id,   // resolved + pinned at create
             last_turn: { id, state, yield_reason?, result_event_id? },
-            limits: { tokens?, turn_seconds?, turns? }, key?, created_at }
+            limits: { tokens?, turn_seconds?, turns? },
+            metadata?,                 // opaque app routing state (null when unset)
+            key?, created_at }
 
 Turn = {
   id, state, yield_reason?, result_event_id?, error?,

--- a/docs/agent-sessions/webhooks.mdx
+++ b/docs/agent-sessions/webhooks.mdx
@@ -4,7 +4,20 @@ title: "Webhooks"
 description: "Deliver a session's output, and control deliveries"
 ---
 
-Register a **destination** and a session's [events](/agent-sessions/events) are delivered to it as **`Event` objects — the same shape the [SSE stream](/agent-sessions/events) emits** — at-least-once, signed, and retried. (Webhooks carry every event `type` — `turn.completed`, `exec.completed`, messages, … — not just messages.) Filter what you receive to avoid internal runtime detail.
+Register a **destination** and a session's [events](/agent-sessions/events) are delivered to it as a small **delivery envelope** — at-least-once, signed, and retried. The envelope carries top-level routing fields plus your session [`metadata`](/agent-sessions/api-reference#sessions), with the full event nested under `event`:
+
+```json
+{
+  "type": "turn.completed",          // the event type (route on this)
+  "sessionId": "ses_…",
+  "eventId": "evt_…",                 // == webhook-id (dedupe on it)
+  "metadata": { "owner": "acme", "repo": "widgets", "pullNumber": 42 },
+  "event": { "id": "evt_…", "seq": 12, "type": "turn.completed",
+             "level": "user", "actor": {…}, "body": {…}, "ts": "…" }
+}
+```
+
+`event` is the full [Event](/agent-sessions/events) — the same shape the [SSE stream](/agent-sessions/events) emits (the SSE stream delivers that bare Event; webhooks wrap it in this envelope). `metadata` is the opaque routing state you set at [create](/agent-sessions/api-reference#sessions), delivered **verbatim on every send and redelivery** (so a handler can route the callback without a lookup); it's `null` if unset. (Webhooks carry every event `type` — `turn.completed`, `exec.completed`, messages, … — not just messages.) Filter what you receive to avoid internal runtime detail.
 
 ## Destinations
 
@@ -39,7 +52,7 @@ Content-Type: application/json
 
 </CodeGroup>
 
-`level` is the visibility threshold (`user` default, or `progress`); `types` is an optional event-type allow-list (default: all — which **includes the terminal `turn.completed`**); `include_raw: false` strips `body.raw` from the delivered Event. To get only completions, set `types: ["turn.completed"]`.
+`level` is the visibility threshold (`user` default, or `progress`); `types` is an optional event-type allow-list (default: all — which **includes the terminal `turn.completed`**); `include_raw: false` strips `body.raw` from the delivered event (the envelope's `event.body.raw`). To get only completions, set `types: ["turn.completed"]`.
 
 <Tabs>
 


### PR DESCRIPTION
Documents the §006 session-metadata feature shipped + live in sessions-api.

## What
- **api-reference.mdx** — `metadata` on session create: opaque application routing state, a JSON object (≤ 16 KB), returned by get/list, delivered verbatim in webhooks, never model-visible, not indexed/queryable, distinct from `key`/`Idempotency-Key`. Added to the `Session` response shape.
- **webhooks.mdx** — the webhook delivery payload is now a **delivery envelope** `{ type, sessionId, eventId, metadata, event }`. The full Event is nested under `event` (the SSE stream still emits the bare Event); session `metadata` rides verbatim on every send + redelivery. Added a payload example; clarified `include_raw` targets `event.body.raw`.

## Note for reviewers
This changes the documented webhook payload: previously webhooks delivered the **bare Event** (same shape as SSE); now they deliver the **envelope** (Event under `.event` + routing fields + metadata). SSE is unchanged. Signing docs are unchanged — verification is over the raw request bytes, so it's shape-agnostic.

Backend: sessions-api `c75f201` (deployed). Follow-up (separate PR): SDK `metadata?` types on `CreateSessionParams`/session/delivery + a `verifyOpenComputerWebhook` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)