### PR TITLE
sdk(agents): session metadata on create + read

### DIFF
--- a/sdks/typescript/src/agents/sessions.ts
+++ b/sdks/typescript/src/agents/sessions.ts
@@ -17,6 +17,14 @@ export interface CreateSessionParams {
    */
   destinations?: Array<{ url: string; level?: Level; types?: string[]; includeRaw?: boolean; enabled?: boolean }>;
   limits?: Limits;
+  /**
+   * Opaque application routing state stored on the session — a JSON object (≤ 16 KB).
+   * Returned on `get`/`list` (as `session.snapshot.metadata`) and delivered verbatim in
+   * webhooks, so a callback handler can route to the right record without a lookup. It is
+   * never shown to the model and not indexed/queryable. Distinct from `key`
+   * (get-or-create) and `idempotencyKey` (dedupe).
+   */
+  metadata?: Record<string, unknown>;
   /** Makes a keyless create retry-safe (sent as the Idempotency-Key header). */
   idempotencyKey?: string;
 }

--- a/sdks/typescript/src/agents/types.ts
+++ b/sdks/typescript/src/agents/types.ts
@@ -58,6 +58,8 @@ export interface SessionData {
   credentialId?: string;
   lastTurn?: LastTurn;
   limits?: Limits;
+  /** Opaque app routing state set at create (`null` when unset). See {@link CreateSessionParams.metadata}. */
+  metadata?: Record<string, unknown> | null;
   key?: string;
   createdAt?: string;
 }


### PR DESCRIPTION
Types the §006 `metadata` field the v3 API now supports (backend shipped + live; docs in #397).

- `CreateSessionParams.metadata?: Record<string, unknown>` — opaque app routing state passed at create.
- `SessionData.metadata?: Record<string, unknown> | null` — returned by `get`/`list`, exposed as `session.snapshot.metadata`.

Types-only: the wire layer already passes `metadata` through opaquely (the `normalize` OPAQUE set), so `sessions.create` forwards it and reads return it unchanged — no request/response logic change. `tsc` green.

Follow-up (separate): a typed webhook-delivery envelope + `verifyOpenComputerWebhook` helper (the signing-side SDK piece).

🤖 Generated with [Claude Code](https://claude.com/claude-code)