### PR TITLE
sdk(agents): bump to 0.7.2 (release session metadata types)

### DIFF
--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
#398 added the `metadata` types but left the version at `0.7.1` (already on npm), so the `publish-ts-sdk` workflow **skipped publishing** (it no-ops when local version == published).

Patch bump `0.7.1 → 0.7.2` (package.json + package-lock.json) so the workflow publishes the metadata types on merge. Additive, types-only — patch is appropriate (matches the prior convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)