### PR TITLE
docs+sdk: runtime accuracy follow-ups (immutable runtime, native step stream, SDK LastTurn/metadata)

### DIFF
--- a/docs/agent-sessions/custom-runtimes.mdx
+++ b/docs/agent-sessions/custom-runtimes.mdx
@@ -25,12 +25,14 @@ GET /healthz
 ```json
 {
   "status": "ready",
-  "contract_version": "oc-runtime-http-2026-06-22",
+  "contract_version": "1",
   "busy": false
 }
 ```
 
 Return `busy: true` while a turn is running. A second turn should return `409`; OpenComputer already serializes real turns, so this is a safety check.
+
+<Note>`contract_version` (`"1"` today) is the internal runtime↔adapter version the built-ins use. The public custom-runtime contract isn't finalized yet, so this value may change when custom runtimes ship.</Note>
 
 ## Turn request
 
@@ -43,7 +45,7 @@ Content-Type: application/json
 
 ```json
 {
-  "contract_version": "oc-runtime-http-2026-06-22",
+  "contract_version": "1",
   "turn_id": "turn_...",
   "input": [
     { "role": "user", "content": "Review this repository." }
@@ -51,7 +53,7 @@ Content-Type: application/json
   "config": {
     "model": "anthropic/claude-opus-4-8",
     "system_prompt": "Run tests and explain risks.",
-    "mcp_endpoint": "http://127.0.0.1:4317/mcp",
+    "mcp_endpoint": "http://127.0.0.1:8765/mcp",
     "state_dir": "/home/sandbox/.oc/runtime-state"
   },
   "deadline_s": 600
@@ -62,22 +64,18 @@ The adapter has already read the event log. Your brain receives the new turn inp
 
 ## Step stream
 
-`POST /turn` responds with newline-delimited JSON. Each line is one step:
+`POST /turn` responds with newline-delimited JSON. The brain streams its SDK's **native** events verbatim, one per line, then a terminal `done`:
 
 ```jsonl
-{"seq":1,"kind":"message","visibility":"progress","text":"Reading files..."}
-{"seq":2,"kind":"message","visibility":"progress","text":"Running tests..."}
-{"seq":3,"kind":"done","reason":"quiescent"}
+{"seq":0,"kind":"assistant","msg":{ "...native SDK message..." }}
+{"seq":1,"kind":"user","msg":{ "...native SDK message, e.g. a tool result..." }}
+{"kind":"done","reason":"quiescent"}
 ```
 
-The adapter maps these steps to [session events](/agent-sessions/events), assigns stable idempotency keys, and flushes committed output before ending the turn.
+- `kind` is the SDK's message/event type; `msg` is the native object, unchanged.
+- `done.reason` is `quiescent` (nothing left to do), `awaiting_input` (the agent called `ask` and is paused for a reply), or `error` (with an `error`).
 
-Core step kinds:
-
-| Step | Purpose |
-| --- | --- |
-| `message` | Activity from the agent. Use `say` or `ask` for human-visible output. |
-| `done` | Terminal step. `reason` is `quiescent`, `awaiting_input`, or `error`. |
+The platform ships a **per-SDK adapter** that knows each SDK's shape: it maps these native events to [session events](/agent-sessions/events) with stable idempotency keys, and flushes committed output before ending the turn. (A single SDK-agnostic step protocol for fully custom runtimes is planned; until then, custom runtimes target an SDK the platform has an adapter for.)
 
 Tool calls, including user-visible `say` and `ask`, are made through MCP, not by emitting HTTP requests to OpenComputer.
 

--- a/docs/agent-sessions/runtimes.mdx
+++ b/docs/agent-sessions/runtimes.mdx
@@ -4,14 +4,14 @@ title: "Runtimes"
 description: "The engine that runs your agent — claude or codex, picked per agent"
 ---
 
-A **runtime** is the engine that executes the agent loop. You pick one per agent with `runtime`; it defaults to `claude`. The runtime image is stateless and interchangeable, and the model it runs is separate configuration — so an agent is just a runtime, a `provider/model`, and a matching [credential](/agent-sessions/authentication#model-credentials).
+A **runtime** is the engine that executes the agent loop — what's often called an **agent harness** (the loop plus its tools that drive the model). The two terms map 1:1; this doc says "runtime" because it's the API field. You pick one per agent with `runtime`; it defaults to `claude`. The runtime image is stateless and interchangeable, and the model it runs is separate configuration — so an agent is just a runtime, a `provider/model`, and a matching [credential](/agent-sessions/authentication#model-credentials).
 
 | Runtime | Models | Credential |
 | --- | --- | --- |
 | `claude` | `anthropic/…` (e.g. `anthropic/claude-opus-4-8`) | Anthropic key |
 | `codex` | `openai/…` (e.g. `openai/gpt-5-codex`) | OpenAI key |
 
-Sessions, [events](/agent-sessions/events), [steering](/agent-sessions/messaging), [tools](/agent-sessions/runtime-tools), and [webhooks](/agent-sessions/webhooks) work the same way whatever runtime you pick — switching is a one-line `runtime` change.
+Sessions, [events](/agent-sessions/events), [steering](/agent-sessions/messaging), [tools](/agent-sessions/runtime-tools), and [webhooks](/agent-sessions/webhooks) work the same way whatever runtime you pick — `runtime` is a single field on the [agent](/agent-sessions/agents), so the rest of your integration is identical across runtimes. (It's fixed once the agent exists; to switch engines, create a new agent with a different `runtime`.)
 
 ## `claude`
 
@@ -84,7 +84,7 @@ Across turns the brain keeps provider-specific state under a checkpointed state 
 
 ### Pinned per session
 
-When a session starts it pins the runtime and version it began on (alongside the rest of the [agent snapshot](/agent-sessions/agents#session-pinned-config)). Changing the agent's `runtime` afterwards never affects a running or resumed session — new sessions pick up the change; in-flight ones keep what they started with.
+When a session starts it pins the runtime and version it began on (alongside the rest of the [agent snapshot](/agent-sessions/agents#session-pinned-config)). `runtime` is fixed at agent creation — to run a different engine, create a new agent. Other agent edits (`model`, `prompt`, `limits`) never affect a running or resumed session: new sessions pick up the change, in-flight ones keep what they started with.
 
 ## Supervision and recovery
 

--- a/docs/agent-sessions/workspaces.mdx
+++ b/docs/agent-sessions/workspaces.mdx
@@ -17,6 +17,6 @@ oc workspace create web \
 
 - **Recipe.** One or more repos (each at an optional ref), a `setup` step, and an optional `warm` step to heat caches.
 - **Builds.** Rebuilt on every push (or on an interval) into an immutable lineage; a session boots from the latest successful build and pins it. `--pool N` keeps machines pre-booted.
-- **Resolution.** A session is not bound to a repo — it resolves which to work in from the triggering event, the conversation, an agent default, or by asking, via a `use_repo` tool. Resolution is lazy and re-resolvable: switch repos mid-session, or open several at once.
+- **Resolution.** A session is not bound to a repo — it resolves which to work in from the triggering event, the conversation, an agent default, or by asking. Resolution is lazy and re-resolvable: switch repos mid-session, or open several at once.
 
 Pairs with the scoped, tokenless private-repo access noted in [Runtime tools](/agent-sessions/runtime-tools).

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/agents/sessions.ts
+++ b/sdks/typescript/src/agents/sessions.ts
@@ -151,6 +151,8 @@ export class Session extends ClientSession {
 
   get status(): SessionStatus { return this.data.status; }
   get lastTurn(): LastTurn | undefined { return this.data.lastTurn; }
+  /** Opaque app routing state set at create (`null` when unset). See {@link CreateSessionParams.metadata}. */
+  get metadata(): Record<string, unknown> | null { return this.data.metadata ?? null; }
   /** The latest fetched session record. */
   get snapshot(): SessionData { return this.data; }
 

--- a/sdks/typescript/src/agents/types.ts
+++ b/sdks/typescript/src/agents/types.ts
@@ -29,9 +29,10 @@ export interface Agent {
 }
 
 export interface LastTurn {
+  /** The turn id (the API/SSE field is `last_turn.id`). */
+  id?: string;
   state?: "queued" | "accepted" | "running" | "ok" | "error";
   yieldReason?: YieldReason;
-  turnId?: string;
   startedAt?: string;
   completedAt?: string;
   resultEventId?: string;


### PR DESCRIPTION
Follow-up review fixes after #401, plus terminology and an SDK type correction.

## Docs
- **`runtimes.mdx`**: `runtime` is fixed at agent creation — removed the "switching is a one-line `runtime` change" and "changing the agent's `runtime` … new sessions pick up the change" claims (PATCH doesn't accept `runtime`). Clarified that **runtime ≈ agent harness** (the terms map 1:1; the API field is `runtime`).
- **`custom-runtimes.mdx`**: the `/turn` step stream is the SDK's **native** events (`{seq, kind, msg}` + a terminal `done`), not a generic `message`/`done` protocol — the platform ships a per-SDK adapter that maps them. `contract_version` shown as the real internal `"1"` (noted the public contract is still TBD); aligned the example `mcp_endpoint` port.
- **`workspaces.mdx`**: dropped the removed `use_repo` reference.

## SDK (`@opencomputer/sdk` 0.7.3 → 0.7.4)
- `LastTurn`: the field is **`id`** (matching the API/SSE `last_turn.id`), not `turnId` — the old type made correct user code fail to typecheck.
- `Session`: added a **`metadata`** getter so `session.metadata` actually resolves (matches the JSDoc + `SessionData`).

## Companion change (separate repo)
The [oc-runtime-examples](https://github.com/diggerhq/oc-runtime-examples) brain servers are being updated to match production (native streaming, real MCP wiring, the codex shell-disable + HTTP-transport recipe). These docs are aligned to that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)