### PR TITLE
sdk+docs: round 2 + verifyWebhook helper, README sessions-first

### DIFF
--- a/docs/agent-sessions/custom-runtimes.mdx
+++ b/docs/agent-sessions/custom-runtimes.mdx
@@ -54,9 +54,10 @@ Content-Type: application/json
     "model": "anthropic/claude-opus-4-8",
     "system_prompt": "Run tests and explain risks.",
     "mcp_endpoint": "http://127.0.0.1:8765/mcp",
-    "state_dir": "/home/sandbox/.oc/runtime-state"
-  },
-  "deadline_s": 600
+    "state_dir": "/home/sandbox/.oc/runtime-state",
+    "resume": false,
+    "max_turns": 24
+  }
 }
 ```
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/agents/normalize.test.ts
+++ b/sdks/typescript/src/agents/normalize.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { normalize, serialize } from "./normalize.js";
+
+describe("normalize (API response → idiomatic TS)", () => {
+  it("camelCases nested keys — last_turn → lastTurn, and the field is `id`", () => {
+    const out = normalize<{ lastTurn?: { id?: string; yieldReason?: string; resultEventId?: string } }>({
+      last_turn: { id: "trn_1", yield_reason: "completed", result_event_id: "evt_9" },
+    });
+    expect(out.lastTurn?.id).toBe("trn_1");
+    expect(out.lastTurn?.yieldReason).toBe("completed");
+    expect(out.lastTurn?.resultEventId).toBe("evt_9");
+  });
+
+  it("coerces known stringified-bigint numerics", () => {
+    const out = normalize<{ seq?: number; head?: number }>({ seq: "12", head: "3" });
+    expect(out.seq).toBe(12);
+    expect(out.head).toBe(3);
+  });
+
+  it("passes `metadata` through verbatim — opaque, inner keys untouched", () => {
+    const out = normalize<{ metadata?: Record<string, unknown> }>({
+      metadata: { pull_number: 42, owner_repo: "acme/widgets", nested: { keep_me: true } },
+    });
+    // Caller's routing JSON must round-trip exactly as set (no snake→camel mangling).
+    expect(out.metadata).toEqual({ pull_number: 42, owner_repo: "acme/widgets", nested: { keep_me: true } });
+  });
+});
+
+describe("serialize (request body → snake_case)", () => {
+  it("snake_cases keys but leaves metadata opaque", () => {
+    const out = serialize({ idempotencyKey: "k1", metadata: { pullNumber: 42 } }) as Record<string, unknown>;
+    expect(out.idempotency_key).toBe("k1");
+    expect(out.metadata).toEqual({ pullNumber: 42 }); // verbatim
+  });
+});

--- a/sdks/typescript/src/agents/normalize.ts
+++ b/sdks/typescript/src/agents/normalize.ts
@@ -1,6 +1,7 @@
 // Normalize API responses to idiomatic TS: snake_case keys → camelCase, and a known set
-// of numeric fields that the API serializes as strings (bigints) → numbers. Leaves the
-// opaque `raw` payload (source-specific adapter data) untouched.
+// of numeric fields that the API serializes as strings (bigints) → numbers. Opaque
+// subtrees are passed through untouched: `raw` (source-specific adapter data) and
+// `metadata` (the caller's own routing JSON — must round-trip verbatim, keys included).
 
 const NUMERIC = new Set([
   "seq", "head", "inputCursor", "inputFromSeq", "inputToSeq", "exitCode", "bytes", "port",
@@ -16,7 +17,7 @@ export function normalize<T = any>(value: unknown): T {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
       const ck = camel(k);
-      if (ck === "raw") { out[ck] = v; continue; }
+      if (ck === "raw" || ck === "metadata") { out[ck] = v; continue; }   // opaque: verbatim, keys untouched
       let nv: unknown = normalize(v);
       if (NUMERIC.has(ck) && typeof nv === "string" && nv !== "" && !Number.isNaN(Number(nv))) {
         nv = Number(nv);


### PR DESCRIPTION
Second SDK/docs review round + the top DX follow-up (`verifyWebhook`). Companion to oc-runtime-examples #1 and docs PR #405.

## SDK (`@opencomputer/sdk` 0.7.4 → 0.7.5)
- **`verifyWebhook(rawBody, headers, secret)`** — Standard Webhooks verification implemented with **Web Crypto** (no deps; runs in Node / Cloudflare Workers / browsers). Returns the parsed delivery envelope; throws on a missing/expired/invalid signature. Handles secret rotation (multi-signature header), constant-time compare, and timestamp tolerance. Top-level export, covered by `webhooks.test.ts` (6 cases). Closes the "signed-destination verification isn't discoverable from the SDK" gap.
- **`normalize`**: treat `metadata` as opaque on the response path so the caller's routing JSON round-trips verbatim (was snake→camel mangling keys, contradicting the docs + the `session.metadata` getter).
- **Tests**: added `normalize.test.ts` + `webhooks.test.ts`; `npm test` was a failing non-gate (no tests → exit 1), now passes (10 tests).
- **README**: leads with both sandboxes **and** Durable Agent Sessions, adds a sessions quick-start (agent bootstrap → session w/ metadata+destination → `verifyWebhook` → result), and clarifies `@opencomputer/sdk` is current vs the superseded `@opencomputer/agents-sdk`.

## Docs
- **`custom-runtimes.mdx`**: `/turn` request matches production (drop `deadline_s`, add `config.resume?`/`max_turns?`).
- **`webhooks.mdx`**: verify section now leads with the SDK helper (the Standard Webhooks library stays as the alternative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)