### PR TITLE
docs: sessions DX quick-wins (idempotency, models, input size, routing)

### DIFF
--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -15,7 +15,7 @@ const session = await oc.sessions.get("sess_...");        // server, org key
 // or, in a browser:  await connectSession({ sessionId, clientToken })
 ```
 
-<Note>The SDK returns the same objects with **camelCase** fields (`client_token` → `session.clientToken`, `created_at` → `createdAt`, `yield_reason` → `yieldReason`, …). The wire shapes below are the raw JSON.</Note>
+<Note>The SDK returns the same objects with **camelCase** fields (`client_token` → `session.clientToken`, `created_at` → `createdAt`, `last_turn` → `lastTurn`, `yield_reason` → `yieldReason`, `turn_seconds` → `turnSeconds`, …) and takes camelCase params (`idempotency_key` → `idempotencyKey`). The wire shapes below are the raw JSON. Opaque blobs you own — `metadata`, event `body`, `refs` — pass through **verbatim** (keys untouched) in both directions.</Note>
 
 ## Sessions
 
@@ -53,7 +53,7 @@ const session = await oc.sessions.get("sess_...");        // server, org key
 
 </Tabs>
 
-`agent` is **required** (create a saved [agent](#agents) first); a resolvable model [credential](#credentials) is also required (`422 no_credential` otherwise). `key` gives get-or-create (one session per key); a request-level `Idempotency-Key` header makes a keyless create retry-safe. `metadata` is opaque **application routing state** — a JSON object (≤ 16 KB) stored on the session, returned by get/list, and delivered **verbatim in webhooks** so a callback handler can route to the right external record without a lookup; it is **never** shown to the model, **not** indexed/queryable, and distinct from `key` (get-or-create) and `Idempotency-Key` (dedupe). `input` is the task — a string or a full [envelope](/agent-sessions/messaging#message-envelope). For the managed runtimes (`claude`, `codex`), put all task-critical context in the task text. `limits` `{ tokens, turn_seconds, turns }` are **non-monetary** — token budget, per-turn wall-clock, auto-run count; hitting one ends the turn with a matching `last_turn.yield_reason`. Destinations on an idempotent create-replay are ignored — manage them via the [destinations API](#destinations).
+`agent` is **required** (create a saved [agent](#agents) first); a resolvable model [credential](#credentials) is also required (`422 no_credential` otherwise). `key` gives get-or-create (one session per key); a request-level `Idempotency-Key` header makes a keyless create retry-safe. `metadata` is opaque **application routing state** — a JSON object (≤ 16 KB) stored on the session, returned by get/list, and delivered **verbatim in webhooks** so a callback handler can route to the right external record without a lookup; it is **never** shown to the model, **not** indexed/queryable, and distinct from `key` (get-or-create) and `Idempotency-Key` (dedupe). `input` is the task — a string or a full [envelope](/agent-sessions/messaging#message-envelope). For the managed runtimes (`claude`, `codex`), put all task-critical context in the task text. There's no fixed byte cap on `input`, but it counts against the model's context window — **truncate large inputs** (e.g. a PR diff) and have the agent pull the rest through its [sandbox tools](/agent-sessions/runtime-tools) (clone the repo, read files) rather than inlining it. `limits` `{ tokens, turn_seconds, turns }` are **non-monetary** — token budget, per-turn wall-clock, auto-run count; hitting one ends the turn with a matching `last_turn.yield_reason`. Destinations on an idempotent create-replay are ignored — manage them via the [destinations API](#destinations).
 
 Client tokens accept `scopes?` (subset of `read`, `steer`) and `ttl?` seconds, clamped to 60–86400 (SDK: `ttlSeconds`).
 
@@ -235,6 +235,8 @@ Delivery = {
 </Tabs>
 
 Create body: `name`, `prompt`, `model`, `runtime?` (`claude` | `codex`), `key?`, `credential?`, `limits?`. Patch accepts `prompt?`, `model?`, `key?`, `credential?`, and `limits?` — **not `runtime`, which is fixed at creation**. The `runtime` / `model` / credential provider must agree (`claude`↔`anthropic/…`, `codex`↔`openai/…`); this is validated at create, and a patched `model`/`credential` must stay within the runtime's provider.
+
+`POST /agents` is **idempotent by `name`**: a repeat with matching non-secret config (`prompt`/`model`/`runtime`/`limits`) returns the existing agent with `created: false` (HTTP 200), while differing config returns **409** — so it's safe to call on every app startup or deploy. (`key` is ignored on an idempotent hit — it never silently rotates.)
 
 Pass `key` **or** `credential` (or neither → org default). The agent's `limits` are the defaults for its sessions; a session's own `limits` override. Each agent has a monotonic `revision` (bumped on PATCH) that sessions pin in `agent_snapshot.revision`, so you can tell which version produced a run.
 

--- a/docs/agent-sessions/runtimes.mdx
+++ b/docs/agent-sessions/runtimes.mdx
@@ -11,6 +11,11 @@ A **runtime** is the engine that executes the agent loop — what's often called
 | `claude` | `anthropic/…` (e.g. `anthropic/claude-opus-4-8`) | Anthropic key |
 | `codex` | `openai/…` (e.g. `openai/gpt-5-codex`) | OpenAI key |
 
+`model` is passed straight through to the provider, so any model that provider serves works — only the **`provider/` prefix** is validated against the runtime (a bad prefix is rejected at agent create, a model the provider doesn't recognize fails on the first turn). Common choices:
+
+- **`claude`:** `anthropic/claude-opus-4-8` (most capable), `anthropic/claude-sonnet-4-6` (balanced), `anthropic/claude-haiku-4-5` (fastest/cheapest).
+- **`codex`:** `openai/gpt-5-codex`.
+
 Sessions, [events](/agent-sessions/events), [steering](/agent-sessions/messaging), [tools](/agent-sessions/runtime-tools), and [webhooks](/agent-sessions/webhooks) work the same way whatever runtime you pick — `runtime` is a single field on the [agent](/agent-sessions/agents), so the rest of your integration is identical across runtimes. (It's fixed once the agent exists; to switch engines, create a new agent with a different `runtime`.)
 
 ## `claude`

--- a/docs/agent-sessions/sessions.mdx
+++ b/docs/agent-sessions/sessions.mdx
@@ -67,6 +67,16 @@ Response:
 }
 ```
 
+<Tip>**For background jobs, don't poll — register a [destination](/agent-sessions/webhooks).** Polling `GET /…/result` ties up a request and doesn't survive your process restarting. The durable pattern: hand off at create (with `metadata` for routing + a `destination`), return, and let OpenComputer call your webhook on `turn.completed` — then fetch the result. Reserve `result()` polling for synchronous/interactive flows.</Tip>
+
+## Idempotency & routing
+
+Three independent knobs — don't overload one for another:
+
+- **`key`** — *get-or-create*. One session per natural key (e.g. one per PR). A second create with the same `key` returns the same session; reusing a `key` with a **different** request body is rejected (`create key already used with a different request`).
+- **`Idempotency-Key`** (header) — *retry-safe create*. Makes a keyless create safe to retry (e.g. on a webhook redelivery) without spawning duplicates.
+- **`metadata`** — *routing / app state*. Opaque JSON (≤ 16 KB) echoed back on get/list and **verbatim in webhooks**, so your callback can route to the right record. Never use `key` for routing — that's what `metadata` is for.
+
 ## Limits
 
 Cap a session at create (or default it on the [agent](/agent-sessions/agents)) with `limits: { tokens, turn_seconds, turns }` — a token budget, per-turn wall-clock, and auto-run count. These are **non-monetary** (no dollar caps — we don't bill model usage yet; you run on your own key). Hitting one ends the turn with the matching `yield_reason`.


### PR DESCRIPTION
Docs quick-wins from the PR-review demo's DX notes (`diggerhq/demo-pr-review-agent`). Tracked in `oc-bg-agents/.agents/work/sessions-dx-followups.md`.

- **api-reference**: idempotent `POST /agents` by name (matching config → existing/`200`, differing → `409` — safe to call on startup/deploy); `input` has no fixed byte cap but counts against the model context window (truncate large diffs, pull the rest via sandbox tools); extended the REST↔SDK camelCase note (`last_turn`, `turn_seconds`, `idempotency_key`) and called out that opaque blobs (`metadata`, `body`, `refs`) pass through verbatim.
- **runtimes**: recommended models per runtime, and that only the `provider/` prefix is validated (the specific model passes straight to the provider).
- **sessions**: a "don't poll — use destinations" tip for background jobs, and an **Idempotency & routing** section disambiguating `key` (get-or-create) / `Idempotency-Key` (retry-safe create) / `metadata` (routing).

Remaining follow-ups (separate): SDK `webhooks.verify` helper + README, and the larger items (structured results, private-repo `sources`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)