### PR TITLE
sdk+docs: verifyWebhook + webhook/contract consistency (0.7.6)

### DIFF
--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -11,11 +11,11 @@ Each section toggles between the **TypeScript** SDK (`@opencomputer/sdk`) and **
 import { OpenComputer, connectSession } from "@opencomputer/sdk";
 
 const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
-const session = await oc.sessions.get("sess_...");        // server, org key
+const session = await oc.sessions.get("ses_...");        // server, org key
 // or, in a browser:  await connectSession({ sessionId, clientToken })
 ```
 
-<Note>The SDK returns the same objects with **camelCase** fields (`client_token` → `session.clientToken`, `created_at` → `createdAt`, `last_turn` → `lastTurn`, `yield_reason` → `yieldReason`, `turn_seconds` → `turnSeconds`, …) and takes camelCase params (`idempotency_key` → `idempotencyKey`). The wire shapes below are the raw JSON. Opaque blobs you own — `metadata`, event `body`, `refs` — pass through **verbatim** (keys untouched) in both directions.</Note>
+<Note>The SDK returns the same objects with **camelCase** fields (`client_token` → `session.clientToken`, `created_at` → `createdAt`, `last_turn` → `lastTurn`, `yield_reason` → `yieldReason`, `turn_seconds` → `turnSeconds`, …) and takes camelCase params (`idempotency_key` → `idempotencyKey`). The wire shapes below are the raw JSON. Truly opaque blobs — your session `metadata` and an event's `raw` field — pass through **verbatim** (keys untouched) in both directions; everything else, **including event `body` and `refs`**, is camelCased like the rest.</Note>
 
 ## Sessions
 
@@ -42,7 +42,7 @@ const session = await oc.sessions.get("sess_...");        // server, org key
 | --- | --- |
 | `POST /sessions` | Start a session → `{ session, client_token }`. |
 | `GET /sessions/:id` | Fetch a session. |
-| `GET /sessions?status=&agent=&key=&after=&before=&limit=` | List sessions (filtered, paginated). |
+| `GET /sessions?status=&agent=&key=&after=&before=&limit=&cursor=` | List sessions (filtered, paginated; `cursor` = `nextCursor` from the previous page). |
 | `POST /sessions/:id/archive` | Cancel any active turn, then close (read-only). |
 | `POST /sessions/:id/cancel` | Cooperatively stop the active turn (no-op if not running). |
 | `GET /sessions/:id/result` | The result helper — `{ last_turn, result? }`. |
@@ -53,7 +53,7 @@ const session = await oc.sessions.get("sess_...");        // server, org key
 
 </Tabs>
 
-`agent` is **required** (create a saved [agent](#agents) first); a resolvable model [credential](#credentials) is also required (`422 no_credential` otherwise). `key` gives get-or-create (one session per key); a request-level `Idempotency-Key` header makes a keyless create retry-safe. `metadata` is opaque **application routing state** — a JSON object (≤ 16 KB) stored on the session, returned by get/list, and delivered **verbatim in webhooks** so a callback handler can route to the right external record without a lookup; it is **never** shown to the model, **not** indexed/queryable, and distinct from `key` (get-or-create) and `Idempotency-Key` (dedupe). `input` is the task — a string or a full [envelope](/agent-sessions/messaging#message-envelope). For the managed runtimes (`claude`, `codex`), put all task-critical context in the task text. There's no fixed byte cap on `input`, but it counts against the model's context window — **truncate large inputs** (e.g. a PR diff) and have the agent pull the rest through its [sandbox tools](/agent-sessions/runtime-tools) (clone the repo, read files) rather than inlining it. `limits` `{ tokens, turn_seconds, turns }` are **non-monetary** — token budget, per-turn wall-clock, auto-run count; hitting one ends the turn with a matching `last_turn.yield_reason`. Destinations on an idempotent create-replay are ignored — manage them via the [destinations API](#destinations).
+`agent` is **required** (create a saved [agent](#agents) first); a resolvable model [credential](#credentials) is also required (`422 no_credential` otherwise). `key` gives get-or-create (one session per key); a request-level `Idempotency-Key` header makes a keyless create retry-safe. `metadata` is opaque **application routing state** — a JSON object (≤ 16 KB) stored on the session, returned by get/list, and delivered **verbatim in webhooks** so a callback handler can route to the right external record without a lookup; it is **never** shown to the model, **not** indexed/queryable, and distinct from `key` (get-or-create) and `Idempotency-Key` (dedupe). `input` is the task — a string or a full [envelope](/agent-sessions/messaging#message-input). For the managed runtimes (`claude`, `codex`), put all task-critical context in the task text. There's no fixed byte cap on `input`, but it counts against the model's context window — **truncate large inputs** (e.g. a PR diff) and have the agent pull the rest through its [sandbox tools](/agent-sessions/runtime-tools) (clone the repo, read files) rather than inlining it. `limits` `{ tokens, turn_seconds, turns }` are **non-monetary** — token budget, per-turn wall-clock, auto-run count; hitting one ends the turn with a matching `last_turn.yield_reason`. Destinations on an idempotent create-replay are ignored — manage them via the [destinations API](#destinations).
 
 Client tokens accept `scopes?` (subset of `read`, `steer`) and `ttl?` seconds, clamped to 60–86400 (SDK: `ttlSeconds`).
 
@@ -106,7 +106,7 @@ Turn = {
 
 Filter events by `type` (exact or `prefix.*`), `turn_id`, and `limit`. `…/messages` is an alias for `level=user` + `type=*.message`.
 
-`after` resumes from a `seq`; `level` is a **visibility threshold** — `user` returns only user-facing events, `progress` adds work updates, `internal` adds everything (see [visibility levels](/agent-sessions/events#visibility-levels)). Omitting `level` defaults to `internal` (you get everything). Switch on [`type`](/agent-sessions/events#event-shape), don't parse prose.
+`after` resumes from a `seq`; `level` is a **visibility threshold** — `user` returns only user-facing events, `progress` adds work updates, `internal` adds everything (see [visibility levels](/agent-sessions/events#visibility-levels)). Omitting `level` defaults to `internal` (you get everything). Switch on [`type`](/agent-sessions/events#event-shape), don't parse prose. `type`/`turn_id` filtering applies to the **list** endpoint; the **SSE stream** filters by `level` + `after` server-side, so the SDK's `events({ type })` applies the type filter client-side as events arrive.
 
 ```
 Event = {
@@ -187,7 +187,7 @@ Destination body: `url`, `secret?`, `level?` (`user`), `types?[]`, `include_raw?
 
 | Method · Path | Purpose |
 | --- | --- |
-| `GET /sessions/:id/deliveries?destination=&status=` | List deliveries — status, attempts, last response/error. |
+| `GET /sessions/:id/deliveries?destination=&status=&after=&limit=` | List deliveries — status, attempts, last response/error (paginated). |
 | `GET /sessions/:id/deliveries/:id` | One delivery, in detail. |
 | `POST /sessions/:id/deliveries/:id/redeliver` | Re-send any delivery (not just dead-lettered). |
 
@@ -236,7 +236,7 @@ Delivery = {
 
 Create body: `name`, `prompt`, `model`, `runtime?` (`claude` | `codex`), `key?`, `credential?`, `limits?`. Patch accepts `prompt?`, `model?`, `key?`, `credential?`, and `limits?` — **not `runtime`, which is fixed at creation**. The `runtime` / `model` / credential provider must agree (`claude`↔`anthropic/…`, `codex`↔`openai/…`); this is validated at create, and a patched `model`/`credential` must stay within the runtime's provider.
 
-`POST /agents` is **idempotent by `name`**: a repeat with matching non-secret config (`prompt`/`model`/`runtime`/`limits`) returns the existing agent with `created: false` (HTTP 200), while differing config returns **409** — so it's safe to call on every app startup or deploy. (`key` is ignored on an idempotent hit — it never silently rotates.)
+`POST /agents` is **idempotent by `name`** — the outcome is in the **status code**, not a body field: a fresh create returns **201**; a repeat with matching non-secret config (`prompt`/`model`/`runtime`/`limits`) returns the existing agent with **200**; differing config returns **409**. Safe to call on every app startup or deploy. (`key` is ignored on a 200 hit — it never silently rotates.)
 
 Pass `key` **or** `credential` (or neither → org default). The agent's `limits` are the defaults for its sessions; a session's own `limits` override. Each agent has a monotonic `revision` (bumped on PATCH) that sessions pin in `agent_snapshot.revision`, so you can tell which version produced a run.
 

--- a/docs/agent-sessions/authentication.mdx
+++ b/docs/agent-sessions/authentication.mdx
@@ -44,7 +44,7 @@ You get one back from `POST /v3/sessions`, and can mint more:
 <CodeGroup>
 
 ```ts TypeScript SDK
-const session = await oc.sessions.get("sess_...");
+const session = await oc.sessions.get("ses_...");
 
 const clientToken = await session.mintClientToken({
   scopes: ["read", "steer"],
@@ -53,7 +53,7 @@ const clientToken = await session.mintClientToken({
 ```
 
 ```http REST API
-POST https://api.opencomputer.dev/v3/sessions/sess_.../client-tokens
+POST https://api.opencomputer.dev/v3/sessions/ses_.../client-tokens
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
 

--- a/docs/agent-sessions/events.mdx
+++ b/docs/agent-sessions/events.mdx
@@ -22,13 +22,13 @@ Everything between `turn.started` and `turn.completed` is that turn's work. **`t
 Each event is one envelope:
 
 ```json
-{ "id": "evt_…", "seq": 12, "ts": "…", "session": "sess_…",
+{ "id": "evt_…", "seq": 12, "ts": "…", "session": "ses_…",
   "actor": { "id": "agent", "type": "agent" },
   "type": "agent.message", "level": "user",
   "body": { "text": "3 tests fail in auth.spec.ts" } }
 ```
 
-The two fields you act on are **`type`** (what happened — the discriminator) and **`level`** (who should see it). `seq` orders and resumes the log, `body` is the payload, and `actor` is who produced it (`{ id, display?, type: "human" | "agent" | "system" }`). The full field reference lives in the [API reference](/agent-sessions/api-reference); inbound and outbound messages share one [envelope](/agent-sessions/messaging#message-envelope) shape.
+The two fields you act on are **`type`** (what happened — the discriminator) and **`level`** (who should see it). `seq` orders and resumes the log, `body` is the payload, and `actor` is who produced it (`{ id, display?, type: "human" | "agent" | "system" }`). The full field reference lives in the [API reference](/agent-sessions/api-reference); for messages, see how input fields map onto an event in [Messaging](/agent-sessions/messaging#message-input).
 
 ## Event types
 

--- a/docs/agent-sessions/messaging.mdx
+++ b/docs/agent-sessions/messaging.mdx
@@ -20,7 +20,7 @@ await live.steer("also check the CI config", { idempotencyKey: "msg_01" });
 ```
 
 ```http REST API
-POST https://api.opencomputer.dev/v3/sessions/sess_.../messages
+POST https://api.opencomputer.dev/v3/sessions/ses_.../messages
 Authorization: Bearer $CLIENT_TOKEN
 Content-Type: application/json
 
@@ -34,29 +34,35 @@ Content-Type: application/json
 
 Pass `idempotency_key` so retries (flaky network, double-click) are de-duplicated — applied at most once **per session**, so the same key is safe to reuse across different sessions.
 
-## Message envelope
+## Message input
 
-Every inbound and outbound message normalizes to this shape. The core fields are fixed; anything source-specific lives under `raw`, which the platform never interprets.
+Steer with `{ text, idempotency_key? }`, or a fuller **envelope** when you need a source or a threading anchor:
 
 ```json
 {
-  "id": "client:abc123",
-  "source": "client",
-  "kind": "message",
-  "actor": { "id": "client:user-7", "display": "Ada", "type": "human" },
-  "conversation": { "source": "client", "ref": "thread-42" },
-  "text": "also check the CI config",
-  "ts": "2026-06-18T12:00:00Z",
-  "raw": {}
+  "envelope": {
+    "id": "client:abc123",
+    "source": "client",
+    "conversation": { "source": "client", "ref": "thread-42" },
+    "text": "also check the CI config",
+    "refs": {},
+    "raw": {}
+  }
 }
 ```
 
-- **`id`** — the idempotency key, deduped **per session** (not global).
-- **`actor`** — who sent it (`human` | `agent` | `system`), namespaced.
-- **`conversation`** — an opaque reply/routing anchor.
-- **`text`** — the content the agent reads (or that you receive).
-- **`raw`** — untouched original payload; optional, never read by the core.
+These fields don't all land in one place — the appended [event](/agent-sessions/events) splits them:
 
-To deliver a session's output, register a webhook destination. Deliveries carry the full [Event](/agent-sessions/events) (a message event's `body` is this envelope) — see [Webhooks](/agent-sessions/webhooks).
+| You send | Lands on the event as |
+| --- | --- |
+| `text` | `body.text` — the content the agent reads |
+| `raw` | `body.raw` — untouched original payload (optional; never interpreted) |
+| `id` (or top-level `idempotency_key`) | the idempotency key, deduped **per session** |
+| `source`, `conversation`, `refs` | merged into the event's top-level `refs` — opaque routing/threading anchors |
+| (the sender) | the event's `actor` — `human` \| `agent` \| `system`, namespaced |
+
+So a `*.message` event's `body` is just `{ text, raw? }` — `source`/`conversation`/`refs` live under the event's top-level `refs`, and the sender under `actor` (not inside `body`). Outbound `agent.message` bodies are likewise `{ text }`.
+
+To deliver a session's output, register a webhook destination — deliveries carry the full [Event](/agent-sessions/events); see [Webhooks](/agent-sessions/webhooks).
 
 <Note>[Inbound channels](/agent-sessions/channels) (Slack, GitHub, Jira, email) are coming soon — they map onto this same envelope; today you steer in via the API.</Note>

--- a/docs/agent-sessions/quickstart.mdx
+++ b/docs/agent-sessions/quickstart.mdx
@@ -101,8 +101,8 @@ Response:
 
 ```json
 {
-  "session": { "id": "sess_...", "status": "queued", "head": 1 },
-  "client_token": "ct_..."
+  "session": { "id": "ses_...", "status": "queued", "head": 1 },
+  "client_token": "eyJ..."
 }
 ```
 
@@ -168,7 +168,7 @@ await live.steer("Add a filter for completed tasks.", { idempotencyKey: "msg_01"
 ```
 
 ```http REST API
-POST https://api.opencomputer.dev/v3/sessions/sess_.../messages
+POST https://api.opencomputer.dev/v3/sessions/ses_.../messages
 Authorization: Bearer $CLIENT_TOKEN
 Content-Type: application/json
 
@@ -185,7 +185,7 @@ Response:
 ```json
 {
   "event": { "id": "evt_...", "seq": 14 },
-  "session": { "id": "sess_...", "status": "queued", "head": 14 }
+  "session": { "id": "ses_...", "status": "queued", "head": 14 }
 }
 ```
 

--- a/docs/agent-sessions/sessions.mdx
+++ b/docs/agent-sessions/sessions.mdx
@@ -38,12 +38,12 @@ Do not infer completion from prose. Await the **`turn.completed`** event (on the
 import { OpenComputer } from "@opencomputer/sdk";
 
 const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
-const session = await oc.sessions.get("sess_...");
+const session = await oc.sessions.get("ses_...");
 const { lastTurn, result } = await session.result();
 ```
 
 ```http REST API
-GET https://api.opencomputer.dev/v3/sessions/sess_.../result
+GET https://api.opencomputer.dev/v3/sessions/ses_.../result
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 ```
 

--- a/docs/agent-sessions/webhooks.mdx
+++ b/docs/agent-sessions/webhooks.mdx
@@ -38,7 +38,7 @@ await session.destinations.create({
 ```
 
 ```http REST API
-POST https://api.opencomputer.dev/v3/sessions/sess_.../destinations
+POST https://api.opencomputer.dev/v3/sessions/ses_.../destinations
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
 

--- a/docs/agent-sessions/webhooks.mdx
+++ b/docs/agent-sessions/webhooks.mdx
@@ -127,7 +127,7 @@ Delivery = {
 
 - **HTTPS only.** Private, loopback, link-local, and cloud-metadata addresses are refused.
 - **At-least-once.** Retried with exponential backoff; after the max attempts a delivery is **dead-lettered** (inspect and redeliver it above). A duplicate can still arrive — a delivery interrupted after it reached you, or a replayed turn — so **dedupe on `webhook-id`** (it equals the event id).
-- **Signed with [Standard Webhooks](https://www.standardwebhooks.com).** Every request carries `webhook-id`, `webhook-timestamp`, and `webhook-signature` — so you can verify with an off-the-shelf library instead of hand-rolling. `webhook-signature` = `v1,<base64(HMAC-SHA256(secret, "{webhook-id}.{webhook-timestamp}.{rawBody}"))>`. Verify against the **raw request body, before parsing it**; `webhook-timestamp` guards replay; your `secret` (`whsec_…`) is write-only — set once, never returned. Plus `X-OC-Delivery-ID` and `X-OC-Session-ID` for correlation.
+- **Signed with [Standard Webhooks](https://www.standardwebhooks.com) — when the destination has a `secret`.** Every request carries `webhook-id` and `webhook-timestamp`; if the destination was created with a `secret`, it also carries `webhook-signature` (= `v1,<base64(HMAC-SHA256(secret, "{webhook-id}.{webhook-timestamp}.{rawBody}"))>`). **Set a `secret` to get signed deliveries** — without one, requests are unsigned. Verify against the **raw request body, before parsing it**; `webhook-timestamp` guards replay; your `secret` (`whsec_…`) is write-only — set once, never returned. Plus `X-OC-Delivery-ID` and `X-OC-Session-ID` for correlation.
 - A delivery succeeds on HTTP `2xx`.
 
 ### Verify a webhook

--- a/docs/agent-sessions/webhooks.mdx
+++ b/docs/agent-sessions/webhooks.mdx
@@ -132,7 +132,20 @@ Delivery = {
 
 ### Verify a webhook
 
-Use a [Standard Webhooks](https://www.standardwebhooks.com) library:
+The SDK ships a verifier — no extra dependency, runs in Node / Cloudflare Workers / browsers — that checks the signature and returns the parsed envelope:
+
+```ts
+import { verifyWebhook } from "@opencomputer/sdk";
+
+// rawBody = the RAW request body string, read BEFORE JSON.parse.
+// Throws on a missing / expired / invalid signature.
+const delivery = await verifyWebhook(rawBody, request.headers, process.env.OC_WEBHOOK_SECRET!);
+if (delivery.type === "turn.completed") {
+  // route on delivery.metadata, then fetch the result
+}
+```
+
+Or verify with any [Standard Webhooks](https://www.standardwebhooks.com) library directly:
 
 ```js
 import { Webhook } from "standardwebhooks";

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -81,6 +81,10 @@ if (delivery.type === "turn.completed") {
 | `baseUrl` | —                      | `https://api.opencomputer.dev/v3`  |
 | `apiKey`  | `OPENCOMPUTER_API_KEY` | (none)                             |
 
+## Releasing
+
+**Bump the `version` in `package.json` (and `package-lock.json`) in any PR that changes the SDK.** Publishing only fires on a version change — a change merged without a bump silently won't release. One bump per PR is enough.
+
 ## License
 
 MIT

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -1,6 +1,8 @@
 # @opencomputer/sdk
 
-TypeScript SDK for [OpenComputer](https://github.com/diggerhq/opensandbox) — cloud sandbox platform.
+The official TypeScript SDK for [OpenComputer](https://github.com/diggerhq/opensandbox): **cloud sandboxes** and **Durable Agent Sessions** (managed background agents).
+
+> This one package covers both surfaces — install **`@opencomputer/sdk`**. (The older `@opencomputer/agents-sdk` is superseded; use this instead.)
 
 ## Install
 
@@ -25,6 +27,41 @@ const content = await sandbox.files.read("/tmp/test.txt");
 
 // Clean up
 await sandbox.kill();
+```
+
+## Durable Agent Sessions
+
+Run a managed background agent: define an agent once, then create sessions that stream durable events and call back on completion.
+
+```typescript
+import { OpenComputer, verifyWebhook } from "@opencomputer/sdk";
+
+const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
+
+// Bootstrap once — idempotent by name (safe on every deploy):
+const agent = await oc.agents.create({
+  name: "reviewer",
+  runtime: "claude",                       // or "codex"
+  model: "anthropic/claude-opus-4-8",
+  prompt: "Review the diff. Run tests. Explain risks.",
+  key: process.env.ANTHROPIC_API_KEY!,     // sealed; never enters the sandbox
+});
+
+// Per request — hand off durable work, route the callback via metadata:
+await oc.sessions.create({
+  agent: agent.id,
+  input: "Review PR #42",
+  metadata: { pullNumber: 42 },            // echoed back verbatim in the webhook
+  idempotencyKey: deliveryId,              // retry-safe
+  destinations: [{ url: "https://app.example.com/oc-callback", secret: process.env.OC_WEBHOOK_SECRET! }],
+});
+
+// In your webhook handler — verify the signature, then fetch the result:
+const delivery = await verifyWebhook(rawBody, request.headers, process.env.OC_WEBHOOK_SECRET!);
+if (delivery.type === "turn.completed") {
+  const session = await oc.sessions.get(delivery.sessionId);
+  const { result } = await session.result();
+}
 ```
 
 ## Configuration

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -48,13 +48,14 @@ const agent = await oc.agents.create({
 });
 
 // Per request — hand off durable work, route the callback via metadata:
-await oc.sessions.create({
+const session = await oc.sessions.create({
   agent: agent.id,
   input: "Review PR #42",
   metadata: { pullNumber: 42 },            // echoed back verbatim in the webhook
   idempotencyKey: deliveryId,              // retry-safe
-  destinations: [{ url: "https://app.example.com/oc-callback", secret: process.env.OC_WEBHOOK_SECRET! }],
 });
+// Register a SIGNED callback (inline create-time destinations can't carry a secret):
+await session.destinations.create({ url: "https://app.example.com/oc-callback", secret: process.env.OC_WEBHOOK_SECRET! });
 
 // In your webhook handler — verify the signature, then fetch the result:
 const delivery = await verifyWebhook(rawBody, request.headers, process.env.OC_WEBHOOK_SECRET!);
@@ -66,10 +67,19 @@ if (delivery.type === "turn.completed") {
 
 ## Configuration
 
-| Option    | Env Variable            | Default                  |
-|-----------|------------------------|--------------------------|
-| `apiUrl`  | `OPENCOMPUTER_API_URL`  | `https://app.opencomputer.dev`  |
-| `apiKey`  | `OPENCOMPUTER_API_KEY`  | (none)                   |
+**Sandboxes** (`Sandbox`):
+
+| Option   | Env Variable           | Default                          |
+|----------|------------------------|----------------------------------|
+| `apiUrl` | `OPENCOMPUTER_API_URL` | `https://app.opencomputer.dev`   |
+| `apiKey` | `OPENCOMPUTER_API_KEY` | (none)                           |
+
+**Durable Agent Sessions** (`OpenComputer`):
+
+| Option    | Env Variable           | Default                            |
+|-----------|------------------------|------------------------------------|
+| `baseUrl` | —                      | `https://api.opencomputer.dev/v3`  |
+| `apiKey`  | `OPENCOMPUTER_API_KEY` | (none)                             |
 
 ## License
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/agents/agents.ts
+++ b/sdks/typescript/src/agents/agents.ts
@@ -27,7 +27,8 @@ export class Agents {
   constructor(private readonly http: Http) {}
 
   create(params: CreateAgentParams): Promise<Agent> {
-    return this.http.request("POST", "/agents", { body: params });
+    // Idempotent by name server-side → safe to auto-retry transient failures.
+    return this.http.request("POST", "/agents", { body: params, idempotent: true });
   }
   get(id: string): Promise<Agent> {
     return this.http.request("GET", `/agents/${id}`);

--- a/sdks/typescript/src/agents/credentials.ts
+++ b/sdks/typescript/src/agents/credentials.ts
@@ -7,6 +7,8 @@ export interface CreateCredentialParams {
   /** Write-only — never returned by the API. */
   key: string;
   name?: string;
+  /** Make this the org default for its provider (sent as `is_default`). */
+  isDefault?: boolean;
 }
 
 /** Provider keys (e.g. Anthropic, OpenAI), stored in the secret store; sessions run on them. */

--- a/sdks/typescript/src/agents/index.ts
+++ b/sdks/typescript/src/agents/index.ts
@@ -9,6 +9,8 @@ export { Credentials } from "./credentials.js";
 export type { CreateCredentialParams } from "./credentials.js";
 export { Destinations, Deliveries } from "./destinations.js";
 export type { CreateDestinationParams, UpdateDestinationParams } from "./destinations.js";
+export { verifyWebhook, WebhookVerificationError } from "./webhooks.js";
+export type { WebhookDelivery, VerifyWebhookOptions } from "./webhooks.js";
 
 export * from "./types.js";
 export * from "./errors.js";

--- a/sdks/typescript/src/agents/sessions.ts
+++ b/sdks/typescript/src/agents/sessions.ts
@@ -32,7 +32,7 @@ export interface CreateSessionParams {
 export interface StreamOptions {
   /** Visibility threshold; default `internal` (the full build trace). */
   level?: Level;
-  /** Filter by event type (exact or `prefix.*`). */
+  /** Filter by event type (exact or `prefix.*`). Applied client-side as the stream arrives. */
   type?: string;
   /** Resume from this seq (default 0 — replays the whole log). */
   after?: number;
@@ -89,7 +89,9 @@ export class ClientSession {
       }
       try {
         for await (const ev of parseEventStream(res)) {
-          after = ev.seq;
+          after = ev.seq;   // advance the cursor on every event, even filtered-out ones
+          // The SSE endpoint streams by level+seq; apply the type filter here (exact or `prefix.*`).
+          if (opts.type && !(opts.type.endsWith(".*") ? ev.type.startsWith(opts.type.slice(0, -1)) : ev.type === opts.type)) continue;
           yield ev;
         }
       } catch {

--- a/sdks/typescript/src/agents/webhooks.test.ts
+++ b/sdks/typescript/src/agents/webhooks.test.ts
@@ -30,7 +30,7 @@ describe("verifyWebhook", () => {
   const ts = 1_700_000_000;
   const body = JSON.stringify({
     type: "turn.completed", sessionId: "ses_1", eventId: "msg_1",
-    metadata: { pull_number: 7 }, event: { id: "evt_1", type: "turn.completed" },
+    metadata: { pull_number: 7 }, event: { id: "evt_1", type: "turn.completed", turn_id: "trn_1" },
   });
   const hdr = (sig: string) => ({ "webhook-id": id, "webhook-timestamp": String(ts), "webhook-signature": sig });
 
@@ -38,7 +38,8 @@ describe("verifyWebhook", () => {
     const delivery = await verifyWebhook(body, hdr(await sign(id, ts, body, SECRET)), SECRET, { nowSeconds: ts });
     expect(delivery.type).toBe("turn.completed");
     expect(delivery.eventId).toBe("msg_1");
-    expect(delivery.metadata).toEqual({ pull_number: 7 });
+    expect(delivery.metadata).toEqual({ pull_number: 7 });   // opaque — verbatim
+    expect((delivery.event as { turnId?: string }).turnId).toBe("trn_1");   // wire turn_id → camelCase
   });
 
   it("rejects a tampered body", async () => {

--- a/sdks/typescript/src/agents/webhooks.test.ts
+++ b/sdks/typescript/src/agents/webhooks.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { verifyWebhook, WebhookVerificationError } from "./webhooks.js";
+
+const SECRET = "whsec_" + btoa("super-secret-key-bytes-123456");
+
+async function sign(id: string, ts: number, body: string, secret: string): Promise<string> {
+  const keyB64 = secret.startsWith("whsec_") ? secret.slice("whsec_".length) : secret;
+  const bin = atob(keyB64);
+  const keyBytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) keyBytes[i] = bin.charCodeAt(i);
+  const key = await crypto.subtle.importKey("raw", keyBytes, { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const mac = new Uint8Array(await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(`${id}.${ts}.${body}`)));
+  let b = "";
+  for (let i = 0; i < mac.length; i++) b += String.fromCharCode(mac[i]);
+  return "v1," + btoa(b);
+}
+
+describe("verifyWebhook", () => {
+  const id = "msg_1";
+  const ts = 1_700_000_000;
+  const body = JSON.stringify({
+    type: "turn.completed", sessionId: "ses_1", eventId: "msg_1",
+    metadata: { pull_number: 7 }, event: { id: "evt_1", type: "turn.completed" },
+  });
+  const hdr = (sig: string) => ({ "webhook-id": id, "webhook-timestamp": String(ts), "webhook-signature": sig });
+
+  it("accepts a valid signature and returns the parsed envelope (metadata verbatim)", async () => {
+    const delivery = await verifyWebhook(body, hdr(await sign(id, ts, body, SECRET)), SECRET, { nowSeconds: ts });
+    expect(delivery.type).toBe("turn.completed");
+    expect(delivery.eventId).toBe("msg_1");
+    expect(delivery.metadata).toEqual({ pull_number: 7 });
+  });
+
+  it("rejects a tampered body", async () => {
+    const sig = await sign(id, ts, body, SECRET);
+    await expect(verifyWebhook(body + " ", hdr(sig), SECRET, { nowSeconds: ts })).rejects.toThrow(WebhookVerificationError);
+  });
+
+  it("rejects an out-of-tolerance timestamp (replay)", async () => {
+    const sig = await sign(id, ts, body, SECRET);
+    await expect(verifyWebhook(body, hdr(sig), SECRET, { nowSeconds: ts + 10_000 })).rejects.toThrow(/tolerance/);
+  });
+
+  it("rejects a wrong secret", async () => {
+    const sig = await sign(id, ts, body, SECRET);
+    const wrong = "whsec_" + btoa("different-key-bytes-000000");
+    await expect(verifyWebhook(body, hdr(sig), wrong, { nowSeconds: ts })).rejects.toThrow(WebhookVerificationError);
+  });
+
+  it("accepts when one of several rotated signatures matches", async () => {
+    const good = await sign(id, ts, body, SECRET);
+    const delivery = await verifyWebhook(body, hdr(`v1,bogus ${good}`), SECRET, { nowSeconds: ts });
+    expect(delivery.sessionId).toBe("ses_1");
+  });
+
+  it("throws on missing headers", async () => {
+    await expect(verifyWebhook(body, {}, SECRET, { nowSeconds: ts })).rejects.toThrow(/missing/);
+  });
+});

--- a/sdks/typescript/src/agents/webhooks.test.ts
+++ b/sdks/typescript/src/agents/webhooks.test.ts
@@ -3,12 +3,22 @@ import { verifyWebhook, WebhookVerificationError } from "./webhooks.js";
 
 const SECRET = "whsec_" + btoa("super-secret-key-bytes-123456");
 
+// Mirror the backend's key derivation (strip whsec_, base64 if it round-trips, else raw UTF-8).
+function keyBytesFor(secret: string): Uint8Array {
+  const s = secret.startsWith("whsec_") ? secret.slice("whsec_".length) : secret;
+  try {
+    const bin = atob(s);
+    const decoded = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) decoded[i] = bin.charCodeAt(i);
+    let re = "";
+    for (let i = 0; i < decoded.length; i++) re += String.fromCharCode(decoded[i]);
+    if (decoded.length > 0 && btoa(re).replace(/=+$/, "") === s.replace(/=+$/, "")) return decoded;
+  } catch { /* not base64 */ }
+  return new TextEncoder().encode(secret);
+}
+
 async function sign(id: string, ts: number, body: string, secret: string): Promise<string> {
-  const keyB64 = secret.startsWith("whsec_") ? secret.slice("whsec_".length) : secret;
-  const bin = atob(keyB64);
-  const keyBytes = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) keyBytes[i] = bin.charCodeAt(i);
-  const key = await crypto.subtle.importKey("raw", keyBytes, { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const key = await crypto.subtle.importKey("raw", new Uint8Array(keyBytesFor(secret)), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
   const mac = new Uint8Array(await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(`${id}.${ts}.${body}`)));
   let b = "";
   for (let i = 0; i < mac.length; i++) b += String.fromCharCode(mac[i]);
@@ -55,5 +65,11 @@ describe("verifyWebhook", () => {
 
   it("throws on missing headers", async () => {
     await expect(verifyWebhook(body, {}, SECRET, { nowSeconds: ts })).rejects.toThrow(/missing/);
+  });
+
+  it("verifies a raw (non-base64) secret — backend signs with UTF-8 bytes", async () => {
+    const raw = "testsecret"; // not a whsec_/base64 secret → both sides use UTF-8 key bytes
+    const delivery = await verifyWebhook(body, hdr(await sign(id, ts, body, raw)), raw, { nowSeconds: ts });
+    expect(delivery.type).toBe("turn.completed");
   });
 });

--- a/sdks/typescript/src/agents/webhooks.ts
+++ b/sdks/typescript/src/agents/webhooks.ts
@@ -63,6 +63,23 @@ function bytesToBase64(bytes: Uint8Array): string {
   return btoa(bin);
 }
 
+/**
+ * Derive the HMAC key bytes EXACTLY as the backend does (delivery signing): strip the
+ * `whsec_` prefix, use the base64-decoded bytes if the remainder round-trips as base64,
+ * otherwise fall back to the raw UTF-8 bytes of the ORIGINAL secret. So a destination made
+ * with a non-base64 secret (e.g. `"testsecret"`) verifies, matching what the server signed.
+ */
+function secretKeyBytes(secret: string): Uint8Array<ArrayBuffer> {
+  const s = secret.startsWith("whsec_") ? secret.slice("whsec_".length) : secret;
+  try {
+    const decoded = base64ToBytes(s);
+    if (decoded.length > 0 && bytesToBase64(decoded).replace(/=+$/, "") === s.replace(/=+$/, "")) return decoded;
+  } catch {
+    /* not base64 → raw bytes below */
+  }
+  return new Uint8Array(new TextEncoder().encode(secret));
+}
+
 /** Constant-time string compare (equal length → no early-exit on content). */
 function timingSafeEqual(a: string, b: string): boolean {
   if (a.length !== b.length) return false;
@@ -103,11 +120,14 @@ export async function verifyWebhook<E = Event>(
     throw new WebhookVerificationError("webhook-timestamp outside tolerance (possible replay)");
   }
 
-  const keyBytes = base64ToBytes(secret.startsWith("whsec_") ? secret.slice("whsec_".length) : secret);
-  const cryptoKey = await crypto.subtle.importKey("raw", keyBytes, { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
-  const msg = new Uint8Array(new TextEncoder().encode(`${id}.${ts}.${rawBody}`));
-  const mac = new Uint8Array(await crypto.subtle.sign("HMAC", cryptoKey, msg));
-  const expected = bytesToBase64(mac);
+  let expected: string;
+  try {
+    const cryptoKey = await crypto.subtle.importKey("raw", secretKeyBytes(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+    const msg = new Uint8Array(new TextEncoder().encode(`${id}.${ts}.${rawBody}`));
+    expected = bytesToBase64(new Uint8Array(await crypto.subtle.sign("HMAC", cryptoKey, msg)));
+  } catch (err) {
+    throw new WebhookVerificationError(`could not compute signature: ${err instanceof Error ? err.message : String(err)}`);
+  }
 
   // Header is space-separated "v1,<sig>" entries (multiple during secret rotation).
   const matched = sigHeader.split(" ").some((entry) => {

--- a/sdks/typescript/src/agents/webhooks.ts
+++ b/sdks/typescript/src/agents/webhooks.ts
@@ -1,0 +1,125 @@
+// Webhook verification for Durable Agent Sessions destinations.
+//
+// Deliveries are signed with the Standard Webhooks scheme (https://www.standardwebhooks.com):
+// headers `webhook-id`, `webhook-timestamp`, `webhook-signature`, where
+//   webhook-signature = "v1,<base64(HMAC-SHA256(secret, `${id}.${timestamp}.${rawBody}`))>"
+// and the secret is the destination's `whsec_…` value. The header may carry several
+// space-separated signatures (key rotation); any match passes.
+//
+// Implemented with Web Crypto (no Node-only deps) so it runs in Cloudflare Workers,
+// browsers, Deno, and Node 16+ — the same places the SDK runs. Verify against the RAW
+// request body, BEFORE JSON-parsing it.
+
+import type { Event } from "./types.js";
+
+/** The envelope OpenComputer POSTs to a destination (see the Webhooks docs). */
+export interface WebhookDelivery<E = Event> {
+  /** The event type — route on this (e.g. `turn.completed`). */
+  type: string;
+  sessionId: string;
+  /** Equals the `webhook-id` header — dedupe on it. */
+  eventId: string;
+  /** The session's opaque routing state, verbatim (`null` when unset). */
+  metadata: Record<string, unknown> | null;
+  /** The full event — the same shape the SSE stream emits. */
+  event: E;
+}
+
+export interface VerifyWebhookOptions {
+  /** Max allowed clock skew between now and `webhook-timestamp`, in seconds (default 300). */
+  toleranceSeconds?: number;
+  /** Override "now" (unix seconds) — for testing. */
+  nowSeconds?: number;
+}
+
+export class WebhookVerificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WebhookVerificationError";
+  }
+}
+
+type HeaderBag = Record<string, string | string[] | undefined>;
+
+function header(headers: HeaderBag | Headers, name: string): string | undefined {
+  if (typeof (headers as Headers).get === "function") {
+    return (headers as Headers).get(name) ?? undefined;   // Headers.get is case-insensitive
+  }
+  const bag = headers as HeaderBag;
+  const v = bag[name] ?? bag[name.toLowerCase()];
+  return Array.isArray(v) ? v[0] : v;
+}
+
+function base64ToBytes(b64: string): Uint8Array<ArrayBuffer> {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+/** Constant-time string compare (equal length → no early-exit on content). */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+/**
+ * Verify a webhook delivery and return its parsed envelope. Throws
+ * {@link WebhookVerificationError} on a missing/expired/invalid signature.
+ *
+ * ```ts
+ * import { verifyWebhook } from "@opencomputer/sdk";
+ * // in your handler — pass the RAW body string, not a parsed object:
+ * const delivery = await verifyWebhook(rawBody, request.headers, process.env.OC_WEBHOOK_SECRET!);
+ * if (delivery.type === "turn.completed") { /* route via delivery.metadata *\/ }
+ * ```
+ */
+export async function verifyWebhook<E = Event>(
+  rawBody: string,
+  headers: HeaderBag | Headers,
+  secret: string,
+  opts: VerifyWebhookOptions = {},
+): Promise<WebhookDelivery<E>> {
+  const id = header(headers, "webhook-id");
+  const ts = header(headers, "webhook-timestamp");
+  const sigHeader = header(headers, "webhook-signature");
+  if (!id || !ts || !sigHeader) {
+    throw new WebhookVerificationError("missing webhook-id / webhook-timestamp / webhook-signature header");
+  }
+
+  const tolerance = opts.toleranceSeconds ?? 300;
+  const now = opts.nowSeconds ?? Math.floor(Date.now() / 1000);
+  const tsNum = Number(ts);
+  if (!Number.isFinite(tsNum)) throw new WebhookVerificationError("invalid webhook-timestamp");
+  if (Math.abs(now - tsNum) > tolerance) {
+    throw new WebhookVerificationError("webhook-timestamp outside tolerance (possible replay)");
+  }
+
+  const keyBytes = base64ToBytes(secret.startsWith("whsec_") ? secret.slice("whsec_".length) : secret);
+  const cryptoKey = await crypto.subtle.importKey("raw", keyBytes, { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const msg = new Uint8Array(new TextEncoder().encode(`${id}.${ts}.${rawBody}`));
+  const mac = new Uint8Array(await crypto.subtle.sign("HMAC", cryptoKey, msg));
+  const expected = bytesToBase64(mac);
+
+  // Header is space-separated "v1,<sig>" entries (multiple during secret rotation).
+  const matched = sigHeader.split(" ").some((entry) => {
+    const comma = entry.indexOf(",");
+    if (comma < 0) return false;
+    return entry.slice(0, comma) === "v1" && timingSafeEqual(entry.slice(comma + 1), expected);
+  });
+  if (!matched) throw new WebhookVerificationError("no matching webhook signature");
+
+  try {
+    return JSON.parse(rawBody) as WebhookDelivery<E>;
+  } catch {
+    throw new WebhookVerificationError("signature valid but body is not JSON");
+  }
+}

--- a/sdks/typescript/src/agents/webhooks.ts
+++ b/sdks/typescript/src/agents/webhooks.ts
@@ -11,6 +11,7 @@
 // request body, BEFORE JSON-parsing it.
 
 import type { Event } from "./types.js";
+import { normalize } from "./normalize.js";
 
 /** The envelope OpenComputer POSTs to a destination (see the Webhooks docs). */
 export interface WebhookDelivery<E = Event> {
@@ -138,7 +139,9 @@ export async function verifyWebhook<E = Event>(
   if (!matched) throw new WebhookVerificationError("no matching webhook signature");
 
   try {
-    return JSON.parse(rawBody) as WebhookDelivery<E>;
+    // Normalize so the returned envelope + nested event match the SDK's camelCase types
+    // (the wire event is snake-cased, e.g. `turn_id`); `metadata` stays verbatim (opaque).
+    return normalize(JSON.parse(rawBody)) as WebhookDelivery<E>;
   } catch {
     throw new WebhookVerificationError("signature valid but body is not JSON");
   }


### PR DESCRIPTION
The webhook + contract-consistency pass, SDK and docs together (the docs describe behavior this PR implements, so they land as one). Bumps `@opencomputer/sdk` 0.7.5 → **0.7.6**.

## SDK (`@opencomputer/sdk`)
- **`verifyWebhook(rawBody, headers, secret)`** — Standard Webhooks verification on Web Crypto (no deps; Node / Workers / browsers). Derives the HMAC key exactly like the backend (strip `whsec_`, base64-if-round-trips, else raw UTF-8), **normalizes** the returned envelope (so the nested event matches the SDK's camelCase types; `metadata` stays verbatim), and throws `WebhookVerificationError` on bad/expired/missing signatures. Tested (valid / tampered / replay / wrong-secret / rotation / raw-secret / missing headers).
- **`events({ type })`** — type filter applied **client-side** as the stream arrives (the SSE route filters by level+seq only), so the advertised option works.
- **`credentials.create({ isDefault })`** exposed; **`agents.create`** uses `idempotent: true`.
- README leads with Durable Agent Sessions (+ sessions quick-start, signed-callback flow, config split, "Releasing: always bump the version" note).

## Docs
- **Messaging**: rewrote "envelope" → **Message input** with where-each-field-lands (a `*.message` body is `{ text, raw? }`; `source`/`conversation`/`refs`→event `refs`; sender→`actor`).
- **POST /agents idempotency** by status code (201/200/409), not a `created:false` body field.
- **Verbatim scope**: only `metadata` + an event's `raw` are verbatim; `body`/`refs` are camelCased (matches `normalize`).
- **Webhook signing** is conditional on a destination `secret`; verify section leads with the SDK helper.
- **Example ids** `ses_…`; `client_token` shown as a JWT; documented `?cursor` and deliveries `?after&limit`.

Remaining contract gap (server change, separate): inline `secret` on **create-time** destinations so a signed callback exists before the agent produces output (today: whole-session capture is unsigned, signed is post-create and can race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)