### PR TITLE
docs: contract-consistency fixes (messaging shape, ids, idempotency, params)

### DIFF
--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -11,11 +11,11 @@ Each section toggles between the **TypeScript** SDK (`@opencomputer/sdk`) and **
 import { OpenComputer, connectSession } from "@opencomputer/sdk";
 
 const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
-const session = await oc.sessions.get("sess_...");        // server, org key
+const session = await oc.sessions.get("ses_...");        // server, org key
 // or, in a browser:  await connectSession({ sessionId, clientToken })
 ```
 
-<Note>The SDK returns the same objects with **camelCase** fields (`client_token` → `session.clientToken`, `created_at` → `createdAt`, `last_turn` → `lastTurn`, `yield_reason` → `yieldReason`, `turn_seconds` → `turnSeconds`, …) and takes camelCase params (`idempotency_key` → `idempotencyKey`). The wire shapes below are the raw JSON. Opaque blobs you own — `metadata`, event `body`, `refs` — pass through **verbatim** (keys untouched) in both directions.</Note>
+<Note>The SDK returns the same objects with **camelCase** fields (`client_token` → `session.clientToken`, `created_at` → `createdAt`, `last_turn` → `lastTurn`, `yield_reason` → `yieldReason`, `turn_seconds` → `turnSeconds`, …) and takes camelCase params (`idempotency_key` → `idempotencyKey`). The wire shapes below are the raw JSON. Truly opaque blobs — your session `metadata` and an event's `raw` field — pass through **verbatim** (keys untouched) in both directions; everything else, **including event `body` and `refs`**, is camelCased like the rest.</Note>
 
 ## Sessions
 
@@ -42,7 +42,7 @@ const session = await oc.sessions.get("sess_...");        // server, org key
 | --- | --- |
 | `POST /sessions` | Start a session → `{ session, client_token }`. |
 | `GET /sessions/:id` | Fetch a session. |
-| `GET /sessions?status=&agent=&key=&after=&before=&limit=` | List sessions (filtered, paginated). |
+| `GET /sessions?status=&agent=&key=&after=&before=&limit=&cursor=` | List sessions (filtered, paginated; `cursor` = `nextCursor` from the previous page). |
 | `POST /sessions/:id/archive` | Cancel any active turn, then close (read-only). |
 | `POST /sessions/:id/cancel` | Cooperatively stop the active turn (no-op if not running). |
 | `GET /sessions/:id/result` | The result helper — `{ last_turn, result? }`. |
@@ -53,7 +53,7 @@ const session = await oc.sessions.get("sess_...");        // server, org key
 
 </Tabs>
 
-`agent` is **required** (create a saved [agent](#agents) first); a resolvable model [credential](#credentials) is also required (`422 no_credential` otherwise). `key` gives get-or-create (one session per key); a request-level `Idempotency-Key` header makes a keyless create retry-safe. `metadata` is opaque **application routing state** — a JSON object (≤ 16 KB) stored on the session, returned by get/list, and delivered **verbatim in webhooks** so a callback handler can route to the right external record without a lookup; it is **never** shown to the model, **not** indexed/queryable, and distinct from `key` (get-or-create) and `Idempotency-Key` (dedupe). `input` is the task — a string or a full [envelope](/agent-sessions/messaging#message-envelope). For the managed runtimes (`claude`, `codex`), put all task-critical context in the task text. There's no fixed byte cap on `input`, but it counts against the model's context window — **truncate large inputs** (e.g. a PR diff) and have the agent pull the rest through its [sandbox tools](/agent-sessions/runtime-tools) (clone the repo, read files) rather than inlining it. `limits` `{ tokens, turn_seconds, turns }` are **non-monetary** — token budget, per-turn wall-clock, auto-run count; hitting one ends the turn with a matching `last_turn.yield_reason`. Destinations on an idempotent create-replay are ignored — manage them via the [destinations API](#destinations).
+`agent` is **required** (create a saved [agent](#agents) first); a resolvable model [credential](#credentials) is also required (`422 no_credential` otherwise). `key` gives get-or-create (one session per key); a request-level `Idempotency-Key` header makes a keyless create retry-safe. `metadata` is opaque **application routing state** — a JSON object (≤ 16 KB) stored on the session, returned by get/list, and delivered **verbatim in webhooks** so a callback handler can route to the right external record without a lookup; it is **never** shown to the model, **not** indexed/queryable, and distinct from `key` (get-or-create) and `Idempotency-Key` (dedupe). `input` is the task — a string or a full [envelope](/agent-sessions/messaging#message-input). For the managed runtimes (`claude`, `codex`), put all task-critical context in the task text. There's no fixed byte cap on `input`, but it counts against the model's context window — **truncate large inputs** (e.g. a PR diff) and have the agent pull the rest through its [sandbox tools](/agent-sessions/runtime-tools) (clone the repo, read files) rather than inlining it. `limits` `{ tokens, turn_seconds, turns }` are **non-monetary** — token budget, per-turn wall-clock, auto-run count; hitting one ends the turn with a matching `last_turn.yield_reason`. Destinations on an idempotent create-replay are ignored — manage them via the [destinations API](#destinations).
 
 Client tokens accept `scopes?` (subset of `read`, `steer`) and `ttl?` seconds, clamped to 60–86400 (SDK: `ttlSeconds`).
 
@@ -106,7 +106,7 @@ Turn = {
 
 Filter events by `type` (exact or `prefix.*`), `turn_id`, and `limit`. `…/messages` is an alias for `level=user` + `type=*.message`.
 
-`after` resumes from a `seq`; `level` is a **visibility threshold** — `user` returns only user-facing events, `progress` adds work updates, `internal` adds everything (see [visibility levels](/agent-sessions/events#visibility-levels)). Omitting `level` defaults to `internal` (you get everything). Switch on [`type`](/agent-sessions/events#event-shape), don't parse prose.
+`after` resumes from a `seq`; `level` is a **visibility threshold** — `user` returns only user-facing events, `progress` adds work updates, `internal` adds everything (see [visibility levels](/agent-sessions/events#visibility-levels)). Omitting `level` defaults to `internal` (you get everything). Switch on [`type`](/agent-sessions/events#event-shape), don't parse prose. `type`/`turn_id` filtering applies to the **list** endpoint; the **SSE stream** filters by `level` + `after` server-side, so the SDK's `events({ type })` applies the type filter client-side as events arrive.
 
 ```
 Event = {
@@ -187,7 +187,7 @@ Destination body: `url`, `secret?`, `level?` (`user`), `types?[]`, `include_raw?
 
 | Method · Path | Purpose |
 | --- | --- |
-| `GET /sessions/:id/deliveries?destination=&status=` | List deliveries — status, attempts, last response/error. |
+| `GET /sessions/:id/deliveries?destination=&status=&after=&limit=` | List deliveries — status, attempts, last response/error (paginated). |
 | `GET /sessions/:id/deliveries/:id` | One delivery, in detail. |
 | `POST /sessions/:id/deliveries/:id/redeliver` | Re-send any delivery (not just dead-lettered). |
 
@@ -236,7 +236,7 @@ Delivery = {
 
 Create body: `name`, `prompt`, `model`, `runtime?` (`claude` | `codex`), `key?`, `credential?`, `limits?`. Patch accepts `prompt?`, `model?`, `key?`, `credential?`, and `limits?` — **not `runtime`, which is fixed at creation**. The `runtime` / `model` / credential provider must agree (`claude`↔`anthropic/…`, `codex`↔`openai/…`); this is validated at create, and a patched `model`/`credential` must stay within the runtime's provider.
 
-`POST /agents` is **idempotent by `name`**: a repeat with matching non-secret config (`prompt`/`model`/`runtime`/`limits`) returns the existing agent with `created: false` (HTTP 200), while differing config returns **409** — so it's safe to call on every app startup or deploy. (`key` is ignored on an idempotent hit — it never silently rotates.)
+`POST /agents` is **idempotent by `name`** — the outcome is in the **status code**, not a body field: a fresh create returns **201**; a repeat with matching non-secret config (`prompt`/`model`/`runtime`/`limits`) returns the existing agent with **200**; differing config returns **409**. Safe to call on every app startup or deploy. (`key` is ignored on a 200 hit — it never silently rotates.)
 
 Pass `key` **or** `credential` (or neither → org default). The agent's `limits` are the defaults for its sessions; a session's own `limits` override. Each agent has a monotonic `revision` (bumped on PATCH) that sessions pin in `agent_snapshot.revision`, so you can tell which version produced a run.
 

--- a/docs/agent-sessions/authentication.mdx
+++ b/docs/agent-sessions/authentication.mdx
@@ -44,7 +44,7 @@ You get one back from `POST /v3/sessions`, and can mint more:
 <CodeGroup>
 
 ```ts TypeScript SDK
-const session = await oc.sessions.get("sess_...");
+const session = await oc.sessions.get("ses_...");
 
 const clientToken = await session.mintClientToken({
   scopes: ["read", "steer"],
@@ -53,7 +53,7 @@ const clientToken = await session.mintClientToken({
 ```
 
 ```http REST API
-POST https://api.opencomputer.dev/v3/sessions/sess_.../client-tokens
+POST https://api.opencomputer.dev/v3/sessions/ses_.../client-tokens
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
 

--- a/docs/agent-sessions/events.mdx
+++ b/docs/agent-sessions/events.mdx
@@ -22,13 +22,13 @@ Everything between `turn.started` and `turn.completed` is that turn's work. **`t
 Each event is one envelope:
 
 ```json
-{ "id": "evt_…", "seq": 12, "ts": "…", "session": "sess_…",
+{ "id": "evt_…", "seq": 12, "ts": "…", "session": "ses_…",
   "actor": { "id": "agent", "type": "agent" },
   "type": "agent.message", "level": "user",
   "body": { "text": "3 tests fail in auth.spec.ts" } }
 ```
 
-The two fields you act on are **`type`** (what happened — the discriminator) and **`level`** (who should see it). `seq` orders and resumes the log, `body` is the payload, and `actor` is who produced it (`{ id, display?, type: "human" | "agent" | "system" }`). The full field reference lives in the [API reference](/agent-sessions/api-reference); inbound and outbound messages share one [envelope](/agent-sessions/messaging#message-envelope) shape.
+The two fields you act on are **`type`** (what happened — the discriminator) and **`level`** (who should see it). `seq` orders and resumes the log, `body` is the payload, and `actor` is who produced it (`{ id, display?, type: "human" | "agent" | "system" }`). The full field reference lives in the [API reference](/agent-sessions/api-reference); for messages, see how input fields map onto an event in [Messaging](/agent-sessions/messaging#message-input).
 
 ## Event types
 

--- a/docs/agent-sessions/messaging.mdx
+++ b/docs/agent-sessions/messaging.mdx
@@ -20,7 +20,7 @@ await live.steer("also check the CI config", { idempotencyKey: "msg_01" });
 ```
 
 ```http REST API
-POST https://api.opencomputer.dev/v3/sessions/sess_.../messages
+POST https://api.opencomputer.dev/v3/sessions/ses_.../messages
 Authorization: Bearer $CLIENT_TOKEN
 Content-Type: application/json
 
@@ -34,29 +34,35 @@ Content-Type: application/json
 
 Pass `idempotency_key` so retries (flaky network, double-click) are de-duplicated — applied at most once **per session**, so the same key is safe to reuse across different sessions.
 
-## Message envelope
+## Message input
 
-Every inbound and outbound message normalizes to this shape. The core fields are fixed; anything source-specific lives under `raw`, which the platform never interprets.
+Steer with `{ text, idempotency_key? }`, or a fuller **envelope** when you need a source or a threading anchor:
 
 ```json
 {
-  "id": "client:abc123",
-  "source": "client",
-  "kind": "message",
-  "actor": { "id": "client:user-7", "display": "Ada", "type": "human" },
-  "conversation": { "source": "client", "ref": "thread-42" },
-  "text": "also check the CI config",
-  "ts": "2026-06-18T12:00:00Z",
-  "raw": {}
+  "envelope": {
+    "id": "client:abc123",
+    "source": "client",
+    "conversation": { "source": "client", "ref": "thread-42" },
+    "text": "also check the CI config",
+    "refs": {},
+    "raw": {}
+  }
 }
 ```
 
-- **`id`** — the idempotency key, deduped **per session** (not global).
-- **`actor`** — who sent it (`human` | `agent` | `system`), namespaced.
-- **`conversation`** — an opaque reply/routing anchor.
-- **`text`** — the content the agent reads (or that you receive).
-- **`raw`** — untouched original payload; optional, never read by the core.
+These fields don't all land in one place — the appended [event](/agent-sessions/events) splits them:
 
-To deliver a session's output, register a webhook destination. Deliveries carry the full [Event](/agent-sessions/events) (a message event's `body` is this envelope) — see [Webhooks](/agent-sessions/webhooks).
+| You send | Lands on the event as |
+| --- | --- |
+| `text` | `body.text` — the content the agent reads |
+| `raw` | `body.raw` — untouched original payload (optional; never interpreted) |
+| `id` (or top-level `idempotency_key`) | the idempotency key, deduped **per session** |
+| `source`, `conversation`, `refs` | merged into the event's top-level `refs` — opaque routing/threading anchors |
+| (the sender) | the event's `actor` — `human` \| `agent` \| `system`, namespaced |
+
+So a `*.message` event's `body` is just `{ text, raw? }` — `source`/`conversation`/`refs` live under the event's top-level `refs`, and the sender under `actor` (not inside `body`). Outbound `agent.message` bodies are likewise `{ text }`.
+
+To deliver a session's output, register a webhook destination — deliveries carry the full [Event](/agent-sessions/events); see [Webhooks](/agent-sessions/webhooks).
 
 <Note>[Inbound channels](/agent-sessions/channels) (Slack, GitHub, Jira, email) are coming soon — they map onto this same envelope; today you steer in via the API.</Note>

--- a/docs/agent-sessions/quickstart.mdx
+++ b/docs/agent-sessions/quickstart.mdx
@@ -101,8 +101,8 @@ Response:
 
 ```json
 {
-  "session": { "id": "sess_...", "status": "queued", "head": 1 },
-  "client_token": "ct_..."
+  "session": { "id": "ses_...", "status": "queued", "head": 1 },
+  "client_token": "eyJ..."
 }
 ```
 
@@ -168,7 +168,7 @@ await live.steer("Add a filter for completed tasks.", { idempotencyKey: "msg_01"
 ```
 
 ```http REST API
-POST https://api.opencomputer.dev/v3/sessions/sess_.../messages
+POST https://api.opencomputer.dev/v3/sessions/ses_.../messages
 Authorization: Bearer $CLIENT_TOKEN
 Content-Type: application/json
 
@@ -185,7 +185,7 @@ Response:
 ```json
 {
   "event": { "id": "evt_...", "seq": 14 },
-  "session": { "id": "sess_...", "status": "queued", "head": 14 }
+  "session": { "id": "ses_...", "status": "queued", "head": 14 }
 }
 ```
 

--- a/docs/agent-sessions/sessions.mdx
+++ b/docs/agent-sessions/sessions.mdx
@@ -38,12 +38,12 @@ Do not infer completion from prose. Await the **`turn.completed`** event (on the
 import { OpenComputer } from "@opencomputer/sdk";
 
 const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
-const session = await oc.sessions.get("sess_...");
+const session = await oc.sessions.get("ses_...");
 const { lastTurn, result } = await session.result();
 ```
 
 ```http REST API
-GET https://api.opencomputer.dev/v3/sessions/sess_.../result
+GET https://api.opencomputer.dev/v3/sessions/ses_.../result
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 ```
 

--- a/docs/agent-sessions/webhooks.mdx
+++ b/docs/agent-sessions/webhooks.mdx
@@ -38,7 +38,7 @@ await session.destinations.create({
 ```
 
 ```http REST API
-POST https://api.opencomputer.dev/v3/sessions/sess_.../destinations
+POST https://api.opencomputer.dev/v3/sessions/ses_.../destinations
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
 


### PR DESCRIPTION
Docs side of a docs/API/SDK contract review. The SDK-side fixes are in #406.

- **P1b — messaging**: rewrote the "envelope" section to **Message input** + a table of where each field actually lands. A `*.message` event `body` is `{ text, raw? }`; `source`/`conversation`/`refs` go to the event's top-level `refs` and the sender to `actor` — the docs previously described a single normalized envelope body the API doesn't emit.
- **P2b — POST /agents idempotency**: it's distinguished by **status code** (201 create / 200 idempotent hit / 409 conflict), not a `created:false` body field (the API/SDK don't return one).
- **P2/P3 — verbatim scope**: only session `metadata` and an event's `raw` pass through verbatim; event `body`/`refs` are camelCased like everything else (matches SDK `normalize`).
- **P2a — SSE filtering**: documented that the live stream filters by `level`+`after` server-side; `type` on a stream is applied client-side by the SDK's `events({ type })` (the matching SDK change is in #406).
- **P3a — example ids**: `ses_…` (not `sess_…`) everywhere; `client_token` shown as a JWT (`eyJ…`).
- **P3b — params**: documented `GET /sessions?cursor=` and `GET …/deliveries?after=&limit=`.

Companion: **#406** (SDK) does the matching `verifyWebhook` normalize, stream `type` client-side filter, and `credentials.create({ isDefault })`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)