### PR TITLE
ci: events-ingest deploy + D1 schema apply workflows

### DIFF
--- a/.github/workflows/apply-d1-schema.yml
+++ b/.github/workflows/apply-d1-schema.yml
@@ -1,0 +1,70 @@
+name: Apply D1 Schema
+
+# CI-assisted application of a D1 schema file to a target database, so schema
+# changes don't require a local wrangler + account juggling.
+#
+# This is workflow_dispatch (NOT push-triggered) on purpose: D1 has no native
+# auto-migration, and the phase schema files use non-idempotent `ALTER TABLE ADD
+# COLUMN` statements (SQLite has no `IF NOT EXISTS` for those), so blindly
+# re-applying them on every push would fail. Pick the DB + file and run it once.
+#
+# A fully-automatic on-merge system would require adopting `wrangler d1
+# migrations` (a tracking table + numbered migrations) plus a one-time baseline
+# of the already-populated prod DB. Tracked as a follow-up — see the PR.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'D1 database'
+        required: true
+        default: 'prod'
+        type: choice
+        options:
+          - prod
+          - dev
+      file:
+        description: 'Schema file under cloudflare-workers/ to apply'
+        required: true
+        default: 'schema_phase8_webhooks.sql'
+
+concurrency:
+  group: apply-d1-schema-${{ inputs.target }}
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    name: Apply ${{ inputs.file }} → ${{ inputs.target }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Resolve database
+        id: db
+        run: |
+          case "${{ inputs.target }}" in
+            prod) echo "name=opencomputer-prod" >> "$GITHUB_OUTPUT" ;;
+            dev)  echo "name=opencomputer-dev"  >> "$GITHUB_OUTPUT" ;;
+            *) echo "unknown target: ${{ inputs.target }}" >&2; exit 1 ;;
+          esac
+
+      - name: Apply ${{ inputs.file }} to ${{ steps.db.outputs.name }}
+        working-directory: cloudflare-workers
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # Run from cloudflare-workers/ (no wrangler.toml here), so the account
+          # comes from this env var, not a worker's stale toml account_id.
+          CLOUDFLARE_ACCOUNT_ID: b8f23cb87a7a6c64040d3134643da448
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "CLOUDFLARE_API_TOKEN GitHub secret is required" >&2
+            exit 1
+          fi
+          test -f "${{ inputs.file }}" || { echo "no such file: ${{ inputs.file }}" >&2; exit 1; }
+          npx wrangler d1 execute "${{ steps.db.outputs.name }}" --remote --yes --file "${{ inputs.file }}"

--- a/.github/workflows/deploy-events-ingest.yml
+++ b/.github/workflows/deploy-events-ingest.yml
@@ -1,0 +1,106 @@
+name: Deploy Events Ingest
+
+# Mirrors deploy-api-edge.yml for the events-ingest Worker, which had no CI deploy
+# (it was deployed by hand). On merge to main touching its sources, deploy to prod.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cloudflare-workers/events-ingest/**'
+      - 'cloudflare-workers/shared/**'
+      - '.github/workflows/deploy-events-ingest.yml'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Cloudflare Worker target'
+        required: true
+        default: 'prod'
+        type: choice
+        options:
+          - prod
+          - dev
+
+concurrency:
+  group: deploy-events-ingest
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Events Ingest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Resolve target
+        id: target
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TARGET="${{ inputs.target }}"
+          else
+            TARGET="prod"
+          fi
+
+          case "$TARGET" in
+            prod)
+              echo "config=wrangler.prod.toml" >> "$GITHUB_OUTPUT"
+              echo "name=opencomputer-events-ingest-prod" >> "$GITHUB_OUTPUT"
+              ;;
+            dev)
+              echo "config=wrangler.toml" >> "$GITHUB_OUTPUT"
+              echo "name=opensandbox-events-ingest-dev" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "unknown target: $TARGET" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Install events-ingest dependencies
+        working-directory: cloudflare-workers/events-ingest
+        run: npm ci
+
+      - name: Prepare CI deploy config
+        working-directory: cloudflare-workers/events-ingest
+        run: |
+          # Strip any `routes = [...]` block — the CI token may lack zone perms,
+          # and the worker is reached directly (CP forwarder / custom domain),
+          # not via a route. Mirrors the api-edge deploy.
+          python3 - <<'PY'
+          from pathlib import Path
+
+          src = Path("${{ steps.target.outputs.config }}")
+          dst = Path("wrangler.ci.toml")
+          lines = src.read_text().splitlines()
+
+          out = []
+          skipping_routes = False
+          for line in lines:
+              if line.startswith("routes = ["):
+                  skipping_routes = True
+                  continue
+              if skipping_routes:
+                  if line.strip() == "]":
+                      skipping_routes = False
+                  continue
+              out.append(line)
+
+          dst.write_text("\n".join(out).rstrip() + "\n")
+          PY
+
+      - name: Deploy ${{ steps.target.outputs.name }}
+        working-directory: cloudflare-workers/events-ingest
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "CLOUDFLARE_API_TOKEN GitHub secret is required for Wrangler deploys" >&2
+            exit 1
+          fi
+          npx wrangler deploy -c wrangler.ci.toml


### PR DESCRIPTION
Closes the two **manual gaps** the PR #410 merge surfaced (webhooks shipped, but two pieces had no automation):

## 1. `deploy-events-ingest.yml` — events-ingest had no CI deploy
api-edge and the control plane auto-deploy on merge; **events-ingest did not** (only a `workflow_dispatch` `deploy-worker.yml` for the sandbox AMI). So on #410's merge its prod worker kept running old code until it was deployed by hand. This mirrors `deploy-api-edge.yml`: auto-deploys to prod on merge touching `cloudflare-workers/events-ingest/**` or `shared/**`, plus a `workflow_dispatch` prod/dev target. (No dashboard-asset build and no test/tsc step — events-ingest has neither.)

## 2. `apply-d1-schema.yml` — D1 schema was applied by hand
CI doesn't run `d1 execute`, so the webhooks D1 schema (`has_webhooks`, `webhook_destinations`, `webhook_idempotency`) was applied manually with local wrangler. This adds a **`workflow_dispatch`** job to apply a chosen schema file to the prod/dev D1 from CI.

**Why manual-trigger (not on-push):** D1 has no native auto-migration, and the `schema_phase*.sql` files use non-idempotent `ALTER TABLE ADD COLUMN` (SQLite has no `IF NOT EXISTS` for columns), so re-applying on every push would fail. This is the safe, immediately-useful version (no local wrangler/account juggling).

### Follow-up (intentionally not in this PR)
Fully-automatic on-merge D1 application would require adopting **`wrangler d1 migrations`** (a `d1_migrations` tracking table + numbered migrations) **plus a one-time baseline** of the already-populated prod D1 (mark existing schema as applied so the ALTERs don't re-run). That's a delicate change on a live DB and deserves its own review — happy to do it next if we want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)