### PR TITLE
Fix live checkpoint source VM thaw

### DIFF
--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -3132,6 +3132,15 @@ func (m *Manager) CreateCheckpoint(ctx context.Context, sandboxID, checkpointID 
 		log.Printf("qemu: CreateCheckpoint %s/%s: failed to resume VM after savevm: %v", sandboxID, checkpointID, contErr)
 	}
 	if saveErr != nil {
+		// The guest may already have been fsfrozen by quiesceAndCloseAgent.
+		// Once QEMU has been resumed, make a best-effort attempt to thaw before
+		// returning the savevm failure so the source sandbox is not left wedged.
+		if agentClient, reconnErr := m.waitForAgentSocket(context.Background(), vm.agentSockPath, 10*time.Second); reconnErr == nil {
+			vm.agent = agentClient
+			m.agentFsThawAfterWake(context.Background(), sandboxID, agentClient)
+		} else {
+			log.Printf("qemu: CreateCheckpoint %s/%s: savevm failed and agent reconnect for fs thaw failed: %v", sandboxID, checkpointID, reconnErr)
+		}
 		os.RemoveAll(stagingDir)
 		failureReason = "qmp_savevm"
 		return "", "", 0, fmt.Errorf("savevm: %w", saveErr)
@@ -3170,6 +3179,11 @@ func (m *Manager) CreateCheckpoint(ctx context.Context, sandboxID, checkpointID 
 	}
 	if reconnErr == nil {
 		vm.agent = agentClient
+		// Live checkpoint uses the same prepareAgentForHibernate path as
+		// hibernate/fork, so thaw the still-running source VM before accepting
+		// any more customer work. Without this, writes can block indefinitely on
+		// the guest fsfreeze semaphore even though QEMU has resumed.
+		m.agentFsThawAfterWake(context.Background(), sandboxID, agentClient)
 	} else {
 		// Agent didn't come back after savevm — the VM is unmanageable. Full
 		// teardown via destroyVM, not the partial QMP-quit-only cleanup that


### PR DESCRIPTION
## Summary

- thaw the source VM filesystem after live checkpoint savevm resumes QEMU
- best-effort thaw on savevm failure after QEMU has been resumed

## Repro Artifacts

Gist: https://gist.github.com/motatoes/9fd3d3dca7dc5ff4eb90f341092d0e1c

- Template builder: https://gist.github.com/motatoes/9fd3d3dca7dc5ff4eb90f341092d0e1c#file-build-template-ts
- Source-VM stall repro: https://gist.github.com/motatoes/9fd3d3dca7dc5ff4eb90f341092d0e1c#file-repro-opencomputer-checkpoint-git-mjs
- Repro/validation notes: https://gist.github.com/motatoes/9fd3d3dca7dc5ff4eb90f341092d0e1c#file-readme-md

## Rebuild Template

Run from the OpenInspect/background-agents repo:

```sh
OPENCOMPUTER_API_URL=https://mo-oc-dev.com/api \
OPENCOMPUTER_API_KEY="$OPENCOMPUTER_API_KEY" \
OPENCOMPUTER_TEMPLATE=openinspect-runtime \
npm run build:opencomputer-template
```

## Reproduce

Run from the OpenInspect/background-agents repo:

```sh
OPENCOMPUTER_API_URL=https://mo-oc-dev.com/api \
OPENCOMPUTER_API_KEY="$OPENCOMPUTER_API_KEY" \
OPENCOMPUTER_TEMPLATE=openinspect-runtime \
REPRO_OPENINSPECT_RUNTIME=true \
REPRO_POST_PROBE_DELAY_SECONDS=30 \
node scripts/repro-opencomputer-checkpoint-git.mjs
```

## Validation

- `go test ./internal/api`
- deployed dev worker build `8dfcb25-thaw-fix` to AWS ap-northeast-2 dev
- before fix, reproduced source-VM post-checkpoint stalls on:
  - `sb-e583e653` / checkpoint `5988ae80-b113-4c96-b321-c8a07ba54abf`
  - `sb-8eb46dcf` / checkpoint `135a1d9f-063d-4675-9811-3206023bef96`
  - `sb-7c2a6a1c` / checkpoint `f685b69a-1f74-4192-a3f2-3b219b344888`
- after fix, `REPRO_POST_PROBE_DELAY_SECONDS=30` still raced checkpoint reconnect/thaw:
  - `sb-0d29e644` / checkpoint `2205ca64-45ae-4d2e-8e18-a7357fe43f2f`
  - script probe started before reconnect/thaw completed
  - direct follow-up exec after reconnect/thaw succeeded: OpenCode health healthy, runtime git status exited `0`
- after fix, `REPRO_POST_PROBE_DELAY_SECONDS=75` passed:
  - `sb-46daa9f3` / checkpoint `4516689a-4d03-4c99-b746-3824751a2745`
  - `runtime_git_config_exit=0`
  - `runtime_git_status_exit=0`
  - OpenCode health returned healthy
  - verdict: `no stall detected`

## Notes

- `go test ./internal/qemu` was blocked locally because `qemu-img` is missing from PATH
