### PR TITLE
docs: link the public OpenComputer GitHub App install URL

### DIFF
--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -259,7 +259,7 @@ Pass `key` **or** `credential` (or neither → org default). The agent's `limits
 
 The OpenComputer GitHub App lets OpenComputer obtain short-lived, repo-scoped tokens for the repositories agents may work in. A **Repo** is a stable repository handle that resolves to the OpenComputer App. See the [Repos & GitHub guide](/agent-sessions/repos).
 
-During preview, OpenComputer installs its App on your repository for you — contact us to enable a repo; there is no SDK method to mint an install URL. **No credential passes through this API.** Bring-your-own GitHub App modes (`byo_stored_key`, `byo_broker`) are **coming later — not yet available**; in preview only `oc_app` (OpenComputer owns and mints) works.
+During preview, **install the [OpenComputer GitHub App](https://github.com/apps/opencomputerdev/installations/new)** on the repos you want OpenComputer to work with (you pick the exact repos); there is no SDK method to mint an install URL. **No credential passes through this API.** Bring-your-own GitHub App modes (`byo_stored_key`, `byo_broker`) are **coming later — not yet available**; in preview only `oc_app` (OpenComputer owns and mints) works.
 
 <Tabs>
 

--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -43,10 +43,11 @@ no App key handling.
 Each operation asks for the minimum GitHub permission it needs. Checkout needs read-only
 contents access; write-capable actions ask for write access only for that operation.
 
-During preview, OpenComputer installs its GitHub App on your repository for you — contact us
-to enable a repo. Once a repo is enabled, reference it in a session's `sources` (below) and
-OpenComputer resolves the App and mints a token just in time. You do not need to enumerate
-installations to use a repo.
+**Install the [OpenComputer GitHub App](https://github.com/apps/opencomputerdev/installations/new)**
+on the repositories you want OpenComputer to work with — you choose the exact repos, so it
+never needs org-wide access. Once it's installed on a repo, reference that repo in a session's
+`sources` (below) and OpenComputer resolves the App and mints a token just in time. You do not
+need to enumerate installations to use a repo.
 
 <Warning>
 The App may request write-capable GitHub permissions on the repos you select. OpenComputer
@@ -69,7 +70,7 @@ from your own App. In preview, only the OpenComputer App is available.
 The no-setup path is to pass a real short-lived token inline on the source, using the
 deliberately-named `risky_short_lived_token` auth. An inline token is **checkout-only**:
 it is used once to check the repo out and then purged, so it **cannot publish or open
-PRs**. Publishing requires a configured GitHub App (the OpenComputer App).
+PRs**. Publishing requires a configured GitHub App — [install the OpenComputer App](https://github.com/apps/opencomputerdev/installations/new).
 
 <CodeGroup>
 
@@ -111,7 +112,8 @@ until the first checkout, then purges it. Use this only when a GitHub App is not
 
 ## Register a repo
 
-Once the GitHub App is enabled on a repo, register a repo — optional: any enabled repo can
+Once the [OpenComputer GitHub App](https://github.com/apps/opencomputerdev/installations/new)
+is installed on a repo, register a repo — optional: any installed repo can
 be used in a session directly; a Repo gives you a stable handle to reference.
 
 <CodeGroup>

--- a/docs/agent-sessions/triggers.mdx
+++ b/docs/agent-sessions/triggers.mdx
@@ -21,7 +21,7 @@ on   = "issue.labeled:agent"
 ## Integrations
 
 Triggers and outbound deliveries run through platform integrations, so the agent holds no
-GitHub or Slack tokens. Installing the OpenComputer GitHub App configures GitHub access;
+GitHub or Slack tokens. [Installing the OpenComputer GitHub App](https://github.com/apps/opencomputerdev/installations/new) configures GitHub access;
 Slack channels use a Slack integration.
 
 ## Deliveries


### PR DESCRIPTION
## What

The GitHub/Repos docs told readers to "contact us to enable a repo" — there was no way to actually install the OpenComputer App. This replaces that placeholder with the public install link so a reader can self-serve.

Link used (verified via GitHub `GET /app`): **https://github.com/apps/opencomputerdev/installations/new**

> The App's GitHub name is `OpenComputerDev`, so the GitHub install page shows "OpenComputerDev". Prose keeps the "OpenComputer App" brand and links to that exact URL.

## Where it's linked (a few discoverable spots, not every mention)

- `docs/agent-sessions/repos.mdx`
  - **Main install section** (`## The OpenComputer GitHub App`) — replaced "contact us" with an actionable install step.
  - **Inline short-lived token** note — "Publishing requires a configured GitHub App → install the OpenComputer App".
  - **Register a repo** — "Once the OpenComputer GitHub App is installed on a repo…".
- `docs/agent-sessions/api-reference.mdx` — GitHub Apps & Repos section (the other "contact us" placeholder).
- `docs/agent-sessions/triggers.mdx` — Integrations note ("Installing the OpenComputer GitHub App configures GitHub access").

## Not changed

Docs only — no SDK change, no version bump. Existing accurate framing is intact: inline tokens are checkout-only, bring-your-own Apps are "coming later", per-repo App pinning is future. The quickstart already links to the (now actionable) Repos page via its card, so no link was forced there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)