### PR TITLE
docs+sdk(repos): "How it works" diagram + bring-your-own GitHub App

### DIFF
--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -63,6 +63,15 @@ sequenceDiagram
     Note over GitR: Destroyed
     Store->>Hands: Extract into /workspace/sources
 
+    Note over Brain: Reason
+    Note over Brain: Plan
+    Brain->>Hands: Read, edit, run commands
+    Note over Hands: Edit files
+    Note over Hands: Run tests
+    Note over Hands: Run tools
+    Hands-->>Brain: Results
+    Note over Brain: Decide next step
+
     Note over GitW: Publish — on github_publish_pull_request
     Brain->>CP: github_publish_pull_request(source, title)
     CP->>Hands: Diff the edits

--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -34,6 +34,65 @@ GitHub uses GitHub Apps as its auth surface. Other providers can add their own a
 surface while sessions continue to reference repos and sources the same way.
 </Note>
 
+## How it works
+
+Every authenticated Git operation runs in its own **Git operations sandbox** — a minimal
+box with `git` and nothing else, provisioned for that one operation and destroyed when it
+finishes. The agent's sandbox is never one of these: it never holds a token and never runs
+authenticated `git` or `gh`. Files and patches move between the two through object storage,
+never next to a credential.
+
+```mermaid
+sequenceDiagram
+    participant Agent as Agent sandbox
+    participant CP as Control plane
+    participant Git as Git operations sandbox
+    participant Store as Object storage
+    participant GH as GitHub
+
+    Note over CP,GH: Checkout — before the first turn
+    CP->>Git: Provision for one operation
+    CP->>GH: Mint just-in-time token (read-only, one repo)
+    CP->>Git: Inject token into this box's env only
+    Git->>GH: Clone at the pinned sha
+    Git->>Store: Write files (no .git, no token)
+    Note over Git: Destroyed — token gone
+    Store->>Agent: Extract into the source path
+
+    Note over Agent,GH: Publish — agent calls github_publish_pull_request
+    Agent->>Store: Write a patch (still no token)
+    CP->>Git: Provision a new box
+    CP->>GH: Mint just-in-time token (write-scoped, one repo)
+    Git->>Store: Read the patch
+    Git->>GH: Push an oc/ branch, open the PR
+    Note over Git: Destroyed — token gone
+    GH-->>Agent: PR URL
+```
+
+**Checkout (read), before the first turn:**
+
+1. OpenComputer provisions a fresh Git operations sandbox for the checkout.
+2. The control plane mints a **just-in-time token**: the GitHub App requests an installation
+   token scoped to that one repo with read-only contents permission, and it is injected into
+   the sandbox's environment only — never `.git/config`, the command line, or any log.
+3. The sandbox clones the exact `sha`, then writes the **files** (no `.git`, no remote, no
+   token) to dedicated object storage.
+4. The sandbox is destroyed; the token dies with it.
+5. The agent's sandbox extracts those bytes into `/workspace/sources/<name>`.
+
+**Publish (write), when the agent calls `github_publish_pull_request`:**
+
+1. The agent's sandbox turns its edits into a patch and writes it to object storage. The
+   agent still has no token.
+2. OpenComputer provisions a **new** Git operations sandbox and mints a fresh,
+   **write-scoped** token for that one repo.
+3. The sandbox applies the patch on an `oc/<session>/<source>-<id>` branch, pushes, and
+   opens the PR.
+4. The sandbox is destroyed; the token dies with it. The PR URL is returned to the agent.
+
+The token is minted per operation, scoped to a single repo, lives only inside a box that
+does nothing but Git, and is gone before the next turn.
+
 ## The OpenComputer GitHub App
 
 In preview, the OpenComputer App is the only GitHub App: OpenComputer owns the App key and

--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -38,35 +38,43 @@ surface while sessions continue to reference repos and sources the same way.
 
 Every authenticated Git operation runs in its own **Git operations sandbox** — a minimal
 box with `git` and nothing else, provisioned for that one operation and destroyed when it
-finishes. The agent's sandbox is never one of these: it never holds a token and never runs
-authenticated `git` or `gh`. Files and patches move between the two through object storage,
-never next to a credential.
+finishes. Checkout and publish get *different* boxes. Your agent's own sandboxes — the
+**brain** that runs the loop and the **hands** sandbox that holds the files — are never one
+of these: they hold no token and never run authenticated `git` or `gh`. Files and patches
+move between them through object storage, never next to a credential.
 
 ```mermaid
 sequenceDiagram
-    participant Agent as Agent sandbox
+    participant Brain as Brain (agent loop)
+    participant Hands as Hands (agent sandbox)
     participant CP as Control plane
-    participant Git as Git operations sandbox
+    participant GitR as Git box (checkout)
+    participant GitW as Git box (publish)
     participant Store as Object storage
     participant GH as GitHub
 
-    Note over CP,GH: Checkout — before the first turn
-    CP->>Git: Provision for one operation
+    Note over GitR: Checkout — before the first turn
+    CP->>GitR: Provision (git only, ephemeral)
     CP->>GH: Mint just-in-time token (read-only, one repo)
-    CP->>Git: Inject token into this box's env only
-    Git->>GH: Clone at the pinned sha
-    Git->>Store: Write files (no .git, no token)
-    Note over Git: Destroyed — token gone
-    Store->>Agent: Extract into the source path
+    GH-->>CP: Scoped token
+    CP->>GitR: Inject token into this box's env only
+    GitR->>GH: Clone at the pinned sha
+    GitR->>Store: Write files (no .git, no token)
+    Note over GitR: Destroyed — token gone
+    Store->>Hands: Extract into /workspace/sources
 
-    Note over Agent,GH: Publish — agent calls github_publish_pull_request
-    Agent->>Store: Write a patch (still no token)
-    CP->>Git: Provision a new box
+    Note over GitW: Publish — on github_publish_pull_request
+    Brain->>CP: github_publish_pull_request(source, title)
+    CP->>Hands: Diff the edits
+    Hands->>Store: Write a patch (no token)
+    CP->>GitW: Provision a separate box (git only)
     CP->>GH: Mint just-in-time token (write-scoped, one repo)
-    Git->>Store: Read the patch
-    Git->>GH: Push an oc/ branch, open the PR
-    Note over Git: Destroyed — token gone
-    GH-->>Agent: PR URL
+    GH-->>CP: Scoped token
+    CP->>GitW: Inject token into this box's env only
+    GitW->>Store: Read the patch
+    GitW->>GH: Push an oc/ branch, open the PR
+    Note over GitW: Destroyed — token gone
+    CP-->>Brain: PR URL
 ```
 
 **Checkout (read), before the first turn:**
@@ -78,11 +86,11 @@ sequenceDiagram
 3. The sandbox clones the exact `sha`, then writes the **files** (no `.git`, no remote, no
    token) to dedicated object storage.
 4. The sandbox is destroyed; the token dies with it.
-5. The agent's sandbox extracts those bytes into `/workspace/sources/<name>`.
+5. The **hands** sandbox extracts those bytes into `/workspace/sources/<name>`.
 
 **Publish (write), when the agent calls `github_publish_pull_request`:**
 
-1. The agent's sandbox turns its edits into a patch and writes it to object storage. The
+1. The **hands** sandbox turns its edits into a patch and writes it to object storage. The
    agent still has no token.
 2. OpenComputer provisions a **new** Git operations sandbox and mints a fresh,
    **write-scoped** token for that one repo.

--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -60,7 +60,7 @@ sequenceDiagram
     CP->>GitR: Inject token into this box's env only
     GitR->>GH: Clone at the pinned sha
     GitR->>Store: Write files (no .git, no token)
-    Note over GitR: Destroyed — token gone
+    Note over GitR: Destroyed
     Store->>Hands: Extract into /workspace/sources
 
     Note over GitW: Publish — on github_publish_pull_request
@@ -73,7 +73,7 @@ sequenceDiagram
     CP->>GitW: Inject token into this box's env only
     GitW->>Store: Read the patch
     GitW->>GH: Push an oc/ branch, open the PR
-    Note over GitW: Destroyed — token gone
+    Note over GitW: Destroyed
     CP-->>Brain: PR URL
 ```
 


### PR DESCRIPTION
Two related improvements to the **Repos & GitHub** surface.

## 1. "How it works" + flow diagram
Makes the private-repo mechanics concrete (the page stated the *guarantee*, not the *how*):
- **Per-operation ephemeral Git box** — git and nothing else, provisioned per op, destroyed after. **Checkout and publish get different boxes.** The agent's own sandboxes are never one of these.
- **Just-in-time token minting** — the control plane mints a single-repo-scoped installation token (read-only for checkout, write for publish) and the **git box** does the clone/push.
- **Byte handoff via object storage** — files/patches move between the agent and git boxes through storage, never alongside a credential.
- Mermaid sequence diagram names the agent side as **brain** + **hands** and shows the agent's work loop.

## 2. Bring your own GitHub App (docs + SDK)
Use your own App so PRs/comments/statuses come from your identity. Two paths, both documented with API + SDK examples:
- **One-click manifest flow** — `createManifest` → submit to GitHub → `completeManifest`. OpenComputer hands you a pre-scoped manifest and captures the new App's key server-side; you never touch the private key.
- **Direct register** — `register({ mode: "byo_stored_key", githubAppId, privateKey })` for an existing App, plus `update`/`delete` (rotate key, change default, remove).

SDK `@opencomputer/sdk` **0.8.1 → 0.9.0**: `oc.github.apps` gains `register`, `update`, `delete`, `createManifest`, `completeManifest`; `GitHubApp` surfaces `githubAppId`. `byo_broker` is documented as registrable but not yet used for minting.

## ⚠️ Merge ordering
The BYO docs/SDK describe endpoints that land on **sessions-api PR #25** (`POST/PATCH/DELETE /v3/github/apps`, `POST /v3/github/apps/manifest[/conversions]`). Those need to be **deployed to prod before this merges**, or the documented endpoints 404. The "How it works" half documents already-deployed `oc_app` behavior and is safe independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)