### PR TITLE
docs+sdk: bring-your-own GitHub App (register + one-click manifest) + review fixes

### DIFF
--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -272,7 +272,8 @@ During preview, **install the [OpenComputer GitHub App](https://github.com/apps/
 | `oc.repos.update(id, params)` | Update `name`. |
 | `oc.github.apps.list()` | List GitHub Apps available to your org. |
 | `oc.github.apps.register(params)` | Register your own App (`byo_stored_key` / `byo_broker`). |
-| `oc.github.apps.createManifest(params)` · `completeManifest(params)` | One-click App creation via GitHub's manifest flow. |
+| `oc.github.apps.createManifestUrl(params)` | One-click: get a link to open; OpenComputer hosts the GitHub flow + key capture. |
+| `oc.github.apps.createManifest(params)` · `completeManifest(params)` | Developer-driven manifest flow (you host the redirect). |
 | `oc.github.apps.update(id, params)` · `delete(id)` | Update / rotate / remove a registered App. |
 | `oc.github.installations.list()` | List GitHub App installations visible to OpenComputer. |
 
@@ -288,7 +289,9 @@ During preview, **install the [OpenComputer GitHub App](https://github.com/apps/
 | `GET /github/apps` | List GitHub Apps available to your org. |
 | `POST /github/apps` | Register your own App (`byo_stored_key` / `byo_broker`). |
 | `PATCH /github/apps/:id` · `DELETE /github/apps/:id` | Update / rotate / remove a registered App. |
-| `POST /github/apps/manifest` · `POST /github/apps/manifest/conversions` | One-click App creation (build manifest → exchange code). |
+| `POST /github/apps/manifest` | Start the manifest flow → `{ start_url }` (hosted) or `{ manifest, … }` (with `redirect_url`). |
+| `GET /github/apps/manifest/start` · `…/callback` | Hosted pages OpenComputer serves (browser, not called directly). |
+| `POST /github/apps/manifest/conversions` | Developer-driven: exchange the code for a registered App. |
 | `GET /github/installations` | List GitHub App installations visible to OpenComputer. |
 
 </Tab>
@@ -303,7 +306,7 @@ Repo               = { id, provider, owner, repo, name?, created_at, updated_at 
 
 Responses **never** contain a token or secret. Registering a repo is **optional** under the OpenComputer App — a session can reference `"owner/repo"` directly.
 
-`GET /github/apps` lists the GitHub Apps available to your org — the built-in OpenComputer App plus any you register. Register your own with `POST /github/apps` (`byo_stored_key`: `github_app_id` + `private_key`; `byo_broker`: `broker_url` + `broker_secret`), or one-click via `POST /github/apps/manifest` → `POST /github/apps/manifest/conversions`. App responses carry `id`, `mode`, `status`, `github_app_id?`, `app_name?`, `is_default?` — **never** a key or secret. `GET /github/installations` lists installations visible to OpenComputer; it may be **empty** for orgs using only the OpenComputer App. See the [Repos & GitHub guide](/agent-sessions/repos#bring-your-own-github-app) for the full flow.
+`GET /github/apps` lists the GitHub Apps available to your org — the built-in OpenComputer App plus any you register. Register your own with `POST /github/apps` (`byo_stored_key`: `github_app_id` + `private_key`; `byo_broker`: `broker_url` + `broker_secret`), or one-click: `POST /github/apps/manifest` returns a `start_url` to open and OpenComputer hosts the GitHub redirect + key capture (creating an App is a GitHub-UI flow, so it's a link to open, not a fully programmatic call). App responses carry `id`, `mode`, `status`, `github_app_id?`, `app_name?`, `is_default?` — **never** a key or secret. `GET /github/installations` lists installations visible to OpenComputer; it may be **empty** for orgs using only the OpenComputer App. See the [Repos & GitHub guide](/agent-sessions/repos#bring-your-own-github-app) for the full flow.
 
 ## Credentials
 

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -259,7 +259,7 @@ Pass `key` **or** `credential` (or neither → org default). The agent's `limits
 
 The OpenComputer GitHub App lets OpenComputer obtain short-lived, repo-scoped tokens for the repositories agents may work in. A **Repo** is a stable repository handle that resolves to the OpenComputer App. See the [Repos & GitHub guide](/agent-sessions/repos).
 
-During preview, **install the [OpenComputer GitHub App](https://github.com/apps/opencomputerdev/installations/new)** on the repos you want OpenComputer to work with (you pick the exact repos); there is no SDK method to mint an install URL. **No credential passes through this API.** Bring-your-own GitHub App modes (`byo_stored_key`, `byo_broker`) are **coming later — not yet available**; in preview only `oc_app` (OpenComputer owns and mints) works.
+During preview, **install the [OpenComputer GitHub App](https://github.com/apps/opencomputerdev/installations/new)** on the repos you want OpenComputer to work with (you pick the exact repos). **No credential passes through this API for the OpenComputer App.** You can also **bring your own GitHub App** (`byo_stored_key`) — register an existing App, or create one in one click via the [manifest flow](/agent-sessions/repos#bring-your-own-github-app); the App key is encrypted at rest and never returned. `byo_broker` is registrable but not yet used for minting.
 
 <Tabs>
 
@@ -271,6 +271,9 @@ During preview, **install the [OpenComputer GitHub App](https://github.com/apps/
 | `oc.repos.get(id)` · `oc.repos.list()` | Fetch / list. |
 | `oc.repos.update(id, params)` | Update `name`. |
 | `oc.github.apps.list()` | List GitHub Apps available to your org. |
+| `oc.github.apps.register(params)` | Register your own App (`byo_stored_key` / `byo_broker`). |
+| `oc.github.apps.createManifest(params)` · `completeManifest(params)` | One-click App creation via GitHub's manifest flow. |
+| `oc.github.apps.update(id, params)` · `delete(id)` | Update / rotate / remove a registered App. |
 | `oc.github.installations.list()` | List GitHub App installations visible to OpenComputer. |
 
 </Tab>
@@ -283,6 +286,9 @@ During preview, **install the [OpenComputer GitHub App](https://github.com/apps/
 | `GET /repos/:id` · `GET /repos` | Fetch / list. |
 | `PATCH /repos/:id` | Update `name`. |
 | `GET /github/apps` | List GitHub Apps available to your org. |
+| `POST /github/apps` | Register your own App (`byo_stored_key` / `byo_broker`). |
+| `PATCH /github/apps/:id` · `DELETE /github/apps/:id` | Update / rotate / remove a registered App. |
+| `POST /github/apps/manifest` · `POST /github/apps/manifest/conversions` | One-click App creation (build manifest → exchange code). |
 | `GET /github/installations` | List GitHub App installations visible to OpenComputer. |
 
 </Tab>
@@ -297,7 +303,7 @@ Repo               = { id, provider, owner, repo, name?, created_at, updated_at 
 
 Responses **never** contain a token or secret. Registering a repo is **optional** under the OpenComputer App — a session can reference `"owner/repo"` directly.
 
-`GET /github/apps` lists the GitHub Apps available to your org (in preview, the OpenComputer App). `GET /github/installations` lists the App installations visible to OpenComputer — it may be **empty** for orgs using only the OpenComputer App (it surfaces bring-your-own installations once those modes are available).
+`GET /github/apps` lists the GitHub Apps available to your org — the built-in OpenComputer App plus any you register. Register your own with `POST /github/apps` (`byo_stored_key`: `github_app_id` + `private_key`; `byo_broker`: `broker_url` + `broker_secret`), or one-click via `POST /github/apps/manifest` → `POST /github/apps/manifest/conversions`. App responses carry `id`, `mode`, `status`, `github_app_id?`, `app_name?`, `is_default?` — **never** a key or secret. `GET /github/installations` lists installations visible to OpenComputer; it may be **empty** for orgs using only the OpenComputer App. See the [Repos & GitHub guide](/agent-sessions/repos#bring-your-own-github-app) for the full flow.
 
 ## Credentials
 

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -257,7 +257,7 @@ Pass `key` **or** `credential` (or neither → org default). The agent's `limits
 
 ## GitHub Apps & Repos
 
-The OpenComputer GitHub App lets OpenComputer obtain short-lived, repo-scoped tokens for the repositories agents may work in. A **Repo** is a stable repository handle that resolves to the OpenComputer App. See the [Repos & GitHub guide](/agent-sessions/repos).
+A GitHub App lets OpenComputer obtain short-lived, repo-scoped tokens for the repositories agents may work in. A **Repo** is a stable repository handle that resolves to your configured GitHub App (the OpenComputer App by default, or your own). See the [Repos & GitHub guide](/agent-sessions/repos).
 
 During preview, **install the [OpenComputer GitHub App](https://github.com/apps/opencomputerdev/installations/new)** on the repos you want OpenComputer to work with (you pick the exact repos). **No credential passes through this API for the OpenComputer App.** You can also **bring your own GitHub App** (`byo_stored_key`) — register an existing App, or create one in one click via the [manifest flow](/agent-sessions/repos#bring-your-own-github-app); the App key is encrypted at rest and never returned. `byo_broker` is registrable but not yet used for minting.
 
@@ -298,7 +298,7 @@ During preview, **install the [OpenComputer GitHub App](https://github.com/apps/
 
 </Tabs>
 
-Repo create body: `owner`, `repo`, `provider?` (`github`, default), `name?` (a handle). **No `auth`** — auth resolves through the OpenComputer App. **Idempotent by `(provider, owner, repo)`** (201 fresh / 200 repeat). (Pinning a repo to a specific App is coming later.)
+Repo create body: `owner`, `repo`, `provider?` (`github`, default), `name?` (a handle). **No `auth`** — auth resolves through your configured GitHub App (the OpenComputer App by default). **Idempotent by `(provider, owner, repo)`** (201 fresh / 200 repeat). (Pinning a repo to a specific App is coming later.)
 
 ```
 Repo               = { id, provider, owner, repo, name?, created_at, updated_at }

--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -8,7 +8,8 @@ authenticated remote, or `gh` session gives it whatever that token can do; hidin
 token behind a proxy does not narrow that authority.
 
 Repos make GitHub access operation-scoped. A **Repo** is a stable repository handle
-(owner/repo) that resolves to the OpenComputer App; a **Source** pins `ref` and `sha`.
+(owner/repo) that resolves to your configured GitHub App (the OpenComputer App by default);
+a **Source** pins `ref` and `sha`.
 OpenComputer checks out the exact commit in a short-lived **Git operations sandbox**,
 copies only files into `/workspace/sources/<name>`, and destroys the token. For writes, the
 agent edits files and calls the
@@ -25,7 +26,7 @@ token.
 | GitHub App | Mints operation-scoped GitHub tokens. | Not session refs. |
 | Installation | GitHub account and repo selection. | The repos the App may work in. |
 | Repo | A stable owner/repo handle. | No tokens, private keys, or session refs. |
-| Source | `ref`, `sha`, and local name for one session. | Auth comes from the OpenComputer App unless inline. |
+| Source | `ref`, `sha`, and local name for one session. | Auth comes from your configured GitHub App (OpenComputer App by default) unless inline. |
 | Git operations sandbox | Runs authenticated clone/fetch/publish work. | Separate from the agent; token lives only for one operation. |
 
 <Note>
@@ -59,7 +60,7 @@ sequenceDiagram
     GH-->>CP: Scoped token
     CP->>GitR: Inject token into this box's env only
     GitR->>GH: Clone at the pinned sha
-    GitR->>Store: Write files (no .git, no token)
+    GitR->>Store: Write files (tokenless .git, no remote)
     Note over GitR: Destroyed
     Store->>Hands: Extract into /workspace/sources
 
@@ -92,8 +93,9 @@ sequenceDiagram
 2. The control plane mints a **just-in-time token**: the GitHub App requests an installation
    token scoped to that one repo with read-only contents permission, and it is injected into
    the sandbox's environment only — never `.git/config`, the command line, or any log.
-3. The sandbox clones the exact `sha`, then writes the **files** (no `.git`, no remote, no
-   token) to dedicated object storage.
+3. The sandbox clones the exact `sha`, then writes the **files** to dedicated object storage —
+   with a shallow, **tokenless** `.git` (the token rode in via an in-memory header, never
+   `.git/config`, and the remote is removed), so no credential travels with the bytes.
 4. The sandbox is destroyed; the token dies with it.
 5. The **hands** sandbox extracts those bytes into `/workspace/sources/<name>`.
 
@@ -110,144 +112,67 @@ sequenceDiagram
 The token is minted per operation, scoped to a single repo, lives only inside a box that
 does nothing but Git, and is gone before the next turn.
 
-## The OpenComputer GitHub App
+## Connecting GitHub
 
-In preview, the OpenComputer App is the only GitHub App: OpenComputer owns the App key and
-mints a fresh, narrowly-scoped token for each operation, so you get private repo access with
-no App key handling.
+Pick one. Either way, OpenComputer mints a fresh, repo-scoped token **per operation** (read-only
+for checkout, write only to publish) — the agent never holds one.
 
-Each operation asks for the minimum GitHub permission it needs. Checkout needs read-only
-contents access; write-capable actions ask for write access only for that operation.
+<CardGroup cols={2}>
+  <Card title="Install the OpenComputer App" icon="github" href="https://github.com/apps/opencomputerdev/installations/new">
+    Zero setup. Choose the repos and go — OpenComputer owns the key and mints per operation.
+  </Card>
+  <Card title="Create your own App" icon="wand-magic-sparkles" href="#bring-your-own-app">
+    GitHub creates it in a few clicks; OpenComputer federates it, so PRs come from your identity.
+  </Card>
+</CardGroup>
 
-**Install the [OpenComputer GitHub App](https://github.com/apps/opencomputerdev/installations/new)**
-on the repositories you want OpenComputer to work with — you choose the exact repos, so it
-never needs org-wide access. Once it's installed on a repo, reference that repo in a session's
-`sources` (below) and OpenComputer resolves the App and mints a token just in time. You do not
-need to enumerate installations to use a repo.
+### Bring your own App
 
-<Warning>
-The App may request write-capable GitHub permissions on the repos you select. OpenComputer
-does **not** hand that broad authority to the agent: each operation gets a fresh token with
-the minimum permission it needs, such as read-only for checkout and write only for a
-publish/comment action.
-</Warning>
+Use your own GitHub App so PRs, comments, and statuses come from **your** identity. OpenComputer
+stores the key encrypted and signs the same per-operation tokens with it.
 
-### Bring your own GitHub App
-
-Register your own GitHub App so pull requests, comments, and statuses come from **your** App
-identity instead of OpenComputer's. Nothing else changes — OpenComputer still mints the same
-per-operation, repo-scoped tokens; it just signs them with your App's key, which it stores
-encrypted and never returns.
-
-Creating a GitHub App is, by GitHub's design, a **user-facing flow through GitHub's UI** —
-GitHub authenticates the person who creates and owns the App, so there's no API that mints one
-on your behalf. OpenComputer hosts that flow behind a single link. (If you already have an App,
-skip to [registering it directly](#already-have-an-app).)
-
-**One-click — open a link (recommended).** Ask OpenComputer for a setup link and open it.
-GitHub walks the user through creating the App; OpenComputer's callback captures the key,
-encrypts it, and registers the App as `byo_stored_key`. You never render a form or touch the
-private key.
+**Create one** — `createManifestUrl` returns a link; open it and GitHub walks you through
+creating the App, then OpenComputer captures the key and registers it. (Creating an App is a
+GitHub-UI flow, so it's a link to open, not a pure API call.)
 
 <CodeGroup>
 
 ```ts TypeScript SDK
-const { startUrl } = await oc.github.apps.createManifestUrl({
-  name: "Acme Agents",
-  isDefault: true,
-  // organization: "acme",   // omit for a user-owned App
-});
-// Open startUrl in a browser (or print it in your CLI). After the user clicks
-// "Create" on GitHub, OpenComputer registers the App — nothing else to call.
+const { startUrl } = await oc.github.apps.createManifestUrl({ name: "Your Agents" });
+// open startUrl → click "Create" on GitHub → done
 ```
 
 ```http REST API
 POST /v3/github/apps/manifest
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 
-{ "name": "Acme Agents", "is_default": true }
-// → { "start_url": "https://api.opencomputer.dev/v3/github/apps/manifest/start?token=…",
-//     "expires_at": "…" }
-// Open start_url in a browser; OpenComputer hosts the GitHub redirect + key capture.
+{ "name": "Your Agents" }
+// → { "start_url": "…", "expires_at": "…" }   — open start_url in a browser
 ```
 
 </CodeGroup>
 
-**Embed it in your own product (developer-driven).** If you want the GitHub redirect to land in
-*your* app (e.g. to attach the new App to your own user), host the redirect yourself: build the
-manifest, render a top-level form that POSTs it to GitHub, then exchange the `code` GitHub
-returns. (The form must be a top-level navigation, not fetch/XHR — GitHub shows the user its
-App-creation screen.)
+**Already have one** — register it with its App id + private key:
 
 <CodeGroup>
 
 ```ts TypeScript SDK
-// 1. Build the manifest + the GitHub URL to submit it to.
-const m = await oc.github.apps.createManifest({
-  redirectUrl: "https://your.app/github/callback",
-  name: "Acme Agents",
-});
-// 2. Render a form that POSTs m.manifest (JSON) as field m.field to m.postUrl.
-// 3. In your redirect handler, exchange the code GitHub appended:
-const app = await oc.github.apps.completeManifest({ code, isDefault: true });
-```
-
-```http REST API
-POST /v3/github/apps/manifest
-Authorization: Bearer $OPENCOMPUTER_API_KEY
-
-{ "redirect_url": "https://your.app/github/callback", "name": "Acme Agents" }
-// → { "manifest": { … }, "post_url": "https://github.com/settings/apps/new?state=…",
-//     "field": "manifest", "state": "…" }
-
-// after GitHub redirects back to your redirect_url with ?code=…
-POST /v3/github/apps/manifest/conversions
-{ "code": "…", "is_default": true }
-// → { "id": "gha_…", "mode": "byo_stored_key", … }
-```
-
-</CodeGroup>
-
-<a id="already-have-an-app" />
-**Already have an App?** Register it directly with its numeric App id and private key.
-
-<CodeGroup>
-
-```ts TypeScript SDK
-const app = await oc.github.apps.register({
-  mode: "byo_stored_key",
-  githubAppId: "123456",
-  privateKey: pem,   // PKCS#1 or PKCS#8 PEM; encrypted at rest, never returned
-  isDefault: true,
-});
+await oc.github.apps.register({ mode: "byo_stored_key", githubAppId: "123456", privateKey: pem });
 ```
 
 ```http REST API
 POST /v3/github/apps
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 
-{
-  "mode": "byo_stored_key",
-  "github_app_id": "123456",
-  "private_key": "-----BEGIN RSA PRIVATE KEY-----\n…",
-  "is_default": true
-}
+{ "mode": "byo_stored_key", "github_app_id": "123456", "private_key": "-----BEGIN…" }
 ```
 
 </CodeGroup>
 
-However you set it up, the last step is to **install the App on the repos you want** (from its
-GitHub settings page) and reference those repos in `sources` exactly as with the OpenComputer
-App — OpenComputer resolves your App and mints per operation. Rotate the key or change the
-default with `oc.github.apps.update(id, { … })`; remove it (and its encrypted key) with
-`oc.github.apps.delete(id)`.
-
-<Note>
-**`byo_broker` is registrable but not yet used for operations.** You can register a broker App
-(`mode: "byo_broker"` with `brokerUrl` + `brokerSecret`) so it shows up in your apps list, but
-minting through a broker is still coming — checkout and publish keep using the OpenComputer App
-until it lands. `byo_stored_key` above is the supported way to use your own App today.
-</Note>
+Then **install your App on the repos** and reference them in `sources` as usual. List / rotate /
+remove with `oc.github.apps.list()` · `update(id, …)` · `delete(id)`. Building this into your own
+product with your own redirect? Use `createManifest` + `completeManifest`. (`byo_broker` can be
+registered but isn't used for minting yet.)
 
 ### Inline short-lived token
 
@@ -319,8 +244,8 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 </CodeGroup>
 
 Get-or-create, owner-scoped, idempotent by `(provider, owner, repo)`. **No credential is
-passed** — auth resolves through the OpenComputer App. (Pinning a repo to a specific App is
-coming later.)
+passed** — auth resolves through your configured GitHub App (the OpenComputer App by default).
+(Pinning a repo to a specific App is coming later.)
 
 ## Use it in a session
 

--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -132,13 +132,94 @@ the minimum permission it needs, such as read-only for checkout and write only f
 publish/comment action.
 </Warning>
 
-### Bring your own GitHub App (coming later)
+### Bring your own GitHub App
+
+Register your own GitHub App so pull requests, comments, and statuses come from **your** App
+identity instead of OpenComputer's. Nothing else changes — OpenComputer still mints the same
+per-operation, repo-scoped tokens; it just signs them with your App's key, which it stores
+encrypted and never returns.
+
+There are two ways to set one up.
+
+**One-click — create an App from a manifest.** OpenComputer hands you a manifest already scoped
+to the permissions it needs; GitHub creates the App and returns a one-time code; OpenComputer
+exchanges it and captures the key. You never handle the private key yourself.
+
+<CodeGroup>
+
+```ts TypeScript SDK
+// 1. Build the manifest + the GitHub URL to submit it to.
+const manifest = await oc.github.apps.createManifest({
+  redirectUrl: "https://your.app/github/callback",
+  name: "Acme Agents",
+  // organization: "acme",   // omit for a user-owned App
+});
+
+// 2. Render a form that POSTs manifest.manifest (JSON) as field manifest.field
+//    to manifest.postUrl. It must be a top-level navigation, not fetch/XHR —
+//    GitHub shows the user its App-creation screen, then redirects to
+//    redirectUrl?code=…&state=…
+
+// 3. In your redirect handler, exchange the code — registers a byo_stored_key App.
+const app = await oc.github.apps.completeManifest({ code, isDefault: true });
+```
+
+```http REST API
+POST /v3/github/apps/manifest
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+
+{ "redirect_url": "https://your.app/github/callback", "name": "Acme Agents" }
+// → { "manifest": { … }, "post_url": "https://github.com/settings/apps/new?state=…",
+//     "field": "manifest", "state": "…" }
+
+// After GitHub redirects back to your redirect_url with ?code=…
+POST /v3/github/apps/manifest/conversions
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+
+{ "code": "…", "is_default": true }
+// → { "id": "gha_…", "mode": "byo_stored_key", "app_name": "Acme Agents", … }
+```
+
+</CodeGroup>
+
+**Already have an App?** Register it directly with its numeric App id and private key.
+
+<CodeGroup>
+
+```ts TypeScript SDK
+const app = await oc.github.apps.register({
+  mode: "byo_stored_key",
+  githubAppId: "123456",
+  privateKey: pem,   // PKCS#1 or PKCS#8 PEM; encrypted at rest, never returned
+  isDefault: true,
+});
+```
+
+```http REST API
+POST /v3/github/apps
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+
+{
+  "mode": "byo_stored_key",
+  "github_app_id": "123456",
+  "private_key": "-----BEGIN RSA PRIVATE KEY-----\n…",
+  "is_default": true
+}
+```
+
+</CodeGroup>
+
+Either way, the last step is to **install the App on the repos you want** (from its GitHub
+settings page) and reference those repos in `sources` exactly as with the OpenComputer App —
+OpenComputer resolves your App and mints per operation. Rotate the key or change the default
+with `oc.github.apps.update(id, { … })`; remove it (and its encrypted key) with
+`oc.github.apps.delete(id)`.
 
 <Note>
-**Not yet available.** Bring-your-own GitHub App modes — `byo_stored_key` (OpenComputer
-stores your App key encrypted and mints) and `byo_broker` (your backend owns the App key and
-returns short-lived tokens) — are planned so that GitHub PRs, comments, and statuses can come
-from your own App. In preview, only the OpenComputer App is available.
+**`byo_broker` is registrable but not yet used for operations.** You can register a broker App
+(`mode: "byo_broker"` with `brokerUrl` + `brokerSecret`) so it shows up in your apps list, but
+minting through a broker is still coming — checkout and publish keep using the OpenComputer App
+until it lands. `byo_stored_key` above is the supported way to use your own App today.
 </Note>
 
 ### Inline short-lived token

--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -139,28 +139,56 @@ identity instead of OpenComputer's. Nothing else changes — OpenComputer still 
 per-operation, repo-scoped tokens; it just signs them with your App's key, which it stores
 encrypted and never returns.
 
-There are two ways to set one up.
+Creating a GitHub App is, by GitHub's design, a **user-facing flow through GitHub's UI** —
+GitHub authenticates the person who creates and owns the App, so there's no API that mints one
+on your behalf. OpenComputer hosts that flow behind a single link. (If you already have an App,
+skip to [registering it directly](#already-have-an-app).)
 
-**One-click — create an App from a manifest.** OpenComputer hands you a manifest already scoped
-to the permissions it needs; GitHub creates the App and returns a one-time code; OpenComputer
-exchanges it and captures the key. You never handle the private key yourself.
+**One-click — open a link (recommended).** Ask OpenComputer for a setup link and open it.
+GitHub walks the user through creating the App; OpenComputer's callback captures the key,
+encrypts it, and registers the App as `byo_stored_key`. You never render a form or touch the
+private key.
+
+<CodeGroup>
+
+```ts TypeScript SDK
+const { startUrl } = await oc.github.apps.createManifestUrl({
+  name: "Acme Agents",
+  isDefault: true,
+  // organization: "acme",   // omit for a user-owned App
+});
+// Open startUrl in a browser (or print it in your CLI). After the user clicks
+// "Create" on GitHub, OpenComputer registers the App — nothing else to call.
+```
+
+```http REST API
+POST /v3/github/apps/manifest
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+
+{ "name": "Acme Agents", "is_default": true }
+// → { "start_url": "https://api.opencomputer.dev/v3/github/apps/manifest/start?token=…",
+//     "expires_at": "…" }
+// Open start_url in a browser; OpenComputer hosts the GitHub redirect + key capture.
+```
+
+</CodeGroup>
+
+**Embed it in your own product (developer-driven).** If you want the GitHub redirect to land in
+*your* app (e.g. to attach the new App to your own user), host the redirect yourself: build the
+manifest, render a top-level form that POSTs it to GitHub, then exchange the `code` GitHub
+returns. (The form must be a top-level navigation, not fetch/XHR — GitHub shows the user its
+App-creation screen.)
 
 <CodeGroup>
 
 ```ts TypeScript SDK
 // 1. Build the manifest + the GitHub URL to submit it to.
-const manifest = await oc.github.apps.createManifest({
+const m = await oc.github.apps.createManifest({
   redirectUrl: "https://your.app/github/callback",
   name: "Acme Agents",
-  // organization: "acme",   // omit for a user-owned App
 });
-
-// 2. Render a form that POSTs manifest.manifest (JSON) as field manifest.field
-//    to manifest.postUrl. It must be a top-level navigation, not fetch/XHR —
-//    GitHub shows the user its App-creation screen, then redirects to
-//    redirectUrl?code=…&state=…
-
-// 3. In your redirect handler, exchange the code — registers a byo_stored_key App.
+// 2. Render a form that POSTs m.manifest (JSON) as field m.field to m.postUrl.
+// 3. In your redirect handler, exchange the code GitHub appended:
 const app = await oc.github.apps.completeManifest({ code, isDefault: true });
 ```
 
@@ -172,16 +200,15 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 // → { "manifest": { … }, "post_url": "https://github.com/settings/apps/new?state=…",
 //     "field": "manifest", "state": "…" }
 
-// After GitHub redirects back to your redirect_url with ?code=…
+// after GitHub redirects back to your redirect_url with ?code=…
 POST /v3/github/apps/manifest/conversions
-Authorization: Bearer $OPENCOMPUTER_API_KEY
-
 { "code": "…", "is_default": true }
-// → { "id": "gha_…", "mode": "byo_stored_key", "app_name": "Acme Agents", … }
+// → { "id": "gha_…", "mode": "byo_stored_key", … }
 ```
 
 </CodeGroup>
 
+<a id="already-have-an-app" />
 **Already have an App?** Register it directly with its numeric App id and private key.
 
 <CodeGroup>
@@ -209,10 +236,10 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 
 </CodeGroup>
 
-Either way, the last step is to **install the App on the repos you want** (from its GitHub
-settings page) and reference those repos in `sources` exactly as with the OpenComputer App —
-OpenComputer resolves your App and mints per operation. Rotate the key or change the default
-with `oc.github.apps.update(id, { … })`; remove it (and its encrypted key) with
+However you set it up, the last step is to **install the App on the repos you want** (from its
+GitHub settings page) and reference those repos in `sources` exactly as with the OpenComputer
+App — OpenComputer resolves your App and mints per operation. Rotate the key or change the
+default with `oc.github.apps.update(id, { … })`; remove it (and its encrypted key) with
 `oc.github.apps.delete(id)`.
 
 <Note>

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/agents/repos.ts
+++ b/sdks/typescript/src/agents/repos.ts
@@ -23,28 +23,95 @@ export interface Repo {
 }
 
 /**
- * How a GitHub App mints operation-scoped tokens. In preview, only `oc_app` is available:
- * - `oc_app`: OpenComputer owns the App key and mints (the only mode that works today).
- * - `byo_stored_key`, `byo_broker`: bring-your-own App modes — coming later, not yet
- *   available. Left as open string values so future values don't break clients.
+ * How a GitHub App mints operation-scoped tokens:
+ * - `oc_app`: the built-in OpenComputer App owns the key and mints. Default if you register
+ *   nothing.
+ * - `byo_stored_key`: your own GitHub App; OpenComputer stores the App private key encrypted
+ *   and mints with it. Register it directly ({@link GitHubApps.register}) or one-click via the
+ *   manifest flow ({@link GitHubApps.createManifest} / {@link GitHubApps.completeManifest}).
+ * - `byo_broker`: your backend owns the key and returns short-lived tokens — registrable now,
+ *   but token minting through a broker is still coming, so it is not yet used for operations.
+ * Left as an open string so future modes don't break clients.
  */
 export type GitHubAppMode = "oc_app" | "byo_stored_key" | "byo_broker" | (string & {});
 export type GitHubAppStatus = "active" | "suspended" | "revoked" | (string & {});
 
 /**
- * A GitHub App authority for repo operations. In preview the only App is the built-in
- * OpenComputer App (`oc_app`); user-owned App modes are planned and would keep the
- * Repo/Source shape unchanged.
+ * A GitHub App authority for repo operations. The built-in OpenComputer App (`oc_app`) is
+ * always present; registering your own adds `byo_stored_key` / `byo_broker` apps. The Repo and
+ * Source shapes are identical regardless of which App authorizes them.
  */
 export interface GitHubApp {
   id: string; // gha_…
   provider: "github" | (string & {});
   mode: GitHubAppMode;
   status: GitHubAppStatus;
+  /** The GitHub numeric App id (App-key modes). Not a secret. */
+  githubAppId?: string;
   appSlug?: string;
   appName?: string;
   isDefault?: boolean;
   createdAt?: string;
+}
+
+/**
+ * Register your own GitHub App. `byo_stored_key` needs the GitHub numeric App id + the App
+ * private key (PEM) — OpenComputer encrypts the key at rest and never returns it. `byo_broker`
+ * needs your HTTPS mint endpoint + a shared secret. Set `isDefault` to make it the App used
+ * when a repo doesn't pin one.
+ */
+export interface RegisterGitHubAppParams {
+  mode: "byo_stored_key" | "byo_broker";
+  /** byo_stored_key: the GitHub numeric App id. */
+  githubAppId?: string;
+  /** byo_stored_key: the App private key, PEM (PKCS#1 or PKCS#8). Encrypted at rest. */
+  privateKey?: string;
+  /** byo_broker: your HTTPS token-mint endpoint. */
+  brokerUrl?: string;
+  /** byo_broker: shared secret OpenComputer presents to your broker. Encrypted at rest. */
+  brokerSecret?: string;
+  appName?: string;
+  appSlug?: string;
+  isDefault?: boolean;
+}
+
+/** Update a registered App. Setting `privateKey` / `brokerSecret` rotates that secret in place. */
+export interface UpdateGitHubAppParams {
+  status?: GitHubAppStatus;
+  appName?: string;
+  appSlug?: string;
+  isDefault?: boolean;
+  privateKey?: string;
+  brokerUrl?: string;
+  brokerSecret?: string;
+}
+
+/** Parameters for building a GitHub App-creation manifest. */
+export interface CreateAppManifestParams {
+  /** Where GitHub returns `?code=&state=` after the App is created (must be https). */
+  redirectUrl: string;
+  /** Suggested App name (GitHub requires global uniqueness; the user can change it). */
+  name?: string;
+  /** App homepage URL; defaults to the redirect URL's origin. */
+  url?: string;
+  /** Org login to create an org-owned App; omit for a user-owned App. */
+  organization?: string;
+}
+
+/** The manifest + where to submit it. POST `manifest` (JSON) as form field `field` to `postUrl`. */
+export interface AppManifest {
+  manifest: Record<string, unknown>;
+  postUrl: string;
+  field: "manifest";
+  /** CSRF/correlation token — echo it from your redirect handler and verify it matches. */
+  state: string;
+}
+
+/** Complete the manifest flow: exchange the `code` GitHub returned for a registered App. */
+export interface CompleteAppManifestParams {
+  /** The one-time `code` GitHub appended to your redirect URL (~1h TTL, single use). */
+  code: string;
+  isDefault?: boolean;
 }
 
 /**
@@ -107,12 +174,52 @@ export class GitHub {
   }
 }
 
-/** GitHub Apps available to your org. In preview this lists the OpenComputer App; BYO App
- *  registration methods are planned for later. */
+/**
+ * GitHub Apps available to your org — the built-in OpenComputer App plus any you register.
+ * Use your own App (`byo_stored_key`) so PRs, comments, and statuses come from your App
+ * identity; register it directly with {@link register}, or one-click with {@link createManifest}
+ * + {@link completeManifest}.
+ */
 export class GitHubApps {
   constructor(private readonly http: Http) {}
+
   list(params: { limit?: number; cursor?: string } = {}): Promise<Page<GitHubApp>> {
     return this.http.request("GET", "/github/apps", { query: params as Query });
+  }
+
+  /** Register your own GitHub App (`byo_stored_key` or `byo_broker`). Secrets are encrypted at
+   *  rest and never returned. */
+  register(params: RegisterGitHubAppParams): Promise<GitHubApp> {
+    return this.http.request("POST", "/github/apps", { body: params });
+  }
+
+  /** Update an App: rename, change status, set as default, or rotate the key/secret. */
+  update(id: string, params: UpdateGitHubAppParams): Promise<GitHubApp> {
+    return this.http.request("PATCH", `/github/apps/${encodeURIComponent(id)}`, { body: params });
+  }
+
+  /** Remove a registered App, its installations, and its encrypted secrets. */
+  delete(id: string): Promise<{ id: string; deleted: boolean }> {
+    return this.http.request("DELETE", `/github/apps/${encodeURIComponent(id)}`);
+  }
+
+  /**
+   * Step 1 of the one-click flow: build a GitHub App-creation manifest pre-scoped to what
+   * OpenComputer needs. Render a form that POSTs `result.manifest` (JSON) as field
+   * `result.field` to `result.postUrl`; GitHub creates the App and redirects to your
+   * `redirectUrl` with a `code`.
+   */
+  createManifest(params: CreateAppManifestParams): Promise<AppManifest> {
+    return this.http.request("POST", "/github/apps/manifest", { body: params });
+  }
+
+  /**
+   * Step 2 of the one-click flow: exchange the `code` GitHub returned for a registered App.
+   * OpenComputer captures the new App's private key server-side, encrypts it, and registers
+   * the App as `byo_stored_key`. The key is never exposed to your code.
+   */
+  completeManifest(params: CompleteAppManifestParams): Promise<GitHubApp> {
+    return this.http.request("POST", "/github/apps/manifest/conversions", { body: params });
   }
 }
 

--- a/sdks/typescript/src/agents/repos.ts
+++ b/sdks/typescript/src/agents/repos.ts
@@ -86,7 +86,27 @@ export interface UpdateGitHubAppParams {
   brokerSecret?: string;
 }
 
-/** Parameters for building a GitHub App-creation manifest. */
+/** Parameters for the hosted one-click flow (OpenComputer hosts the start page + callback). */
+export interface CreateAppManifestUrlParams {
+  /** Suggested App name (GitHub requires global uniqueness; the user can change it). */
+  name?: string;
+  /** Org login to create an org-owned App; omit for a user-owned App. */
+  organization?: string;
+  /** Make the new App your org's default. */
+  isDefault?: boolean;
+}
+
+/** A short-lived link to open in a browser to create + connect a GitHub App. */
+export interface AppManifestUrl {
+  /** Open this in a browser: it sends the user to GitHub, and OpenComputer's callback captures
+   *  the key and registers the App. No form to render, no code to handle. */
+  startUrl: string;
+  expiresAt: string;
+}
+
+/** Parameters for building a GitHub App-creation manifest (developer-driven; you host the
+ *  redirect and exchange the code yourself). For the one-click path use
+ *  {@link GitHubApps.createManifestUrl} instead. */
 export interface CreateAppManifestParams {
   /** Where GitHub returns `?code=&state=` after the App is created (must be https). */
   redirectUrl: string;
@@ -177,8 +197,8 @@ export class GitHub {
 /**
  * GitHub Apps available to your org — the built-in OpenComputer App plus any you register.
  * Use your own App (`byo_stored_key`) so PRs, comments, and statuses come from your App
- * identity; register it directly with {@link register}, or one-click with {@link createManifest}
- * + {@link completeManifest}.
+ * identity. Easiest is {@link createManifestUrl} (one link, OpenComputer hosts the rest); if
+ * you already have an App, {@link register} it directly.
  */
 export class GitHubApps {
   constructor(private readonly http: Http) {}
@@ -204,19 +224,32 @@ export class GitHubApps {
   }
 
   /**
-   * Step 1 of the one-click flow: build a GitHub App-creation manifest pre-scoped to what
-   * OpenComputer needs. Render a form that POSTs `result.manifest` (JSON) as field
-   * `result.field` to `result.postUrl`; GitHub creates the App and redirects to your
-   * `redirectUrl` with a `code`.
+   * **One-click (recommended).** Returns a `startUrl` to open in a browser. It sends the user
+   * to GitHub to create the App, and OpenComputer's hosted callback captures the key and
+   * registers it as `byo_stored_key` — you don't render a form or handle the redirect code.
+   * Creating an App from a manifest is inherently a GitHub-UI flow, so this is a link to open,
+   * not a fully programmatic call. The link is short-lived.
+   */
+  createManifestUrl(params: CreateAppManifestUrlParams = {}): Promise<AppManifestUrl> {
+    return this.http.request("POST", "/github/apps/manifest", { body: params });
+  }
+
+  /**
+   * Developer-driven manifest flow (use {@link createManifestUrl} unless you need to host the
+   * redirect yourself — e.g. to attach the App to your own user in your UI). Builds a manifest
+   * pre-scoped to what OpenComputer needs; render a form that POSTs `result.manifest` (JSON) as
+   * field `result.field` to `result.postUrl`. GitHub redirects to your `redirectUrl` with a
+   * `code` — finish with {@link completeManifest}.
    */
   createManifest(params: CreateAppManifestParams): Promise<AppManifest> {
     return this.http.request("POST", "/github/apps/manifest", { body: params });
   }
 
   /**
-   * Step 2 of the one-click flow: exchange the `code` GitHub returned for a registered App.
-   * OpenComputer captures the new App's private key server-side, encrypts it, and registers
-   * the App as `byo_stored_key`. The key is never exposed to your code.
+   * Finish the developer-driven flow: exchange the `code` GitHub returned for a registered App.
+   * OpenComputer captures the new App's private key server-side, encrypts it, and registers the
+   * App as `byo_stored_key`. The key is never exposed to your code. (Not needed for
+   * {@link createManifestUrl}, whose callback does this for you.)
    */
   completeManifest(params: CompleteAppManifestParams): Promise<GitHubApp> {
     return this.http.request("POST", "/github/apps/manifest/conversions", { body: params });


### PR DESCRIPTION
Carries the BYO GitHub App work that landed on the `docs/repos-how-it-works` branch **after #420 was merged** (so it's not in `main`).

## Docs — Repos & GitHub
- **Connecting GitHub** rewritten to three tight options: install the OpenComputer App, **create your own App** (one-click hosted link), or register an existing App. With API + SDK examples.
- Accuracy fixes from review: checkout preserves a **tokenless shallow `.git`** (remote removed), not "no .git"; repos/sources resolve through your **configured GitHub App (OC App by default)**, not always the OC App.
- `api-reference` tables + prose updated for the new endpoints.

## SDK (`@opencomputer/sdk` 0.8.1 → 0.9.0)
`oc.github.apps` gains `register`, `update`, `delete`, `createManifestUrl` (hosted one-click), `createManifest` + `completeManifest` (developer-driven); `GitHubApp` surfaces `githubAppId`.

Backend endpoints are on **sessions-api PR #25** and are **deployed to prod** (api.opencomputer.dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)