### PR TITLE
Auto-promote disk-only checkpoints by default

### DIFF
--- a/cmd/oc/internal/commands/checkpoint.go
+++ b/cmd/oc/internal/commands/checkpoint.go
@@ -213,6 +213,7 @@ func init() {
 	checkpointCreateCmd.Flags().String("name", "", "Checkpoint name (required)")
 	checkpointCreateCmd.Flags().String("kind", "full", "Checkpoint kind (full, disk_only)")
 	checkpointCreateCmd.Flags().Bool("promote-to-full", false, "For disk_only checkpoints, asynchronously create a derived full checkpoint for faster forks")
+	checkpointCreateCmd.Flags().MarkHidden("promote-to-full")
 	checkpointCreateCmd.Flags().String("retention-policy", "none", "Retention policy for automatic checkpoint cleanup (none, delete_oldest)")
 	checkpointCreateCmd.Flags().Int("retention-max-count", 0, "Maximum checkpoints of this kind to keep when --retention-policy=delete_oldest (full: 1-10, disk_only: 1-100, default server limit)")
 	checkpointCreateCmd.MarkFlagRequired("name")

--- a/docs/reference/python-sdk.mdx
+++ b/docs/reference/python-sdk.mdx
@@ -121,7 +121,7 @@ Update idle timeout.
 | --- | --- | --- |
 | `timeout` | int | New timeout in seconds |
 
-#### `await sandbox.create_checkpoint(name, kind=None, promote_to_full=False, retention_policy=None): dict`
+#### `await sandbox.create_checkpoint(name, kind=None, retention_policy=None): dict`
 
 Create a named checkpoint. Full checkpoints are limited to 10 per sandbox; disk-only checkpoints are limited to 100 per sandbox. Pass `retention_policy={"mode": "delete_oldest", "maxCount": 10}` for full checkpoints or `kind="disk_only", retention_policy={"mode": "delete_oldest", "maxCount": 100}` to delete the oldest eligible checkpoint of the same type before creating a new one. Returns checkpoint info as a dictionary.
 

--- a/docs/reference/python-sdk/sandbox.mdx
+++ b/docs/reference/python-sdk/sandbox.mdx
@@ -175,7 +175,7 @@ Update idle timeout. [HTTP API →](/api-reference/sandboxes/set-timeout)
 
 **Returns:** `None`
 
-### `await sandbox.create_checkpoint(name, kind=None, promote_to_full=False, retention_policy=None)`
+### `await sandbox.create_checkpoint(name, kind=None, retention_policy=None)`
 
 Create a named checkpoint. [HTTP API →](/api-reference/checkpoints/create)
 

--- a/internal/api/sandbox.go
+++ b/internal/api/sandbox.go
@@ -38,13 +38,17 @@ func maxCheckpointsForKind(kind string) int {
 type createCheckpointRequest struct {
 	Name            string                    `json:"name"`
 	Kind            string                    `json:"kind"`
-	PromoteToFull   bool                      `json:"promoteToFull"`
+	PromoteToFull   *bool                     `json:"promoteToFull"`
 	RetentionPolicy checkpointRetentionPolicy `json:"retentionPolicy"`
 }
 
 type checkpointRetentionPolicy struct {
 	Mode     string `json:"mode"`
 	MaxCount int    `json:"maxCount"`
+}
+
+func shouldPromoteCheckpoint(kind string, promoteToFull *bool) bool {
+	return kind == "disk_only" && (promoteToFull == nil || *promoteToFull)
 }
 
 func (s *Server) createSandbox(c echo.Context) error {
@@ -2204,9 +2208,10 @@ func (s *Server) createCheckpoint(c echo.Context) error {
 	if kind != "full" && kind != "disk_only" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "kind must be full or disk_only"})
 	}
-	if req.PromoteToFull && kind != "disk_only" {
+	if req.PromoteToFull != nil && *req.PromoteToFull && kind != "disk_only" {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "promoteToFull is only supported for disk_only checkpoints"})
 	}
+	shouldPromoteToFull := shouldPromoteCheckpoint(kind, req.PromoteToFull)
 
 	// Enforce checkpoint limits per kind. Full checkpoints are heavier because
 	// they include memory/CPU state; disk-only checkpoints are cheaper and get
@@ -2264,7 +2269,7 @@ func (s *Server) createCheckpoint(c echo.Context) error {
 		SandboxConfig: session.Config,
 	}
 	var promotedArtifactID string
-	if req.PromoteToFull {
+	if shouldPromoteToFull {
 		promotionStatus := "pending"
 		promotedArtifactID = uuid.New().String()
 		cp.PromotionStatus = &promotionStatus
@@ -2333,7 +2338,7 @@ func (s *Server) createCheckpoint(c echo.Context) error {
 				s.recordLifecycleID(context.Background(), orgID, sandboxID, types.WebhookEventCheckpointCreated,
 					sandboxID+":sandbox.checkpoint.created:"+checkpointID.String(),
 					map[string]any{"checkpointId": checkpointID.String()})
-				if req.PromoteToFull {
+				if shouldPromoteToFull {
 					s.startCheckpointPromotion(context.Background(), checkpointID, promotedArtifactID, sandboxID, req.Name, session.WorkerID, session.Config, grpcResp.RootfsS3Key, grpcResp.WorkspaceS3Key)
 				}
 			}
@@ -2398,7 +2403,7 @@ func (s *Server) createCheckpoint(c echo.Context) error {
 				s.recordLifecycleID(context.Background(), orgID, sandboxID, types.WebhookEventCheckpointCreated,
 					sandboxID+":sandbox.checkpoint.created:"+checkpointID.String(),
 					map[string]any{"checkpointId": checkpointID.String()})
-				if req.PromoteToFull {
+				if shouldPromoteToFull {
 					s.startCheckpointPromotion(context.Background(), checkpointID, promotedArtifactID, sandboxID, req.Name, session.WorkerID, session.Config, rootfsKey, workspaceKey)
 				}
 			}

--- a/internal/api/sandbox_test.go
+++ b/internal/api/sandbox_test.go
@@ -48,10 +48,10 @@ func TestForkCheckpointAuthMatrix(t *testing.T) {
 	otherOrg := uuid.New()
 
 	cases := []struct {
-		name      string
-		cp        db.Checkpoint
-		caller    uuid.UUID
-		wantDeny  bool
+		name     string
+		cp       db.Checkpoint
+		caller   uuid.UUID
+		wantDeny bool
 	}{
 		{"owner forks private", db.Checkpoint{OrgID: ownerOrg, IsPublic: false}, ownerOrg, false},
 		{"owner forks public", db.Checkpoint{OrgID: ownerOrg, IsPublic: true}, ownerOrg, false},
@@ -65,6 +65,32 @@ func TestForkCheckpointAuthMatrix(t *testing.T) {
 			if deny != tc.wantDeny {
 				t.Fatalf("deny=%v, want %v (cp.OrgID=%s caller=%s public=%v)",
 					deny, tc.wantDeny, tc.cp.OrgID, tc.caller, tc.cp.IsPublic)
+			}
+		})
+	}
+}
+
+func TestShouldPromoteCheckpointDefault(t *testing.T) {
+	ptrue := true
+	pfalse := false
+	cases := []struct {
+		name          string
+		kind          string
+		promoteToFull *bool
+		want          bool
+	}{
+		{"full omitted", "full", nil, false},
+		{"full explicit true", "full", &ptrue, false},
+		{"full explicit false", "full", &pfalse, false},
+		{"disk only omitted defaults true", "disk_only", nil, true},
+		{"disk only explicit true", "disk_only", &ptrue, true},
+		{"disk only explicit false", "disk_only", &pfalse, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldPromoteCheckpoint(tc.kind, tc.promoteToFull); got != tc.want {
+				t.Fatalf("shouldPromoteCheckpoint(%q, %v) = %v, want %v", tc.kind, tc.promoteToFull, got, tc.want)
 			}
 		})
 	}

--- a/sdks/python/opencomputer/sandbox.py
+++ b/sdks/python/opencomputer/sandbox.py
@@ -606,7 +606,7 @@ class Sandbox:
         self,
         name: str,
         kind: str | None = None,
-        promote_to_full: bool = False,
+        promote_to_full: bool | None = None,
         retention_policy: dict | None = None,
     ) -> dict:
         """Create a named checkpoint of the running sandbox.
@@ -615,9 +615,9 @@ class Sandbox:
             name: A unique name for this checkpoint.
             kind: Optional checkpoint kind. Use "full" for disk, memory, and
                 device state, or "disk_only" for a disk-only checkpoint that
-                restores with a cold boot.
-            promote_to_full: For disk-only checkpoints, asynchronously create
-                a derived full checkpoint so future forks can use warm restore.
+                automatically prepares a full artifact for faster future forks.
+            promote_to_full: Advanced override for disk-only checkpoints.
+                Defaults to server behavior.
             retention_policy: Optional policy such as
                 {"mode": "delete_oldest", "maxCount": 10}. When set, the
                 server may delete older eligible checkpoints before creating
@@ -629,8 +629,8 @@ class Sandbox:
         body = {"name": name}
         if kind is not None:
             body["kind"] = kind
-        if promote_to_full:
-            body["promoteToFull"] = True
+        if promote_to_full is not None:
+            body["promoteToFull"] = promote_to_full
         if retention_policy is not None:
             body["retentionPolicy"] = retention_policy
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opencomputer-sdk"
-version = "0.6.4"
+version = "0.6.5"
 description = "Python SDK for OpenComputer - cloud sandbox platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/sandbox.test.ts
+++ b/sdks/typescript/src/sandbox.test.ts
@@ -36,4 +36,38 @@ describe("Sandbox checkpoint requests", () => {
       retentionPolicy: { mode: "delete_oldest", maxCount: 3 },
     });
   });
+
+  it("preserves explicit false for disk-only promotion override", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({
+        id: "cp_1",
+        sandboxId: "sb_1",
+        orgId: "org_1",
+        name: "manual",
+        sandboxConfig: {},
+        kind: "disk_only",
+        status: "processing",
+        sizeBytes: 0,
+        createdAt: "2026-01-01T00:00:00Z",
+      }), { status: 201, headers: { "content-type": "application/json" } }),
+    );
+
+    const sandbox = Object.create(Sandbox.prototype) as Sandbox;
+    const sandboxState = sandbox as unknown as Record<string, unknown>;
+    sandboxState.apiUrl = "https://api.example.test/api";
+    sandboxState.apiKey = "osb_test";
+    sandboxState.sandboxId = "sb_1";
+
+    await sandbox.createCheckpoint("manual", {
+      kind: "disk_only",
+      promoteToFull: false,
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init?.body as string)).toEqual({
+      name: "manual",
+      kind: "disk_only",
+      promoteToFull: false,
+    });
+  });
 });

--- a/sdks/typescript/src/sandbox.ts
+++ b/sdks/typescript/src/sandbox.ts
@@ -708,8 +708,8 @@ export class Sandbox {
     if (opts.kind) {
       body.kind = opts.kind;
     }
-    if (opts.promoteToFull) {
-      body.promoteToFull = true;
+    if (opts.promoteToFull !== undefined) {
+      body.promoteToFull = opts.promoteToFull;
     }
     if (opts.retentionPolicy) {
       body.retentionPolicy = opts.retentionPolicy;


### PR DESCRIPTION
## Summary
- Default disk-only checkpoints to background full promotion when promoteToFull is omitted
- Preserve the hidden explicit promoteToFull=false override for advanced/manual testing
- Hide the CLI promotion flag from normal help and remove it from public Python SDK docs
- Add API and TypeScript SDK regression coverage

## Tests
- go test ./internal/api -run TestShouldPromoteCheckpointDefault
- npm test -- --run src/sandbox.test.ts
- python3 -m py_compile opencomputer/sandbox.py