### PR TITLE
feat(sdk): add browser API entities

### DIFF
--- a/docs/browser-sessions/overview.mdx
+++ b/docs/browser-sessions/overview.mdx
@@ -1,0 +1,262 @@
+---
+title: "Browser Sessions"
+description: "Preview: create cloud browser sessions for Playwright, Magnitude, and profile-backed web automation"
+---
+
+<Warning>
+Browser Sessions are currently in preview. API routes, SDK method names,
+response fields, limits, and pricing may change before general availability.
+</Warning>
+
+Browser Sessions create managed Chromium sessions for web agents and browser
+automation. OpenComputer handles API-key auth and org ownership, then returns
+browser connection URLs for tools such as Playwright and Magnitude.
+
+Use Browser Sessions when you want a cloud browser without installing Chromium
+inside an OpenComputer sandbox. Use [sandboxes](/sandboxes/overview) when you
+need a full Linux VM with your own browser runtime and filesystem.
+
+## Create a Browser
+
+<CodeGroup>
+
+```typescript TypeScript
+import { Browser } from "@opencomputer/sdk";
+
+const browser = await Browser.create({
+  headless: false,
+  stealth: true,
+  startUrl: "https://example.com",
+  timeoutSeconds: 120,
+});
+
+console.log(browser.id);
+console.log(browser.cdpWsUrl);
+console.log(browser.liveViewUrl);
+
+await browser.delete();
+```
+
+```python Python
+from opencomputer import Browser
+
+browser = await Browser.create(
+    headless=False,
+    stealth=True,
+    start_url="https://example.com",
+    timeout_seconds=120,
+)
+
+print(browser.id)
+print(browser.cdp_ws_url)
+print(browser.live_view_url)
+
+await browser.delete()
+```
+
+</CodeGroup>
+
+Headful browsers return a live-view URL. Headless browsers are lighter, but do
+not provide a live view.
+
+## Playwright
+
+The browser response includes a CDP WebSocket URL. Pass it directly to
+Playwright's `connectOverCDP`.
+
+<CodeGroup>
+
+```typescript TypeScript
+import { Browser } from "@opencomputer/sdk";
+import { chromium } from "playwright";
+
+const ocBrowser = await Browser.create({
+  headless: false,
+  startUrl: "https://example.com",
+});
+
+try {
+  const browser = await chromium.connectOverCDP(ocBrowser.cdpWsUrl);
+  const context = browser.contexts()[0] || await browser.newContext();
+  const page = context.pages()[0] || await context.newPage();
+
+  await page.goto("https://example.com");
+  console.log(await page.title());
+
+  await browser.close();
+} finally {
+  await ocBrowser.delete();
+}
+```
+
+```python Python
+from opencomputer import Browser
+from playwright.async_api import async_playwright
+
+oc_browser = await Browser.create(
+    headless=False,
+    start_url="https://example.com",
+)
+
+try:
+    async with async_playwright() as p:
+        browser = await p.chromium.connect_over_cdp(oc_browser.cdp_ws_url)
+        context = browser.contexts[0] if browser.contexts else await browser.new_context()
+        page = context.pages[0] if context.pages else await context.new_page()
+
+        await page.goto("https://example.com")
+        print(await page.title())
+
+        await browser.close()
+finally:
+    await oc_browser.delete()
+```
+
+</CodeGroup>
+
+## Magnitude
+
+Magnitude can use a Playwright-connected browser. Create the OpenComputer
+browser first, connect over CDP, then hand the page to your Magnitude agent.
+
+```typescript TypeScript
+import { Browser } from "@opencomputer/sdk";
+import { chromium } from "playwright";
+import { startBrowserAgent } from "magnitude-core";
+
+const ocBrowser = await Browser.create({
+  headless: false,
+  stealth: true,
+  startUrl: "https://example.com",
+});
+
+try {
+  const browser = await chromium.connectOverCDP(ocBrowser.cdpWsUrl);
+  const context = browser.contexts()[0] || await browser.newContext();
+  const page = context.pages()[0] || await context.newPage();
+
+  const agent = await startBrowserAgent({ page });
+  await agent.act("Find the page title and summarize what this site is for.");
+
+  await browser.close();
+} finally {
+  await ocBrowser.delete();
+}
+```
+
+<Note>
+Magnitude package names and constructors can vary by version. The
+OpenComputer-specific step is stable: create a `Browser`, connect to
+`cdpWsUrl` with Playwright, then pass the resulting page or browser object to
+Magnitude.
+</Note>
+
+## Save and Load Profiles
+
+Profiles persist browser state such as cookies and local storage across browser
+sessions. Profiles are scoped to your OpenComputer org; another org cannot
+list, load, or delete your profiles.
+
+Create a profile once:
+
+<CodeGroup>
+
+```typescript TypeScript
+import { BrowserProfile } from "@opencomputer/sdk";
+
+const profile = await BrowserProfile.create({
+  name: "github-login",
+});
+```
+
+```python Python
+from opencomputer import BrowserProfile
+
+profile = await BrowserProfile.create(name="github-login")
+```
+
+</CodeGroup>
+
+Use the profile when creating a browser:
+
+<CodeGroup>
+
+```typescript TypeScript
+import { Browser } from "@opencomputer/sdk";
+
+const browser = await Browser.create({
+  profile: {
+    id: profile.id,
+    saveChanges: true,
+  },
+  headless: false,
+});
+
+// Log in or update session state, then delete the browser.
+// With saveChanges enabled, changes are saved back to the profile.
+await browser.delete();
+```
+
+```python Python
+from opencomputer import Browser
+
+browser = await Browser.create(
+    profile={
+        "id": profile.id,
+        "save_changes": True,
+    },
+    headless=False,
+)
+
+# Log in or update session state, then delete the browser.
+# With save_changes enabled, changes are saved back to the profile.
+await browser.delete()
+```
+
+</CodeGroup>
+
+Load the same profile later by ID or name:
+
+<CodeGroup>
+
+```typescript TypeScript
+import { Browser, BrowserProfile } from "@opencomputer/sdk";
+
+const profile = await BrowserProfile.connect("github-login");
+
+const browser = await Browser.create({
+  profile: {
+    id: profile.id,
+    saveChanges: true,
+  },
+  headless: false,
+});
+```
+
+```python Python
+from opencomputer import Browser, BrowserProfile
+
+profile = await BrowserProfile.connect("github-login")
+
+browser = await Browser.create(
+    profile={
+        "id": profile.id,
+        "save_changes": True,
+    },
+    headless=False,
+)
+```
+
+</CodeGroup>
+
+## Environment
+
+The SDK uses:
+
+| Variable | Description |
+| --- | --- |
+| `OPENCOMPUTER_API_KEY` | OpenComputer API key used for browser API auth |
+| `OPENCOMPUTER_BROWSER_API_URL` | Optional browser API URL override |
+
+By default, the SDK calls `https://browser.opencomputer.dev`. During preview,
+your workspace may use a dev endpoint such as `https://browser.mo-oc-dev.com`.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -60,6 +60,13 @@
         ]
       },
       {
+        "group": "Browser Sessions",
+        "tag": "Preview",
+        "pages": [
+          "browser-sessions/overview"
+        ]
+      },
+      {
         "group": "Durable Agent Sessions",
         "tag": "Preview",
         "pages": [

--- a/sdks/python/opencomputer/__init__.py
+++ b/sdks/python/opencomputer/__init__.py
@@ -1,6 +1,7 @@
 """OpenComputer Python SDK - cloud sandbox platform."""
 
 from opencomputer.sandbox import Sandbox, ScalingLockedError, PlanLimitError, SandboxFamilyLimitError
+from opencomputer.browser import Browser, BrowserProfile
 from opencomputer.agent import Agent, AgentEvent, AgentSession, AgentSessionInfo
 from opencomputer.filesystem import Filesystem
 from opencomputer.exec import Exec, ProcessResult, ExecSession, ExecSessionInfo
@@ -28,6 +29,8 @@ from opencomputer.usage import (
 
 __all__ = [
     "Sandbox",
+    "Browser",
+    "BrowserProfile",
     "ScalingLockedError",
     "PlanLimitError",
     "SandboxFamilyLimitError",

--- a/sdks/python/opencomputer/browser.py
+++ b/sdks/python/opencomputer/browser.py
@@ -1,0 +1,260 @@
+"""Browser entity for OpenComputer's Kernel-backed browser API."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+DEFAULT_BROWSER_API_URL = "https://browser.opencomputer.dev"
+
+
+def _resolve_browser_api_url(api_url: str | None) -> str:
+    return (api_url or os.environ.get("OPENCOMPUTER_BROWSER_API_URL") or DEFAULT_BROWSER_API_URL).rstrip("/")
+
+
+@dataclass
+class Browser:
+    """Kernel-backed browser session managed through OpenComputer."""
+
+    id: str
+    provider: str
+    provider_session_id: str
+    status: str
+    cdp_ws_url: str
+    webdriver_ws_url: str
+    live_view_url: str | None = None
+    base_url: str | None = None
+    headless: bool | None = None
+    stealth: bool | None = None
+    gpu: bool | None = None
+    timeout_seconds: int | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    deleted_at: str | None = None
+    _api_url: str = ""
+    _api_key: str = ""
+    _client: httpx.AsyncClient | None = None
+
+    @classmethod
+    async def create(
+        cls,
+        *,
+        api_key: str | None = None,
+        api_url: str | None = None,
+        name: str | None = None,
+        tags: dict[str, str] | None = None,
+        stealth: bool | None = None,
+        headless: bool | None = None,
+        gpu: bool | None = None,
+        timeout_seconds: int | None = None,
+        profile: dict[str, Any] | None = None,
+        extensions: list[dict[str, str]] | None = None,
+        proxy_id: str | None = None,
+        viewport: dict[str, int] | None = None,
+        kiosk_mode: bool | None = None,
+        start_url: str | None = None,
+        chrome_policy: dict[str, Any] | None = None,
+        telemetry: dict[str, Any] | None = None,
+    ) -> Browser:
+        """Create a browser session and return Kernel's direct connection URLs."""
+        url = _resolve_browser_api_url(api_url)
+        key = api_key or os.environ.get("OPENCOMPUTER_API_KEY", "")
+        client = httpx.AsyncClient(base_url=url, headers=_headers(key), timeout=30.0)
+
+        body = _create_body(
+            name=name,
+            tags=tags,
+            stealth=stealth,
+            headless=headless,
+            gpu=gpu,
+            timeout_seconds=timeout_seconds,
+            profile=profile,
+            extensions=extensions,
+            proxy_id=proxy_id,
+            viewport=viewport,
+            kiosk_mode=kiosk_mode,
+            start_url=start_url,
+            chrome_policy=chrome_policy,
+            telemetry=telemetry,
+        )
+        resp = await client.post("/v1/browsers", json=body)
+        resp.raise_for_status()
+        return cls._from_data(resp.json(), url, key, client)
+
+    @classmethod
+    async def connect(
+        cls,
+        browser_id: str,
+        *,
+        api_key: str | None = None,
+        api_url: str | None = None,
+    ) -> Browser:
+        """Load an existing browser session by OpenComputer browser ID."""
+        url = _resolve_browser_api_url(api_url)
+        key = api_key or os.environ.get("OPENCOMPUTER_API_KEY", "")
+        client = httpx.AsyncClient(base_url=url, headers=_headers(key), timeout=30.0)
+        resp = await client.get(f"/v1/browsers/{browser_id}")
+        resp.raise_for_status()
+        return cls._from_data(resp.json(), url, key, client)
+
+    async def delete(self) -> None:
+        """Delete the browser session."""
+        client = self._client or httpx.AsyncClient(base_url=self._api_url, headers=_headers(self._api_key), timeout=30.0)
+        resp = await client.delete(f"/v1/browsers/{self.id}")
+        resp.raise_for_status()
+
+    async def close(self) -> None:
+        """Close the SDK HTTP client. This does not delete the browser."""
+        if self._client is not None:
+            await self._client.aclose()
+
+    @classmethod
+    def _from_data(
+        cls,
+        data: dict[str, Any],
+        api_url: str,
+        api_key: str,
+        client: httpx.AsyncClient,
+    ) -> Browser:
+        return cls(
+            id=data["id"],
+            provider=data.get("provider", "kernel"),
+            provider_session_id=data["provider_session_id"],
+            status=data.get("status", ""),
+            cdp_ws_url=data["cdp_ws_url"],
+            webdriver_ws_url=data["webdriver_ws_url"],
+            live_view_url=data.get("live_view_url"),
+            base_url=data.get("base_url"),
+            headless=data.get("headless"),
+            stealth=data.get("stealth"),
+            gpu=data.get("gpu"),
+            timeout_seconds=data.get("timeout_seconds"),
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at"),
+            deleted_at=data.get("deleted_at"),
+            _api_url=api_url,
+            _api_key=api_key,
+            _client=client,
+        )
+
+
+@dataclass
+class BrowserProfile:
+    """Browser profile metadata managed through OpenComputer."""
+
+    id: str
+    provider: str
+    provider_profile_id: str
+    name: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    deleted_at: str | None = None
+    provider_created_at: str | None = None
+    provider_updated_at: str | None = None
+    provider_last_used_at: str | None = None
+    _api_url: str = ""
+    _api_key: str = ""
+    _client: httpx.AsyncClient | None = None
+
+    @classmethod
+    async def create(
+        cls,
+        *,
+        api_key: str | None = None,
+        api_url: str | None = None,
+        name: str | None = None,
+    ) -> BrowserProfile:
+        """Create a browser profile."""
+        url = _resolve_browser_api_url(api_url)
+        key = api_key or os.environ.get("OPENCOMPUTER_API_KEY", "")
+        client = httpx.AsyncClient(base_url=url, headers=_headers(key), timeout=30.0)
+        body = {"name": name} if name is not None else {}
+        resp = await client.post("/v1/profiles", json=body)
+        resp.raise_for_status()
+        return cls._from_data(resp.json(), url, key, client)
+
+    @classmethod
+    async def list(
+        cls,
+        *,
+        api_key: str | None = None,
+        api_url: str | None = None,
+    ) -> list[BrowserProfile]:
+        """List browser profiles for the authenticated org."""
+        url = _resolve_browser_api_url(api_url)
+        key = api_key or os.environ.get("OPENCOMPUTER_API_KEY", "")
+        client = httpx.AsyncClient(base_url=url, headers=_headers(key), timeout=30.0)
+        resp = await client.get("/v1/profiles")
+        resp.raise_for_status()
+        data = resp.json()
+        return [cls._from_data(item, url, key, client) for item in data.get("profiles", [])]
+
+    @classmethod
+    async def connect(
+        cls,
+        id_or_name: str,
+        *,
+        api_key: str | None = None,
+        api_url: str | None = None,
+    ) -> BrowserProfile:
+        """Load a browser profile by OpenComputer profile ID or name."""
+        url = _resolve_browser_api_url(api_url)
+        key = api_key or os.environ.get("OPENCOMPUTER_API_KEY", "")
+        client = httpx.AsyncClient(base_url=url, headers=_headers(key), timeout=30.0)
+        resp = await client.get(f"/v1/profiles/{id_or_name}")
+        resp.raise_for_status()
+        return cls._from_data(resp.json(), url, key, client)
+
+    async def delete(self) -> None:
+        """Delete the browser profile."""
+        client = self._client or httpx.AsyncClient(base_url=self._api_url, headers=_headers(self._api_key), timeout=30.0)
+        resp = await client.delete(f"/v1/profiles/{self.id}")
+        resp.raise_for_status()
+
+    async def close(self) -> None:
+        """Close the SDK HTTP client. This does not delete the profile."""
+        if self._client is not None:
+            await self._client.aclose()
+
+    @classmethod
+    def _from_data(
+        cls,
+        data: dict[str, Any],
+        api_url: str,
+        api_key: str,
+        client: httpx.AsyncClient,
+    ) -> BrowserProfile:
+        return cls(
+            id=data["id"],
+            provider=data.get("provider", "kernel"),
+            provider_profile_id=data["provider_profile_id"],
+            name=data.get("name"),
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at"),
+            deleted_at=data.get("deleted_at"),
+            provider_created_at=data.get("provider_created_at"),
+            provider_updated_at=data.get("provider_updated_at"),
+            provider_last_used_at=data.get("provider_last_used_at"),
+            _api_url=api_url,
+            _api_key=api_key,
+            _client=client,
+        )
+
+
+def _headers(api_key: str) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["X-API-Key"] = api_key
+    return headers
+
+
+def _create_body(**kwargs: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {}
+    for key, value in kwargs.items():
+        if value is not None:
+            body[key] = value
+    return body

--- a/sdks/typescript/src/browser.test.ts
+++ b/sdks/typescript/src/browser.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Browser } from "./browser.js";
+import { BrowserProfile } from "./browser.js";
+
+const browserResponse = {
+  id: "br_1",
+  provider: "kernel",
+  provider_session_id: "kernel_1",
+  status: "active",
+  cdp_ws_url: "wss://proxy.example.onkernel.com/browser/cdp?jwt=abc",
+  webdriver_ws_url: "wss://proxy.example.onkernel.com/browser/webdriver/session?jwt=abc",
+  live_view_url: "https://proxy.example.onkernel.com/browser/live?jwt=abc",
+  base_url: "https://proxy.example.onkernel.com/browser/kernel",
+  headless: false,
+  stealth: true,
+  timeout_seconds: 60,
+};
+
+describe("Browser", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a browser with OpenComputer browser API shape", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json(browserResponse, { status: 201 }),
+    );
+
+    const browser = await Browser.create({
+      apiKey: "osb_test",
+      apiUrl: "https://browser.example.test/",
+      stealth: true,
+      timeoutSeconds: 120,
+      startUrl: "https://example.com",
+      viewport: { width: 1280, height: 800, refreshRate: 60 },
+      profile: { name: "default", saveChanges: true },
+    });
+
+    expect(browser.id).toBe("br_1");
+    expect(browser.providerSessionId).toBe("kernel_1");
+    expect(browser.cdpWsUrl).toContain("onkernel.com");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://browser.example.test/v1/browsers",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "X-API-Key": "osb_test" }),
+        body: JSON.stringify({
+          stealth: true,
+          timeout_seconds: 120,
+          profile: { name: "default", save_changes: true },
+          viewport: { width: 1280, height: 800, refresh_rate: 60 },
+          start_url: "https://example.com",
+        }),
+      }),
+    );
+  });
+
+  it("connects and deletes a browser", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json(browserResponse))
+      .mockResolvedValueOnce(Response.json({ id: "br_1", status: "deleted" }));
+
+    const browser = await Browser.connect("br_1", {
+      apiKey: "osb_test",
+      apiUrl: "https://browser.example.test",
+    });
+    await browser.delete();
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://browser.example.test/v1/browsers/br_1",
+      expect.objectContaining({ headers: expect.objectContaining({ "X-API-Key": "osb_test" }) }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://browser.example.test/v1/browsers/br_1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("creates, lists, connects, and deletes browser profiles", async () => {
+    const profileResponse = {
+      id: "prof_1",
+      provider: "kernel",
+      provider_profile_id: "kernel_profile_1",
+      name: "github-login",
+      created_at: "2026-06-27T00:00:00.000Z",
+      updated_at: "2026-06-27T00:00:00.000Z",
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json(profileResponse, { status: 201 }))
+      .mockResolvedValueOnce(Response.json({ profiles: [profileResponse] }))
+      .mockResolvedValueOnce(Response.json(profileResponse))
+      .mockResolvedValueOnce(Response.json({ id: "prof_1", status: "deleted" }));
+
+    const profile = await BrowserProfile.create({
+      apiKey: "osb_test",
+      apiUrl: "https://browser.example.test",
+      name: "github-login",
+    });
+    expect(profile.id).toBe("prof_1");
+    expect(profile.providerProfileId).toBe("kernel_profile_1");
+
+    const profiles = await BrowserProfile.list({
+      apiKey: "osb_test",
+      apiUrl: "https://browser.example.test",
+    });
+    expect(profiles).toHaveLength(1);
+
+    await BrowserProfile.connect("github-login", {
+      apiKey: "osb_test",
+      apiUrl: "https://browser.example.test",
+    });
+    await profile.delete();
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://browser.example.test/v1/profiles",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ name: "github-login" }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      "https://browser.example.test/v1/profiles/prof_1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+});

--- a/sdks/typescript/src/browser.ts
+++ b/sdks/typescript/src/browser.ts
@@ -1,0 +1,262 @@
+const DEFAULT_BROWSER_API_URL = "https://browser.opencomputer.dev";
+
+function resolveBrowserApiUrl(url?: string): string {
+  return (url || process.env.OPENCOMPUTER_BROWSER_API_URL || DEFAULT_BROWSER_API_URL).replace(/\/+$/, "");
+}
+
+export interface BrowserCreateOpts {
+  apiKey?: string;
+  apiUrl?: string;
+  name?: string;
+  tags?: Record<string, string>;
+  stealth?: boolean;
+  headless?: boolean;
+  gpu?: boolean;
+  timeoutSeconds?: number;
+  profile?: { id?: string; name?: string; saveChanges?: boolean };
+  extensions?: Array<{ id?: string; name?: string }>;
+  proxyId?: string;
+  viewport?: { width: number; height: number; refreshRate?: number };
+  kioskMode?: boolean;
+  startUrl?: string;
+  chromePolicy?: Record<string, unknown>;
+  telemetry?: Record<string, unknown> | null;
+}
+
+export interface BrowserData {
+  id: string;
+  provider: "kernel";
+  provider_session_id: string;
+  status: string;
+  cdp_ws_url: string;
+  webdriver_ws_url: string;
+  live_view_url?: string | null;
+  base_url?: string | null;
+  headless?: boolean;
+  stealth?: boolean;
+  gpu?: boolean;
+  timeout_seconds?: number;
+  created_at?: string;
+  updated_at?: string;
+  deleted_at?: string | null;
+}
+
+export interface BrowserProfileCreateOpts {
+  apiKey?: string;
+  apiUrl?: string;
+  name?: string;
+}
+
+export interface BrowserProfileData {
+  id: string;
+  provider: "kernel";
+  provider_profile_id: string;
+  name?: string | null;
+  created_at?: string;
+  updated_at?: string;
+  deleted_at?: string | null;
+  provider_created_at?: string;
+  provider_updated_at?: string;
+  provider_last_used_at?: string;
+}
+
+export class Browser {
+  readonly id: string;
+  readonly provider: "kernel";
+  readonly providerSessionId: string;
+  readonly status: string;
+  readonly cdpWsUrl: string;
+  readonly webdriverWsUrl: string;
+  readonly liveViewUrl: string | null;
+  readonly baseUrl: string | null;
+  readonly headless?: boolean;
+  readonly stealth?: boolean;
+  readonly gpu?: boolean;
+  readonly timeoutSeconds?: number;
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
+  readonly deletedAt?: string | null;
+
+  private readonly apiUrl: string;
+  private readonly apiKey: string;
+
+  constructor(data: BrowserData, apiUrl: string, apiKey: string) {
+    this.id = data.id;
+    this.provider = data.provider;
+    this.providerSessionId = data.provider_session_id;
+    this.status = data.status;
+    this.cdpWsUrl = data.cdp_ws_url;
+    this.webdriverWsUrl = data.webdriver_ws_url;
+    this.liveViewUrl = data.live_view_url ?? null;
+    this.baseUrl = data.base_url ?? null;
+    this.headless = data.headless;
+    this.stealth = data.stealth;
+    this.gpu = data.gpu;
+    this.timeoutSeconds = data.timeout_seconds;
+    this.createdAt = data.created_at;
+    this.updatedAt = data.updated_at;
+    this.deletedAt = data.deleted_at;
+    this.apiUrl = apiUrl;
+    this.apiKey = apiKey;
+  }
+
+  static async create(opts: BrowserCreateOpts = {}): Promise<Browser> {
+    const apiUrl = resolveBrowserApiUrl(opts.apiUrl);
+    const apiKey = opts.apiKey || process.env.OPENCOMPUTER_API_KEY || "";
+    const resp = await fetch(`${apiUrl}/v1/browsers`, {
+      method: "POST",
+      headers: headers(apiKey),
+      body: JSON.stringify(toCreateBody(opts)),
+    });
+    if (!resp.ok) {
+      throw await browserError(resp, "create browser");
+    }
+    return new Browser(await resp.json() as BrowserData, apiUrl, apiKey);
+  }
+
+  static async connect(id: string, opts: { apiKey?: string; apiUrl?: string } = {}): Promise<Browser> {
+    const apiUrl = resolveBrowserApiUrl(opts.apiUrl);
+    const apiKey = opts.apiKey || process.env.OPENCOMPUTER_API_KEY || "";
+    const resp = await fetch(`${apiUrl}/v1/browsers/${encodeURIComponent(id)}`, {
+      headers: headers(apiKey),
+    });
+    if (!resp.ok) {
+      throw await browserError(resp, "connect browser");
+    }
+    return new Browser(await resp.json() as BrowserData, apiUrl, apiKey);
+  }
+
+  async delete(): Promise<void> {
+    const resp = await fetch(`${this.apiUrl}/v1/browsers/${encodeURIComponent(this.id)}`, {
+      method: "DELETE",
+      headers: headers(this.apiKey),
+    });
+    if (!resp.ok) {
+      throw await browserError(resp, "delete browser");
+    }
+  }
+}
+
+export class BrowserProfile {
+  readonly id: string;
+  readonly provider: "kernel";
+  readonly providerProfileId: string;
+  readonly name: string | null;
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
+  readonly deletedAt?: string | null;
+  readonly providerCreatedAt?: string;
+  readonly providerUpdatedAt?: string;
+  readonly providerLastUsedAt?: string;
+
+  private readonly apiUrl: string;
+  private readonly apiKey: string;
+
+  constructor(data: BrowserProfileData, apiUrl: string, apiKey: string) {
+    this.id = data.id;
+    this.provider = data.provider;
+    this.providerProfileId = data.provider_profile_id;
+    this.name = data.name ?? null;
+    this.createdAt = data.created_at;
+    this.updatedAt = data.updated_at;
+    this.deletedAt = data.deleted_at;
+    this.providerCreatedAt = data.provider_created_at;
+    this.providerUpdatedAt = data.provider_updated_at;
+    this.providerLastUsedAt = data.provider_last_used_at;
+    this.apiUrl = apiUrl;
+    this.apiKey = apiKey;
+  }
+
+  static async create(opts: BrowserProfileCreateOpts = {}): Promise<BrowserProfile> {
+    const apiUrl = resolveBrowserApiUrl(opts.apiUrl);
+    const apiKey = opts.apiKey || process.env.OPENCOMPUTER_API_KEY || "";
+    const body: Record<string, unknown> = {};
+    if (opts.name !== undefined) body.name = opts.name;
+    const resp = await fetch(`${apiUrl}/v1/profiles`, {
+      method: "POST",
+      headers: headers(apiKey),
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      throw await browserError(resp, "create browser profile");
+    }
+    return new BrowserProfile(await resp.json() as BrowserProfileData, apiUrl, apiKey);
+  }
+
+  static async list(opts: { apiKey?: string; apiUrl?: string } = {}): Promise<BrowserProfile[]> {
+    const apiUrl = resolveBrowserApiUrl(opts.apiUrl);
+    const apiKey = opts.apiKey || process.env.OPENCOMPUTER_API_KEY || "";
+    const resp = await fetch(`${apiUrl}/v1/profiles`, {
+      headers: headers(apiKey),
+    });
+    if (!resp.ok) {
+      throw await browserError(resp, "list browser profiles");
+    }
+    const data = await resp.json() as { profiles: BrowserProfileData[] };
+    return (data.profiles ?? []).map((profile) => new BrowserProfile(profile, apiUrl, apiKey));
+  }
+
+  static async connect(idOrName: string, opts: { apiKey?: string; apiUrl?: string } = {}): Promise<BrowserProfile> {
+    const apiUrl = resolveBrowserApiUrl(opts.apiUrl);
+    const apiKey = opts.apiKey || process.env.OPENCOMPUTER_API_KEY || "";
+    const resp = await fetch(`${apiUrl}/v1/profiles/${encodeURIComponent(idOrName)}`, {
+      headers: headers(apiKey),
+    });
+    if (!resp.ok) {
+      throw await browserError(resp, "connect browser profile");
+    }
+    return new BrowserProfile(await resp.json() as BrowserProfileData, apiUrl, apiKey);
+  }
+
+  async delete(): Promise<void> {
+    const resp = await fetch(`${this.apiUrl}/v1/profiles/${encodeURIComponent(this.id)}`, {
+      method: "DELETE",
+      headers: headers(this.apiKey),
+    });
+    if (!resp.ok) {
+      throw await browserError(resp, "delete browser profile");
+    }
+  }
+}
+
+function headers(apiKey: string): HeadersInit {
+  const h: Record<string, string> = { "Content-Type": "application/json" };
+  if (apiKey) h["X-API-Key"] = apiKey;
+  return h;
+}
+
+function toCreateBody(opts: BrowserCreateOpts): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  if (opts.name !== undefined) body.name = opts.name;
+  if (opts.tags !== undefined) body.tags = opts.tags;
+  if (opts.stealth !== undefined) body.stealth = opts.stealth;
+  if (opts.headless !== undefined) body.headless = opts.headless;
+  if (opts.gpu !== undefined) body.gpu = opts.gpu;
+  if (opts.timeoutSeconds !== undefined) body.timeout_seconds = opts.timeoutSeconds;
+  if (opts.profile !== undefined) {
+    body.profile = {
+      ...(opts.profile.id !== undefined ? { id: opts.profile.id } : {}),
+      ...(opts.profile.name !== undefined ? { name: opts.profile.name } : {}),
+      ...(opts.profile.saveChanges !== undefined ? { save_changes: opts.profile.saveChanges } : {}),
+    };
+  }
+  if (opts.extensions !== undefined) body.extensions = opts.extensions;
+  if (opts.proxyId !== undefined) body.proxy_id = opts.proxyId;
+  if (opts.viewport !== undefined) {
+    body.viewport = {
+      width: opts.viewport.width,
+      height: opts.viewport.height,
+      ...(opts.viewport.refreshRate !== undefined ? { refresh_rate: opts.viewport.refreshRate } : {}),
+    };
+  }
+  if (opts.kioskMode !== undefined) body.kiosk_mode = opts.kioskMode;
+  if (opts.startUrl !== undefined) body.start_url = opts.startUrl;
+  if (opts.chromePolicy !== undefined) body.chrome_policy = opts.chromePolicy;
+  if (opts.telemetry !== undefined) body.telemetry = opts.telemetry;
+  return body;
+}
+
+async function browserError(resp: Response, action: string): Promise<Error> {
+  const text = await resp.text();
+  return new Error(`Failed to ${action}: ${resp.status} ${text}`);
+}

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -15,6 +15,7 @@ export {
   type ScalingLockStatus,
   type AllowedHostsInfo,
 } from "./sandbox.js";
+export { Browser, BrowserProfile, type BrowserCreateOpts, type BrowserData, type BrowserProfileCreateOpts, type BrowserProfileData } from "./browser.js";
 export { SandboxAgent, type SandboxAgentEvent, type SandboxAgentConfig, type SandboxAgentStartOpts, type SandboxAgentSession, type McpServerConfig } from "./agent.js";
 // Managed Durable Agent Sessions (the OpenComputer client + Session handle).
 export * from "./agents/index.js";


### PR DESCRIPTION
## Summary
- add TypeScript Browser and BrowserProfile entities for the browser API
- add Python Browser and BrowserProfile entities and exports
- support profile-aware browser creation using OpenComputer profile IDs/names

## Tests
- cd sdks/typescript && npm test -- --run src/browser.test.ts
- cd sdks/python && PYTHONDONTWRITEBYTECODE=1 python3 - <<'PY'
import ast
from pathlib import Path
for path in [Path('opencomputer/browser.py'), Path('opencomputer/__init__.py')]:
    ast.parse(path.read_text(), filename=str(path))
print('python syntax ok')
PY