### PR TITLE
feat(web): brand favicon — paper tile, ink terminal prompt

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="theme-color" content="#161513" />
     <title>OpenComputer</title>
   </head>
   <body>

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="OpenComputer">
+  <!-- Brand tokens: paper tile hsl(40 33% 97%), ink glyph hsl(45 8% 8%). A
+       minimal shell prompt `>_` for the console dialect. A hairline ink border
+       keeps the paper tile visible against light browser tab strips. -->
+  <rect x="1" y="1" width="30" height="30" rx="6.5" fill="#FAF8F5" stroke="#161513" stroke-width="1.5" />
+  <path
+    d="M10 11l5 5-5 5"
+    fill="none"
+    stroke="#161513"
+    stroke-width="2.6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M17.5 21.2h5.5"
+    fill="none"
+    stroke="#161513"
+    stroke-width="2.6"
+    stroke-linecap="round"
+  />
+</svg>


### PR DESCRIPTION
## What

The dashboard shipped with **no favicon**, so browsers fell back to a generic/default icon. This adds a minimal SVG favicon that matches the new light *"ink on paper"* brand.

**Design:** a paper-colored squircle with a hairline ink border and an ink `>_` shell prompt — leaning into the dashboard's console/mono dialect, legible at 16px, and (thanks to the border) visible against light tab strips while popping on dark browser themes.

Colors are the exact brand tokens: paper `hsl(40 33% 97%)`, ink `hsl(45 8% 8%)`.

## Changes
- `web/public/favicon.svg` *(new)* — the icon.
- `web/index.html` — `<link rel="icon" type="image/svg+xml">` + `theme-color` meta.

## Preview
Open `web/public/favicon.svg`, or after build it serves at `/favicon.svg`. SVG favicons are crisp at every size and supported by all current browsers.

## Notes
- Scoped intentionally to the favicon. The companion stale-chunk recovery fix (`f8f31d3`) already landed via #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)