### PR TITLE
fix(web): session events live alignment (tiny)

### DIFF
--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -245,11 +245,12 @@ export default function SessionDetail() {
       {/* Event stream */}
       <Panel className="overflow-hidden">
         <div className="flex items-center justify-between border-b px-4 py-2.5">
-          <div className="flex items-center gap-2">
+          <div className="flex items-baseline gap-2">
             <h2 className="text-sm font-semibold">Events</h2>
             {streamOk ? (
-              <span className="text-status-running flex items-center gap-1 text-[10px] font-medium tracking-wide uppercase">
-                <span className="bg-status-running size-1.5 rounded-full" />
+              // Sits on the Events text baseline; the dot rides the "Live" line.
+              <span className="text-status-running text-[10px] font-medium tracking-wide uppercase">
+                <span className="bg-status-running mr-1 inline-block size-1.5 rounded-full align-middle" />
                 Live
               </span>
             ) : null}


### PR DESCRIPTION
Small dashboard UI fixes (branch for ongoing minor polish).

### Session view — "Events / Live" alignment
The `Events` heading and the `Live` indicator were box-centered (`items-center`) with the dot in a nested flex, so the smaller `Live` label floated off the heading's baseline. Now the group is baseline-aligned (`items-baseline`) and the status dot renders inline (`align-middle`), so `Live` sits on the `Events` text baseline.

_Note: `eslint` reports one pre-existing `react-hooks/set-state-in-effect` warning in this file's SSE effect (line ~85) — unrelated to this change; left as-is._

🤖 Generated with [Claude Code](https://claude.com/claude-code)