### PR TITLE
Fix dialog dropdown outside-dismiss handling

### DIFF
--- a/.agents/work/web-known-issues.md
+++ b/.agents/work/web-known-issues.md
@@ -5,56 +5,47 @@ something is reproducible but not yet fixed, with enough detail to resume cold.
 
 ---
 
-## Dialog closes when interacting with a Select/dropdown inside it
+## Dialog closes when interacting with a Select/dropdown inside it — RESOLVED
 
-**Status:** open · **Severity:** minor–moderate UX (loses in-progress form input) · **Filed:** 2026-06-28
+**Status:** resolved (PR #443) · **Filed:** 2026-06-28 · **Fixed:** 2026-06-29 · **Severity:** minor–moderate UX (lost in-progress form input)
 
-**Symptom.** Open a Radix `Select` (or any dropdown) rendered *inside* a `Dialog`, then
-click an item — notably opening the dropdown a second time and clicking again — and the
-**whole Dialog closes** instead of just the dropdown. Confirmed **generic to every modal
-with a dropdown**, not specific to one screen (first reported on the agent-create dialog's
-credential picker; reproduced elsewhere).
+**Symptom.** Open a Radix `Select` inside a `Dialog`, then click the trigger a *second*
+time to close it — and the **whole Dialog closes** instead of just the menu. Generic to
+every modal with a dropdown (first hit on the agent-create credential picker).
 
-**Environment.** `radix-ui ^1.6.0` (the unified package), React 19, vite dev on `:3000`,
-`web/`. Affected primitives: `web/src/components/ui/dialog.tsx` (Dialog) +
-`web/src/components/form.tsx` (`Select`, `position="popper"`). Surfaces: any dialog with a
-`Select` — e.g. `pages/Agents.tsx` (model + credential pickers), `pages/Credentials.tsx`
-(provider).
+**Actual root cause (confirmed, not the original guess).** `Select` is hardcoded
+`disableOutsidePointerEvents` (no `modal` opt-out). While open it sets
+`pointer-events: none` outside its menu. The second trigger click closes the menu and the
+**tail of that same gesture** (pointerup/click, after pointer-events are restored) retargets
+onto the Dialog overlay → the Dialog reads it as an outside click and dismisses. The menu has
+already left Radix's layer stack by then, so the native `DismissableLayer` shielding (which
+*does* protect the common cases) can't cover it. Radix treats this as by-design and won't fix
+it (primitives [#2961](https://github.com/radix-ui/primitives/issues/2961) closed not-planned;
+[#2731](https://github.com/radix-ui/primitives/issues/2731) documents the "click twice"
+behavior). **It was not a version-mismatch / duplicate-`dismissable-layer` bug** — the unified
+`radix-ui` 1.6.0 already deduplicates that; the original `npm ls` / standalone-package leads
+were dead ends.
 
-**Suspected cause.** A Radix `Select` portals its menu *outside* the dialog DOM. Normally
-the Select's `DismissableLayer` registers as a nested "branch" of the Dialog's layer (via
-React context, which crosses portals), so interacting with the menu is NOT treated as
-"outside" the dialog. Here that shielding appears to fail — the menu interaction reaches the
-Dialog's dismiss path and closes it. Likely a layer/context nesting bug in the unified
-`radix-ui` build (or duplicate copies of `@radix-ui/react-dismissable-layer` /
-`react-focus-scope` breaking the shared context).
+**Why the earlier `[data-radix-popper-content-wrapper]` guard "didn't work."** Two missing
+pieces, both required:
+1. **Unwrap the native event.** Radix wraps it — `event.target` on the outside-event is the
+   *layer node*, not the click target — so `target.closest(...)` checked the wrong element and
+   silently never matched. Must read `event.detail.originalEvent.target`.
+2. **Survive the whole gesture.** The retarget dismiss fires later in the same
+   pointerdown→pointerup→click sequence; a guard that clears too early misses it.
 
-**What was tried (and did NOT fix it)** — all reverted to keep `DialogContent` clean:
-- `onInteractOutside` guard on `DialogContent` that `preventDefault`s when the event target
-  is inside a popper (`[data-radix-popper-content-wrapper]` / `[role=listbox]`).
-- Broadened guard across **all three** outside-dismiss callbacks
-  (`onPointerDownOutside`, `onFocusOutside`, `onInteractOutside`) that also `preventDefault`s
-  whenever a dropdown is open anywhere in the DOM (`[data-radix-select-viewport]` /
-  `[role=menu]`).
-- `modal={false}` on the shared `Select` — **not typed** in this `radix-ui` version (tsc
-  rejects the prop); abandoned.
+**The fix (`web/src/components/ui/floating-layer.ts` + dialog/sheet/form/dropdown).** Use
+Radix's intended override — `preventDefault()` on the Dialog/Sheet `onInteractOutside` /
+`onPointerDownOutside` / `onFocusOutside` — gated by two signals: (1) the interaction's
+*unwrapped* target is inside `[data-radix-popper-content-wrapper]` (Radix's own popper marker —
+no custom tagging), or (2) a **gesture flag**: a popper's `onPointerDownOutside` marks the
+current gesture, and the flag is cleared on the next document `pointerdown` (capture), so it
+covers exactly the one retarget gesture and never a later genuine backdrop click.
 
-None stopped the close. That strongly implies the dismissal is **not** going through the
-standard `DismissableLayer` outside-interaction callbacks (or HMR on the shared component
-masked testing — but a hard reload didn't help either).
+**Verified** (headless Chrome, real hit-tested clicks via CDP): second trigger click keeps the
+dialog open and closes the menu; a genuine backdrop click still dismisses the dialog. Disabling
+the guard flips the second-click assertion to fail, confirming the test discriminates.
 
-**Next things to try (resume here):**
-1. **Confirm the actual path first.** Temporarily log in the Dialog's `onOpenChange`
-   (or wrap with `onEscapeKeyDown` / `onPointerDownOutside` / `onFocusOutside` loggers) to
-   capture *what* fires the close — we never proved it's outside-interaction vs. focus-scope
-   vs. something else. Everything below is guesswork until this is known.
-2. `npm ls @radix-ui/react-dismissable-layer @radix-ui/react-focus-scope` — if there are
-   multiple copies, the Select/Dialog don't share the layer context → branch registration
-   fails. Dedupe / pin to fix.
-3. Try the standalone `@radix-ui/react-select` + `@radix-ui/react-dialog` (not the unified
-   `radix-ui`) for the affected dialogs, or bump `radix-ui`.
-4. Last resort: disable outside-click-to-close on the *form* dialogs only (per-dialog
-   `onInteractOutside={(e) => e.preventDefault()}` + rely on X/Cancel/Escape) — acceptable
-   for forms, but only worth it once #1 confirms outside-interaction is even the trigger.
-
-**Workaround for users today:** reopen the dialog (it's closed, not crashed).
+**Follow-up:** no automated browser test harness exists in `web/` yet — add a Playwright
+regression covering both directions (second-click-keeps-open; backdrop-dismisses) when one is
+set up, so this can't silently regress.

--- a/web/src/components/form.tsx
+++ b/web/src/components/form.tsx
@@ -3,6 +3,7 @@ import { Select as SelectPrimitive } from 'radix-ui'
 import { Check, ChevronDown } from 'lucide-react'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
+import { floatingLayerProps } from '@/components/ui/floating-layer'
 import { cn } from '@/lib/utils'
 
 // Re-exported so screens import all form primitives from one place.
@@ -48,6 +49,7 @@ export function Select({
       </SelectPrimitive.Trigger>
       <SelectPrimitive.Portal>
         <SelectPrimitive.Content
+          {...floatingLayerProps}
           position="popper"
           sideOffset={4}
           className="bg-popover text-popover-foreground ring-foreground/10 shadow-overlay data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 z-50 max-h-(--radix-select-content-available-height) min-w-(--radix-select-trigger-width) origin-(--radix-select-content-transform-origin) overflow-hidden rounded-lg p-1 ring-1 duration-100"

--- a/web/src/components/form.tsx
+++ b/web/src/components/form.tsx
@@ -51,9 +51,7 @@ export function Select({
         <SelectPrimitive.Content
           position="popper"
           sideOffset={4}
-          // Mark the gesture that closes this menu so a parent Dialog/Sheet
-          // doesn't dismiss on the retargeted tail of the same click. See
-          // floating-layer.ts for the full rationale.
+          // Don't let closing this menu dismiss a parent Dialog (floating-layer.ts).
           onPointerDownOutside={markFloatingLayerPointerDismiss}
           className="bg-popover text-popover-foreground ring-foreground/10 shadow-overlay data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 z-50 max-h-(--radix-select-content-available-height) min-w-(--radix-select-trigger-width) origin-(--radix-select-content-transform-origin) overflow-hidden rounded-lg p-1 ring-1 duration-100"
         >

--- a/web/src/components/form.tsx
+++ b/web/src/components/form.tsx
@@ -3,7 +3,10 @@ import { Select as SelectPrimitive } from 'radix-ui'
 import { Check, ChevronDown } from 'lucide-react'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
-import { floatingLayerProps } from '@/components/ui/floating-layer'
+import {
+  floatingLayerProps,
+  markFloatingLayerOutsideInteraction,
+} from '@/components/ui/floating-layer'
 import { cn } from '@/lib/utils'
 
 // Re-exported so screens import all form primitives from one place.
@@ -52,6 +55,7 @@ export function Select({
           {...floatingLayerProps}
           position="popper"
           sideOffset={4}
+          onPointerDownOutside={markFloatingLayerOutsideInteraction}
           className="bg-popover text-popover-foreground ring-foreground/10 shadow-overlay data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 z-50 max-h-(--radix-select-content-available-height) min-w-(--radix-select-trigger-width) origin-(--radix-select-content-transform-origin) overflow-hidden rounded-lg p-1 ring-1 duration-100"
         >
           <SelectPrimitive.Viewport>

--- a/web/src/components/form.tsx
+++ b/web/src/components/form.tsx
@@ -3,10 +3,7 @@ import { Select as SelectPrimitive } from 'radix-ui'
 import { Check, ChevronDown } from 'lucide-react'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
-import {
-  floatingLayerProps,
-  markFloatingLayerOutsideInteraction,
-} from '@/components/ui/floating-layer'
+import { markFloatingLayerPointerDismiss } from '@/components/ui/floating-layer'
 import { cn } from '@/lib/utils'
 
 // Re-exported so screens import all form primitives from one place.
@@ -52,10 +49,12 @@ export function Select({
       </SelectPrimitive.Trigger>
       <SelectPrimitive.Portal>
         <SelectPrimitive.Content
-          {...floatingLayerProps}
           position="popper"
           sideOffset={4}
-          onPointerDownOutside={markFloatingLayerOutsideInteraction}
+          // Mark the gesture that closes this menu so a parent Dialog/Sheet
+          // doesn't dismiss on the retargeted tail of the same click. See
+          // floating-layer.ts for the full rationale.
+          onPointerDownOutside={markFloatingLayerPointerDismiss}
           className="bg-popover text-popover-foreground ring-foreground/10 shadow-overlay data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 z-50 max-h-(--radix-select-content-available-height) min-w-(--radix-select-trigger-width) origin-(--radix-select-content-transform-origin) overflow-hidden rounded-lg p-1 ring-1 duration-100"
         >
           <SelectPrimitive.Viewport>

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -4,6 +4,11 @@ import { Dialog as DialogPrimitive } from 'radix-ui'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { XIcon } from 'lucide-react'
+import { isEventFromFloatingLayer } from '@/components/ui/floating-layer'
+
+function keepDialogOpenForFloatingLayer(event: Event) {
+  if (isEventFromFloatingLayer(event)) event.preventDefault()
+}
 
 function Dialog({
   ...props
@@ -49,6 +54,9 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  onInteractOutside,
+  onPointerDownOutside,
+  onFocusOutside,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
@@ -62,6 +70,18 @@ function DialogContent({
           'bg-popover text-popover-foreground data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 shadow-overlay fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border p-5 text-sm duration-100 outline-none sm:max-w-lg',
           className,
         )}
+        onInteractOutside={(event) => {
+          keepDialogOpenForFloatingLayer(event)
+          onInteractOutside?.(event)
+        }}
+        onPointerDownOutside={(event) => {
+          keepDialogOpenForFloatingLayer(event)
+          onPointerDownOutside?.(event)
+        }}
+        onFocusOutside={(event) => {
+          keepDialogOpenForFloatingLayer(event)
+          onFocusOutside?.(event)
+        }}
         {...props}
       >
         {children}

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -6,6 +6,11 @@ import { Button } from '@/components/ui/button'
 import { XIcon } from 'lucide-react'
 import { shouldKeepParentOpenForFloatingLayer } from '@/components/ui/floating-layer'
 
+// Radix dismisses a modal Dialog on any "outside" interaction. A Select/dropdown
+// inside the dialog portals out, so interacting with it — or, worse, the
+// retargeted tail of the click that closes it — reads as outside and wrongly
+// closes the dialog. preventDefault() on these handlers is Radix's intended
+// override; the decision of when to override lives in floating-layer.ts.
 function keepDialogOpenForFloatingLayer(event: Event) {
   if (shouldKeepParentOpenForFloatingLayer(event)) event.preventDefault()
 }

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -4,10 +4,10 @@ import { Dialog as DialogPrimitive } from 'radix-ui'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { XIcon } from 'lucide-react'
-import { isEventFromFloatingLayer } from '@/components/ui/floating-layer'
+import { shouldKeepParentOpenForFloatingLayer } from '@/components/ui/floating-layer'
 
 function keepDialogOpenForFloatingLayer(event: Event) {
-  if (isEventFromFloatingLayer(event)) event.preventDefault()
+  if (shouldKeepParentOpenForFloatingLayer(event)) event.preventDefault()
 }
 
 function Dialog({

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -6,11 +6,8 @@ import { Button } from '@/components/ui/button'
 import { XIcon } from 'lucide-react'
 import { shouldKeepParentOpenForFloatingLayer } from '@/components/ui/floating-layer'
 
-// Radix dismisses a modal Dialog on any "outside" interaction. A Select/dropdown
-// inside the dialog portals out, so interacting with it — or, worse, the
-// retargeted tail of the click that closes it — reads as outside and wrongly
-// closes the dialog. preventDefault() on these handlers is Radix's intended
-// override; the decision of when to override lives in floating-layer.ts.
+// A portaled Select/dropdown inside the dialog reads as an "outside" click and
+// wrongly dismisses it; suppress that case (why/when: floating-layer.ts).
 function keepDialogOpenForFloatingLayer(event: Event) {
   if (shouldKeepParentOpenForFloatingLayer(event)) event.preventDefault()
 }

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -3,7 +3,10 @@ import { DropdownMenu as DropdownMenuPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
 import { CheckIcon, ChevronRightIcon } from 'lucide-react'
-import { floatingLayerProps } from '@/components/ui/floating-layer'
+import {
+  floatingLayerProps,
+  markFloatingLayerOutsideInteraction,
+} from '@/components/ui/floating-layer'
 
 function DropdownMenu({
   ...props
@@ -34,6 +37,9 @@ function DropdownMenuContent({
   className,
   align = 'start',
   sideOffset = 4,
+  onInteractOutside,
+  onPointerDownOutside,
+  onFocusOutside,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
   return (
@@ -47,6 +53,18 @@ function DropdownMenuContent({
           'bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 shadow-overlay z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg p-1 ring-1 duration-100 data-[state=closed]:overflow-hidden',
           className,
         )}
+        onInteractOutside={(event) => {
+          markFloatingLayerOutsideInteraction()
+          onInteractOutside?.(event)
+        }}
+        onPointerDownOutside={(event) => {
+          markFloatingLayerOutsideInteraction()
+          onPointerDownOutside?.(event)
+        }}
+        onFocusOutside={(event) => {
+          markFloatingLayerOutsideInteraction()
+          onFocusOutside?.(event)
+        }}
         {...props}
       />
     </DropdownMenuPrimitive.Portal>
@@ -240,6 +258,9 @@ function DropdownMenuSubTrigger({
 
 function DropdownMenuSubContent({
   className,
+  onInteractOutside,
+  onPointerDownOutside,
+  onFocusOutside,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
   return (
@@ -250,6 +271,18 @@ function DropdownMenuSubContent({
         'bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 shadow-overlay z-50 min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg p-1 ring-1 duration-100',
         className,
       )}
+      onInteractOutside={(event) => {
+        markFloatingLayerOutsideInteraction()
+        onInteractOutside?.(event)
+      }}
+      onPointerDownOutside={(event) => {
+        markFloatingLayerOutsideInteraction()
+        onPointerDownOutside?.(event)
+      }}
+      onFocusOutside={(event) => {
+        markFloatingLayerOutsideInteraction()
+        onFocusOutside?.(event)
+      }}
       {...props}
     />
   )

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -3,10 +3,7 @@ import { DropdownMenu as DropdownMenuPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
 import { CheckIcon, ChevronRightIcon } from 'lucide-react'
-import {
-  floatingLayerProps,
-  markFloatingLayerOutsideInteraction,
-} from '@/components/ui/floating-layer'
+import { markFloatingLayerPointerDismiss } from '@/components/ui/floating-layer'
 
 function DropdownMenu({
   ...props
@@ -37,33 +34,24 @@ function DropdownMenuContent({
   className,
   align = 'start',
   sideOffset = 4,
-  onInteractOutside,
   onPointerDownOutside,
-  onFocusOutside,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
   return (
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Content
         data-slot="dropdown-menu-content"
-        {...floatingLayerProps}
         sideOffset={sideOffset}
         align={align}
         className={cn(
           'bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 shadow-overlay z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg p-1 ring-1 duration-100 data-[state=closed]:overflow-hidden',
           className,
         )}
-        onInteractOutside={(event) => {
-          markFloatingLayerOutsideInteraction()
-          onInteractOutside?.(event)
-        }}
+        // Mark the gesture that closes this menu so a parent Dialog/Sheet doesn't
+        // dismiss on the retargeted tail of the same click (floating-layer.ts).
         onPointerDownOutside={(event) => {
-          markFloatingLayerOutsideInteraction()
+          markFloatingLayerPointerDismiss()
           onPointerDownOutside?.(event)
-        }}
-        onFocusOutside={(event) => {
-          markFloatingLayerOutsideInteraction()
-          onFocusOutside?.(event)
         }}
         {...props}
       />
@@ -258,31 +246,17 @@ function DropdownMenuSubTrigger({
 
 function DropdownMenuSubContent({
   className,
-  onInteractOutside,
-  onPointerDownOutside,
-  onFocusOutside,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  // No floating-layer guard here: a submenu is nested inside its parent menu, not
+  // a dialog, so it never produces the Select-in-Dialog dismiss (floating-layer.ts).
   return (
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
-      {...floatingLayerProps}
       className={cn(
         'bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 shadow-overlay z-50 min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg p-1 ring-1 duration-100',
         className,
       )}
-      onInteractOutside={(event) => {
-        markFloatingLayerOutsideInteraction()
-        onInteractOutside?.(event)
-      }}
-      onPointerDownOutside={(event) => {
-        markFloatingLayerOutsideInteraction()
-        onPointerDownOutside?.(event)
-      }}
-      onFocusOutside={(event) => {
-        markFloatingLayerOutsideInteraction()
-        onFocusOutside?.(event)
-      }}
       {...props}
     />
   )

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -47,8 +47,7 @@ function DropdownMenuContent({
           'bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 shadow-overlay z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg p-1 ring-1 duration-100 data-[state=closed]:overflow-hidden',
           className,
         )}
-        // Mark the gesture that closes this menu so a parent Dialog/Sheet doesn't
-        // dismiss on the retargeted tail of the same click (floating-layer.ts).
+        // Don't let closing this menu dismiss a parent Dialog (floating-layer.ts).
         onPointerDownOutside={(event) => {
           markFloatingLayerPointerDismiss()
           onPointerDownOutside?.(event)
@@ -248,8 +247,7 @@ function DropdownMenuSubContent({
   className,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
-  // No floating-layer guard here: a submenu is nested inside its parent menu, not
-  // a dialog, so it never produces the Select-in-Dialog dismiss (floating-layer.ts).
+  // No guard: a submenu is nested in its parent menu, never a dialog.
   return (
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -3,6 +3,7 @@ import { DropdownMenu as DropdownMenuPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
 import { CheckIcon, ChevronRightIcon } from 'lucide-react'
+import { floatingLayerProps } from '@/components/ui/floating-layer'
 
 function DropdownMenu({
   ...props
@@ -39,6 +40,7 @@ function DropdownMenuContent({
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Content
         data-slot="dropdown-menu-content"
+        {...floatingLayerProps}
         sideOffset={sideOffset}
         align={align}
         className={cn(
@@ -243,6 +245,7 @@ function DropdownMenuSubContent({
   return (
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
+      {...floatingLayerProps}
       className={cn(
         'bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 shadow-overlay z-50 min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg p-1 ring-1 duration-100',
         className,

--- a/web/src/components/ui/floating-layer.ts
+++ b/web/src/components/ui/floating-layer.ts
@@ -1,5 +1,6 @@
 const FLOATING_LAYER_ATTR = 'data-oc-floating-layer'
 const FLOATING_LAYER_SELECTOR = `[${FLOATING_LAYER_ATTR}]`
+let floatingLayerOutsideInteractionDepth = 0
 
 type OutsideEventDetail = {
   originalEvent?: Event
@@ -9,13 +10,36 @@ export const floatingLayerProps = {
   [FLOATING_LAYER_ATTR]: '',
 } as const
 
-export function isEventFromFloatingLayer(event: Event) {
+function originalEventTarget(event: Event) {
   const originalEvent = (event as CustomEvent<OutsideEventDetail>).detail
     ?.originalEvent
-  const target = originalEvent?.target ?? event.target
+
+  return originalEvent?.target ?? event.target
+}
+
+function ownerDocumentForEvent(event: Event) {
+  const target = originalEventTarget(event)
+
+  return target instanceof Node ? target.ownerDocument : globalThis.document
+}
+
+export function markFloatingLayerOutsideInteraction() {
+  floatingLayerOutsideInteractionDepth += 1
+  globalThis.setTimeout(() => {
+    floatingLayerOutsideInteractionDepth = Math.max(
+      0,
+      floatingLayerOutsideInteractionDepth - 1,
+    )
+  }, 0)
+}
+
+export function shouldKeepParentOpenForFloatingLayer(event: Event) {
+  const target = originalEventTarget(event)
 
   return (
-    target instanceof Element &&
-    target.closest(FLOATING_LAYER_SELECTOR) !== null
+    floatingLayerOutsideInteractionDepth > 0 ||
+    (target instanceof Element &&
+      target.closest(FLOATING_LAYER_SELECTOR) !== null) ||
+    ownerDocumentForEvent(event)?.querySelector(FLOATING_LAYER_SELECTOR) !== null
   )
 }

--- a/web/src/components/ui/floating-layer.ts
+++ b/web/src/components/ui/floating-layer.ts
@@ -1,6 +1,7 @@
 const FLOATING_LAYER_ATTR = 'data-oc-floating-layer'
 const FLOATING_LAYER_SELECTOR = `[${FLOATING_LAYER_ATTR}]`
-let floatingLayerOutsideInteractionDepth = 0
+const FLOATING_LAYER_OUTSIDE_INTERACTION_WINDOW_MS = 500
+let lastFloatingLayerOutsideInteractionAt = 0
 
 type OutsideEventDetail = {
   originalEvent?: Event
@@ -24,20 +25,17 @@ function ownerDocumentForEvent(event: Event) {
 }
 
 export function markFloatingLayerOutsideInteraction() {
-  floatingLayerOutsideInteractionDepth += 1
-  globalThis.setTimeout(() => {
-    floatingLayerOutsideInteractionDepth = Math.max(
-      0,
-      floatingLayerOutsideInteractionDepth - 1,
-    )
-  }, 0)
+  lastFloatingLayerOutsideInteractionAt = Date.now()
 }
 
 export function shouldKeepParentOpenForFloatingLayer(event: Event) {
   const target = originalEventTarget(event)
+  const isRecentFloatingLayerOutsideInteraction =
+    Date.now() - lastFloatingLayerOutsideInteractionAt <=
+    FLOATING_LAYER_OUTSIDE_INTERACTION_WINDOW_MS
 
   return (
-    floatingLayerOutsideInteractionDepth > 0 ||
+    isRecentFloatingLayerOutsideInteraction ||
     (target instanceof Element &&
       target.closest(FLOATING_LAYER_SELECTOR) !== null) ||
     ownerDocumentForEvent(event)?.querySelector(FLOATING_LAYER_SELECTOR) !== null

--- a/web/src/components/ui/floating-layer.ts
+++ b/web/src/components/ui/floating-layer.ts
@@ -1,0 +1,21 @@
+const FLOATING_LAYER_ATTR = 'data-oc-floating-layer'
+const FLOATING_LAYER_SELECTOR = `[${FLOATING_LAYER_ATTR}]`
+
+type OutsideEventDetail = {
+  originalEvent?: Event
+}
+
+export const floatingLayerProps = {
+  [FLOATING_LAYER_ATTR]: '',
+} as const
+
+export function isEventFromFloatingLayer(event: Event) {
+  const originalEvent = (event as CustomEvent<OutsideEventDetail>).detail
+    ?.originalEvent
+  const target = originalEvent?.target ?? event.target
+
+  return (
+    target instanceof Element &&
+    target.closest(FLOATING_LAYER_SELECTOR) !== null
+  )
+}

--- a/web/src/components/ui/floating-layer.ts
+++ b/web/src/components/ui/floating-layer.ts
@@ -1,80 +1,35 @@
 /**
- * Keep a parent Dialog/Sheet open when the user interacts with a Radix
- * Select / DropdownMenu rendered inside it.
+ * Keep a parent Dialog/Sheet open when a Radix Select/DropdownMenu inside it is
+ * dismissed.
  *
- * ── WHY THIS EXISTS ─────────────────────────────────────────────────────────
- * Radix portals Select/DropdownMenu content to <body>, so the menu is a DOM
- * sibling of the dialog, not a descendant. Radix's DismissableLayer normally
- * shields the dialog while a menu is open (nested layers share a context, and a
- * child layer's interaction is not treated as "outside" the parent). That
- * shielding holds for the ordinary cases — but NOT for one specific, by-design
- * Radix behavior that produces the bug we actually hit:
- *
- *   `Select` is hardcoded `disableOutsidePointerEvents` and exposes no `modal`
- *   opt-out. While open it sets `pointer-events: none` on everything outside its
- *   menu. When you click the trigger a SECOND time to close the menu, that
- *   pointer-down hits the now-non-interactive trigger, closes the menu, and the
- *   TAIL of the same gesture (the pointerup/click, once pointer-events are
- *   restored) retargets onto the dialog overlay. The dialog reads that as an
- *   outside click and dismisses — even though the user only meant to close the
- *   menu. The menu has already left the layer stack by then, so Radix's native
- *   shielding can't catch it.
- *
- * Radix considers this intended and won't change it (primitives #2961 closed as
- * not-planned; #2731 documents the "you have to click twice" behavior of
- * `disableOutsidePointerEvents`). The blessed escape hatch is exactly what we
- * use: Dialog/Sheet forward `onInteractOutside` / `onPointerDownOutside` /
- * `onFocusOutside` into DismissableLayer, and we `preventDefault()` when an
- * "outside" interaction is really part of a menu interaction.
- *
- * ── TWO SIGNALS (the two failure modes look different to the dialog) ─────────
- *  1. ELEMENT — the interaction's target is inside a portaled popper, i.e. the
- *     user clicked into the menu itself. We match Radix's own marker
- *     `[data-radix-popper-content-wrapper]`, which Radix stamps on every popper
- *     layer (Select, DropdownMenu, Popover, …), so new floating components are
- *     covered for free without us tagging each one.
- *  2. GESTURE — the second-click retarget above. Here the dialog's handler sees
- *     the dialog OVERLAY as the target (the menu is already gone), so signal (1)
- *     can't catch it. When a popper dismisses from a pointer interaction it calls
- *     `markFloatingLayerPointerDismiss()`, and we then swallow the dialog's
- *     dismiss for the rest of THAT single pointer gesture.
- *
- * ── WHY A GESTURE FLAG, NOT A TIMER ─────────────────────────────────────────
- * An earlier version used a 500ms wall-clock window plus "is any popper mounted
- * anywhere in the document". Both are too broad: they also swallow genuine
- * backdrop clicks for 500ms after using a menu, and disable outside-dismiss
- * entirely whenever any unrelated dropdown is mounted. The precise fact we want
- * is "this is the same physical gesture that just closed a menu" — so we set a
- * flag on the menu's pointer-dismiss and clear it at the very start of the next
- * gesture (a fresh document `pointerdown`, capture phase, before Radix's own
- * handlers run). The flag therefore survives exactly one gesture's
- * pointerdown → pointerup → click and never a later, genuine outside click.
- *
- * ── A SHARP EDGE THAT WASTED EARLIER ATTEMPTS ───────────────────────────────
- * Radix wraps the native event: `event.target` on the synthetic outside-event is
- * the layer node, NOT the click target. The element check must read
- * `event.detail.originalEvent.target`. Missing this is why prior tries at the
- * `data-radix-popper-content-wrapper` guard silently did nothing.
+ * Bug: Select hardcodes `disableOutsidePointerEvents` (no `modal` opt-out), so a
+ * second click on its trigger closes the menu and that same gesture's tail
+ * retargets onto the dialog overlay → the dialog dismisses. The menu has left
+ * Radix's layer stack by then, so its native shielding can't catch it, and Radix
+ * considers this by-design (primitives #2961, #2731). Fix = Radix's intended
+ * override, preventDefault() on the dialog's outside handlers, when the "outside"
+ * event is really a menu interaction — detected two ways:
+ *   1. target is inside Radix's own `[data-radix-popper-content-wrapper]` (clicked
+ *      into the menu). Read detail.originalEvent.target, NOT event.target: Radix
+ *      wraps the event so event.target is the layer node — missing this silently
+ *      no-ops the guard, which is why earlier attempts failed.
+ *   2. the retarget, where target is the overlay that (1) can't see: the popper
+ *      flags its dismissing gesture (below); we honor it until the next pointerdown.
  */
 
-// Radix's built-in marker on every portaled popper layer. Keying off Radix's own
-// attribute (rather than a tag we add) means future floating components are
-// covered automatically.
 const POPPER_WRAPPER_SELECTOR = '[data-radix-popper-content-wrapper]'
 
 type OutsideEventDetail = {
   originalEvent?: Event
 }
 
-// True only between a popper's pointer-dismiss and the start of the next pointer
-// gesture — i.e. for the single gesture whose retargeted tail would otherwise
-// close the parent dialog.
+// Set while a popper's dismissing gesture is in flight (signal 2). Cleared at the
+// start of each gesture — capture phase, registered at module load, so it runs
+// before Radix's per-menu handlers and the flag spans exactly one gesture
+// (pointerdown→pointerup→click), never a later genuine backdrop click. A timer or
+// "any popper mounted" check would instead swallow real outside clicks too.
 let swallowDialogDismissForGesture = false
 
-// Clear the flag at the very start of every new gesture. Capture phase + a
-// module-load registration means this runs before Radix's per-layer pointerdown
-// handlers (which register later, when a menu opens), so the flag set during a
-// gesture is never cleared within that same gesture — only at the next one.
 if (typeof document !== 'undefined') {
   document.addEventListener(
     'pointerdown',
@@ -92,22 +47,12 @@ function originalEventTarget(event: Event): EventTarget | null {
   return originalEvent?.target ?? event.target
 }
 
-/**
- * Call from a Select/DropdownMenu `onPointerDownOutside`. The pointer gesture
- * that dismissed the menu is the one whose tail can retarget onto and close the
- * parent dialog; this marks that gesture so the dialog ignores the resulting
- * dismiss. (Item clicks and keyboard selection don't need this — they don't
- * retarget outside the menu.)
- */
+// Call from a popper's onPointerDownOutside — the gesture whose tail can retarget
+// onto and close the parent dialog. (Item clicks / keyboard don't retarget out.)
 export function markFloatingLayerPointerDismiss(): void {
   swallowDialogDismissForGesture = true
 }
 
-/**
- * True when a Dialog/Sheet outside-dismiss should be suppressed because it is
- * really a menu interaction — either a click into a portaled popper (element
- * signal) or the tail of the gesture that just dismissed one (gesture signal).
- */
 export function shouldKeepParentOpenForFloatingLayer(event: Event): boolean {
   if (swallowDialogDismissForGesture) return true
 

--- a/web/src/components/ui/floating-layer.ts
+++ b/web/src/components/ui/floating-layer.ts
@@ -1,43 +1,119 @@
-const FLOATING_LAYER_ATTR = 'data-oc-floating-layer'
-const FLOATING_LAYER_SELECTOR = `[${FLOATING_LAYER_ATTR}]`
-const FLOATING_LAYER_OUTSIDE_INTERACTION_WINDOW_MS = 500
-let lastFloatingLayerOutsideInteractionAt = 0
+/**
+ * Keep a parent Dialog/Sheet open when the user interacts with a Radix
+ * Select / DropdownMenu rendered inside it.
+ *
+ * ── WHY THIS EXISTS ─────────────────────────────────────────────────────────
+ * Radix portals Select/DropdownMenu content to <body>, so the menu is a DOM
+ * sibling of the dialog, not a descendant. Radix's DismissableLayer normally
+ * shields the dialog while a menu is open (nested layers share a context, and a
+ * child layer's interaction is not treated as "outside" the parent). That
+ * shielding holds for the ordinary cases — but NOT for one specific, by-design
+ * Radix behavior that produces the bug we actually hit:
+ *
+ *   `Select` is hardcoded `disableOutsidePointerEvents` and exposes no `modal`
+ *   opt-out. While open it sets `pointer-events: none` on everything outside its
+ *   menu. When you click the trigger a SECOND time to close the menu, that
+ *   pointer-down hits the now-non-interactive trigger, closes the menu, and the
+ *   TAIL of the same gesture (the pointerup/click, once pointer-events are
+ *   restored) retargets onto the dialog overlay. The dialog reads that as an
+ *   outside click and dismisses — even though the user only meant to close the
+ *   menu. The menu has already left the layer stack by then, so Radix's native
+ *   shielding can't catch it.
+ *
+ * Radix considers this intended and won't change it (primitives #2961 closed as
+ * not-planned; #2731 documents the "you have to click twice" behavior of
+ * `disableOutsidePointerEvents`). The blessed escape hatch is exactly what we
+ * use: Dialog/Sheet forward `onInteractOutside` / `onPointerDownOutside` /
+ * `onFocusOutside` into DismissableLayer, and we `preventDefault()` when an
+ * "outside" interaction is really part of a menu interaction.
+ *
+ * ── TWO SIGNALS (the two failure modes look different to the dialog) ─────────
+ *  1. ELEMENT — the interaction's target is inside a portaled popper, i.e. the
+ *     user clicked into the menu itself. We match Radix's own marker
+ *     `[data-radix-popper-content-wrapper]`, which Radix stamps on every popper
+ *     layer (Select, DropdownMenu, Popover, …), so new floating components are
+ *     covered for free without us tagging each one.
+ *  2. GESTURE — the second-click retarget above. Here the dialog's handler sees
+ *     the dialog OVERLAY as the target (the menu is already gone), so signal (1)
+ *     can't catch it. When a popper dismisses from a pointer interaction it calls
+ *     `markFloatingLayerPointerDismiss()`, and we then swallow the dialog's
+ *     dismiss for the rest of THAT single pointer gesture.
+ *
+ * ── WHY A GESTURE FLAG, NOT A TIMER ─────────────────────────────────────────
+ * An earlier version used a 500ms wall-clock window plus "is any popper mounted
+ * anywhere in the document". Both are too broad: they also swallow genuine
+ * backdrop clicks for 500ms after using a menu, and disable outside-dismiss
+ * entirely whenever any unrelated dropdown is mounted. The precise fact we want
+ * is "this is the same physical gesture that just closed a menu" — so we set a
+ * flag on the menu's pointer-dismiss and clear it at the very start of the next
+ * gesture (a fresh document `pointerdown`, capture phase, before Radix's own
+ * handlers run). The flag therefore survives exactly one gesture's
+ * pointerdown → pointerup → click and never a later, genuine outside click.
+ *
+ * ── A SHARP EDGE THAT WASTED EARLIER ATTEMPTS ───────────────────────────────
+ * Radix wraps the native event: `event.target` on the synthetic outside-event is
+ * the layer node, NOT the click target. The element check must read
+ * `event.detail.originalEvent.target`. Missing this is why prior tries at the
+ * `data-radix-popper-content-wrapper` guard silently did nothing.
+ */
+
+// Radix's built-in marker on every portaled popper layer. Keying off Radix's own
+// attribute (rather than a tag we add) means future floating components are
+// covered automatically.
+const POPPER_WRAPPER_SELECTOR = '[data-radix-popper-content-wrapper]'
 
 type OutsideEventDetail = {
   originalEvent?: Event
 }
 
-export const floatingLayerProps = {
-  [FLOATING_LAYER_ATTR]: '',
-} as const
+// True only between a popper's pointer-dismiss and the start of the next pointer
+// gesture — i.e. for the single gesture whose retargeted tail would otherwise
+// close the parent dialog.
+let swallowDialogDismissForGesture = false
 
-function originalEventTarget(event: Event) {
+// Clear the flag at the very start of every new gesture. Capture phase + a
+// module-load registration means this runs before Radix's per-layer pointerdown
+// handlers (which register later, when a menu opens), so the flag set during a
+// gesture is never cleared within that same gesture — only at the next one.
+if (typeof document !== 'undefined') {
+  document.addEventListener(
+    'pointerdown',
+    () => {
+      swallowDialogDismissForGesture = false
+    },
+    true,
+  )
+}
+
+function originalEventTarget(event: Event): EventTarget | null {
   const originalEvent = (event as CustomEvent<OutsideEventDetail>).detail
     ?.originalEvent
 
   return originalEvent?.target ?? event.target
 }
 
-function ownerDocumentForEvent(event: Event) {
-  const target = originalEventTarget(event)
-
-  return target instanceof Node ? target.ownerDocument : globalThis.document
+/**
+ * Call from a Select/DropdownMenu `onPointerDownOutside`. The pointer gesture
+ * that dismissed the menu is the one whose tail can retarget onto and close the
+ * parent dialog; this marks that gesture so the dialog ignores the resulting
+ * dismiss. (Item clicks and keyboard selection don't need this — they don't
+ * retarget outside the menu.)
+ */
+export function markFloatingLayerPointerDismiss(): void {
+  swallowDialogDismissForGesture = true
 }
 
-export function markFloatingLayerOutsideInteraction() {
-  lastFloatingLayerOutsideInteractionAt = Date.now()
-}
+/**
+ * True when a Dialog/Sheet outside-dismiss should be suppressed because it is
+ * really a menu interaction — either a click into a portaled popper (element
+ * signal) or the tail of the gesture that just dismissed one (gesture signal).
+ */
+export function shouldKeepParentOpenForFloatingLayer(event: Event): boolean {
+  if (swallowDialogDismissForGesture) return true
 
-export function shouldKeepParentOpenForFloatingLayer(event: Event) {
   const target = originalEventTarget(event)
-  const isRecentFloatingLayerOutsideInteraction =
-    Date.now() - lastFloatingLayerOutsideInteractionAt <=
-    FLOATING_LAYER_OUTSIDE_INTERACTION_WINDOW_MS
-
   return (
-    isRecentFloatingLayerOutsideInteraction ||
-    (target instanceof Element &&
-      target.closest(FLOATING_LAYER_SELECTOR) !== null) ||
-    ownerDocumentForEvent(event)?.querySelector(FLOATING_LAYER_SELECTOR) !== null
+    target instanceof Element &&
+    target.closest(POPPER_WRAPPER_SELECTOR) !== null
   )
 }

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -6,6 +6,11 @@ import { Dialog as SheetPrimitive } from 'radix-ui'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { XIcon } from 'lucide-react'
+import { shouldKeepParentOpenForFloatingLayer } from '@/components/ui/floating-layer'
+
+function keepSheetOpenForFloatingLayer(event: Event) {
+  if (shouldKeepParentOpenForFloatingLayer(event)) event.preventDefault()
+}
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />
@@ -50,6 +55,9 @@ function SheetContent({
   children,
   side = 'right',
   showCloseButton = true,
+  onInteractOutside,
+  onPointerDownOutside,
+  onFocusOutside,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: 'top' | 'right' | 'bottom' | 'left'
@@ -65,6 +73,18 @@ function SheetContent({
           'bg-popover text-popover-foreground data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10 shadow-overlay fixed z-50 flex flex-col gap-4 bg-clip-padding text-sm transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm',
           className,
         )}
+        onInteractOutside={(event) => {
+          keepSheetOpenForFloatingLayer(event)
+          onInteractOutside?.(event)
+        }}
+        onPointerDownOutside={(event) => {
+          keepSheetOpenForFloatingLayer(event)
+          onPointerDownOutside?.(event)
+        }}
+        onFocusOutside={(event) => {
+          keepSheetOpenForFloatingLayer(event)
+          onFocusOutside?.(event)
+        }}
         {...props}
       >
         {children}

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -8,6 +8,9 @@ import { Button } from '@/components/ui/button'
 import { XIcon } from 'lucide-react'
 import { shouldKeepParentOpenForFloatingLayer } from '@/components/ui/floating-layer'
 
+// Same Select/dropdown-dismiss guard as Dialog — a Sheet is a Radix Dialog under
+// the hood, so a portaled menu inside it can wrongly dismiss it. See
+// floating-layer.ts for the full rationale.
 function keepSheetOpenForFloatingLayer(event: Event) {
   if (shouldKeepParentOpenForFloatingLayer(event)) event.preventDefault()
 }

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -8,9 +8,7 @@ import { Button } from '@/components/ui/button'
 import { XIcon } from 'lucide-react'
 import { shouldKeepParentOpenForFloatingLayer } from '@/components/ui/floating-layer'
 
-// Same Select/dropdown-dismiss guard as Dialog — a Sheet is a Radix Dialog under
-// the hood, so a portaled menu inside it can wrongly dismiss it. See
-// floating-layer.ts for the full rationale.
+// A Sheet is a Radix Dialog; same Select/dropdown-dismiss guard (floating-layer.ts).
 function keepSheetOpenForFloatingLayer(event: Event) {
   if (shouldKeepParentOpenForFloatingLayer(event)) event.preventDefault()
 }


### PR DESCRIPTION
## Summary
- marks portaled Select and DropdownMenu content as floating layers
- prevents DialogContent and SheetContent from treating nested floating-layer interactions as outside-dismiss events
- handles the Radix Select edge case where `disableOutsidePointerEvents` retargets a second same-position click to the overlay while the select layer is still open/dismissing
- keeps the guard alive through the pointerdown → pointerup → click sequence instead of clearing it on `setTimeout(0)`

## Testing
- `PATH="$HOME/.nvm/versions/node/v22.13.0/bin:$PATH" npm run typecheck`
- `PATH="$HOME/.nvm/versions/node/v22.13.0/bin:$PATH" npx eslint src/components/form.tsx src/components/ui/dialog.tsx src/components/ui/dropdown-menu.tsx src/components/ui/floating-layer.ts src/components/ui/sheet.tsx`
- `PATH="$HOME/.nvm/versions/node/v22.13.0/bin:$PATH" npm run build`
- Headless Chrome against `http://localhost:3000` with only `/api/dashboard/*` mocked in-page: verified Agents, Sessions, and Credentials dialogs stay open after the same-position second click on nested selects, including after a 1s wait.
- Earlier preview-mode check also verified selecting nested select items keeps the parent dialog open.

## Note
- Full `npm run lint` still fails on existing `src/pages/SessionDetail.tsx:82` (`react-hooks/set-state-in-effect`), unrelated to this change.