### PR TITLE
feat(web): agent detail screen — sessions + Slack connect

### DIFF
--- a/docs/agent-sessions/channels.mdx
+++ b/docs/agent-sessions/channels.mdx
@@ -6,10 +6,10 @@ description: "Bind sessions to external threads"
 
 <Note>**Labs preview.** Channels are not part of the stable Durable Sessions API. For stable API access, use [Messaging](/agent-sessions/messaging) for input and [Webhooks](/agent-sessions/webhooks) for output.</Note>
 
-A **channel** binds a session to an external thread, such as Slack or GitHub.
+A **channel** binds a session to an external thread, such as Slack or GitHub. To connect an agent to Slack, see [Slack](/agent-sessions/slack).
 
-- **Inbound.** A Slack `@mention` or thread reply is verified, de-duplicated, and appended to the session as a [steer](/agent-sessions/messaging) — the same inbound message you can post over the API.
-- **Outbound.** The platform delivers the session's `user` and `progress` [events](/agent-sessions/events#visibility-levels) back to the thread. The agent never calls Slack itself.
+- **Inbound.** A Slack `@mention` is verified, de-duplicated, and appended to the session as a [steer](/agent-sessions/messaging) — the same inbound message you can post over the API.
+- **Outbound.** The platform delivers the session's `user`-level [events](/agent-sessions/events#visibility-levels) back to the thread. The agent never calls Slack itself.
 - **Bindings.** A session can have multiple bindings. A Slack-started session that opens a PR can also bind to that PR. Routing follows event level: conversation events go to conversation bindings, work output goes to delivery targets.
 
 A channel uses the same primitives as a custom UI: append messages and render the [event stream](/agent-sessions/events).

--- a/docs/agent-sessions/credentials.mdx
+++ b/docs/agent-sessions/credentials.mdx
@@ -84,16 +84,16 @@ If neither resolves, the session fails to start with `422 no_credential`.
 
 ## Rotation
 
-Rotating the **key value** behind a credential flows to **running** sessions too — the one exception to a session's otherwise [pinned config](/agent-sessions/agents#session-pinned-config), so a compromised key can be swapped without restarting work. Rotate by updating the agent's `key`:
+Rotating the **key value** behind a credential flows to **running** sessions too — the one exception to a session's otherwise [pinned config](/agent-sessions/agents#session-pinned-config), so a compromised key can be swapped without restarting work. Rotate the credential:
 
 <CodeGroup>
 
 ```ts TypeScript SDK
-await oc.agents.update("agt_...", { key: "sk-ant-NEW..." });
+await oc.credentials.rotate("cred_...", "sk-ant-NEW...");
 ```
 
 ```http REST API
-PATCH https://api.opencomputer.dev/v3/agents/agt_...
+PATCH https://api.opencomputer.dev/v3/credentials/cred_...
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
 
@@ -101,6 +101,8 @@ Content-Type: application/json
 ```
 
 </CodeGroup>
+
+Passing a new `key` to [`oc.agents.update`](/agent-sessions/agents) still works as a shortcut — it rotates the agent's attached credential.
 
 Changing **which** credential an agent uses (a different `credential` id) affects only **future** sessions — existing sessions keep the one they pinned.
 

--- a/docs/agent-sessions/slack.mdx
+++ b/docs/agent-sessions/slack.mdx
@@ -12,13 +12,13 @@ Connect from the agent's page in the [dashboard](https://app.opencomputer.dev) (
 
 ```ts TypeScript SDK
 // 1. Manifest to create the Slack app from (Create app → From a manifest).
-const { manifest, create_url } = await oc.agents.slackManifest(agentId);
+const { manifest, createUrl } = await oc.agents.slackManifest(agentId);
 
 // 2. Finalize with the App ID, Signing Secret, and Bot User OAuth Token.
 const slack = await oc.agents.connectSlack(agentId, {
-  app_id: "A0…",
-  signing_secret: "…",
-  bot_token: "xoxb-…",
+  appId: "A0…",
+  signingSecret: "…",
+  botToken: "xoxb-…",
 });
 
 await oc.agents.getSlack(agentId); // { status: "active", … } — no secrets

--- a/docs/agent-sessions/slack.mdx
+++ b/docs/agent-sessions/slack.mdx
@@ -4,74 +4,70 @@ title: "Slack"
 description: "Give an agent its own Slack handle"
 ---
 
-<Note>**Labs preview.** Slack connect is a control-plane flow (dashboard + REST) — there are no SDK methods for it. Inbound and outbound ride the standard session model: see [Channels](/agent-sessions/channels), [Messaging](/agent-sessions/messaging), [Webhooks](/agent-sessions/webhooks), and [Events](/agent-sessions/events).</Note>
+Connect an [agent](/agent-sessions/agents) to its own Slack app so members `@mention` it in a channel to start and steer [sessions](/agent-sessions/sessions). One app per agent, per workspace. You bring the app; OpenComputer keeps the bot token and signing secret in a sealed secret store — never returned, never exposed to a sandbox.
 
-Connect an [agent](/agent-sessions/agents) to its **own** Slack app so members can `@mention` it in a channel to start and steer [sessions](/agent-sessions/sessions). One Slack app maps to one agent and one workspace (1 ⟷ 1 ⟷ 1). The agent brings its own app — you paste three values from Slack; OpenComputer holds the bot token and signing secret in a dedicated secret store, never returns them, and never exposes them to a sandbox.
-
-## How it works
-
-- **Connect** is a two-step wizard: create the Slack app *from a manifest* OpenComputer generates (it already points Event Subscriptions back at OpenComputer), then paste back the App ID, Signing Secret, and Bot Token.
-- **Inbound.** An `@mention` is signature-verified, de-duplicated, and appended to a session as a [steer](/agent-sessions/messaging) — the same inbound message you can post over the API. The first mention in a thread starts a session; later mentions in that thread steer the same one (thread ⟷ session).
-- **Outbound.** The session's `user`-level [events](/agent-sessions/events#visibility-levels) post back to the thread. The agent never calls Slack itself.
-
-## Connect (dashboard)
-
-<Steps>
-  <Step title="Start">On the agent's page, open **Slack → Connect Slack**. OpenComputer generates an app manifest.</Step>
-  <Step title="Create the app">Copy the manifest and create the app in Slack via **From a manifest**.</Step>
-  <Step title="Paste details">From **Basic Information → App Credentials**, paste the **App ID** and **Signing Secret**.</Step>
-  <Step title="Install">**Install App → Install to Workspace**, then paste the **Bot User OAuth Token** (`xoxb-…`) and finish.</Step>
-  <Step title="Use it">Invite the bot (`/invite @handle`), then `@mention` it to start a session.</Step>
-</Steps>
-
-## Connect (API)
-
-The same flow over REST — org-key authenticated, scoped to the agent.
+Connect from the agent's page in the [dashboard](https://app.opencomputer.dev) (a guided wizard), or over the API: get a manifest, create the Slack app from it, then finalize with the three values Slack shows you.
 
 <CodeGroup>
-```bash Start (manifest)
-curl -X POST https://api.opencomputer.dev/v3/agents/{agent_id}/slack/manifest \
-  -H "Authorization: Bearer $OC_API_KEY"
-# → { manifest, create_url, steps, status }
+
+```ts TypeScript SDK
+// 1. Manifest to create the Slack app from (Create app → From a manifest).
+const { manifest, create_url } = await oc.agents.slackManifest(agentId);
+
+// 2. Finalize with the App ID, Signing Secret, and Bot User OAuth Token.
+const slack = await oc.agents.connectSlack(agentId, {
+  app_id: "A0…",
+  signing_secret: "…",
+  bot_token: "xoxb-…",
+});
+
+await oc.agents.getSlack(agentId); // { status: "active", … } — no secrets
+await oc.agents.disconnectSlack(agentId); // purge + stop routing
 ```
 
-```bash Finalize
-curl -X POST https://api.opencomputer.dev/v3/agents/{agent_id}/slack \
-  -H "Authorization: Bearer $OC_API_KEY" -H "content-type: application/json" \
-  -d '{"app_id":"A0…","bot_token":"xoxb-…","signing_secret":"…"}'
-# → the connection (status: active; never any secrets)
+```http REST API
+POST   https://api.opencomputer.dev/v3/agents/{agent_id}/slack/manifest
+POST   https://api.opencomputer.dev/v3/agents/{agent_id}/slack
+GET    https://api.opencomputer.dev/v3/agents/{agent_id}/slack
+DELETE https://api.opencomputer.dev/v3/agents/{agent_id}/slack
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+
+// finalize body
+{ "app_id": "A0…", "signing_secret": "…", "bot_token": "xoxb-…" }
 ```
 
-```bash Status
-curl https://api.opencomputer.dev/v3/agents/{agent_id}/slack \
-  -H "Authorization: Bearer $OC_API_KEY"
-```
-
-```bash Disconnect
-curl -X DELETE https://api.opencomputer.dev/v3/agents/{agent_id}/slack \
-  -H "Authorization: Bearer $OC_API_KEY"
-```
 </CodeGroup>
 
-Create the Slack app from the returned `manifest`, then post the three pasted values to finalize. `status` moves `pending → active`. Disconnect purges the stored secrets and stops routing.
+Then invite the bot (`/invite @handle`) and `@mention` it.
+
+## Routing
+
+An `@mention` is signature-verified, de-duplicated, and appended to a session as a [steer](/agent-sessions/messaging). The first mention in a thread starts a session; later mentions in that thread steer the same one. The session's `user`-level [events](/agent-sessions/events#visibility-levels) post back to the thread — the agent never calls Slack itself.
 
 ## Reconnect
 
-Replacing the Slack app (new keys, or a fresh app) requires explicit intent, so a stray request can't break a live connection:
+Replacing the app requires explicit intent, so a stray request can't tear down a live connection:
 
-```bash
-curl -X POST https://api.opencomputer.dev/v3/agents/{agent_id}/slack/manifest \
-  -H "Authorization: Bearer $OC_API_KEY" -H "content-type: application/json" \
-  -d '{"reconnect": true}'
+<CodeGroup>
+
+```ts TypeScript SDK
+await oc.agents.slackManifest(agentId, { reconnect: true });
 ```
 
-Calling `manifest` on an already-active connection **without** `reconnect: true` returns `409`. A reconnect resets the connection to `pending` — the agent stops responding in Slack until you finish the new setup — and retires the prior threads' session bindings so future mentions start fresh. In the dashboard, use the **Reconnect** button on a connected agent.
+```http REST API
+POST https://api.opencomputer.dev/v3/agents/{agent_id}/slack/manifest
 
-## Limits (v1)
+{ "reconnect": true }
+```
+
+</CodeGroup>
+
+Calling it on an active connection without `reconnect` returns `409`. A reconnect resets the connection to `pending` and retires the prior threads' bindings, so future mentions start fresh.
+
+## Limits
 
 <Warning>
-- **Anyone who can `@mention` the bot** in a channel it has joined can start and steer the agent. There is no per-user, per-channel, or per-org allow-list yet — invite the bot only to channels you trust.
-- **Mention-only.** The agent responds to `@mentions`; it does not passively follow thread replies.
-- **Final replies only.** Outbound posts `user`-level events; live progress narration isn't streamed into the thread yet.
-- **One Slack app per agent, per workspace.**
+- Anyone who can `@mention` the bot in a channel it has joined can start and steer the agent — there is no per-user or per-channel allow-list yet. Invite it only where you trust the members.
+- Mention-only: it doesn't passively follow thread replies.
+- Outbound posts `user`-level events; live progress isn't streamed into the thread yet.
 </Warning>

--- a/docs/agent-sessions/slack.mdx
+++ b/docs/agent-sessions/slack.mdx
@@ -4,7 +4,7 @@ title: "Slack"
 description: "Give an agent its own Slack handle"
 ---
 
-Connect an [agent](/agent-sessions/agents) to its own Slack app so members `@mention` it in a channel to start and steer [sessions](/agent-sessions/sessions). One app per agent, per workspace. The bot token and signing secret are stored encrypted and never returned by the API.
+Connect an [agent](/agent-sessions/agents) to its own Slack app so members `@mention` it in a channel to start and steer [sessions](/agent-sessions/sessions). One app per agent, per workspace.
 
 Connect from the agent's page in the [dashboard](https://app.opencomputer.dev) (a guided wizard), or over the API: get a manifest, create the Slack app from it, then finalize with the three values Slack shows you.
 

--- a/docs/agent-sessions/slack.mdx
+++ b/docs/agent-sessions/slack.mdx
@@ -4,7 +4,7 @@ title: "Slack"
 description: "Give an agent its own Slack handle"
 ---
 
-Connect an [agent](/agent-sessions/agents) to its own Slack app so members `@mention` it in a channel to start and steer [sessions](/agent-sessions/sessions). One app per agent, per workspace. You bring the app; OpenComputer keeps the bot token and signing secret in a sealed secret store — never returned, never exposed to a sandbox.
+Connect an [agent](/agent-sessions/agents) to its own Slack app so members `@mention` it in a channel to start and steer [sessions](/agent-sessions/sessions). One app per agent, per workspace. The bot token and signing secret are stored encrypted and never returned by the API.
 
 Connect from the agent's page in the [dashboard](https://app.opencomputer.dev) (a guided wizard), or over the API: get a manifest, create the Slack app from it, then finalize with the three values Slack shows you.
 

--- a/docs/agent-sessions/slack.mdx
+++ b/docs/agent-sessions/slack.mdx
@@ -1,0 +1,77 @@
+---
+mode: "wide"
+title: "Slack"
+description: "Give an agent its own Slack handle"
+---
+
+<Note>**Labs preview.** Slack connect is a control-plane flow (dashboard + REST) — there are no SDK methods for it. Inbound and outbound ride the standard session model: see [Channels](/agent-sessions/channels), [Messaging](/agent-sessions/messaging), [Webhooks](/agent-sessions/webhooks), and [Events](/agent-sessions/events).</Note>
+
+Connect an [agent](/agent-sessions/agents) to its **own** Slack app so members can `@mention` it in a channel to start and steer [sessions](/agent-sessions/sessions). One Slack app maps to one agent and one workspace (1 ⟷ 1 ⟷ 1). The agent brings its own app — you paste three values from Slack; OpenComputer holds the bot token and signing secret in a dedicated secret store, never returns them, and never exposes them to a sandbox.
+
+## How it works
+
+- **Connect** is a two-step wizard: create the Slack app *from a manifest* OpenComputer generates (it already points Event Subscriptions back at OpenComputer), then paste back the App ID, Signing Secret, and Bot Token.
+- **Inbound.** An `@mention` is signature-verified, de-duplicated, and appended to a session as a [steer](/agent-sessions/messaging) — the same inbound message you can post over the API. The first mention in a thread starts a session; later mentions in that thread steer the same one (thread ⟷ session).
+- **Outbound.** The session's `user`-level [events](/agent-sessions/events#visibility-levels) post back to the thread. The agent never calls Slack itself.
+
+## Connect (dashboard)
+
+<Steps>
+  <Step title="Start">On the agent's page, open **Slack → Connect Slack**. OpenComputer generates an app manifest.</Step>
+  <Step title="Create the app">Copy the manifest and create the app in Slack via **From a manifest**.</Step>
+  <Step title="Paste details">From **Basic Information → App Credentials**, paste the **App ID** and **Signing Secret**.</Step>
+  <Step title="Install">**Install App → Install to Workspace**, then paste the **Bot User OAuth Token** (`xoxb-…`) and finish.</Step>
+  <Step title="Use it">Invite the bot (`/invite @handle`), then `@mention` it to start a session.</Step>
+</Steps>
+
+## Connect (API)
+
+The same flow over REST — org-key authenticated, scoped to the agent.
+
+<CodeGroup>
+```bash Start (manifest)
+curl -X POST https://api.opencomputer.dev/v3/agents/{agent_id}/slack/manifest \
+  -H "Authorization: Bearer $OC_API_KEY"
+# → { manifest, create_url, steps, status }
+```
+
+```bash Finalize
+curl -X POST https://api.opencomputer.dev/v3/agents/{agent_id}/slack \
+  -H "Authorization: Bearer $OC_API_KEY" -H "content-type: application/json" \
+  -d '{"app_id":"A0…","bot_token":"xoxb-…","signing_secret":"…"}'
+# → the connection (status: active; never any secrets)
+```
+
+```bash Status
+curl https://api.opencomputer.dev/v3/agents/{agent_id}/slack \
+  -H "Authorization: Bearer $OC_API_KEY"
+```
+
+```bash Disconnect
+curl -X DELETE https://api.opencomputer.dev/v3/agents/{agent_id}/slack \
+  -H "Authorization: Bearer $OC_API_KEY"
+```
+</CodeGroup>
+
+Create the Slack app from the returned `manifest`, then post the three pasted values to finalize. `status` moves `pending → active`. Disconnect purges the stored secrets and stops routing.
+
+## Reconnect
+
+Replacing the Slack app (new keys, or a fresh app) requires explicit intent, so a stray request can't break a live connection:
+
+```bash
+curl -X POST https://api.opencomputer.dev/v3/agents/{agent_id}/slack/manifest \
+  -H "Authorization: Bearer $OC_API_KEY" -H "content-type: application/json" \
+  -d '{"reconnect": true}'
+```
+
+Calling `manifest` on an already-active connection **without** `reconnect: true` returns `409`. A reconnect resets the connection to `pending` — the agent stops responding in Slack until you finish the new setup — and retires the prior threads' session bindings so future mentions start fresh. In the dashboard, use the **Reconnect** button on a connected agent.
+
+## Limits (v1)
+
+<Warning>
+- **Anyone who can `@mention` the bot** in a channel it has joined can start and steer the agent. There is no per-user, per-channel, or per-org allow-list yet — invite the bot only to channels you trust.
+- **Mention-only.** The agent responds to `@mentions`; it does not passively follow thread replies.
+- **Final replies only.** Outbound posts `user`-level events; live progress narration isn't streamed into the thread yet.
+- **One Slack app per agent, per workspace.**
+</Warning>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -84,6 +84,7 @@
               "agent-sessions/custom-runtimes",
               "agent-sessions/triggers",
               "agent-sessions/channels",
+              "agent-sessions/slack",
               "agent-sessions/workspaces",
               "agent-sessions/artifacts"
             ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -73,6 +73,7 @@
           "agent-sessions/authentication",
           "agent-sessions/messaging",
           "agent-sessions/webhooks",
+          "agent-sessions/slack",
           "agent-sessions/runtimes",
           "agent-sessions/runtime-tools",
           "agent-sessions/api-reference",
@@ -84,7 +85,6 @@
               "agent-sessions/custom-runtimes",
               "agent-sessions/triggers",
               "agent-sessions/channels",
-              "agent-sessions/slack",
               "agent-sessions/workspaces",
               "agent-sessions/artifacts"
             ]

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/agents/agents.ts
+++ b/sdks/typescript/src/agents/agents.ts
@@ -22,6 +22,31 @@ export interface UpdateAgentParams {
 
 export interface Page<T> { data: T[]; nextCursor?: string | null; }
 
+/** The Slack app manifest to create in Slack (from `slackManifest`). */
+export interface SlackManifest {
+  manifest: Record<string, unknown>;
+  create_url: string;
+  steps?: unknown;
+  status: string;
+}
+
+/** A Slack connection's public state — never carries the bot token / signing secret. */
+export interface SlackConnection {
+  id: string;
+  agent_id: string;
+  status: string; // pending | active | revoked | error
+  slack_app_id?: string | null;
+  team_id?: string | null;
+  account_login?: string | null;
+}
+
+/** The three values pasted back from Slack to finalize a connection. */
+export interface ConnectSlackParams {
+  app_id: string;
+  bot_token: string;
+  signing_secret: string;
+}
+
 /** Reusable agents — the "what" a session runs. */
 export class Agents {
   constructor(private readonly http: Http) {}
@@ -38,5 +63,25 @@ export class Agents {
   }
   list(params: { limit?: number; cursor?: string } = {}): Promise<Page<Agent>> {
     return this.http.request("GET", "/agents", { query: params as Query });
+  }
+
+  // ── Slack (give the agent its own @handle; BYO app, 1 app ⟷ 1 agent ⟷ 1 workspace) ──
+
+  /** Start the connect intent → returns the app manifest to create in Slack. Pass
+   *  `reconnect: true` to replace an already-active connection (otherwise 409). */
+  slackManifest(id: string, opts: { reconnect?: boolean } = {}): Promise<SlackManifest> {
+    return this.http.request("POST", `/agents/${id}/slack/manifest`, { body: opts });
+  }
+  /** Finalize the connection with the three values Slack shows after install. */
+  connectSlack(id: string, params: ConnectSlackParams): Promise<SlackConnection> {
+    return this.http.request("POST", `/agents/${id}/slack`, { body: params });
+  }
+  /** Current connection (no secrets). */
+  getSlack(id: string): Promise<SlackConnection> {
+    return this.http.request("GET", `/agents/${id}/slack`);
+  }
+  /** Disconnect — purges the stored secrets and stops routing. */
+  disconnectSlack(id: string): Promise<{ ok: boolean }> {
+    return this.http.request("DELETE", `/agents/${id}/slack`);
   }
 }

--- a/sdks/typescript/src/agents/agents.ts
+++ b/sdks/typescript/src/agents/agents.ts
@@ -25,7 +25,7 @@ export interface Page<T> { data: T[]; nextCursor?: string | null; }
 /** The Slack app manifest to create in Slack (from `slackManifest`). */
 export interface SlackManifest {
   manifest: Record<string, unknown>;
-  create_url: string;
+  createUrl: string;
   steps?: unknown;
   status: string;
 }
@@ -33,18 +33,18 @@ export interface SlackManifest {
 /** A Slack connection's public state — never carries the bot token / signing secret. */
 export interface SlackConnection {
   id: string;
-  agent_id: string;
+  agentId: string;
   status: string; // pending | active | revoked | error
-  slack_app_id?: string | null;
-  team_id?: string | null;
-  account_login?: string | null;
+  slackAppId?: string | null;
+  teamId?: string | null;
+  accountLogin?: string | null;
 }
 
 /** The three values pasted back from Slack to finalize a connection. */
 export interface ConnectSlackParams {
-  app_id: string;
-  bot_token: string;
-  signing_secret: string;
+  appId: string;
+  botToken: string;
+  signingSecret: string;
 }
 
 /** Reusable agents — the "what" a session runs. */
@@ -72,7 +72,8 @@ export class Agents {
   slackManifest(id: string, opts: { reconnect?: boolean } = {}): Promise<SlackManifest> {
     return this.http.request("POST", `/agents/${id}/slack/manifest`, { body: opts });
   }
-  /** Finalize the connection with the three values Slack shows after install. */
+  /** Finalize the connection with the three values Slack shows after install.
+   *  (The HTTP layer converts appId → app_id, etc. on the wire.) */
   connectSlack(id: string, params: ConnectSlackParams): Promise<SlackConnection> {
     return this.http.request("POST", `/agents/${id}/slack`, { body: params });
   }

--- a/sdks/typescript/src/agents/credentials.ts
+++ b/sdks/typescript/src/agents/credentials.ts
@@ -25,6 +25,10 @@ export class Credentials {
   delete(id: string): Promise<void> {
     return this.http.request("DELETE", `/credentials/${id}`);
   }
+  /** Rotate the key VALUE behind a credential (versioned) — flows to running sessions. */
+  rotate(id: string, key: string): Promise<Credential> {
+    return this.http.request("PATCH", `/credentials/${id}`, { body: { key } });
+  }
   setDefault(params: { credential: string; provider?: string }): Promise<void> {
     return this.http.request("PUT", "/credentials/default", { body: params });
   }

--- a/sdks/typescript/src/agents/index.ts
+++ b/sdks/typescript/src/agents/index.ts
@@ -8,7 +8,10 @@ export type {
   SourceErrorCode, SourceSummary,
 } from "./sessions.js";
 export { Agents } from "./agents.js";
-export type { CreateAgentParams, UpdateAgentParams, Page } from "./agents.js";
+export type {
+  CreateAgentParams, UpdateAgentParams, Page,
+  SlackManifest, SlackConnection, ConnectSlackParams,
+} from "./agents.js";
 export { Repos, GitHub, GitHubApps, GitHubInstallations } from "./repos.js";
 export type {
   CreateRepoParams, UpdateRepoParams, Repo,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import AppShell from './components/app-shell'
 // deps (xterm, in Terminal/LogsPanel) only load on SandboxDetail when opened.
 const Dashboard = lazy(() => import('./pages/Dashboard'))
 const Agents = lazy(() => import('./pages/Agents'))
+const AgentDetail = lazy(() => import('./pages/AgentDetail'))
 const Credentials = lazy(() => import('./pages/Credentials'))
 const Sessions = lazy(() => import('./pages/Sessions'))
 const SessionDetail = lazy(() => import('./pages/SessionDetail'))
@@ -29,6 +30,7 @@ export default function App() {
             <Route index element={<Dashboard />} />
             {/* Agent plane */}
             <Route path="agents" element={<Agents />} />
+            <Route path="agents/:agentId" element={<AgentDetail />} />
             <Route path="credentials" element={<Credentials />} />
             <Route path="sessions" element={<Sessions />} />
             <Route path="sessions/:sessionId" element={<SessionDetail />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -393,6 +393,45 @@ export const updateAgent = (
     S.AgentSchema,
   )
 
+// Slack — an agent's BYO Slack app (1 app ⟷ 1 agent ⟷ 1 workspace). Two-step
+// connect: START (manifest) returns the app manifest + guided steps; COMPLETE
+// posts the three pasted values back. No secrets are ever returned.
+// `getSlackConnection` maps the 404 "not connected" into null so callers can
+// branch on absence without treating it as an error.
+export async function getSlackConnection(agentId: string) {
+  try {
+    return await apiFetch(
+      `/v3/agents/${agentId}/slack`,
+      {},
+      S.SlackConnectionSchema,
+    )
+  } catch (e) {
+    if (e instanceof Error && /no slack connection/i.test(e.message))
+      return null
+    throw e
+  }
+}
+
+export const startSlackConnect = (agentId: string) =>
+  apiFetch(
+    `/v3/agents/${agentId}/slack/manifest`,
+    { method: 'POST' },
+    S.SlackManifestResponseSchema,
+  )
+
+export const completeSlackConnect = (
+  agentId: string,
+  body: { app_id: string; bot_token: string; signing_secret: string },
+) =>
+  apiFetch(
+    `/v3/agents/${agentId}/slack`,
+    { method: 'POST', body: JSON.stringify(body) },
+    S.SlackConnectionSchema,
+  )
+
+export const disconnectSlack = (agentId: string) =>
+  apiFetch<void>(`/v3/agents/${agentId}/slack`, { method: 'DELETE' })
+
 // Credentials — reusable model-provider keys (the raw key is write-only). An
 // agent pins one (credential_id); sessions resolve the agent's, else the org
 // default for the provider.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -370,7 +370,8 @@ export const createAgent = (body: {
   prompt: string
   model: string
   runtime: string
-  credential_id?: string
+  // The request field is `credential` (the response carries `credential_id`).
+  credential?: string
   // `key` sugar: mints a model credential of the runtime's provider for this
   // agent (write-only). Without it (and no org default) sessions 422 no_credential.
   key?: string
@@ -479,12 +480,21 @@ export const rotateCredential = (id: string, key: string) =>
   )
 
 // Sessions — the durable runs.
-export const getSessions = (status?: string) =>
-  apiFetch(
-    `/v3/sessions${status ? `?status=${status}` : ''}`,
+export const getSessions = (
+  params: { agent?: string; status?: string; limit?: number; cursor?: string } = {},
+) => {
+  const q = new URLSearchParams()
+  if (params.agent) q.set('agent', params.agent)
+  if (params.status) q.set('status', params.status)
+  if (params.limit) q.set('limit', String(params.limit))
+  if (params.cursor) q.set('cursor', params.cursor)
+  const qs = q.toString()
+  return apiFetch(
+    `/v3/sessions${qs ? `?${qs}` : ''}`,
     {},
     S.SessionListSchema,
   ).then((r) => r.data)
+}
 
 export const getSession = (id: string) =>
   apiFetch(`/v3/sessions/${id}`, {}, S.SessionSchema)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -418,10 +418,12 @@ export async function getSlackConnection(agentId: string) {
   }
 }
 
-export const startSlackConnect = (agentId: string) =>
+// `reconnect: true` is required to replace an ALREADY-ACTIVE connection (the server
+// refuses to tear down a live one otherwise). First connect / pending / error → false.
+export const startSlackConnect = (agentId: string, reconnect = false) =>
   apiFetch(
     `/v3/agents/${agentId}/slack/manifest`,
-    { method: 'POST' },
+    { method: 'POST', body: JSON.stringify({ reconnect }) },
     S.SlackManifestResponseSchema,
   )
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -381,11 +381,12 @@ export const createAgent = (body: {
     S.AgentSchema,
   )
 
-// PATCH bumps revision; name is immutable (create idempotency key). `key`
-// rotates the model credential.
+// PATCH bumps revision; name is immutable (create idempotency key). `credential`
+// switches which credential the agent runs on; `key` (legacy) rotates the pinned
+// credential's value — rotation now lives on the Credentials page.
 export const updateAgent = (
   id: string,
-  body: Partial<{ prompt: string; model: string; key: string }>,
+  body: Partial<{ prompt: string; model: string; key: string; credential: string }>,
 ) =>
   apiFetch(
     `/v3/agents/${id}`,
@@ -458,6 +459,15 @@ export const setDefaultCredential = (id: string) =>
   apiFetch(
     '/v3/credentials/default',
     { method: 'PUT', body: JSON.stringify({ credential: id }) },
+    S.CredentialSchema,
+  )
+
+// Rotate a credential's secret VALUE (versioned, write-only key). Returns updated
+// metadata (new last4). Switching which credential an agent uses is updateAgent({ credential }).
+export const rotateCredential = (id: string, key: string) =>
+  apiFetch(
+    `/v3/credentials/${id}`,
+    { method: 'PATCH', body: JSON.stringify({ key }) },
     S.CredentialSchema,
   )
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -386,7 +386,12 @@ export const createAgent = (body: {
 // credential's value — rotation now lives on the Credentials page.
 export const updateAgent = (
   id: string,
-  body: Partial<{ prompt: string; model: string; key: string; credential: string }>,
+  body: Partial<{
+    prompt: string
+    model: string
+    key: string
+    credential: string | null // null clears the pin → org default resolves
+  }>,
 ) =>
   apiFetch(
     `/v3/agents/${id}`,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -351,14 +351,14 @@ export const setAutumnAutoTopup = (cfg: {
 export const getSandboxUsage = (days = 30) =>
   apiFetch(`/usage/sandboxes?days=${days}`, {}, S.SandboxUsageSchema)
 
-// ── Durable Agent Sessions (/v3) ─────────────────────────────────────────────
+// ── Durable Agent Sessions ───────────────────────────────────────────────────
 // A separate service (sessions-api). Reached through the OC edge under
 // `/api/dashboard/v3/*`, so these reuse apiFetch (cookie auth, validation, mock).
 // Org-key management lives server-side at the edge; live event/steer can move to
 // a browser-direct client-token path later without changing these signatures.
 
 // Agents — the reusable definition (prompt, model, runtime, credential).
-// /v3 lists wrap rows in { data: [...] }; callers want the array.
+// List endpoints wrap rows in { data: [...] }; callers want the array.
 export const getAgents = () =>
   apiFetch('/v3/agents', {}, S.AgentListSchema).then((r) => r.data)
 
@@ -472,7 +472,7 @@ export const getSessions = (status?: string) =>
 export const getSession = (id: string) =>
   apiFetch(`/v3/sessions/${id}`, {}, S.SessionSchema)
 
-// /v3 wants { agent: <id>, input } (input required). The response is an envelope
+// The API wants { agent: <id>, input } (input required). The response is an envelope
 // { session, client_token } — return the session.
 export const createSession = (
   body: { agent: string; input: string },

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -394,6 +394,46 @@ const v3agents = [
   },
 ]
 
+// A connected Slack app for the first agent (the AgentDetail Slack panel).
+const v3slack = {
+  id: 'sla_5p6q7r',
+  agent_id: 'agt_3kf9xz',
+  handle: 'PR Reviewer',
+  slack_app_id: 'A0123ABCDEF',
+  team_id: 'T0123ABCDEF',
+  account_login: 'Acme',
+  status: 'active',
+  bot_token_verified: true,
+  signing_verified: false,
+  created_at: at(5),
+  updated_at: at(0, 2),
+}
+
+// START-intent response for the Slack connect wizard (POST …/slack/manifest).
+const v3slackManifest = {
+  manifest: {
+    display_information: { name: 'PR Reviewer' },
+    features: {
+      bot_user: { display_name: 'PR Reviewer', always_online: true },
+    },
+    oauth_config: { scopes: { bot: ['app_mentions:read', 'chat:write'] } },
+    settings: {
+      event_subscriptions: {
+        request_url: 'https://api.opencomputer.dev/v3/slack/events/abc123nonce',
+        bot_events: ['app_mention'],
+      },
+    },
+  },
+  create_url: 'https://api.slack.com/apps',
+  steps: [
+    'Open api.slack.com/apps → Create New App → From a manifest.',
+    'Pick your workspace, paste the manifest, and click Create.',
+    'Click Install to Workspace and approve.',
+    'Copy three values back here: App ID, Bot User OAuth Token (xoxb-…), and Signing Secret.',
+  ],
+  status: 'pending',
+}
+
 const v3credentials = [
   {
     id: 'cred_anth_1',
@@ -613,6 +653,7 @@ const ROUTES: Array<[RegExp, Handler]> = [
   [/^\/org$/, () => org],
   [/^\/agents$/, () => []],
   // Durable Agent Sessions (/v3) — lists return the { data: [...] } envelope.
+  [/^\/v3\/agents\/[^/]+\/slack$/, () => v3slack],
   [/^\/v3\/agents\/[^/]+$/, () => v3agents[0]],
   [/^\/v3\/agents$/, () => ({ data: v3agents })],
   [/^\/v3\/credentials$/, () => ({ data: v3credentials })],
@@ -632,9 +673,21 @@ const ROUTES: Array<[RegExp, Handler]> = [
   [/^\/webhooks$/, () => ({ data: sandboxWebhooks })],
 ]
 
+// Mutations the preview needs to echo something parseable (e.g. the Slack
+// wizard's POST …/slack/manifest → manifest+steps). Everything else 204-ish.
+const POST_ROUTES: [RegExp, () => unknown][] = [
+  [/^\/v3\/agents\/[^/]+\/slack\/manifest$/, () => v3slackManifest],
+  [/^\/v3\/agents\/[^/]+\/slack$/, () => ({ ...v3slack, status: 'active' })],
+]
+
 export function mockFetch<T>(path: string, options: RequestInit = {}): T {
   const method = (options.method ?? 'GET').toUpperCase()
-  if (method !== 'GET') return {} as T
+  if (method !== 'GET') {
+    for (const [re, handler] of POST_ROUTES) {
+      if (re.test(path)) return handler() as T
+    }
+    return {} as T
+  }
   for (const [re, handler] of ROUTES) {
     if (re.test(path)) return handler() as T
   }

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -375,6 +375,8 @@ const agents = [
   {
     id: 'agt_3kf9xz',
     name: 'PR Reviewer',
+    prompt:
+      'You are a meticulous code reviewer. Flag correctness, security, and clarity issues; be concise and cite line numbers.',
     prompt_hash: 'sha256:9c1a4f',
     model: 'anthropic/claude-opus-4-8',
     runtime: 'claude',
@@ -385,6 +387,8 @@ const agents = [
   {
     id: 'agt_7mq2aa',
     name: 'Docs Writer',
+    prompt:
+      'You write clear, friendly developer documentation. Prefer short sentences and runnable examples.',
     prompt_hash: 'sha256:42bd07',
     model: 'anthropic/claude-sonnet-4-6',
     runtime: 'claude',

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -370,8 +370,8 @@ const orgInvitations = [
   },
 ]
 
-// ── Durable Agent Sessions (/v3) ─────────────────────────────────────────────
-const v3agents = [
+// ── Durable Agent Sessions ─────────────────────────────────────────────
+const agents = [
   {
     id: 'agt_3kf9xz',
     name: 'PR Reviewer',
@@ -395,7 +395,7 @@ const v3agents = [
 ]
 
 // A connected Slack app for the first agent (the AgentDetail Slack panel).
-const v3slack = {
+const slackConnection = {
   id: 'sla_5p6q7r',
   agent_id: 'agt_3kf9xz',
   handle: 'PR Reviewer',
@@ -410,7 +410,7 @@ const v3slack = {
 }
 
 // START-intent response for the Slack connect wizard (POST …/slack/manifest).
-const v3slackManifest = {
+const slackManifest = {
   manifest: {
     display_information: { name: 'PR Reviewer' },
     features: {
@@ -434,7 +434,7 @@ const v3slackManifest = {
   status: 'pending',
 }
 
-const v3credentials = [
+const credentials = [
   {
     id: 'cred_anth_1',
     provider: 'anthropic',
@@ -453,7 +453,7 @@ const v3credentials = [
   },
 ]
 
-const v3sessions = [
+const sessions = [
   {
     id: 'ses_a1b2c3',
     status: 'running',
@@ -497,7 +497,7 @@ const v3sessions = [
   },
 ]
 
-const v3events = [
+const sessionEvents = [
   {
     id: 'evt_1',
     seq: 1,
@@ -548,7 +548,7 @@ const v3events = [
   },
 ]
 
-const v3destinations = [
+const destinations = [
   {
     id: 'dst_1',
     url: 'https://acme.dev/hooks/oc',
@@ -561,7 +561,7 @@ const v3destinations = [
   },
 ]
 
-const v3deliveries = [
+const deliveries = [
   {
     id: 'dlv_1',
     destination: 'dst_1',
@@ -652,16 +652,16 @@ const ROUTES: Array<[RegExp, Handler]> = [
   [/^\/org\/custom-domain$/, () => ({})],
   [/^\/org$/, () => org],
   [/^\/agents$/, () => []],
-  // Durable Agent Sessions (/v3) — lists return the { data: [...] } envelope.
-  [/^\/v3\/agents\/[^/]+\/slack$/, () => v3slack],
-  [/^\/v3\/agents\/[^/]+$/, () => v3agents[0]],
-  [/^\/v3\/agents$/, () => ({ data: v3agents })],
-  [/^\/v3\/credentials$/, () => ({ data: v3credentials })],
-  [/^\/v3\/sessions\/[^/]+\/events/, () => ({ data: v3events })],
-  [/^\/v3\/sessions\/[^/]+\/destinations$/, () => ({ data: v3destinations })],
-  [/^\/v3\/sessions\/[^/]+\/deliveries$/, () => ({ data: v3deliveries })],
-  [/^\/v3\/sessions\/[^/]+$/, () => v3sessions[0]],
-  [/^\/v3\/sessions(\?.*)?$/, () => ({ data: v3sessions, next_cursor: null })],
+  // Durable Agent Sessions — lists return the { data: [...] } envelope.
+  [/^\/v3\/agents\/[^/]+\/slack$/, () => slackConnection],
+  [/^\/v3\/agents\/[^/]+$/, () => agents[0]],
+  [/^\/v3\/agents$/, () => ({ data: agents })],
+  [/^\/v3\/credentials$/, () => ({ data: credentials })],
+  [/^\/v3\/sessions\/[^/]+\/events/, () => ({ data: sessionEvents })],
+  [/^\/v3\/sessions\/[^/]+\/destinations$/, () => ({ data: destinations })],
+  [/^\/v3\/sessions\/[^/]+\/deliveries$/, () => ({ data: deliveries })],
+  [/^\/v3\/sessions\/[^/]+$/, () => sessions[0]],
+  [/^\/v3\/sessions(\?.*)?$/, () => ({ data: sessions, next_cursor: null })],
   [
     /^\/webhooks\/[^/]+\/deliveries$/,
     () => ({ data: sandboxWebhookDeliveries }),
@@ -676,8 +676,11 @@ const ROUTES: Array<[RegExp, Handler]> = [
 // Mutations the preview needs to echo something parseable (e.g. the Slack
 // wizard's POST …/slack/manifest → manifest+steps). Everything else 204-ish.
 const POST_ROUTES: [RegExp, () => unknown][] = [
-  [/^\/v3\/agents\/[^/]+\/slack\/manifest$/, () => v3slackManifest],
-  [/^\/v3\/agents\/[^/]+\/slack$/, () => ({ ...v3slack, status: 'active' })],
+  [/^\/v3\/agents\/[^/]+\/slack\/manifest$/, () => slackManifest],
+  [
+    /^\/v3\/agents\/[^/]+\/slack$/,
+    () => ({ ...slackConnection, status: 'active' }),
+  ],
 ]
 
 export function mockFetch<T>(path: string, options: RequestInit = {}): T {

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -305,6 +305,32 @@ export const CredentialListSchema = z.object({
   next_cursor: z.string().nullish(),
 })
 
+// Slack connection (sessions-api `serializeSlackApp`) — an agent's BYO Slack app.
+// Never carries secrets (bot token / signing secret stay in the secret backend).
+// `handle` is the agent's name; slack_app_id/team_id/account_login fill in once
+// connected. status: pending | active | revoked | error.
+export const SlackConnectionSchema = z.object({
+  id: z.string(),
+  agent_id: z.string(),
+  handle: z.string().nullish(),
+  slack_app_id: z.string().nullable().optional(),
+  team_id: z.string().nullable().optional(),
+  account_login: z.string().nullable().optional(),
+  status: z.string(),
+  bot_token_verified: z.boolean().optional(),
+  signing_verified: z.boolean().optional(),
+  created_at: z.string().nullish(),
+  updated_at: z.string().nullish(),
+})
+// START intent: the generated manifest (an object to copy), the Slack apps URL,
+// and the ordered human steps the wizard renders.
+export const SlackManifestResponseSchema = z.object({
+  manifest: record,
+  create_url: z.string(),
+  steps: z.array(z.string()),
+  status: z.string(),
+})
+
 export const SessionSchema = z.object({
   id: z.string(),
   status: z.string(),
@@ -394,6 +420,8 @@ export const DeliverySchema = z.object({
 
 export type Agent = z.infer<typeof AgentSchema>
 export type Credential = z.infer<typeof CredentialSchema>
+export type SlackConnection = z.infer<typeof SlackConnectionSchema>
+export type SlackManifestResponse = z.infer<typeof SlackManifestResponseSchema>
 export type Session = z.infer<typeof SessionSchema>
 export type SessionEvent = z.infer<typeof SessionEventSchema>
 export type Turn = z.infer<typeof TurnSchema>

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -268,8 +268,8 @@ export const SandboxWebhookDeliveryListSchema = z.object({
   data: z.array(SandboxWebhookDeliverySchema),
 })
 
-// ── Durable Agent Sessions (/v3) ─────────────────────────────────────────────
-// Mirrors the sessions-api /v3 contract verbatim (snake_case as the API returns
+// ── Durable Agent Sessions ───────────────────────────────────────────────────
+// Mirrors the sessions-api contract verbatim (snake_case as the API returns
 // it) — no transform layer to keep in sync. Reached via the edge proxy; lenient
 // string fields so a new server enum never fails validation.
 
@@ -284,7 +284,7 @@ export const AgentSchema = z.object({
   limits: record.nullish(),
   created_at: z.string(),
 })
-// /v3 list endpoints wrap rows in { data: [...], next_cursor? }.
+// List endpoints wrap rows in { data: [...], next_cursor? }.
 export const AgentListSchema = z.object({
   data: z.array(AgentSchema),
   next_cursor: z.string().nullish(),

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -276,6 +276,7 @@ export const SandboxWebhookDeliveryListSchema = z.object({
 export const AgentSchema = z.object({
   id: z.string(),
   name: z.string(),
+  prompt: z.string().nullish(),
   prompt_hash: z.string().nullish(),
   model: z.string(),
   runtime: z.string(),

--- a/web/src/components/session-webhooks.tsx
+++ b/web/src/components/session-webhooks.tsx
@@ -28,7 +28,7 @@ import { ConfirmDialog } from '@/components/confirm-dialog'
 import { cn } from '@/lib/utils'
 
 // Predefined event types a destination can subscribe to (exact + the error.*
-// prefix), from the /v3 event taxonomy. Empty selection = deliver every event.
+// prefix), from the event taxonomy. Empty selection = deliver every event.
 const EVENT_TYPES = [
   { value: 'turn.completed', label: 'Turn completed' },
   { value: 'turn.started', label: 'Turn started' },
@@ -39,7 +39,7 @@ const EVENT_TYPES = [
   { value: 'error.*', label: 'Errors' },
 ]
 
-// Webhooks are session-scoped in /v3 (a destination is created per session), so
+// Webhooks are session-scoped (a destination is created per session), so
 // they live on the session detail rather than a global page.
 export function SessionWebhooks({ sessionId }: { sessionId: string }) {
   const queryClient = useQueryClient()

--- a/web/src/components/slack-connect.tsx
+++ b/web/src/components/slack-connect.tsx
@@ -120,7 +120,7 @@ export function SlackConnect({
   }
 
   const startMutation = useMutation({
-    mutationFn: (reconnect = false) => startSlackConnect(agentId, reconnect),
+    mutationFn: (reconnect: boolean) => startSlackConnect(agentId, reconnect),
     onSuccess: (m) => {
       setManifest(m)
       setStep('create')

--- a/web/src/components/slack-connect.tsx
+++ b/web/src/components/slack-connect.tsx
@@ -269,9 +269,7 @@ export function SlackConnect({
               ) : (
                 <>
                   <p className="text-muted-foreground text-sm">
-                    In Slack, create the app from this manifest (New App → From
-                    a manifest), then Install to Workspace. Come back with the
-                    three values it gives you.
+                    Create the app from this manifest in Slack, then install it.
                   </p>
                   <div className="min-w-0">
                     <div className="mb-1.5 flex items-center justify-between">

--- a/web/src/components/slack-connect.tsx
+++ b/web/src/components/slack-connect.tsx
@@ -269,40 +269,34 @@ export function SlackConnect({
                 </p>
               ) : (
                 <>
+                  {/* Linear flow: read → Copy → Open Slack. The action row sits
+                      right under the explainer (Copy before the link), with the
+                      manifest below as reference. */}
                   <p className="text-muted-foreground text-sm">
-                    Create the app from this manifest in Slack.
+                    Copy this manifest, then create the app from it in Slack.
                   </p>
-                  <div className="min-w-0">
-                    <div className="mb-1.5 flex items-center justify-between">
-                      <span className="text-muted-foreground text-xs font-medium">
-                        App manifest
-                      </span>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={copyManifest}
-                      >
-                        {copied ? (
-                          <Check className="size-3.5" />
-                        ) : (
-                          <Copy className="size-3.5" />
-                        )}
-                        {copied ? 'Copied' : 'Copy'}
-                      </Button>
-                    </div>
-                    <pre className="bg-panel-2 max-h-60 overflow-auto rounded-md border p-3 font-mono text-xs">
-                      {JSON.stringify(manifest.manifest, null, 2)}
-                    </pre>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <Button variant="outline" size="sm" onClick={copyManifest}>
+                      {copied ? (
+                        <Check className="size-3.5" />
+                      ) : (
+                        <Copy className="size-3.5" />
+                      )}
+                      {copied ? 'Copied' : 'Copy manifest'}
+                    </Button>
+                    <a
+                      href={manifest.create_url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-foreground inline-flex items-center gap-1.5 text-sm underline underline-offset-4"
+                    >
+                      Open Slack apps
+                      <ExternalLink className="size-3.5" />
+                    </a>
                   </div>
-                  <a
-                    href={manifest.create_url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-foreground inline-flex items-center gap-1.5 text-sm underline underline-offset-4"
-                  >
-                    Open Slack apps
-                    <ExternalLink className="size-3.5" />
-                  </a>
+                  <pre className="bg-panel-2 max-h-60 min-w-0 overflow-auto rounded-md border p-3 font-mono text-xs">
+                    {JSON.stringify(manifest.manifest, null, 2)}
+                  </pre>
                 </>
               )}
               <DialogFooter>

--- a/web/src/components/slack-connect.tsx
+++ b/web/src/components/slack-connect.tsx
@@ -304,7 +304,7 @@ export function SlackConnect({
                       <ExternalLink className="size-3.5" />
                     </a>
                   </div>
-                  <pre className="bg-panel-2 max-h-60 min-w-0 overflow-auto rounded-md border p-3 font-mono text-xs">
+                  <pre className="bg-panel-2 max-h-60 min-w-0 overflow-y-auto rounded-md border p-3 font-mono text-xs [overflow-wrap:anywhere] whitespace-pre-wrap">
                     {JSON.stringify(manifest.manifest, null, 2)}
                   </pre>
                 </>

--- a/web/src/components/slack-connect.tsx
+++ b/web/src/components/slack-connect.tsx
@@ -282,7 +282,17 @@ export function SlackConnect({
                       ) : (
                         <Copy className="size-3.5" />
                       )}
-                      {copied ? 'Copied' : 'Copy manifest'}
+                      {/* Reserve the wider label's width (stacked grid) so the
+                          button — and the link beside it — don't shift when it
+                          flips to "Copied". */}
+                      <span className="grid">
+                        <span className="invisible col-start-1 row-start-1">
+                          Copy manifest
+                        </span>
+                        <span className="col-start-1 row-start-1 text-left">
+                          {copied ? 'Copied' : 'Copy manifest'}
+                        </span>
+                      </span>
                     </Button>
                     <a
                       href={manifest.create_url}

--- a/web/src/components/slack-connect.tsx
+++ b/web/src/components/slack-connect.tsx
@@ -108,6 +108,7 @@ export function SlackConnect({
   const [botToken, setBotToken] = useState('')
   const [signingSecret, setSigningSecret] = useState('')
   const [confirmDisconnect, setConfirmDisconnect] = useState(false)
+  const [confirmReconnect, setConfirmReconnect] = useState(false)
   const [copied, markCopied] = useTransientFlag(1500)
 
   const resetWizard = () => {
@@ -119,7 +120,7 @@ export function SlackConnect({
   }
 
   const startMutation = useMutation({
-    mutationFn: () => startSlackConnect(agentId),
+    mutationFn: (reconnect = false) => startSlackConnect(agentId, reconnect),
     onSuccess: (m) => {
       setManifest(m)
       setStep('create')
@@ -152,10 +153,10 @@ export function SlackConnect({
     onError: (e) => notifyError("Couldn't disconnect Slack.", e),
   })
 
-  const beginConnect = () => {
+  const beginConnect = (reconnect = false) => {
     resetWizard()
     setOpen(true)
-    startMutation.mutate()
+    startMutation.mutate(reconnect)
   }
 
   const copyManifest = () => {
@@ -202,13 +203,22 @@ export function SlackConnect({
               <code className="text-foreground">/invite @{conn?.handle}</code>,
               then <strong>@-mention</strong> it to start or steer a session.
             </p>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setConfirmDisconnect(true)}
-            >
-              Disconnect
-            </Button>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setConfirmReconnect(true)}
+              >
+                Reconnect
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setConfirmDisconnect(true)}
+              >
+                Disconnect
+              </Button>
+            </div>
           </div>
         ) : isErrorStatus ? (
           <div className="space-y-3">
@@ -217,7 +227,7 @@ export function SlackConnect({
               revoked). Reconnect to fix it.
             </p>
             <div className="flex gap-2">
-              <Button size="sm" onClick={beginConnect}>
+              <Button size="sm" onClick={() => beginConnect()}>
                 Reconnect
               </Button>
               <Button
@@ -235,7 +245,7 @@ export function SlackConnect({
               Give this agent its own Slack handle. Members @-mention it to
               start and steer sessions from a channel.
             </p>
-            <Button size="sm" onClick={beginConnect}>
+            <Button size="sm" onClick={() => beginConnect()}>
               {isPending ? 'Continue Slack setup' : 'Connect Slack'}
             </Button>
           </div>
@@ -463,6 +473,18 @@ export function SlackConnect({
         destructive
         pending={disconnectMutation.isPending}
         onConfirm={() => disconnectMutation.mutate()}
+      />
+
+      <ConfirmDialog
+        open={confirmReconnect}
+        onOpenChange={setConfirmReconnect}
+        title="Reconnect Slack?"
+        description="This replaces the current Slack app. The agent stops responding in Slack until you finish setting up the new one."
+        confirmLabel="Reconnect"
+        onConfirm={() => {
+          setConfirmReconnect(false)
+          beginConnect(true)
+        }}
       />
     </Panel>
   )

--- a/web/src/components/slack-connect.tsx
+++ b/web/src/components/slack-connect.tsx
@@ -29,6 +29,7 @@ import { CopyRow } from '@/components/copy-row'
 import { StatusBadge } from '@/components/status-badge'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 import { useTransientFlag } from '@/lib/use-transient-flag'
+import { cn } from '@/lib/utils'
 
 // An agent connects its OWN Slack app (BYO, 1:1:1). Connect is a two-step,
 // manifest-route wizard (oc-bg-agents/.agents/design/008-slack-presence.md §2):
@@ -36,6 +37,48 @@ import { useTransientFlag } from '@/lib/use-transient-flag'
 // flow; COMPLETE takes the three values Slack then hands back. No OAuth, no
 // secrets in responses.
 type Step = 'create' | 'paste' | 'done'
+
+const WIZARD_STEPS = ['Create app', 'Connect', 'Done']
+
+// Horizontal progress indicator — shows which step we're on; detail for each
+// step is only shown when it's reached (in the body below).
+function WizardSteps({ current }: { current: number }) {
+  return (
+    <ol className="flex items-center gap-2 pt-2">
+      {WIZARD_STEPS.map((label, i) => {
+        const done = i < current
+        const active = i === current
+        return (
+          <li key={label} className="flex min-w-0 items-center gap-2">
+            <span
+              className={cn(
+                'flex size-5 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold',
+                done || active
+                  ? 'bg-foreground text-background'
+                  : 'bg-secondary text-muted-foreground',
+              )}
+            >
+              {done ? <Check className="size-3" /> : i + 1}
+            </span>
+            <span
+              className={cn(
+                'truncate text-xs',
+                active
+                  ? 'text-foreground font-medium'
+                  : 'text-muted-foreground',
+              )}
+            >
+              {label}
+            </span>
+            {i < WIZARD_STEPS.length - 1 ? (
+              <span className="bg-border h-px w-4 shrink-0" />
+            ) : null}
+          </li>
+        )
+      })}
+    </ol>
+  )
+}
 
 export function SlackConnect({
   agentId,
@@ -130,6 +173,7 @@ export function SlackConnect({
   const isPending = status === 'pending'
   const isErrorStatus = status === 'error'
   const workspace = conn?.account_login || conn?.team_id || null
+  const stepIndex = step === 'create' ? 0 : step === 'paste' ? 1 : 2
 
   return (
     <Panel className="overflow-hidden">
@@ -205,36 +249,31 @@ export function SlackConnect({
           if (!o) resetWizard()
         }}
       >
-        <DialogContent className="sm:max-w-xl">
+        <DialogContent className="sm:max-w-2xl">
           <DialogHeader>
             <DialogTitle>
               {step === 'done' ? 'Slack connected' : 'Connect Slack'}
             </DialogTitle>
-            <DialogDescription>
-              {step === 'create'
-                ? 'Create the agent’s Slack app from a manifest, install it, then copy three values back.'
-                : step === 'paste'
-                  ? 'Paste the three values from your new Slack app.'
-                  : `@${agentName} is ready to use in Slack.`}
+            <DialogDescription className="sr-only">
+              Connect this agent’s own Slack app so members can @-mention it.
             </DialogDescription>
+            <WizardSteps current={stepIndex} />
           </DialogHeader>
 
           {step === 'create' ? (
-            <div className="space-y-4">
+            <div className="min-w-0 space-y-4">
               {startMutation.isPending || !manifest ? (
                 <p className="text-muted-foreground text-sm">
                   Preparing the manifest…
                 </p>
               ) : (
                 <>
-                  <ol className="text-foreground list-decimal space-y-1.5 pl-5 text-sm">
-                    {manifest.steps.map((s, i) => (
-                      <li key={i} className="text-muted-foreground">
-                        {s}
-                      </li>
-                    ))}
-                  </ol>
-                  <div>
+                  <p className="text-muted-foreground text-sm">
+                    In Slack, create the app from this manifest (New App → From
+                    a manifest), then Install to Workspace. Come back with the
+                    three values it gives you.
+                  </p>
+                  <div className="min-w-0">
                     <div className="mb-1.5 flex items-center justify-between">
                       <span className="text-muted-foreground text-xs font-medium">
                         App manifest
@@ -252,7 +291,7 @@ export function SlackConnect({
                         {copied ? 'Copied' : 'Copy'}
                       </Button>
                     </div>
-                    <pre className="bg-panel-2 max-h-52 overflow-auto rounded-md border p-3 font-mono text-xs">
+                    <pre className="bg-panel-2 max-h-60 overflow-auto rounded-md border p-3 font-mono text-xs">
                       {JSON.stringify(manifest.manifest, null, 2)}
                     </pre>
                   </div>
@@ -287,7 +326,7 @@ export function SlackConnect({
             </div>
           ) : step === 'paste' ? (
             <form
-              className="space-y-4"
+              className="min-w-0 space-y-4"
               onSubmit={(e) => {
                 e.preventDefault()
                 completeMutation.mutate()
@@ -353,7 +392,7 @@ export function SlackConnect({
               </DialogFooter>
             </form>
           ) : (
-            <div className="space-y-4">
+            <div className="min-w-0 space-y-4">
               <div className="space-y-2 text-sm">
                 <p>
                   <span className="text-foreground font-medium">

--- a/web/src/components/slack-connect.tsx
+++ b/web/src/components/slack-connect.tsx
@@ -36,9 +36,9 @@ import { cn } from '@/lib/utils'
 // START returns a manifest the user pastes into Slack's "From a manifest"
 // flow; COMPLETE takes the three values Slack then hands back. No OAuth, no
 // secrets in responses.
-type Step = 'create' | 'paste' | 'done'
+type Step = 'create' | 'details' | 'install' | 'done'
 
-const WIZARD_STEPS = ['Create app', 'Connect', 'Done']
+const WIZARD_STEPS = ['Create app', 'Details', 'Install', 'Done']
 
 // Horizontal progress indicator — shows which step we're on; detail for each
 // step is only shown when it's reached (in the body below).
@@ -173,7 +173,8 @@ export function SlackConnect({
   const isPending = status === 'pending'
   const isErrorStatus = status === 'error'
   const workspace = conn?.account_login || conn?.team_id || null
-  const stepIndex = step === 'create' ? 0 : step === 'paste' ? 1 : 2
+  const stepIndex =
+    step === 'create' ? 0 : step === 'details' ? 1 : step === 'install' ? 2 : 3
 
   return (
     <Panel className="overflow-hidden">
@@ -269,7 +270,7 @@ export function SlackConnect({
               ) : (
                 <>
                   <p className="text-muted-foreground text-sm">
-                    Create the app from this manifest in Slack, then install it.
+                    Create the app from this manifest in Slack.
                   </p>
                   <div className="min-w-0">
                     <div className="mb-1.5 flex items-center justify-between">
@@ -315,25 +316,28 @@ export function SlackConnect({
                   Cancel
                 </Button>
                 <Button
-                  onClick={() => setStep('paste')}
+                  onClick={() => setStep('details')}
                   disabled={!manifest || startMutation.isPending}
                 >
-                  Next: paste values
+                  Next: app details
                 </Button>
               </DialogFooter>
             </div>
-          ) : step === 'paste' ? (
+          ) : step === 'details' ? (
             <form
               className="min-w-0 space-y-4"
               onSubmit={(e) => {
                 e.preventDefault()
-                completeMutation.mutate()
+                if (appId.trim() && signingSecret.trim()) setStep('install')
               }}
             >
+              <p className="text-muted-foreground text-sm">
+                From Basic Information → App Credentials, copy these two.
+              </p>
               <Field
                 label="App ID"
                 htmlFor="slack-app-id"
-                description="On the app’s Basic Information page."
+                description="Top of the App Credentials section."
               >
                 <Input
                   id="slack-app-id"
@@ -343,22 +347,9 @@ export function SlackConnect({
                 />
               </Field>
               <Field
-                label="Bot User OAuth Token"
-                htmlFor="slack-bot-token"
-                description="OAuth & Permissions → after Install to Workspace."
-              >
-                <Input
-                  id="slack-bot-token"
-                  type="password"
-                  value={botToken}
-                  onChange={(e) => setBotToken(e.target.value)}
-                  placeholder="xoxb-…"
-                />
-              </Field>
-              <Field
                 label="Signing Secret"
                 htmlFor="slack-signing-secret"
-                description="Basic Information → App Credentials."
+                description="Same section, under Client Secret."
               >
                 <Input
                   id="slack-signing-secret"
@@ -378,11 +369,52 @@ export function SlackConnect({
                 </Button>
                 <Button
                   type="submit"
+                  disabled={!appId.trim() || !signingSecret.trim()}
+                >
+                  Next: install
+                </Button>
+              </DialogFooter>
+            </form>
+          ) : step === 'install' ? (
+            <form
+              className="min-w-0 space-y-4"
+              onSubmit={(e) => {
+                e.preventDefault()
+                completeMutation.mutate()
+              }}
+            >
+              <p className="text-muted-foreground text-sm">
+                In the sidebar, open Install App → Install to Workspace to get
+                the token.
+              </p>
+              <Field
+                label="Bot User OAuth Token"
+                htmlFor="slack-bot-token"
+                description="Install App → Bot User OAuth Token (starts with xoxb-)."
+              >
+                <Input
+                  id="slack-bot-token"
+                  type="password"
+                  value={botToken}
+                  onChange={(e) => setBotToken(e.target.value)}
+                  placeholder="xoxb-…"
+                />
+              </Field>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setStep('details')}
+                >
+                  Back
+                </Button>
+                <Button
+                  type="submit"
                   disabled={
                     completeMutation.isPending ||
                     !appId.trim() ||
-                    !botToken.trim() ||
-                    !signingSecret.trim()
+                    !signingSecret.trim() ||
+                    !botToken.trim()
                   }
                 >
                   {completeMutation.isPending ? 'Connecting…' : 'Connect'}

--- a/web/src/components/slack-connect.tsx
+++ b/web/src/components/slack-connect.tsx
@@ -1,0 +1,396 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Check, Copy, ExternalLink } from 'lucide-react'
+import { notifyError } from '@/lib/errors'
+import {
+  getSlackConnection,
+  startSlackConnect,
+  completeSlackConnect,
+  disconnectSlack,
+} from '@/api/client'
+import type { SlackManifestResponse } from '@/api/schemas'
+import {
+  Panel,
+  PanelContent,
+  PanelHeader,
+  PanelTitle,
+} from '@/components/panel'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Field, Input } from '@/components/form'
+import { CopyRow } from '@/components/copy-row'
+import { StatusBadge } from '@/components/status-badge'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+import { useTransientFlag } from '@/lib/use-transient-flag'
+
+// An agent connects its OWN Slack app (BYO, 1:1:1). Connect is a two-step,
+// manifest-route wizard (oc-bg-agents/.agents/design/008-slack-presence.md §2):
+// START returns a manifest the user pastes into Slack's "From a manifest"
+// flow; COMPLETE takes the three values Slack then hands back. No OAuth, no
+// secrets in responses.
+type Step = 'create' | 'paste' | 'done'
+
+export function SlackConnect({
+  agentId,
+  agentName,
+}: {
+  agentId: string
+  agentName: string
+}) {
+  const queryClient = useQueryClient()
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ['slack', agentId] })
+
+  const {
+    data: conn,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['slack', agentId],
+    queryFn: () => getSlackConnection(agentId),
+  })
+
+  // Wizard state.
+  const [open, setOpen] = useState(false)
+  const [step, setStep] = useState<Step>('create')
+  const [manifest, setManifest] = useState<SlackManifestResponse | null>(null)
+  const [appId, setAppId] = useState('')
+  const [botToken, setBotToken] = useState('')
+  const [signingSecret, setSigningSecret] = useState('')
+  const [confirmDisconnect, setConfirmDisconnect] = useState(false)
+  const [copied, markCopied] = useTransientFlag(1500)
+
+  const resetWizard = () => {
+    setStep('create')
+    setManifest(null)
+    setAppId('')
+    setBotToken('')
+    setSigningSecret('')
+  }
+
+  const startMutation = useMutation({
+    mutationFn: () => startSlackConnect(agentId),
+    onSuccess: (m) => {
+      setManifest(m)
+      setStep('create')
+      void invalidate() // the row is now pending
+    },
+    onError: (e) => notifyError("Couldn't start the Slack connection.", e),
+  })
+
+  const completeMutation = useMutation({
+    mutationFn: () =>
+      completeSlackConnect(agentId, {
+        app_id: appId.trim(),
+        bot_token: botToken.trim(),
+        signing_secret: signingSecret.trim(),
+      }),
+    onSuccess: () => {
+      void invalidate()
+      setStep('done')
+    },
+    onError: (e) =>
+      notifyError('Slack rejected those values. Double-check them.', e),
+  })
+
+  const disconnectMutation = useMutation({
+    mutationFn: () => disconnectSlack(agentId),
+    onSuccess: () => {
+      void invalidate()
+      setConfirmDisconnect(false)
+    },
+    onError: (e) => notifyError("Couldn't disconnect Slack.", e),
+  })
+
+  const beginConnect = () => {
+    resetWizard()
+    setOpen(true)
+    startMutation.mutate()
+  }
+
+  const copyManifest = () => {
+    if (!manifest) return
+    void navigator.clipboard
+      .writeText(JSON.stringify(manifest.manifest, null, 2))
+      .then(
+        () => markCopied(),
+        (e: unknown) => notifyError("Couldn't copy the manifest.", e),
+      )
+  }
+
+  const status = conn?.status
+  const isActive = status === 'active'
+  const isPending = status === 'pending'
+  const isErrorStatus = status === 'error'
+  const workspace = conn?.account_login || conn?.team_id || null
+
+  return (
+    <Panel className="overflow-hidden">
+      <PanelHeader>
+        <PanelTitle>Slack</PanelTitle>
+        {conn ? <StatusBadge status={status ?? 'pending'} /> : null}
+      </PanelHeader>
+      <PanelContent>
+        {isLoading ? (
+          <p className="text-muted-foreground text-sm">Checking Slack…</p>
+        ) : isError ? (
+          <p className="text-muted-foreground text-sm">
+            Slack status unavailable.
+          </p>
+        ) : isActive ? (
+          <div className="space-y-3">
+            <p className="text-sm">
+              <span className="text-foreground font-medium">
+                @{conn?.handle}
+              </span>{' '}
+              is connected{workspace ? ` to ${workspace}` : ''}.
+            </p>
+            <p className="text-muted-foreground text-sm">
+              Invite it to a channel with{' '}
+              <code className="text-foreground">/invite @{conn?.handle}</code>,
+              then <strong>@-mention</strong> it to start or steer a session.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setConfirmDisconnect(true)}
+            >
+              Disconnect
+            </Button>
+          </div>
+        ) : isErrorStatus ? (
+          <div className="space-y-3">
+            <p className="text-status-error text-sm">
+              Slack reported a connection error (the token may have been
+              revoked). Reconnect to fix it.
+            </p>
+            <div className="flex gap-2">
+              <Button size="sm" onClick={beginConnect}>
+                Reconnect
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setConfirmDisconnect(true)}
+              >
+                Disconnect
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <p className="text-muted-foreground text-sm">
+              Give this agent its own Slack handle. Members @-mention it to
+              start and steer sessions from a channel.
+            </p>
+            <Button size="sm" onClick={beginConnect}>
+              {isPending ? 'Continue Slack setup' : 'Connect Slack'}
+            </Button>
+          </div>
+        )}
+      </PanelContent>
+
+      {/* Connect wizard */}
+      <Dialog
+        open={open}
+        onOpenChange={(o) => {
+          setOpen(o)
+          if (!o) resetWizard()
+        }}
+      >
+        <DialogContent className="sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>
+              {step === 'done' ? 'Slack connected' : 'Connect Slack'}
+            </DialogTitle>
+            <DialogDescription>
+              {step === 'create'
+                ? 'Create the agent’s Slack app from a manifest, install it, then copy three values back.'
+                : step === 'paste'
+                  ? 'Paste the three values from your new Slack app.'
+                  : `@${agentName} is ready to use in Slack.`}
+            </DialogDescription>
+          </DialogHeader>
+
+          {step === 'create' ? (
+            <div className="space-y-4">
+              {startMutation.isPending || !manifest ? (
+                <p className="text-muted-foreground text-sm">
+                  Preparing the manifest…
+                </p>
+              ) : (
+                <>
+                  <ol className="text-foreground list-decimal space-y-1.5 pl-5 text-sm">
+                    {manifest.steps.map((s, i) => (
+                      <li key={i} className="text-muted-foreground">
+                        {s}
+                      </li>
+                    ))}
+                  </ol>
+                  <div>
+                    <div className="mb-1.5 flex items-center justify-between">
+                      <span className="text-muted-foreground text-xs font-medium">
+                        App manifest
+                      </span>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={copyManifest}
+                      >
+                        {copied ? (
+                          <Check className="size-3.5" />
+                        ) : (
+                          <Copy className="size-3.5" />
+                        )}
+                        {copied ? 'Copied' : 'Copy'}
+                      </Button>
+                    </div>
+                    <pre className="bg-panel-2 max-h-52 overflow-auto rounded-md border p-3 font-mono text-xs">
+                      {JSON.stringify(manifest.manifest, null, 2)}
+                    </pre>
+                  </div>
+                  <a
+                    href={manifest.create_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-foreground inline-flex items-center gap-1.5 text-sm underline underline-offset-4"
+                  >
+                    Open Slack apps
+                    <ExternalLink className="size-3.5" />
+                  </a>
+                </>
+              )}
+              <DialogFooter>
+                <Button
+                  variant="ghost"
+                  onClick={() => {
+                    setOpen(false)
+                    resetWizard()
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={() => setStep('paste')}
+                  disabled={!manifest || startMutation.isPending}
+                >
+                  Next: paste values
+                </Button>
+              </DialogFooter>
+            </div>
+          ) : step === 'paste' ? (
+            <form
+              className="space-y-4"
+              onSubmit={(e) => {
+                e.preventDefault()
+                completeMutation.mutate()
+              }}
+            >
+              <Field
+                label="App ID"
+                htmlFor="slack-app-id"
+                description="On the app’s Basic Information page."
+              >
+                <Input
+                  id="slack-app-id"
+                  value={appId}
+                  onChange={(e) => setAppId(e.target.value)}
+                  placeholder="A01234ABCDE"
+                />
+              </Field>
+              <Field
+                label="Bot User OAuth Token"
+                htmlFor="slack-bot-token"
+                description="OAuth & Permissions → after Install to Workspace."
+              >
+                <Input
+                  id="slack-bot-token"
+                  type="password"
+                  value={botToken}
+                  onChange={(e) => setBotToken(e.target.value)}
+                  placeholder="xoxb-…"
+                />
+              </Field>
+              <Field
+                label="Signing Secret"
+                htmlFor="slack-signing-secret"
+                description="Basic Information → App Credentials."
+              >
+                <Input
+                  id="slack-signing-secret"
+                  type="password"
+                  value={signingSecret}
+                  onChange={(e) => setSigningSecret(e.target.value)}
+                  placeholder="••••••••"
+                />
+              </Field>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setStep('create')}
+                >
+                  Back
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={
+                    completeMutation.isPending ||
+                    !appId.trim() ||
+                    !botToken.trim() ||
+                    !signingSecret.trim()
+                  }
+                >
+                  {completeMutation.isPending ? 'Connecting…' : 'Connect'}
+                </Button>
+              </DialogFooter>
+            </form>
+          ) : (
+            <div className="space-y-4">
+              <div className="space-y-2 text-sm">
+                <p>
+                  <span className="text-foreground font-medium">
+                    @{conn?.handle ?? agentName}
+                  </span>{' '}
+                  is connected{workspace ? ` to ${workspace}` : ''}.
+                </p>
+                <p className="text-muted-foreground">
+                  Invite it to a channel, then @-mention it:
+                </p>
+                <CopyRow value={`/invite @${conn?.handle ?? agentName}`} />
+              </div>
+              <DialogFooter>
+                <Button
+                  onClick={() => {
+                    setOpen(false)
+                    resetWizard()
+                  }}
+                >
+                  Done
+                </Button>
+              </DialogFooter>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={confirmDisconnect}
+        onOpenChange={setConfirmDisconnect}
+        title="Disconnect Slack?"
+        description="The agent’s Slack app stops working until reconnected. Its bot token and signing secret are purged."
+        confirmLabel="Disconnect"
+        destructive
+        pending={disconnectMutation.isPending}
+        onConfirm={() => disconnectMutation.mutate()}
+      />
+    </Panel>
+  )
+}

--- a/web/src/components/slack-connect.tsx
+++ b/web/src/components/slack-connect.tsx
@@ -25,7 +25,6 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Field, Input } from '@/components/form'
-import { CopyRow } from '@/components/copy-row'
 import { StatusBadge } from '@/components/status-badge'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 import { useTransientFlag } from '@/lib/use-transient-flag'
@@ -139,6 +138,9 @@ export function SlackConnect({
     onSuccess: () => {
       void invalidate()
       setStep('done')
+      setAppId('')
+      setBotToken('')
+      setSigningSecret('') // don't keep secrets in state past a successful connect
     },
     onError: (e) =>
       notifyError('Slack rejected those values. Double-check them.', e),
@@ -199,9 +201,8 @@ export function SlackConnect({
               is connected{workspace ? ` to ${workspace}` : ''}.
             </p>
             <p className="text-muted-foreground text-sm">
-              Invite it to a channel with{' '}
-              <code className="text-foreground">/invite @{conn?.handle}</code>,
-              then <strong>@-mention</strong> it to start or steer a session.
+              Invite the bot to a channel, then <strong>@-mention</strong> it to
+              start or steer a session.
             </p>
             <div className="flex gap-2">
               <Button
@@ -445,9 +446,9 @@ export function SlackConnect({
                   is connected{workspace ? ` to ${workspace}` : ''}.
                 </p>
                 <p className="text-muted-foreground">
-                  Invite it to a channel, then @-mention it:
+                  Invite the bot to a channel, then @-mention it to start a
+                  session.
                 </p>
-                <CopyRow value={`/invite @${conn?.handle ?? agentName}`} />
               </div>
               <DialogFooter>
                 <Button

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -57,12 +57,12 @@ export default function AgentDetail() {
     enabled: !!agentId,
   })
 
-  // This agent's sessions. The API has no per-agent filter, so scope client-side.
-  const { data: allSessions, isLoading: loadingSessions } = useQuery({
-    queryKey: ['sessions'],
-    queryFn: () => getSessions(),
+  // This agent's sessions — filtered server-side (not a client slice of an unfiltered
+  // first page, which would drop older sessions once the org is busy).
+  const { data: sessions = [], isLoading: loadingSessions } = useQuery({
+    queryKey: ['sessions', { agent: agentId }],
+    queryFn: () => getSessions({ agent: agentId }),
   })
-  const sessions = (allSessions ?? []).filter((s) => s.agent_id === agentId)
 
   // Credentials for the switch picker + to label the current one.
   const { data: credentials } = useQuery({

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -3,7 +3,14 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { ArrowLeft, MessagesSquare, Pencil, Send } from 'lucide-react'
 import { notifyError } from '@/lib/errors'
-import { getAgent, updateAgent, getSessions, createSession } from '@/api/client'
+import {
+  getAgent,
+  updateAgent,
+  getSessions,
+  createSession,
+  getCredentials,
+  createCredential,
+} from '@/api/client'
 import type { Session } from '@/api/schemas'
 import { PageHeader } from '@/components/page-header'
 import {
@@ -28,6 +35,13 @@ const MODELS = [
   { value: 'anthropic/claude-haiku-4-5', label: 'Claude Haiku 4.5' },
 ]
 
+// Agents run on the "claude" runtime → anthropic credentials. Sentinel for the
+// "create one inline" choice in the credential picker.
+const CRED_PROVIDER = 'anthropic'
+const NEW_CRED = '__new__'
+
+type EditField = 'model' | 'prompt' | 'credential'
+
 export default function AgentDetail() {
   const { agentId = '' } = useParams()
   const navigate = useNavigate()
@@ -50,14 +64,27 @@ export default function AgentDetail() {
   })
   const sessions = (allSessions ?? []).filter((s) => s.agent_id === agentId)
 
+  // Credentials for the switch picker + to label the current one.
+  const { data: credentials } = useQuery({
+    queryKey: ['credentials'],
+    queryFn: getCredentials,
+  })
+  const anthropicCreds = (credentials ?? []).filter(
+    (c) => c.provider === CRED_PROVIDER,
+  )
+  const credLabel = (id: string) => {
+    const c = anthropicCreds.find((x) => x.id === id)
+    if (!c) return id
+    return `${c.name || 'Unnamed'}${c.last4 ? ` ·· ${c.last4}` : ''}${
+      c.is_default ? ' (default)' : ''
+    }`
+  }
+
   // ── Start a session (inline composer) ─────────────────────────────────────
   const [task, setTask] = useState('')
   const startMutation = useMutation({
     mutationFn: () =>
-      createSession(
-        { agent: agentId, input: task.trim() },
-        crypto.randomUUID(),
-      ),
+      createSession({ agent: agentId, input: task.trim() }, crypto.randomUUID()),
     onSuccess: (session) => {
       void queryClient.invalidateQueries({ queryKey: ['sessions'] })
       void navigate(`/sessions/${session.id}`)
@@ -65,41 +92,76 @@ export default function AgentDetail() {
     onError: (e) => notifyError("Couldn't start the session.", e),
   })
 
-  // ── Edit (inline, no popup) ───────────────────────────────────────────────
-  const [editing, setEditing] = useState(false)
-  const [editModel, setEditModel] = useState('')
-  const [editPrompt, setEditPrompt] = useState('')
-  const [editKey, setEditKey] = useState('')
+  // ── Field-by-field inline edit ────────────────────────────────────────────
+  // One field at a time; the pencil on a row opens just that row's editor.
+  const [editField, setEditField] = useState<EditField | null>(null)
+  const [draftModel, setDraftModel] = useState('')
+  const [draftPrompt, setDraftPrompt] = useState('')
+  const [draftCred, setDraftCred] = useState('') // credential id or NEW_CRED
+  const [newCredName, setNewCredName] = useState('')
+  const [newCredKey, setNewCredKey] = useState('')
 
-  const openEdit = () => {
+  const startEdit = (field: EditField) => {
     if (!agent) return
-    setEditModel(agent.model)
-    setEditPrompt('')
-    setEditKey('')
-    setEditing(true)
+    if (field === 'model') setDraftModel(agent.model)
+    if (field === 'prompt') setDraftPrompt(agent.prompt ?? '')
+    if (field === 'credential') {
+      setDraftCred(agent.credential_id ?? anthropicCreds[0]?.id ?? NEW_CRED)
+      setNewCredName('')
+      setNewCredKey('')
+    }
+    setEditField(field)
   }
-  const closeEdit = () => {
-    setEditing(false)
-    setEditKey('') // never leave a model key in state
+  const cancelEdit = () => {
+    setEditField(null)
+    setNewCredKey('') // never leave a model key in state
   }
 
-  const updateMutation = useMutation({
-    mutationFn: () => {
+  const saveMutation = useMutation({
+    mutationFn: async () => {
       if (!agent) throw new Error('no agent loaded')
-      const body: { model?: string; prompt?: string; key?: string } = {}
-      if (editModel.trim() && editModel.trim() !== agent.model)
-        body.model = editModel.trim()
-      if (editPrompt.trim()) body.prompt = editPrompt.trim()
-      if (editKey.trim()) body.key = editKey.trim()
-      return updateAgent(agent.id, body)
+      if (editField === 'model')
+        return updateAgent(agent.id, { model: draftModel.trim() })
+      if (editField === 'prompt')
+        return updateAgent(agent.id, { prompt: draftPrompt.trim() })
+      // credential: switch to a chosen one, or mint a new one then switch.
+      let credentialId = draftCred
+      if (draftCred === NEW_CRED) {
+        const cred = await createCredential({
+          key: newCredKey.trim(),
+          provider: CRED_PROVIDER,
+          name: newCredName.trim() || undefined,
+          is_default: !anthropicCreds.some((c) => c.is_default),
+        })
+        credentialId = cred.id
+      }
+      return updateAgent(agent.id, { credential: credentialId })
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['agent', agentId] })
       void queryClient.invalidateQueries({ queryKey: ['agents'] })
-      closeEdit()
+      void queryClient.invalidateQueries({ queryKey: ['credentials'] })
+      cancelEdit()
     },
     onError: (e) => notifyError("Couldn't update the agent.", e),
   })
+
+  // Whether the open editor has a saveable value.
+  const canSave =
+    editField === 'model'
+      ? draftModel.trim().length > 0
+      : editField === 'prompt'
+        ? draftPrompt.trim().length > 0
+        : editField === 'credential'
+          ? draftCred === NEW_CRED
+            ? newCredKey.trim().length > 0
+            : draftCred.length > 0
+          : false
+
+  const credOptions = [
+    ...anthropicCreds.map((c) => ({ value: c.id, label: credLabel(c.id) })),
+    { value: NEW_CRED, label: '＋ New credential…' },
+  ]
 
   const sessionColumns: Column<Session>[] = [
     {
@@ -162,97 +224,138 @@ export default function AgentDetail() {
               sdk: 'oc.sessions.create()',
               docs: 'https://docs.opencomputer.dev/agent-sessions/sessions',
             }}
-            actions={
-              !editing ? (
-                <Button variant="outline" size="sm" onClick={openEdit}>
-                  <Pencil className="size-4" />
-                  Edit
-                </Button>
-              ) : null
-            }
           />
 
-          {/* Overview */}
-          <Panel className="p-5">
-            <div className="text-muted-foreground grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-xs">
-              <span>Agent ID</span>
-              <span className="text-foreground font-mono">{agent.id}</span>
-              <span>Model</span>
-              <span className="text-foreground font-mono">{agent.model}</span>
-              <span>Runtime</span>
-              <span className="text-foreground capitalize">
+          {/* Configuration — each field edits in place. */}
+          <Panel className="px-5 py-1.5">
+            {/* Read-only identity rows */}
+            <Row label="Agent ID">
+              <span className="text-foreground font-mono text-sm">
+                {agent.id}
+              </span>
+            </Row>
+            <Row label="Runtime">
+              <span className="text-foreground text-sm capitalize">
                 {agent.runtime}
               </span>
-              <span>Revision</span>
-              <span className="text-foreground font-mono">
+            </Row>
+            <Row label="Revision">
+              <span className="text-foreground font-mono text-sm">
                 {agent.revision ?? 1}
               </span>
-              <span>Credential</span>
-              <span className="text-foreground">
-                {agent.credential_id ? 'Set' : 'None'}
-              </span>
-              <span>Created</span>
-              <span className="text-foreground">
-                {new Date(agent.created_at).toLocaleString()}
-              </span>
-            </div>
+            </Row>
 
-            {editing ? (
-              <form
-                className="mt-5 space-y-4 border-t pt-5"
-                onSubmit={(e) => {
-                  e.preventDefault()
-                  updateMutation.mutate()
-                }}
-              >
-                <Field label="Model" htmlFor="edit-model">
-                  <Select
-                    id="edit-model"
-                    value={editModel}
-                    onValueChange={setEditModel}
-                    options={
-                      MODELS.some((m) => m.value === editModel) || !editModel
-                        ? MODELS
-                        : [{ value: editModel, label: editModel }, ...MODELS]
-                    }
-                  />
-                </Field>
-                <Field
-                  label="New prompt"
-                  htmlFor="edit-prompt"
-                  description="Leave blank to keep the current prompt (it isn't shown)."
-                >
-                  <Textarea
-                    id="edit-prompt"
-                    value={editPrompt}
-                    onChange={(e) => setEditPrompt(e.target.value)}
-                    placeholder="Replace the system prompt…"
-                    className="min-h-24"
-                  />
-                </Field>
-                <Field
-                  label="Rotate Anthropic API key"
-                  htmlFor="edit-key"
-                  description="Leave blank to keep the current credential."
-                >
-                  <Input
-                    id="edit-key"
-                    type="password"
-                    value={editKey}
-                    onChange={(e) => setEditKey(e.target.value)}
-                    placeholder="sk-ant-…"
-                  />
-                </Field>
-                <div className="flex justify-end gap-2">
-                  <Button type="button" variant="ghost" onClick={closeEdit}>
-                    Cancel
-                  </Button>
-                  <Button type="submit" disabled={updateMutation.isPending}>
-                    {updateMutation.isPending ? 'Saving…' : 'Save changes'}
-                  </Button>
-                </div>
-              </form>
-            ) : null}
+            {/* Model */}
+            <EditRow
+              label="Model"
+              editing={editField === 'model'}
+              onEdit={() => startEdit('model')}
+              onCancel={cancelEdit}
+              onSave={() => saveMutation.mutate()}
+              saving={saveMutation.isPending}
+              canSave={canSave}
+              display={
+                <span className="text-foreground font-mono text-sm">
+                  {agent.model}
+                </span>
+              }
+            >
+              <Select
+                value={draftModel}
+                onValueChange={setDraftModel}
+                options={
+                  MODELS.some((m) => m.value === draftModel) || !draftModel
+                    ? MODELS
+                    : [{ value: draftModel, label: draftModel }, ...MODELS]
+                }
+              />
+            </EditRow>
+
+            {/* Prompt — now shown, edited in place */}
+            <EditRow
+              label="Prompt"
+              editing={editField === 'prompt'}
+              onEdit={() => startEdit('prompt')}
+              onCancel={cancelEdit}
+              onSave={() => saveMutation.mutate()}
+              saving={saveMutation.isPending}
+              canSave={canSave}
+              display={
+                <p className="text-foreground text-sm whitespace-pre-wrap">
+                  {agent.prompt || (
+                    <span className="text-muted-foreground">No prompt set</span>
+                  )}
+                </p>
+              }
+            >
+              <Textarea
+                value={draftPrompt}
+                onChange={(e) => setDraftPrompt(e.target.value)}
+                placeholder="You are a meticulous code reviewer…"
+                className="min-h-32"
+              />
+            </EditRow>
+
+            {/* Credential — switch (pick existing / create new), not rotate */}
+            <EditRow
+              label="Credential"
+              editing={editField === 'credential'}
+              onEdit={() => startEdit('credential')}
+              onCancel={cancelEdit}
+              onSave={() => saveMutation.mutate()}
+              saving={saveMutation.isPending}
+              canSave={canSave}
+              display={
+                <span className="text-foreground text-sm">
+                  {agent.credential_id ? (
+                    credLabel(agent.credential_id)
+                  ) : (
+                    <span className="text-muted-foreground">
+                      None — uses the org default
+                    </span>
+                  )}
+                </span>
+              }
+            >
+              <div className="space-y-3">
+                <Select
+                  value={draftCred}
+                  onValueChange={setDraftCred}
+                  options={credOptions}
+                  placeholder="Choose a credential"
+                />
+                {draftCred === NEW_CRED ? (
+                  <div className="border-border bg-panel-2 grid grid-cols-1 gap-3 rounded-md border p-3 sm:grid-cols-2">
+                    <Field label="Credential name" htmlFor="new-cred-name">
+                      <Input
+                        id="new-cred-name"
+                        value={newCredName}
+                        onChange={(e) => setNewCredName(e.target.value)}
+                        placeholder="e.g. Production"
+                      />
+                    </Field>
+                    <Field
+                      label="Anthropic API key"
+                      htmlFor="new-cred-key"
+                      description="Encrypted in a dedicated secret store."
+                    >
+                      <Input
+                        id="new-cred-key"
+                        type="password"
+                        value={newCredKey}
+                        onChange={(e) => setNewCredKey(e.target.value)}
+                        placeholder="sk-ant-…"
+                      />
+                    </Field>
+                  </div>
+                ) : (
+                  <p className="text-muted-foreground text-xs">
+                    Switches which credential this agent runs on. To change a
+                    key's value, rotate it on the Credentials page.
+                  </p>
+                )}
+              </div>
+            </EditRow>
           </Panel>
 
           {/* Slack — kept above Sessions so it's visible without scrolling */}
@@ -311,6 +414,86 @@ export default function AgentDetail() {
               }
             />
           </Panel>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// A read-only configuration row: a fixed-width label + value.
+function Row({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="border-border/60 flex items-baseline gap-4 border-b py-3 last:border-0">
+      <span className="text-muted-foreground w-28 shrink-0 text-xs">
+        {label}
+      </span>
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
+  )
+}
+
+// An editable configuration row: shows the value with a subtle pencil; clicking
+// swaps in the editor (the children) with Save / Cancel. One row edits at a time.
+function EditRow({
+  label,
+  editing,
+  onEdit,
+  onCancel,
+  onSave,
+  saving,
+  canSave,
+  display,
+  children,
+}: {
+  label: string
+  editing: boolean
+  onEdit: () => void
+  onCancel: () => void
+  onSave: () => void
+  saving: boolean
+  canSave: boolean
+  display: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <div className="border-border/60 flex gap-4 border-b py-3 last:border-0">
+      <span className="text-muted-foreground w-28 shrink-0 pt-1 text-xs">
+        {label}
+      </span>
+      {!editing ? (
+        <div className="flex min-w-0 flex-1 items-start justify-between gap-2">
+          <div className="min-w-0">{display}</div>
+          <button
+            type="button"
+            onClick={onEdit}
+            aria-label={`Edit ${label.toLowerCase()}`}
+            className="text-muted-foreground hover:text-foreground -mt-0.5 shrink-0 rounded p-1"
+          >
+            <Pencil className="size-3.5" />
+          </button>
+        </div>
+      ) : (
+        <div className="flex-1 space-y-2.5">
+          {children}
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={onSave}
+              disabled={saving || !canSave}
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
         </div>
       )}
     </div>

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -1,0 +1,316 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { ArrowLeft, MessagesSquare, Pencil, Send } from 'lucide-react'
+import { notifyError } from '@/lib/errors'
+import { getAgent, updateAgent, getSessions, createSession } from '@/api/client'
+import type { Session } from '@/api/schemas'
+import { PageHeader } from '@/components/page-header'
+import {
+  Panel,
+  PanelContent,
+  PanelHeader,
+  PanelTitle,
+} from '@/components/panel'
+import { Button } from '@/components/ui/button'
+import { Field, Input, Select, Textarea } from '@/components/form'
+import { StatusBadge } from '@/components/status-badge'
+import { EmptyState } from '@/components/empty-state'
+import { ResourceTable, type Column } from '@/components/resource-table'
+import { Skeleton } from '@/components/ui/skeleton'
+
+// Mirrors the curated list in Agents.tsx (the create flow). /v3 wants a
+// provider-prefixed model id.
+const MODELS = [
+  { value: 'anthropic/claude-opus-4-8', label: 'Claude Opus 4.8' },
+  { value: 'anthropic/claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+  { value: 'anthropic/claude-haiku-4-5', label: 'Claude Haiku 4.5' },
+]
+
+export default function AgentDetail() {
+  const { agentId = '' } = useParams()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const {
+    data: agent,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['agent', agentId],
+    queryFn: () => getAgent(agentId),
+    enabled: !!agentId,
+  })
+
+  // This agent's sessions. /v3 has no per-agent filter, so scope client-side.
+  const { data: allSessions, isLoading: loadingSessions } = useQuery({
+    queryKey: ['sessions'],
+    queryFn: () => getSessions(),
+  })
+  const sessions = (allSessions ?? []).filter((s) => s.agent_id === agentId)
+
+  // ── Start a session (inline composer) ─────────────────────────────────────
+  const [task, setTask] = useState('')
+  const startMutation = useMutation({
+    mutationFn: () =>
+      createSession(
+        { agent: agentId, input: task.trim() },
+        crypto.randomUUID(),
+      ),
+    onSuccess: (session) => {
+      void queryClient.invalidateQueries({ queryKey: ['sessions'] })
+      void navigate(`/sessions/${session.id}`)
+    },
+    onError: (e) => notifyError("Couldn't start the session.", e),
+  })
+
+  // ── Edit (inline, no popup) ───────────────────────────────────────────────
+  const [editing, setEditing] = useState(false)
+  const [editModel, setEditModel] = useState('')
+  const [editPrompt, setEditPrompt] = useState('')
+  const [editKey, setEditKey] = useState('')
+
+  const openEdit = () => {
+    if (!agent) return
+    setEditModel(agent.model)
+    setEditPrompt('')
+    setEditKey('')
+    setEditing(true)
+  }
+  const closeEdit = () => {
+    setEditing(false)
+    setEditKey('') // never leave a model key in state
+  }
+
+  const updateMutation = useMutation({
+    mutationFn: () => {
+      if (!agent) throw new Error('no agent loaded')
+      const body: { model?: string; prompt?: string; key?: string } = {}
+      if (editModel.trim() && editModel.trim() !== agent.model)
+        body.model = editModel.trim()
+      if (editPrompt.trim()) body.prompt = editPrompt.trim()
+      if (editKey.trim()) body.key = editKey.trim()
+      return updateAgent(agent.id, body)
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['agent', agentId] })
+      void queryClient.invalidateQueries({ queryKey: ['agents'] })
+      closeEdit()
+    },
+    onError: (e) => notifyError("Couldn't update the agent.", e),
+  })
+
+  const sessionColumns: Column<Session>[] = [
+    {
+      key: 'id',
+      header: 'Session',
+      cell: (s) => (
+        <Link
+          to={`/sessions/${s.id}`}
+          className="text-foreground font-mono text-[13px] underline-offset-4 hover:underline"
+        >
+          {s.id}
+        </Link>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      cell: (s) => <StatusBadge status={s.status} />,
+    },
+    {
+      key: 'created',
+      header: 'Created',
+      cell: (s) => (
+        <span className="text-muted-foreground font-mono text-xs">
+          {new Date(s.created_at).toLocaleString()}
+        </span>
+      ),
+    },
+  ]
+
+  return (
+    <div className="max-w-4xl">
+      <Link
+        to="/agents"
+        className="text-muted-foreground hover:text-foreground mb-4 inline-flex items-center gap-1.5 text-sm"
+      >
+        <ArrowLeft className="size-4" />
+        Agents
+      </Link>
+
+      {isLoading ? (
+        <Skeleton className="h-40 w-full" />
+      ) : isError || !agent ? (
+        <EmptyState
+          icon={MessagesSquare}
+          title="Agent not found"
+          description="This agent doesn't exist or you don't have access to it."
+          action={
+            <Button size="sm" onClick={() => void navigate('/agents')}>
+              Back to agents
+            </Button>
+          }
+        />
+      ) : (
+        <div className="space-y-6">
+          <PageHeader
+            title={agent.name}
+            description="A reusable definition. Sessions pin a snapshot of it at create time."
+            api={{
+              method: 'POST',
+              path: '/v3/sessions',
+              sdk: 'oc.sessions.create()',
+              docs: 'https://docs.opencomputer.dev/agent-sessions/sessions',
+            }}
+            actions={
+              !editing ? (
+                <Button variant="outline" size="sm" onClick={openEdit}>
+                  <Pencil className="size-4" />
+                  Edit
+                </Button>
+              ) : null
+            }
+          />
+
+          {/* Overview */}
+          <Panel className="p-5">
+            <div className="text-muted-foreground grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-xs">
+              <span>Agent ID</span>
+              <span className="text-foreground font-mono">{agent.id}</span>
+              <span>Model</span>
+              <span className="text-foreground font-mono">{agent.model}</span>
+              <span>Runtime</span>
+              <span className="text-foreground capitalize">
+                {agent.runtime}
+              </span>
+              <span>Revision</span>
+              <span className="text-foreground font-mono">
+                {agent.revision ?? 1}
+              </span>
+              <span>Credential</span>
+              <span className="text-foreground">
+                {agent.credential_id ? 'Set' : 'None'}
+              </span>
+              <span>Created</span>
+              <span className="text-foreground">
+                {new Date(agent.created_at).toLocaleString()}
+              </span>
+            </div>
+
+            {editing ? (
+              <form
+                className="mt-5 space-y-4 border-t pt-5"
+                onSubmit={(e) => {
+                  e.preventDefault()
+                  updateMutation.mutate()
+                }}
+              >
+                <Field label="Model" htmlFor="edit-model">
+                  <Select
+                    id="edit-model"
+                    value={editModel}
+                    onValueChange={setEditModel}
+                    options={
+                      MODELS.some((m) => m.value === editModel) || !editModel
+                        ? MODELS
+                        : [{ value: editModel, label: editModel }, ...MODELS]
+                    }
+                  />
+                </Field>
+                <Field
+                  label="New prompt"
+                  htmlFor="edit-prompt"
+                  description="Leave blank to keep the current prompt (it isn't shown)."
+                >
+                  <Textarea
+                    id="edit-prompt"
+                    value={editPrompt}
+                    onChange={(e) => setEditPrompt(e.target.value)}
+                    placeholder="Replace the system prompt…"
+                    className="min-h-24"
+                  />
+                </Field>
+                <Field
+                  label="Rotate Anthropic API key"
+                  htmlFor="edit-key"
+                  description="Leave blank to keep the current credential."
+                >
+                  <Input
+                    id="edit-key"
+                    type="password"
+                    value={editKey}
+                    onChange={(e) => setEditKey(e.target.value)}
+                    placeholder="sk-ant-…"
+                  />
+                </Field>
+                <div className="flex justify-end gap-2">
+                  <Button type="button" variant="ghost" onClick={closeEdit}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={updateMutation.isPending}>
+                    {updateMutation.isPending ? 'Saving…' : 'Save changes'}
+                  </Button>
+                </div>
+              </form>
+            ) : null}
+          </Panel>
+
+          {/* Sessions */}
+          <Panel className="overflow-hidden">
+            <PanelHeader>
+              <PanelTitle>Sessions</PanelTitle>
+              <Link
+                to="/sessions"
+                className="text-muted-foreground hover:text-foreground text-xs underline-offset-4 hover:underline"
+              >
+                All sessions
+              </Link>
+            </PanelHeader>
+
+            <PanelContent className="border-b">
+              <form
+                className="space-y-2"
+                onSubmit={(e) => {
+                  e.preventDefault()
+                  if (task.trim()) startMutation.mutate()
+                }}
+              >
+                <Textarea
+                  value={task}
+                  onChange={(e) => setTask(e.target.value)}
+                  placeholder="Give this agent a task — it runs durably as a new session…"
+                  className="min-h-20"
+                />
+                <div className="flex justify-end">
+                  <Button
+                    type="submit"
+                    size="sm"
+                    disabled={startMutation.isPending || !task.trim()}
+                  >
+                    <Send className="size-4" />
+                    {startMutation.isPending ? 'Starting…' : 'Start session'}
+                  </Button>
+                </div>
+              </form>
+            </PanelContent>
+
+            <ResourceTable
+              columns={sessionColumns}
+              rows={sessions}
+              rowKey={(s) => s.id}
+              loading={loadingSessions}
+              empty={
+                <EmptyState
+                  icon={MessagesSquare}
+                  title="No sessions yet"
+                  description="Start a session above to give this agent a durable task."
+                />
+              }
+            />
+          </Panel>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -255,6 +255,9 @@ export default function AgentDetail() {
             ) : null}
           </Panel>
 
+          {/* Slack — kept above Sessions so it's visible without scrolling */}
+          <SlackConnect agentId={agent.id} agentName={agent.name} />
+
           {/* Sessions */}
           <Panel className="overflow-hidden">
             <PanelHeader>
@@ -308,8 +311,6 @@ export default function AgentDetail() {
               }
             />
           </Panel>
-
-          <SlackConnect agentId={agent.id} agentName={agent.name} />
         </div>
       )}
     </div>

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -20,7 +20,7 @@ import { ResourceTable, type Column } from '@/components/resource-table'
 import { Skeleton } from '@/components/ui/skeleton'
 import { SlackConnect } from '@/components/slack-connect'
 
-// Mirrors the curated list in Agents.tsx (the create flow). /v3 wants a
+// Mirrors the curated list in Agents.tsx (the create flow). The API wants a
 // provider-prefixed model id.
 const MODELS = [
   { value: 'anthropic/claude-opus-4-8', label: 'Claude Opus 4.8' },
@@ -43,7 +43,7 @@ export default function AgentDetail() {
     enabled: !!agentId,
   })
 
-  // This agent's sessions. /v3 has no per-agent filter, so scope client-side.
+  // This agent's sessions. The API has no per-agent filter, so scope client-side.
   const { data: allSessions, isLoading: loadingSessions } = useQuery({
     queryKey: ['sessions'],
     queryFn: () => getSessions(),
@@ -159,8 +159,6 @@ export default function AgentDetail() {
             title={agent.name}
             description="A reusable definition. Sessions pin a snapshot of it at create time."
             api={{
-              method: 'POST',
-              path: '/v3/sessions',
               sdk: 'oc.sessions.create()',
               docs: 'https://docs.opencomputer.dev/agent-sessions/sessions',
             }}

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -291,11 +291,7 @@ export default function AgentDetail() {
               </Field>
 
               {/* Prompt — draft with Save/Discard */}
-              <Field
-                label="System prompt"
-                htmlFor="agent-prompt"
-                description="How the agent behaves. Saving bumps the agent's revision."
-              >
+              <Field label="System prompt" htmlFor="agent-prompt">
                 <Textarea
                   id="agent-prompt"
                   value={promptValue}
@@ -303,9 +299,12 @@ export default function AgentDetail() {
                   placeholder="You are a meticulous code reviewer…"
                   className="min-h-32"
                 />
-                <div className="mt-2 flex items-center gap-2">
-                  <Saving show={promptMutation.isPending} />
-                  <div className="ml-auto flex gap-2">
+                <div className="mt-2 flex items-center gap-3">
+                  <p className="text-muted-foreground text-xs">
+                    How the agent behaves. Saving bumps the agent's revision.
+                  </p>
+                  <div className="ml-auto flex items-center gap-2">
+                    <Saving show={promptMutation.isPending} />
                     <Button
                       type="button"
                       variant="ghost"

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -18,6 +18,7 @@ import { StatusBadge } from '@/components/status-badge'
 import { EmptyState } from '@/components/empty-state'
 import { ResourceTable, type Column } from '@/components/resource-table'
 import { Skeleton } from '@/components/ui/skeleton'
+import { SlackConnect } from '@/components/slack-connect'
 
 // Mirrors the curated list in Agents.tsx (the create flow). /v3 wants a
 // provider-prefixed model id.
@@ -309,6 +310,8 @@ export default function AgentDetail() {
               }
             />
           </Panel>
+
+          <SlackConnect agentId={agent.id} agentName={agent.name} />
         </div>
       )}
     </div>

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link, useNavigate, useParams } from 'react-router-dom'
-import { ArrowLeft, MessagesSquare, Pencil, Send } from 'lucide-react'
+import { ArrowLeft, MessagesSquare, Send } from 'lucide-react'
 import { notifyError } from '@/lib/errors'
 import {
   getAgent,
@@ -10,6 +10,7 @@ import {
   createSession,
   getCredentials,
   createCredential,
+  type Agent,
 } from '@/api/client'
 import type { Session } from '@/api/schemas'
 import { PageHeader } from '@/components/page-header'
@@ -35,12 +36,11 @@ const MODELS = [
   { value: 'anthropic/claude-haiku-4-5', label: 'Claude Haiku 4.5' },
 ]
 
-// Agents run on the "claude" runtime → anthropic credentials. Sentinel for the
-// "create one inline" choice in the credential picker.
+// Agents run on the "claude" runtime → anthropic credentials. Sentinels for the
+// non-credential choices in the picker.
 const CRED_PROVIDER = 'anthropic'
-const NEW_CRED = '__new__'
-
-type EditField = 'model' | 'prompt' | 'credential'
+const ORG_DEFAULT = '__default__' // no pinned credential → org default resolves
+const NEW_CRED = '__new__' // create one inline
 
 export default function AgentDetail() {
   const { agentId = '' } = useParams()
@@ -92,76 +92,108 @@ export default function AgentDetail() {
     onError: (e) => notifyError("Couldn't start the session.", e),
   })
 
-  // ── Field-by-field inline edit ────────────────────────────────────────────
-  // One field at a time; the pencil on a row opens just that row's editor.
-  const [editField, setEditField] = useState<EditField | null>(null)
-  const [draftModel, setDraftModel] = useState('')
-  const [draftPrompt, setDraftPrompt] = useState('')
-  const [draftCred, setDraftCred] = useState('') // credential id or NEW_CRED
-  const [newCredName, setNewCredName] = useState('')
-  const [newCredKey, setNewCredKey] = useState('')
-
-  const startEdit = (field: EditField) => {
-    if (!agent) return
-    if (field === 'model') setDraftModel(agent.model)
-    if (field === 'prompt') setDraftPrompt(agent.prompt ?? '')
-    if (field === 'credential') {
-      setDraftCred(agent.credential_id ?? anthropicCreds[0]?.id ?? NEW_CRED)
-      setNewCredName('')
-      setNewCredKey('')
-    }
-    setEditField(field)
+  // ── Live config controls (no edit mode) ───────────────────────────────────
+  // Dropdowns autosave on change (optimistic → no flicker); the prompt is a draft
+  // with Save/Discard that enable only when it differs from what's saved.
+  const settleAgent = () => {
+    void queryClient.invalidateQueries({ queryKey: ['agent', agentId] })
+    void queryClient.invalidateQueries({ queryKey: ['agents'] })
   }
-  const cancelEdit = () => {
-    setEditField(null)
-    setNewCredKey('') // never leave a model key in state
+  const optimistic = async (patch: Partial<Agent>) => {
+    await queryClient.cancelQueries({ queryKey: ['agent', agentId] })
+    const prev = queryClient.getQueryData<Agent>(['agent', agentId])
+    queryClient.setQueryData<Agent>(['agent', agentId], (old) =>
+      old ? { ...old, ...patch } : old,
+    )
+    return prev
+  }
+  const rollback = (prev?: Agent) => {
+    if (prev) queryClient.setQueryData(['agent', agentId], prev)
   }
 
-  const saveMutation = useMutation({
-    mutationFn: async () => {
-      if (!agent) throw new Error('no agent loaded')
-      if (editField === 'model')
-        return updateAgent(agent.id, { model: draftModel.trim() })
-      if (editField === 'prompt')
-        return updateAgent(agent.id, { prompt: draftPrompt.trim() })
-      // credential: switch to a chosen one, or mint a new one then switch.
-      let credentialId = draftCred
-      if (draftCred === NEW_CRED) {
-        const cred = await createCredential({
-          key: newCredKey.trim(),
-          provider: CRED_PROVIDER,
-          name: newCredName.trim() || undefined,
-          is_default: !anthropicCreds.some((c) => c.is_default),
-        })
-        credentialId = cred.id
-      }
-      return updateAgent(agent.id, { credential: credentialId })
+  const modelMutation = useMutation({
+    mutationFn: (model: string) => updateAgent(agentId, { model }),
+    onMutate: (model) => optimistic({ model }),
+    onError: (e, _v, prev) => {
+      rollback(prev)
+      notifyError("Couldn't update the model.", e)
     },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['agent', agentId] })
-      void queryClient.invalidateQueries({ queryKey: ['agents'] })
-      void queryClient.invalidateQueries({ queryKey: ['credentials'] })
-      cancelEdit()
-    },
-    onError: (e) => notifyError("Couldn't update the agent.", e),
+    onSettled: settleAgent,
   })
 
-  // Whether the open editor has a saveable value.
-  const canSave =
-    editField === 'model'
-      ? draftModel.trim().length > 0
-      : editField === 'prompt'
-        ? draftPrompt.trim().length > 0
-        : editField === 'credential'
-          ? draftCred === NEW_CRED
-            ? newCredKey.trim().length > 0
-            : draftCred.length > 0
-          : false
+  const [promptDraft, setPromptDraft] = useState<string | undefined>(undefined)
+  const promptMutation = useMutation({
+    mutationFn: (prompt: string) => updateAgent(agentId, { prompt }),
+    onMutate: (prompt) => optimistic({ prompt }),
+    onError: (e, _v, prev) => {
+      rollback(prev)
+      notifyError("Couldn't update the prompt.", e)
+    },
+    onSuccess: () => setPromptDraft(undefined), // re-sync to saved
+    onSettled: settleAgent,
+  })
 
+  const switchCredMutation = useMutation({
+    mutationFn: (credential: string | null) =>
+      updateAgent(agentId, { credential }),
+    onMutate: (credential) => optimistic({ credential_id: credential }),
+    onError: (e, _v, prev) => {
+      rollback(prev)
+      notifyError("Couldn't switch the credential.", e)
+    },
+    onSettled: settleAgent,
+  })
+
+  // Create a new credential inline, then switch the agent to it.
+  const [credNew, setCredNew] = useState(false)
+  const [newCredName, setNewCredName] = useState('')
+  const [newCredKey, setNewCredKey] = useState('')
+  const addCredMutation = useMutation({
+    mutationFn: async () => {
+      const cred = await createCredential({
+        key: newCredKey.trim(),
+        provider: CRED_PROVIDER,
+        name: newCredName.trim() || undefined,
+        is_default: !anthropicCreds.some((c) => c.is_default),
+      })
+      return updateAgent(agentId, { credential: cred.id })
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(['agent', agentId], data)
+      void queryClient.invalidateQueries({ queryKey: ['credentials'] })
+      void queryClient.invalidateQueries({ queryKey: ['agents'] })
+      setCredNew(false)
+      setNewCredName('')
+      setNewCredKey('')
+    },
+    onError: (e) => notifyError("Couldn't add the credential.", e),
+  })
+
+  const credSaving = switchCredMutation.isPending || addCredMutation.isPending
+
+  // Derived control values.
+  const modelOptions = MODELS.some((m) => m.value === agent?.model)
+    ? MODELS
+    : [{ value: agent?.model ?? '', label: agent?.model ?? '' }, ...MODELS]
+  const savedPrompt = agent?.prompt ?? ''
+  const promptValue = promptDraft ?? savedPrompt
+  const promptDirty = promptDraft !== undefined && promptDraft !== savedPrompt
+  const credSelectValue = credNew
+    ? NEW_CRED
+    : (agent?.credential_id ?? ORG_DEFAULT)
   const credOptions = [
+    { value: ORG_DEFAULT, label: 'Org default (no pinned credential)' },
     ...anthropicCreds.map((c) => ({ value: c.id, label: credLabel(c.id) })),
     { value: NEW_CRED, label: '＋ New credential…' },
   ]
+  const onCredChange = (v: string) => {
+    if (v === NEW_CRED) {
+      setCredNew(true)
+      return
+    }
+    setCredNew(false)
+    switchCredMutation.mutate(v === ORG_DEFAULT ? null : v)
+  }
 
   const sessionColumns: Column<Session>[] = [
     {
@@ -226,106 +258,97 @@ export default function AgentDetail() {
             }}
           />
 
-          {/* Configuration — each field edits in place. */}
-          <Panel className="px-5 py-1.5">
-            {/* Read-only identity rows */}
-            <Row label="Agent ID">
-              <span className="text-foreground font-mono text-sm">
-                {agent.id}
-              </span>
-            </Row>
-            <Row label="Runtime">
-              <span className="text-foreground text-sm capitalize">
-                {agent.runtime}
-              </span>
-            </Row>
-            <Row label="Revision">
-              <span className="text-foreground font-mono text-sm">
+          {/* Configuration — live controls; changes save in place. */}
+          <Panel className="space-y-5 p-5">
+            <div className="text-muted-foreground grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-xs">
+              <span>Agent ID</span>
+              <span className="text-foreground font-mono">{agent.id}</span>
+              <span>Runtime</span>
+              <span className="text-foreground capitalize">{agent.runtime}</span>
+              <span>Revision</span>
+              <span className="text-foreground font-mono">
                 {agent.revision ?? 1}
               </span>
-            </Row>
+              <span>Created</span>
+              <span className="text-foreground">
+                {new Date(agent.created_at).toLocaleString()}
+              </span>
+            </div>
 
-            {/* Model */}
-            <EditRow
-              label="Model"
-              editing={editField === 'model'}
-              onEdit={() => startEdit('model')}
-              onCancel={cancelEdit}
-              onSave={() => saveMutation.mutate()}
-              saving={saveMutation.isPending}
-              canSave={canSave}
-              display={
-                <span className="text-foreground font-mono text-sm">
-                  {agent.model}
-                </span>
-              }
-            >
-              <Select
-                value={draftModel}
-                onValueChange={setDraftModel}
-                options={
-                  MODELS.some((m) => m.value === draftModel) || !draftModel
-                    ? MODELS
-                    : [{ value: draftModel, label: draftModel }, ...MODELS]
-                }
-              />
-            </EditRow>
+            <div className="space-y-5 border-t pt-5">
+              {/* Model — autosaves */}
+              <Field label="Model" htmlFor="agent-model">
+                <div className="flex items-center gap-3">
+                  <Select
+                    id="agent-model"
+                    value={agent.model}
+                    onValueChange={(m) => modelMutation.mutate(m)}
+                    options={modelOptions}
+                    className="max-w-xs"
+                  />
+                  <Saving show={modelMutation.isPending} />
+                </div>
+              </Field>
 
-            {/* Prompt — now shown, edited in place */}
-            <EditRow
-              label="Prompt"
-              editing={editField === 'prompt'}
-              onEdit={() => startEdit('prompt')}
-              onCancel={cancelEdit}
-              onSave={() => saveMutation.mutate()}
-              saving={saveMutation.isPending}
-              canSave={canSave}
-              display={
-                <p className="text-foreground text-sm whitespace-pre-wrap">
-                  {agent.prompt || (
-                    <span className="text-muted-foreground">No prompt set</span>
-                  )}
-                </p>
-              }
-            >
-              <Textarea
-                value={draftPrompt}
-                onChange={(e) => setDraftPrompt(e.target.value)}
-                placeholder="You are a meticulous code reviewer…"
-                className="min-h-32"
-              />
-            </EditRow>
-
-            {/* Credential — switch (pick existing / create new), not rotate */}
-            <EditRow
-              label="Credential"
-              editing={editField === 'credential'}
-              onEdit={() => startEdit('credential')}
-              onCancel={cancelEdit}
-              onSave={() => saveMutation.mutate()}
-              saving={saveMutation.isPending}
-              canSave={canSave}
-              display={
-                <span className="text-foreground text-sm">
-                  {agent.credential_id ? (
-                    credLabel(agent.credential_id)
-                  ) : (
-                    <span className="text-muted-foreground">
-                      None — uses the org default
-                    </span>
-                  )}
-                </span>
-              }
-            >
-              <div className="space-y-3">
-                <Select
-                  value={draftCred}
-                  onValueChange={setDraftCred}
-                  options={credOptions}
-                  placeholder="Choose a credential"
+              {/* Prompt — draft with Save/Discard */}
+              <Field
+                label="System prompt"
+                htmlFor="agent-prompt"
+                description="How the agent behaves. Saving bumps the agent's revision."
+              >
+                <Textarea
+                  id="agent-prompt"
+                  value={promptValue}
+                  onChange={(e) => setPromptDraft(e.target.value)}
+                  placeholder="You are a meticulous code reviewer…"
+                  className="min-h-32"
                 />
-                {draftCred === NEW_CRED ? (
-                  <div className="border-border bg-panel-2 grid grid-cols-1 gap-3 rounded-md border p-3 sm:grid-cols-2">
+                <div className="mt-2 flex items-center gap-2">
+                  <Saving show={promptMutation.isPending} />
+                  <div className="ml-auto flex gap-2">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      disabled={!promptDirty || promptMutation.isPending}
+                      onClick={() => setPromptDraft(undefined)}
+                    >
+                      Discard
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      disabled={
+                        !promptDirty ||
+                        promptMutation.isPending ||
+                        !promptValue.trim()
+                      }
+                      onClick={() => promptMutation.mutate(promptValue.trim())}
+                    >
+                      Save prompt
+                    </Button>
+                  </div>
+                </div>
+              </Field>
+
+              {/* Credential — switch (autosaves) or create new inline */}
+              <Field
+                label="Credential"
+                htmlFor="agent-cred"
+                description="Which credential this agent runs on. To change a key's value, rotate it on the Credentials page."
+              >
+                <div className="flex items-center gap-3">
+                  <Select
+                    id="agent-cred"
+                    value={credSelectValue}
+                    onValueChange={onCredChange}
+                    options={credOptions}
+                    className="max-w-md"
+                  />
+                  <Saving show={credSaving} />
+                </div>
+                {credNew ? (
+                  <div className="border-border bg-panel-2 mt-3 grid grid-cols-1 gap-3 rounded-md border p-3 sm:grid-cols-2">
                     <Field label="Credential name" htmlFor="new-cred-name">
                       <Input
                         id="new-cred-name"
@@ -347,15 +370,34 @@ export default function AgentDetail() {
                         placeholder="sk-ant-…"
                       />
                     </Field>
+                    <div className="flex justify-end gap-2 sm:col-span-2">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setCredNew(false)
+                          setNewCredName('')
+                          setNewCredKey('')
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        disabled={
+                          !newCredKey.trim() || addCredMutation.isPending
+                        }
+                        onClick={() => addCredMutation.mutate()}
+                      >
+                        {addCredMutation.isPending ? 'Adding…' : 'Add & use'}
+                      </Button>
+                    </div>
                   </div>
-                ) : (
-                  <p className="text-muted-foreground text-xs">
-                    Switches which credential this agent runs on. To change a
-                    key's value, rotate it on the Credentials page.
-                  </p>
-                )}
-              </div>
-            </EditRow>
+                ) : null}
+              </Field>
+            </div>
           </Panel>
 
           {/* Slack — kept above Sessions so it's visible without scrolling */}
@@ -420,82 +462,8 @@ export default function AgentDetail() {
   )
 }
 
-// A read-only configuration row: a fixed-width label + value.
-function Row({
-  label,
-  children,
-}: {
-  label: string
-  children: React.ReactNode
-}) {
-  return (
-    <div className="border-border/60 flex items-baseline gap-4 border-b py-3 last:border-0">
-      <span className="text-muted-foreground w-28 shrink-0 text-xs">
-        {label}
-      </span>
-      <div className="min-w-0 flex-1">{children}</div>
-    </div>
-  )
-}
-
-// An editable configuration row: shows the value with a subtle pencil; clicking
-// swaps in the editor (the children) with Save / Cancel. One row edits at a time.
-function EditRow({
-  label,
-  editing,
-  onEdit,
-  onCancel,
-  onSave,
-  saving,
-  canSave,
-  display,
-  children,
-}: {
-  label: string
-  editing: boolean
-  onEdit: () => void
-  onCancel: () => void
-  onSave: () => void
-  saving: boolean
-  canSave: boolean
-  display: React.ReactNode
-  children: React.ReactNode
-}) {
-  return (
-    <div className="border-border/60 flex gap-4 border-b py-3 last:border-0">
-      <span className="text-muted-foreground w-28 shrink-0 pt-1 text-xs">
-        {label}
-      </span>
-      {!editing ? (
-        <div className="flex min-w-0 flex-1 items-start justify-between gap-2">
-          <div className="min-w-0">{display}</div>
-          <button
-            type="button"
-            onClick={onEdit}
-            aria-label={`Edit ${label.toLowerCase()}`}
-            className="text-muted-foreground hover:text-foreground -mt-0.5 shrink-0 rounded p-1"
-          >
-            <Pencil className="size-3.5" />
-          </button>
-        </div>
-      ) : (
-        <div className="flex-1 space-y-2.5">
-          {children}
-          <div className="flex justify-end gap-2">
-            <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              onClick={onSave}
-              disabled={saving || !canSave}
-            >
-              {saving ? 'Saving…' : 'Save'}
-            </Button>
-          </div>
-        </div>
-      )}
-    </div>
-  )
+// Subtle inline "Saving…" shown while an autosave is in flight.
+function Saving({ show }: { show: boolean }) {
+  if (!show) return null
+  return <span className="text-muted-foreground text-xs">Saving…</span>
 }

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -253,8 +253,10 @@ export default function AgentDetail() {
             title={agent.name}
             description="A reusable definition. Sessions pin a snapshot of it at create time."
             api={{
-              sdk: 'oc.sessions.create()',
-              docs: 'https://docs.opencomputer.dev/agent-sessions/sessions',
+              method: 'GET',
+              path: '/v3/agents/{id}',
+              sdk: 'oc.agents.get()',
+              docs: 'https://docs.opencomputer.dev/agent-sessions/agents',
             }}
           />
 

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
 import { Bot, Plus } from 'lucide-react'
 import { notifyError } from '@/lib/errors'
 import {
   getAgents,
   createAgent,
-  updateAgent,
   getCredentials,
   createCredential,
   type Agent,
@@ -41,6 +41,7 @@ const NEW_CRED = '__new__'
 
 export default function Agents() {
   const queryClient = useQueryClient()
+  const navigate = useNavigate()
   const { data: agents, isLoading } = useQuery({
     queryKey: ['agents'],
     queryFn: getAgents,
@@ -122,44 +123,15 @@ export default function Agents() {
         credential_id: credentialId,
       })
     },
-    onSuccess: () => {
+    onSuccess: (agent) => {
       void queryClient.invalidateQueries({ queryKey: ['agents'] })
       void queryClient.invalidateQueries({ queryKey: ['credentials'] })
       setShowCreate(false)
       resetForm()
+      // Land on the new agent's screen, not back on the list.
+      void navigate(`/agents/${agent.id}`)
     },
     onError: (e) => notifyError("Couldn't create the agent.", e),
-  })
-
-  // See / edit an agent. name is immutable (PATCH covers model/prompt/key); the
-  // current prompt isn't returned (write-only), so editing it is a replace.
-  const [editing, setEditing] = useState<Agent | null>(null)
-  const [editModel, setEditModel] = useState('')
-  const [editPrompt, setEditPrompt] = useState('')
-  const [editKey, setEditKey] = useState('')
-
-  const openEdit = (a: Agent) => {
-    setEditing(a)
-    setEditModel(a.model)
-    setEditPrompt('')
-    setEditKey('')
-  }
-
-  const updateMutation = useMutation({
-    mutationFn: () => {
-      if (!editing) throw new Error('no agent selected')
-      const body: { model?: string; prompt?: string; key?: string } = {}
-      if (editModel.trim() && editModel.trim() !== editing.model)
-        body.model = editModel.trim()
-      if (editPrompt.trim()) body.prompt = editPrompt.trim()
-      if (editKey.trim()) body.key = editKey.trim()
-      return updateAgent(editing.id, body)
-    },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['agents'] })
-      setEditing(null)
-    },
-    onError: (e) => notifyError("Couldn't update the agent.", e),
   })
 
   const columns: Column<Agent>[] = [
@@ -238,7 +210,7 @@ export default function Agents() {
           columns={columns}
           rows={agents ?? []}
           rowKey={(a) => a.id}
-          onRowClick={openEdit}
+          onRowClick={(a) => void navigate(`/agents/${a.id}`)}
           loading={isLoading}
           empty={
             <EmptyState
@@ -373,102 +345,6 @@ export default function Agents() {
               </Button>
             </DialogFooter>
           </form>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog
-        open={editing !== null}
-        onOpenChange={(open) => {
-          if (!open) {
-            setEditing(null)
-            setEditKey('') // never leave a model key in state after close
-          }
-        }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{editing?.name}</DialogTitle>
-            <DialogDescription>
-              Edit the model, prompt, or credential. Changes bump the agent's
-              revision; the name is fixed.
-            </DialogDescription>
-          </DialogHeader>
-          {editing ? (
-            <form
-              className="space-y-4"
-              onSubmit={(e) => {
-                e.preventDefault()
-                updateMutation.mutate()
-              }}
-            >
-              <div className="bg-panel-2 text-muted-foreground grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 rounded-md border p-3 text-xs">
-                <span>Agent ID</span>
-                <span className="text-foreground font-mono">{editing.id}</span>
-                <span>Runtime</span>
-                <span className="text-foreground capitalize">
-                  {editing.runtime}
-                </span>
-                <span>Revision</span>
-                <span className="text-foreground font-mono">
-                  {editing.revision ?? 1}
-                </span>
-                <span>Credential</span>
-                <span className="text-foreground">
-                  {editing.credential_id ? 'Set' : 'None'}
-                </span>
-              </div>
-              <Field label="Model" htmlFor="edit-model">
-                <Select
-                  id="edit-model"
-                  value={editModel}
-                  onValueChange={setEditModel}
-                  options={
-                    MODELS.some((m) => m.value === editModel) || !editModel
-                      ? MODELS
-                      : [{ value: editModel, label: editModel }, ...MODELS]
-                  }
-                />
-              </Field>
-              <Field
-                label="New prompt"
-                htmlFor="edit-prompt"
-                description="Leave blank to keep the current prompt (it isn't shown)."
-              >
-                <Textarea
-                  id="edit-prompt"
-                  value={editPrompt}
-                  onChange={(e) => setEditPrompt(e.target.value)}
-                  placeholder="Replace the system prompt…"
-                  className="min-h-24"
-                />
-              </Field>
-              <Field
-                label="Rotate Anthropic API key"
-                htmlFor="edit-key"
-                description="Leave blank to keep the current credential."
-              >
-                <Input
-                  id="edit-key"
-                  type="password"
-                  value={editKey}
-                  onChange={(e) => setEditKey(e.target.value)}
-                  placeholder="sk-ant-…"
-                />
-              </Field>
-              <DialogFooter className="mt-2">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  onClick={() => setEditing(null)}
-                >
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={updateMutation.isPending}>
-                  {updateMutation.isPending ? 'Saving…' : 'Save changes'}
-                </Button>
-              </DialogFooter>
-            </form>
-          ) : null}
         </DialogContent>
       </Dialog>
     </div>

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -25,7 +25,7 @@ import { Field, Input, Select, Textarea } from '@/components/form'
 import { EmptyState } from '@/components/empty-state'
 import { ResourceTable, type Column } from '@/components/resource-table'
 
-// Curated model list. /v3 requires a provider-prefixed id; runtime "claude" ⇒
+// Curated model list. The API requires a provider-prefixed id; runtime "claude" ⇒
 // anthropic/… (codex/openai land when that runtime ships).
 const MODELS = [
   { value: 'anthropic/claude-opus-4-8', label: 'Claude Opus 4.8' },
@@ -192,8 +192,6 @@ export default function Agents() {
         title="Agents"
         description="Reusable definitions — a prompt, model, and runtime a session runs."
         api={{
-          method: 'POST',
-          path: '/v3/agents',
           sdk: 'oc.agents.create()',
           docs: 'https://docs.opencomputer.dev/agent-sessions/agents',
         }}

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -192,6 +192,8 @@ export default function Agents() {
         title="Agents"
         description="Reusable definitions — a prompt, model, and runtime a session runs."
         api={{
+          method: 'POST',
+          path: '/v3/agents',
           sdk: 'oc.agents.create()',
           docs: 'https://docs.opencomputer.dev/agent-sessions/agents',
         }}

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -120,7 +120,7 @@ export default function Agents() {
         prompt: prompt.trim(),
         model,
         runtime: 'claude',
-        credential_id: credentialId,
+        credential: credentialId,
       })
     },
     onSuccess: (agent) => {

--- a/web/src/pages/Credentials.tsx
+++ b/web/src/pages/Credentials.tsx
@@ -265,8 +265,6 @@ export default function Credentials() {
         title="Credentials"
         description="Model-provider keys your agents run on. Pick one per agent or set an org default."
         api={{
-          method: 'POST',
-          path: '/v3/credentials',
           sdk: 'oc.credentials.create()',
           docs: 'https://docs.opencomputer.dev/agent-sessions/credentials',
         }}

--- a/web/src/pages/Credentials.tsx
+++ b/web/src/pages/Credentials.tsx
@@ -6,6 +6,7 @@ import {
   createCredential,
   deleteCredential,
   getCredentials,
+  rotateCredential,
   setDefaultCredential,
   type Credential,
 } from '@/api/client'
@@ -65,6 +66,8 @@ export default function Credentials() {
   const [key, setKey] = useState('')
   const [makeDefault, setMakeDefault] = useState(true)
   const [toDelete, setToDelete] = useState<Credential | null>(null)
+  const [toRotate, setToRotate] = useState<Credential | null>(null)
+  const [rotateKey, setRotateKey] = useState('')
 
   const resetForm = () => {
     setName('')
@@ -173,6 +176,19 @@ export default function Credentials() {
     onSettled: () => queryClient.invalidateQueries({ queryKey: CREDS_KEY }),
   })
 
+  // Rotate the secret VALUE of an existing credential (versioned; running sessions
+  // re-seal to the new key). Not optimistic — it's a provisioning write.
+  const rotateMutation = useMutation({
+    mutationFn: ({ id, key }: { id: string; key: string }) =>
+      rotateCredential(id, key),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: CREDS_KEY })
+      setToRotate(null)
+      setRotateKey('')
+    },
+    onError: (e) => notifyError("Couldn't rotate the key.", e),
+  })
+
   const openCreate = () => {
     setPhase('form')
     setStep(0)
@@ -244,6 +260,17 @@ export default function Credentials() {
               Set default
             </Button>
           ) : null}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground hover:text-foreground underline-offset-2 hover:bg-transparent hover:underline"
+            onClick={() => {
+              setToRotate(c)
+              setRotateKey('')
+            }}
+          >
+            Rotate key
+          </Button>
           <Button
             variant="ghost"
             size="sm"
@@ -403,6 +430,65 @@ export default function Credentials() {
               </>
             )}
           </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={toRotate !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setToRotate(null)
+            setRotateKey('')
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              Rotate {toRotate?.name ? `"${toRotate.name}"` : 'credential'}
+            </DialogTitle>
+            <DialogDescription>
+              Replace the secret value. Running sessions re-seal to the new key
+              and the old value is purged. The key is write-only — never shown
+              again.
+            </DialogDescription>
+          </DialogHeader>
+          <form
+            className="space-y-4"
+            onSubmit={(e) => {
+              e.preventDefault()
+              if (toRotate && rotateKey.trim())
+                rotateMutation.mutate({ id: toRotate.id, key: rotateKey.trim() })
+            }}
+          >
+            <Field label="New API key" htmlFor="rotate-key">
+              <Input
+                id="rotate-key"
+                type="password"
+                value={rotateKey}
+                onChange={(e) => setRotateKey(e.target.value)}
+                placeholder={KEY_HINT[toRotate?.provider ?? 'anthropic'] ?? 'sk-…'}
+              />
+            </Field>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => {
+                  setToRotate(null)
+                  setRotateKey('')
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={rotateMutation.isPending || !rotateKey.trim()}
+              >
+                {rotateMutation.isPending ? 'Rotating…' : 'Rotate key'}
+              </Button>
+            </DialogFooter>
+          </form>
         </DialogContent>
       </Dialog>
 

--- a/web/src/pages/Credentials.tsx
+++ b/web/src/pages/Credentials.tsx
@@ -292,6 +292,8 @@ export default function Credentials() {
         title="Credentials"
         description="Model-provider keys your agents run on. Pick one per agent or set an org default."
         api={{
+          method: 'POST',
+          path: '/v3/credentials',
           sdk: 'oc.credentials.create()',
           docs: 'https://docs.opencomputer.dev/agent-sessions/credentials',
         }}

--- a/web/src/pages/SandboxWebhooks.tsx
+++ b/web/src/pages/SandboxWebhooks.tsx
@@ -40,7 +40,7 @@ import { EmptyState } from '@/components/empty-state'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 import { cn } from '@/lib/utils'
 
-// The /v3 event taxonomy's sandbox-plane counterpart (pkg/types/webhook.go).
+// The event taxonomy's sandbox-plane counterpart (pkg/types/webhook.go).
 // Empty selection = every event.
 const SANDBOX_EVENT_TYPES = [
   { value: 'sandbox.created', label: 'Created' },

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -211,8 +211,6 @@ export default function SessionDetail() {
               </p>
             ) : null}
             <ApiHint
-              method="GET"
-              path="/v3/sessions/:id"
               sdk="oc.sessions.get()"
               docs="https://docs.opencomputer.dev/agent-sessions/sessions"
             />

--- a/web/src/pages/Sessions.tsx
+++ b/web/src/pages/Sessions.tsx
@@ -116,6 +116,8 @@ export default function Sessions() {
         title="Sessions"
         description="Durable agent runs — an append-only event log you can steer."
         api={{
+          method: 'POST',
+          path: '/v3/sessions',
           sdk: 'oc.sessions.create()',
           docs: 'https://docs.opencomputer.dev/agent-sessions/sessions',
         }}

--- a/web/src/pages/Sessions.tsx
+++ b/web/src/pages/Sessions.tsx
@@ -46,7 +46,11 @@ export default function Sessions() {
   }
 
   const startMutation = useMutation({
-    mutationFn: () => createSession({ agent: agentId, input: message.trim() }, crypto.randomUUID()),
+    mutationFn: () =>
+      createSession(
+        { agent: agentId, input: message.trim() },
+        crypto.randomUUID(),
+      ),
     onSuccess: (session) => {
       setShowStart(false)
       void queryClient.invalidateQueries({ queryKey: ['sessions'] })
@@ -112,8 +116,6 @@ export default function Sessions() {
         title="Sessions"
         description="Durable agent runs — an append-only event log you can steer."
         api={{
-          method: 'POST',
-          path: '/v3/sessions',
           sdk: 'oc.sessions.create()',
           docs: 'https://docs.opencomputer.dev/agent-sessions/sessions',
         }}


### PR DESCRIPTION
Turns the agent view into a real screen (was a popup), surfaces sessions on it, and adds a guided Slack connect wizard. Two reviewable commits.

## 1. Agent detail screen (`78424d5`)
- New **`/agents/:agentId`** screen (`AgentDetail`): overview, **inline** Edit (model / prompt / key rotate — no dialog), and a **Sessions** panel with an inline "Start a session" composer + this agent's sessions (link to `/sessions/:id`).
- The Agents list: a **row click now navigates to the screen** (was an edit popup), and **creating an agent lands on its new screen** instead of the list. The edit dialog is removed from the list.
- Start-session posts to `/v3/sessions` for the agent and navigates to the new session. Sessions are scoped to the agent client-side (`/v3` has no per-agent filter — noted inline).

## 2. Slack connect wizard (`6aa4425`)
- Against the v3 agent-nested Slack API (`oc-bg-agents/.agents/design/008-slack-presence.md`; live on sessions-api `feat/slack-connect`).
- **client + zod schemas** (snake_case, no secrets in responses): `getSlackConnection` (maps the 404 "not connected" → `null`), `startSlackConnect` (manifest), `completeSlackConnect`, `disconnectSlack`.
- **`SlackConnect`** panel reflects status (not-connected / pending / active / error); the wizard is **(1)** show the generated manifest + guided steps + a link to Slack → **(2)** paste App ID / Bot User OAuth Token / Signing Secret → connect → **(3)** done with the `/invite @handle` hint. Disconnect behind a confirm.
- **Mock parity** added so the preview harness renders the panel + wizard.

## Verification
Headless (CDP) against the `VITE_PREVIEW` mock harness:
- agent screen renders: overview, sessions list (3 sessions), inline composer, and the connected Slack panel ("@PR Reviewer is connected to Acme");
- the wizard renders the manifest JSON, 4 numbered steps, the "Open Slack apps" link, and the paste form.

`tsc -b` · `eslint` · `vite build` green.

## Notes
- Backend dependency: the Slack endpoints live on sessions-api **`feat/slack-connect`** (in testing). The wizard is wired to the real contract but won't work end-to-end until that branch is deployed to the env the dashboard's `/api/dashboard/v3/*` proxies to. Everything else (screen, sessions) uses already-shipped `/v3`.
- Edit stays an inline section on the screen (not a popup), per the "screen not popup" intent. The Slack wizard is a focused modal (standard for a transient guided connect flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)