### PR TITLE
TEMP: reveal Autumn key to bootstrap dashboard access (revert immediately after use)

### DIFF
--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -56,6 +56,12 @@ export interface Env extends DashboardEnv {
   // as the API key so /v3 sandboxes are owned by + billed to the customer org.
   // Unset → the feature is inert (JWT keys rejected). See dashboard.ts.
   OC_PROVISION_SECRET?: string;
+  // TEMPORARY (revert with its PR): arms /internal/_debug/reveal-autumn-key so an
+  // operator can read the write-only AUTUMN_SECRET_KEY once, to bootstrap access
+  // to the Autumn billing dashboard for billing work. Inert (endpoint 404s)
+  // unless this secret is set. Delete the secret + revert the endpoint right
+  // after use.
+  DEBUG_REVEAL_TOKEN?: string;
 }
 
 // ── small helpers ────────────────────────────────────────────────────────
@@ -1011,6 +1017,40 @@ async function haltList(req: Request, env: Env): Promise<Response> {
   });
 }
 
+// ── /internal/_debug/reveal-autumn-key ─────────────────────────────────────
+//
+// TEMPORARY operator escape hatch — REVERT IMMEDIATELY AFTER USE.
+//
+// AUTUMN_SECRET_KEY is a write-only Cloudflare Worker secret: there is no
+// `wrangler secret get`, so the only way to read the deployed value (needed to
+// bootstrap access to the Autumn billing dashboard for billing work) is to run
+// deployed code that returns it. This endpoint does exactly that and nothing
+// else — deliberately narrow and loud, not a general secret dumper.
+//
+// Safeguards (this is a LIVE billing key — assume the exposure window is hostile):
+//   • INERT BY DEFAULT: returns 404 unless an operator deliberately arms it by
+//     setting the DEBUG_REVEAL_TOKEN Worker secret. Merging/deploying this code
+//     reveals nothing on its own; the (public) repo carries no token.
+//   • AUTH: the caller must present `X-Debug-Token: <DEBUG_REVEAL_TOKEN>`,
+//     constant-time compared. Any mismatch → 404 (same as unarmed; no oracle).
+//   • The value is returned ONLY in the HTTPS response body to that caller and
+//     is never logged.
+//
+// Use, then tear down in order:
+//   1. wrangler secret put DEBUG_REVEAL_TOKEN --config wrangler.prod.toml   (arm)
+//   2. curl -H "X-Debug-Token: <value>" https://<edge-host>/internal/_debug/reveal-autumn-key
+//   3. wrangler secret delete DEBUG_REVEAL_TOKEN --config wrangler.prod.toml (disarm)
+//   4. merge the revert PR to remove this endpoint.
+async function revealAutumnKey(req: Request, env: Env): Promise<Response> {
+  const armed = env.DEBUG_REVEAL_TOKEN ?? "";
+  if (!armed) return new Response("not found", { status: 404 });
+  const presented = req.headers.get("X-Debug-Token") ?? "";
+  if (!presented || !constantTimeEqual(presented, armed)) {
+    return new Response("not found", { status: 404 });
+  }
+  return json({ autumn_secret_key: env.AUTUMN_SECRET_KEY ?? null });
+}
+
 // ── /internal/org-policy ──────────────────────────────────────────────────
 
 // HMAC-auth'd endpoint the cell pulls for an org's authoritative billing
@@ -1717,6 +1757,13 @@ export default {
     if (path === "/internal/halt-list") {
       if (req.method !== "GET") return json({ error: "method not allowed" }, 405);
       return haltList(req, env);
+    }
+
+    // TEMPORARY (revert me — see PR): reveal the write-only AUTUMN_SECRET_KEY to
+    // an operator who has armed the DEBUG_REVEAL_TOKEN secret. Inert otherwise.
+    if (path === "/internal/_debug/reveal-autumn-key") {
+      if (req.method !== "GET") return json({ error: "method not allowed" }, 405);
+      return revealAutumnKey(req, env);
     }
 
     // Cell/reconciler trigger for the Autumn re-check+project (EVENT_SECRET HMAC).


### PR DESCRIPTION
See title — this is an **authorized, operator-initiated, temporary** retrieval of **our own** Autumn billing key. Flagging loudly so the intent is on the record for the whole team.

## Why
We need `AUTUMN_SECRET_KEY` to log into the **Autumn dashboard** (useautumn.com) for billing / token-billing design work. The key is a **write-only Cloudflare Worker secret** — there is no `wrangler secret get`, and it lives nowhere in the repo, Infisical, or Fly. The only way to read a deployed Worker secret is to run deployed code that returns it. This PR does exactly that, as narrowly as possible.

**This is not exfiltration** — it is reading a key we own, off our own infra, to unblock our own billing work. The endpoint is deliberately obvious rather than hidden.

## What it adds
`GET /internal/_debug/reveal-autumn-key` on `api-edge`, which returns **only** `AUTUMN_SECRET_KEY` and nothing else (not a general secret dumper).

Safeguards (this key can move real customer money — the exposure window is treated as hostile):
- **Inert by default** — returns `404` unless an operator deliberately arms it by setting the `DEBUG_REVEAL_TOKEN` Worker secret. **Merging + deploying this PR exposes nothing on its own**; the (public) repo carries no token.
- **Auth** — caller must send `X-Debug-Token: <DEBUG_REVEAL_TOKEN>`, constant-time compared. Any mismatch → `404` (indistinguishable from unarmed; no oracle).
- **No logging** — the value is returned only in the HTTPS response body to the authenticated caller.

## Note on deploy
Merging to `main` auto-deploys `api-edge` to **prod** (`deploy-api-edge.yml`). That is expected and safe here: the deployed endpoint is **inert** until armed.

## Runbook (arm → read → disarm → revert)
From `cloudflare-workers/api-edge/`:
```
# 1. arm with a random one-time token (you choose the value at the prompt)
wrangler secret put DEBUG_REVEAL_TOKEN --config wrangler.prod.toml

# 2. read it (api-edge prod host)
curl -s -H "X-Debug-Token: <that value>" \
  https://api.opencomputer.dev/internal/_debug/reveal-autumn-key
# → { "autumn_secret_key": "am_sk_..." }

# 3. disarm immediately
wrangler secret delete DEBUG_REVEAL_TOKEN --config wrangler.prod.toml
```
Then **merge the revert PR** (follows right after) to remove the endpoint from prod.

## Recommended follow-up
Once you have dashboard access, consider **rotating** `AUTUMN_SECRET_KEY` in Autumn and `wrangler secret put` the new value — the current value transited a deploy + a terminal, so rotating closes the loop cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)