### PR TITLE
fix: publish-snapshot cascades to its checkpoint (+ checkpoint-publish edge routing)

### DIFF
--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -2065,6 +2065,25 @@ export default {
       }
     }
 
+    // /api/sandboxes/checkpoints/:id[/...] — checkpoint-scoped ops (publish,
+    // unpublish, patches). The URL carries no sandbox_id, so the generic
+    // /api/sandboxes/:id matcher below would read "checkpoints" as a sandbox id
+    // and 404 ("sandbox not found"). Route by the checkpoint's owning cell
+    // (checkpoints_index), like the snapshot patch/publish paths.
+    {
+      const cpm = path.match(/^\/api\/sandboxes\/checkpoints\/([^/]+)(\/.*)?$/);
+      if (cpm) {
+        const caller = await authenticate(req, env);
+        if (!caller) return json({ error: "missing or invalid API key" }, 401);
+        { const g = provisionScopeGate(caller, path); if (g) return g; }
+        const cpRow = await env.OPENCOMPUTER_DB.prepare(
+          `SELECT owner_cell_id FROM checkpoints_index WHERE id = ?1`,
+        ).bind(cpm[1]).first<{ owner_cell_id: string }>();
+        if (!cpRow?.owner_cell_id) return json({ error: "checkpoint not found" }, 404);
+        return proxyToCellAuthed(req, env, caller, { cellId: cpRow.owner_cell_id });
+      }
+    }
+
     const m = path.match(/^\/api\/sandboxes\/([^/]+)(\/.*)?$/);
     if (m) {
       const id = m[1];

--- a/internal/api/snapshots.go
+++ b/internal/api/snapshots.go
@@ -368,8 +368,14 @@ func (s *Server) setSnapshotPublic(c echo.Context, isPublic bool) error {
 		return c.JSON(http.StatusForbidden, map[string]string{"error": "only the platform org may publish snapshots to the shared catalog"})
 	}
 
+	// Cascade to the backing checkpoint. The fork path (createFromCheckpointCore)
+	// gates on sandbox_checkpoints.is_public separately, so publishing only the
+	// image_cache row makes the NAME resolve but the fork still 403s with
+	// "checkpoint does not belong to this organization". SetSnapshotPublic flips
+	// both atomically (unpublish revokes the checkpoint only if no other public
+	// snapshot still references it).
 	name := c.Param("name")
-	if err := s.store.SetImageCachePublicByName(c.Request().Context(), orgID, name, isPublic); err != nil {
+	if err := s.store.SetSnapshotPublic(c.Request().Context(), orgID, name, isPublic); err != nil {
 		return c.JSON(http.StatusNotFound, map[string]string{"error": err.Error()})
 	}
 

--- a/internal/db/image_cache_resolve_pgfixture_test.go
+++ b/internal/db/image_cache_resolve_pgfixture_test.go
@@ -151,3 +151,85 @@ func TestSetImageCachePublicByName_OwnerScoped(t *testing.T) {
 		t.Fatalf("expected snapshot to remain private after failed publish")
 	}
 }
+
+// checkpointIsPublic reads sandbox_checkpoints.is_public for a checkpoint id.
+func checkpointIsPublic(t *testing.T, store *Store, cpID uuid.UUID) bool {
+	t.Helper()
+	var pub bool
+	if err := store.pool.QueryRow(context.Background(),
+		`SELECT is_public FROM sandbox_checkpoints WHERE id=$1`, cpID).Scan(&pub); err != nil {
+		t.Fatalf("read checkpoint is_public: %v", err)
+	}
+	return pub
+}
+
+// seedSnapshotForCheckpoint inserts a named snapshot pointing at an EXISTING
+// checkpoint (lets a test share one checkpoint across snapshots).
+func seedSnapshotForCheckpoint(t *testing.T, store *Store, orgID uuid.UUID, name string, cpID uuid.UUID, isPublic bool) {
+	t.Helper()
+	id := uuid.New()
+	if _, err := store.pool.Exec(context.Background(),
+		`INSERT INTO image_cache (id, org_id, content_hash, checkpoint_id, name, manifest, status, is_public)
+		 VALUES ($1, $2, $3, $4, $5, $6, 'ready', $7)`,
+		id, orgID, "hash-"+id.String(), cpID, name, json.RawMessage(`{}`), isPublic); err != nil {
+		t.Fatalf("seed snapshot %q: %v", name, err)
+	}
+}
+
+// Publishing a snapshot must cascade is_public to its backing checkpoint — the
+// fork path (createFromCheckpointCore) gates on the checkpoint separately, so a
+// non-cascaded publish resolves the name but 403s the fork. This is the gap the
+// live prod test caught; unit/dev coverage didn't, because resolution and the
+// fork gate are different layers.
+func TestSetSnapshotPublic_CascadesToCheckpoint(t *testing.T) {
+	store := openPgStore(t)
+	ctx := context.Background()
+	org := seedOrgWithCap(t, store, 64)
+	cp := seedCheckpoint(t, store, org)
+	seedSnapshotForCheckpoint(t, store, org, "runtime-cascade", cp, false)
+
+	if err := store.SetSnapshotPublic(ctx, org, "runtime-cascade", true); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if !checkpointIsPublic(t, store, cp) {
+		t.Fatalf("publish must cascade is_public to the backing checkpoint")
+	}
+
+	if err := store.SetSnapshotPublic(ctx, org, "runtime-cascade", false); err != nil {
+		t.Fatalf("unpublish: %v", err)
+	}
+	if checkpointIsPublic(t, store, cp) {
+		t.Fatalf("unpublish must revoke the checkpoint when no other public snapshot uses it")
+	}
+}
+
+// Unpublishing one snapshot must NOT strand a sibling that shares the checkpoint.
+func TestSetSnapshotPublic_UnpublishKeepsCheckpointForSibling(t *testing.T) {
+	store := openPgStore(t)
+	ctx := context.Background()
+	org := seedOrgWithCap(t, store, 64)
+	cp := seedCheckpoint(t, store, org)
+	seedSnapshotForCheckpoint(t, store, org, "runtime-a", cp, false)
+	seedSnapshotForCheckpoint(t, store, org, "runtime-b", cp, false)
+
+	if err := store.SetSnapshotPublic(ctx, org, "runtime-a", true); err != nil {
+		t.Fatalf("publish a: %v", err)
+	}
+	if err := store.SetSnapshotPublic(ctx, org, "runtime-b", true); err != nil {
+		t.Fatalf("publish b: %v", err)
+	}
+	// Unpublish A — checkpoint must stay public because B still references it.
+	if err := store.SetSnapshotPublic(ctx, org, "runtime-a", false); err != nil {
+		t.Fatalf("unpublish a: %v", err)
+	}
+	if !checkpointIsPublic(t, store, cp) {
+		t.Fatalf("checkpoint must stay public while a sibling public snapshot still uses it")
+	}
+	// Unpublish B — now no public snapshot references it → revoke.
+	if err := store.SetSnapshotPublic(ctx, org, "runtime-b", false); err != nil {
+		t.Fatalf("unpublish b: %v", err)
+	}
+	if checkpointIsPublic(t, store, cp) {
+		t.Fatalf("checkpoint must be revoked after the last public snapshot is unpublished")
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2799,6 +2799,60 @@ func (s *Store) SetImageCachePublicByName(ctx context.Context, orgID uuid.UUID, 
 	return nil
 }
 
+// SetSnapshotPublic publishes/unpublishes a named snapshot AND its backing
+// checkpoint atomically. The fork path (createFromCheckpointCore) gates on
+// sandbox_checkpoints.is_public independently of image_cache.is_public, so
+// flipping only the snapshot resolves the NAME but the fork still fails with
+// "checkpoint does not belong to this organization". Both must move together.
+//
+// Owner-scoped (an org only touches its own rows). On unpublish, the backing
+// checkpoint is revoked only if no OTHER public snapshot of the org still
+// references it, so unpublishing one version can't strand a sibling.
+func (s *Store) SetSnapshotPublic(ctx context.Context, orgID uuid.UUID, name string, isPublic bool) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	var checkpointID *uuid.UUID
+	err = tx.QueryRow(ctx,
+		`UPDATE image_cache SET is_public = $3 WHERE org_id = $1 AND name = $2 RETURNING checkpoint_id`,
+		orgID, name, isPublic,
+	).Scan(&checkpointID)
+	if err != nil {
+		// pgx.ErrNoRows when the snapshot is missing or not owned by the org.
+		return fmt.Errorf("snapshot %q not found or not owned by org", name)
+	}
+
+	if checkpointID != nil {
+		if isPublic {
+			if _, err := tx.Exec(ctx,
+				`UPDATE sandbox_checkpoints SET is_public = true WHERE id = $1 AND org_id = $2`,
+				*checkpointID, orgID); err != nil {
+				return err
+			}
+		} else {
+			var othersUsingIt int
+			if err := tx.QueryRow(ctx,
+				`SELECT count(*) FROM image_cache
+				 WHERE checkpoint_id = $1 AND is_public = true AND NOT (org_id = $2 AND name = $3)`,
+				*checkpointID, orgID, name).Scan(&othersUsingIt); err != nil {
+				return err
+			}
+			if othersUsingIt == 0 {
+				if _, err := tx.Exec(ctx,
+					`UPDATE sandbox_checkpoints SET is_public = false WHERE id = $1 AND org_id = $2`,
+					*checkpointID, orgID); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
 // --- Preview URL operations ---
 
 // PreviewURL represents an on-demand preview URL for a sandbox.


### PR DESCRIPTION
Follow-up to #450, found by **live prod verification** of the act-as-org snapshot fix.

## The gap
After #450, a non-platform org provisioning `{snapshot:"runtime-claude-0.0.11"}` got past "snapshot not found" but then **403'd `checkpoint does not belong to this organization`**. Forking checks **two** independent gates:
1. `image_cache.is_public` → makes the snapshot **name** resolve (shipped in #450).
2. `sandbox_checkpoints.is_public` → `createFromCheckpointCore` re-checks the **checkpoint** owner.

Publishing a snapshot only flipped (1). The unit tests and the S3-less dev box couldn't surface (2) — resolution and the fork gate are different layers; only a real cross-org fork exercised both. (The reviewer's P3 on #450 pointed right at this.)

## Fix
- **`store.SetSnapshotPublic`** — flips the snapshot **and its backing checkpoint** in one transaction. On unpublish it revokes the checkpoint **only if no other public snapshot** of the org still references it (no stranded siblings). `publishSnapshot`/`unpublishSnapshot` now call this.
- **Edge routing** — `/api/sandboxes/checkpoints/:id/*` is now routed by the checkpoint's owning cell (`checkpoints_index`). The generic `/api/sandboxes/:id` matcher had been reading `checkpoints` as a sandbox id → `404 "sandbox not found"`, so the checkpoint publish/unpublish/patch endpoints were unreachable through the edge (that's why the SEV cutover had to publish checkpoints via raw SQL).
- **Tests** — pgfixture coverage for the cascade and the sibling-guard, against real Postgres.

## Prod state
Already reconciled by hand during the SEV cutover (15 backing checkpoints set `is_public=true` via cell-PG SQL), so prod is working now. This change makes **future** runtime releases need a single `POST /api/snapshots/:name/publish` instead of a snapshot-publish + a manual checkpoint SQL.

## Verification
`go build`/`vet` clean; edge `tsc --noEmit` clean; 5/5 pgfixture tests pass on real Postgres (incl. `TestSetSnapshotPublic_CascadesToCheckpoint`, `TestSetSnapshotPublic_UnpublishKeepsCheckpointForSibling`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)