### PR TITLE
Managed keys for everyone — decouple from billing + make it an invariant

### DIFF
--- a/.agents/work/managed-keys-for-everyone.md
+++ b/.agents/work/managed-keys-for-everyone.md
@@ -105,9 +105,12 @@ customers (pro + active Stripe sub): **33 on legacy** (all `model_billing_status
   `autumn_meter.ts:61`).
 - **Global config first** for the budget; add a per-org `managed_budget` column only when
   top-ups need to differ.
-- **Enablement = provision-on-first-use** (lazy), Managed offered to all in the UI — that's
-  what actually removes the per-org conditional enablement (vs pre-minting 482 keys).
-  Slice 2 below.
+- **Enablement = make Managed an INVARIANT, not a conditional.** Every org has a managed
+  credential the same way every org has an Autumn customer — provisioned at org birth +
+  backfilled, never gated. No runtime "provision-if-needed" branch, no `managedAvailable`
+  flag. (Rejected: the per-org enable step, AND a lazy provision-on-first-use trigger —
+  both keep a fork in the hot path and a new cross-service call. Reuses the existing
+  `enableManagedBilling`; **no new endpoint**.)
 
 ## 7b. Slices
 
@@ -117,28 +120,27 @@ customers (pro + active Stripe sub): **33 on legacy** (all `model_billing_status
   (`model_meter.ts` early-return). Tests updated + non-autumn cases added (21/21 green,
   tsc clean). After this, *any* org can be enabled with bounded exposure and zero
   wrongful halts. *Still requires the per-org enable step — that's Slice 2.*
-- **Slice 2 (remove per-org enablement + kill `managedAvailable`):** Managed becomes a
-  universal capability — **provisioned automatically at agent create**, offered to all,
-  no `managedAvailable` flag (it's a reality-fork; remove it from edge `/billing` + web +
-  `schemas.ts`). Provisioning is idempotent (`reconcileManagedBilling`).
-
-  **Trigger MUST be in sessions-api, not the edge.** `api.opencomputer.dev` *is*
-  sessions-api; the edge only proxies the dashboard path (`dashboard.ts:proxyToV3`).
-  Programmatic agent-create (SDK → sessions-api direct) never hits the edge, so an
-  edge intercept would miss it → offer-then-fail. So sessions-api triggers provisioning
-  at agent-create (`core/agents.ts:161`, the MANAGED branch), with the session-create
-  resolve path (`core/credentials.ts:328`) as an idempotent fallback.
-
-  **This forces a new sessions-api → edge "ensure provisioned" call** (provisioning is
-  edge-native — OR/Autumn ownership). Decision: reuse the **existing**
-  `OC_MANAGED_CRED_HMAC_SECRET` (already shared edge↔sessions-api for the bind hand-off)
-  on a new edge internal route `POST /internal/managed-credential/ensure?org=…` that
-  calls `reconcileManagedBilling`, rather than handing sessions-api the broader
-  `CF_ADMIN_SECRET`.
-
-  **Ordering constraint:** removing `managedAvailable` (always-show) and wiring the
-  auto-provision trigger MUST land together — shipping the first without the second
-  recreates offer-then-fail.
+- **Slice 2 (make Managed an invariant + kill `managedAvailable`):** No new endpoint, no
+  sessions-api→edge trigger, no hot-path fork. `enableManagedBilling` /
+  `reconcileManagedBilling` already mint+bind idempotently; we just make *every* org carry
+  a managed credential (like every org carries an Autumn customer).
+  - **Provision at org birth:** add `enableManagedBilling(orgID)` in the edge signup
+    handler, beside the existing `createAutumnCustomer` call (`index.ts:~1251`,
+    best-effort — don't fail signup on a provisioning hiccup; the sweep heals it).
+  - **Backfill + self-heal via a reconcile sweep:** a small edge cron (mirrors the
+    model_meter / autumn_meter cron pattern) that ensures every org is provisioned.
+    Path-agnostic (also covers the Go/WorkOS `ProvisionOrgAndUser` create path → cell PG →
+    D1), subsumes the one-time backfill, and repairs any failed provision — with zero
+    hot-path code. *Step 0: verify whether the edge signup handler is the ONLY org-create
+    path; if it is, the org-birth hook + a one-shot backfill may suffice and the cron is
+    optional.*
+  - **Remove `managedAvailable`:** delete it from edge `/billing` (`dashboard.ts:996–1040`)
+    and the web (`AgentDetail.tsx`, `Agents.tsx`, `schemas.ts`) — Managed is always
+    offered. Must land WITH the provisioning, never before (else offer-then-fail).
+  - **sessions-api:** no trigger change — resolve "just works" because the credential is
+    always bound. (Verify `credentials.ts:328` resolve has no provider assumption.)
+  - **Tradeoff:** one OR key per org (free until used; $10 cap). Consistent with the
+    invariant choice; if key-count ever bites, fall back to lazy-at-first-use.
 
 ## 8. Non-goals
 

--- a/.agents/work/managed-keys-for-everyone.md
+++ b/.agents/work/managed-keys-for-everyone.md
@@ -169,5 +169,8 @@ customers (pro + active Stripe sub): **33 on legacy** (all `model_billing_status
 
 ## 9. Rollout
 
-One cutover: ship the decoupled path, provision for all, remove the
-`model_billing_status` conditional. No gradual ramp (see §2).
+One cutover (#452 edge/web + sessions-api #35 deploy together): ship the decoupled path
+and remove the `managedAvailable` flag. **No backfill** — provisioning is just-in-time at
+agent-create / session-resolve, so each org gets its key the first time it actually uses
+Managed (existing orgs included; no Managed agents sit on unprovisioned orgs). No gradual
+ramp, no sweep.

--- a/.agents/work/managed-keys-for-everyone.md
+++ b/.agents/work/managed-keys-for-everyone.md
@@ -1,0 +1,114 @@
+# Managed keys for everyone — decouple Managed from billing
+
+Status: **working doc / plan (2026-06-29).** Objective decided; implementation not
+started. Builds on the shipped Managed work (`token-billing.md`, PRs #445 + sessions-api
+#34). Governing principle: `oc-bg-agents/.agents/conventions/shift-left-over-feature-flags.md`.
+
+## 1. Objective
+
+**Enable Managed model keys for every org and delete the conditional enablement.**
+Today Managed is forked along the billing axis and gated per org; we make Managed and
+billing **orthogonal**. The OpenRouter key's native spend `limit` becomes the hard
+ceiling; billing (metering) becomes a best-effort accounting layer *on top*, not a
+precondition for the feature to work. When an org's budget runs out the key simply
+stops working — they tell us, and we **move them to Autumn billing + grant new
+credits**. That conversation *is* the upgrade funnel, not a code fork.
+
+## 2. Why (principle)
+
+This is the shift-left / de-fork move applied one level up from the snapshot fix. A
+per-provider refusal + a per-org `model_billing_status` gate = two runtime behaviors
+that drift and a standing "for whom is it on?" question (today: **1 org on, 480 off**).
+Ship **one** Managed path for everyone; make billing independent and best-effort. No
+gradual rollout, no flag — one cutover.
+
+## 3. Current coupling (what we remove)
+
+Managed is welded to the Autumn billing provider in four places:
+
+1. **Provisioning refuses non-autumn** — `model_billing.ts:288`
+   (`if (org.billing_provider !== "autumn") throw … "refusing"`).
+2. **Budget is sourced from credits** — at mint, `limitUsd = initialCapUsd(remainingCreditsUsd, markup)` (`model_billing.ts:318–320`).
+3. **Cap is re-synced to credits every tick** — `pushCaps` PATCHes the key limit to `remaining/(1+markup)` (`model_meter.ts:158–196`).
+4. **Org is halted on model spend** — at `remaining <= 0`, `projectOrg` hibernates the org's boxes (`model_meter.ts:102–105`).
+
+Plus visibility gate: `managedAvailable = (model_billing_status === 'active')`
+(`dashboard.ts`). Net effect: the metering loop keys off `managed_model_keys` rows,
+which only exist for autumn orgs, so non-autumn orgs can't be metered, halted, or even
+provisioned.
+
+**Data (prod, 2026-06-29):** `billing_provider` = legacy **454** / autumn **28**. Real
+customers (pro + active Stripe sub): **33 on legacy** (all `model_billing_status=off`),
+**2 on autumn**. So Managed structurally cannot serve the paying base today.
+
+## 4. Target design
+
+- **Provision Managed for ANY org.** Drop the `billing_provider` refusal. The OR key is
+  minted with a **fixed default budget** (config) for non-autumn orgs; credits-derived
+  for autumn (unchanged). The bind-to-sessions-api step is already provider-agnostic.
+- **OR key `limit` is the hard ceiling.** OpenRouter enforces it. Exhaustion → 402 on
+  model calls → Managed stops; the **sandbox and BYO keep running**. No org halt on
+  model spend.
+- **Metering = best-effort accounting.** Debit Autumn credits only where there's an
+  Autumn customer (autumn orgs, as today). For non-autumn: skip — optionally record
+  per-key OR usage for manual reconcile. Exposure is bounded by the fixed budget.
+- **Visibility decoupled from provider.** `managedAvailable` no longer depends on
+  `billing_provider`; Managed is offered to all (provisioned for all, or on first use).
+- **Upgrade funnel = the runout path.** Budget exhausted → customer pings us → we move
+  them to Autumn (`autumnSetProviderInternal`) + grant credits; their key budget then
+  tracks credits as today. Sales motion, not a fork.
+
+## 5. What fails when decoupled — deliberately, "not much"
+
+- We don't **auto-bill** non-autumn Managed usage. Exposure = the fixed budget per org
+  (a number we choose); reconcile manually / "they tell us." Acceptable, bounded.
+- No **auto-halt**; the key limit is the ceiling. A billing gap can no longer break
+  Managed, and Managed runout can no longer hibernate an org's compute. **No
+  cross-aspect leakage** — the whole point.
+- Everything else (provision → bind → use → cap-enforce) is unchanged and already
+  provider-agnostic.
+
+## 6. Implementation plan (contained to the edge)
+
+- **`model_billing.ts`**
+  - Remove the `billing_provider !== "autumn"` refusal (`:288`).
+  - Mint with `budgetFor(org)`: autumn → `initialCapUsd(remaining, markup)` (today);
+    non-autumn → fixed `MANAGED_DEFAULT_BUDGET_USD` / per-org override.
+    *(Required — `remainingCreditsUsd` is 0 for non-autumn → would mint a dead $0 key.)*
+- **`model_meter.ts`**
+  - `meterOrg`/`debitKey`: skip the Autumn track for orgs with no Autumn customer
+    (else it errors); accounting runs only where there's something to debit.
+  - Halt (`:102–105`): stop calling `projectOrg` on model spend (decide whether to drop
+    it for autumn too — see §8).
+  - `pushCaps`: run the credit-headroom shrink only for autumn; non-autumn keeps its
+    static fixed budget (don't collapse the cap to their zero credits).
+- **Config / schema**: `MANAGED_DEFAULT_BUDGET_USD`; optional `managed_budget_micro`
+  per-org column for overrides + top-ups. Top-up is already `patchOrKey({limitUsd})`.
+- **`dashboard.ts`**: `managedAvailable` independent of `billing_provider`.
+- **sessions-api**: verify managed-credential resolution has no provider check
+  (expected: none — it binds/resolves a credential by id).
+- **Tests**: extend `model_billing.test.ts` / `model_meter.test.ts` — non-autumn
+  provisions, isn't debited/halted, budget caps spend; `managedAvailable` for non-autumn.
+
+## 7. Open decisions
+
+- **Default budget amount** (our prepaid exposure per org). Start small.
+- **Remove org-halt-on-model-spend for autumn too?** Recommended **yes** — model
+  exhaustion shouldn't hibernate compute; the key cap already stops spend. (Behavior
+  change for autumn — conscious yes.)
+- **Per-org budget column now, or global config first?** Global first; add column when
+  top-ups need to differ per org.
+- **Offer Managed to ALL in the UI by default, or provision-on-first-select?**
+
+## 8. Non-goals
+
+- **Not** building a Managed-on-Stripe metering path (a second billing backend = the
+  sprawl we're removing).
+- **Not** gating Managed per provider or behind a flag.
+- **Not** blocking on a full legacy→autumn *compute*-billing migration — Managed no
+  longer needs it. (That migration may still happen for compute, separately.)
+
+## 9. Rollout
+
+One cutover: ship the decoupled path, provision for all, remove the
+`model_billing_status` conditional. No gradual ramp (see §2).

--- a/.agents/work/managed-keys-for-everyone.md
+++ b/.agents/work/managed-keys-for-everyone.md
@@ -117,9 +117,28 @@ customers (pro + active Stripe sub): **33 on legacy** (all `model_billing_status
   (`model_meter.ts` early-return). Tests updated + non-autumn cases added (21/21 green,
   tsc clean). After this, *any* org can be enabled with bounded exposure and zero
   wrongful halts. *Still requires the per-org enable step — that's Slice 2.*
-- **Slice 2 (remove per-org enablement):** provision-on-first-use so Managed "just works"
-  for any org with no operator action, and surface it to all in the UI. One UX seam to
-  settle: provision when the user selects Managed, or silently on the first Managed turn.
+- **Slice 2 (remove per-org enablement + kill `managedAvailable`):** Managed becomes a
+  universal capability — **provisioned automatically at agent create**, offered to all,
+  no `managedAvailable` flag (it's a reality-fork; remove it from edge `/billing` + web +
+  `schemas.ts`). Provisioning is idempotent (`reconcileManagedBilling`).
+
+  **Trigger MUST be in sessions-api, not the edge.** `api.opencomputer.dev` *is*
+  sessions-api; the edge only proxies the dashboard path (`dashboard.ts:proxyToV3`).
+  Programmatic agent-create (SDK → sessions-api direct) never hits the edge, so an
+  edge intercept would miss it → offer-then-fail. So sessions-api triggers provisioning
+  at agent-create (`core/agents.ts:161`, the MANAGED branch), with the session-create
+  resolve path (`core/credentials.ts:328`) as an idempotent fallback.
+
+  **This forces a new sessions-api → edge "ensure provisioned" call** (provisioning is
+  edge-native — OR/Autumn ownership). Decision: reuse the **existing**
+  `OC_MANAGED_CRED_HMAC_SECRET` (already shared edge↔sessions-api for the bind hand-off)
+  on a new edge internal route `POST /internal/managed-credential/ensure?org=…` that
+  calls `reconcileManagedBilling`, rather than handing sessions-api the broader
+  `CF_ADMIN_SECRET`.
+
+  **Ordering constraint:** removing `managedAvailable` (always-show) and wiring the
+  auto-provision trigger MUST land together — shipping the first without the second
+  recreates offer-then-fail.
 
 ## 8. Non-goals
 

--- a/.agents/work/managed-keys-for-everyone.md
+++ b/.agents/work/managed-keys-for-everyone.md
@@ -1,8 +1,8 @@
 # Managed keys for everyone — decouple Managed from billing
 
-Status: **working doc / plan (2026-06-29).** Objective decided; implementation not
-started. Builds on the shipped Managed work (`token-billing.md`, PRs #445 + sessions-api
-#34). Governing principle: `oc-bg-agents/.agents/conventions/shift-left-over-feature-flags.md`.
+Status: **Slice 1 implemented (2026-06-29); Slice 2 pending.** Builds on the shipped
+Managed work (`token-billing.md`, PRs #445 + sessions-api #34). Governing principle:
+`oc-bg-agents/.agents/conventions/shift-left-over-feature-flags.md`.
 
 ## 1. Objective
 
@@ -90,15 +90,36 @@ customers (pro + active Stripe sub): **33 on legacy** (all `model_billing_status
 - **Tests**: extend `model_billing.test.ts` / `model_meter.test.ts` — non-autumn
   provisions, isn't debited/halted, budget caps spend; `managedAvailable` for non-autumn.
 
-## 7. Open decisions
+## 7. Decisions
 
-- **Default budget amount** (our prepaid exposure per org). Start small.
-- **Remove org-halt-on-model-spend for autumn too?** Recommended **yes** — model
-  exhaustion shouldn't hibernate compute; the key cap already stops spend. (Behavior
-  change for autumn — conscious yes.)
-- **Per-org budget column now, or global config first?** Global first; add column when
-  top-ups need to differ per org.
-- **Offer Managed to ALL in the UI by default, or provision-on-first-select?**
+- **Default budget = `$10`** per org (`MANAGED_DEFAULT_BUDGET_USD`). Our prepaid exposure
+  per non-autumn org; deliberately small.
+- **KEEP the org-halt-on-credit-runout for Autumn orgs.** (Corrected — earlier draft
+  said remove it.) For autumn, model + compute share one credit pool; hitting 0 → halt
+  → top-up is the *intended billing nudge*, unrelated to decoupling. What the decoupling
+  does instead: **fence the meter so it never touches non-autumn orgs** — no debit, no
+  halt, no credit-derived cap. This is a *required correctness fix*, not optional: as
+  written, a provisioned non-autumn org would hit `model_meter.ts:99–105` with no Autumn
+  customer → `remaining` defaults to `0` → it would **wrongly halt** the org. Gate the
+  whole debit/halt/cap block on `billing_provider === 'autumn'` (mirrors
+  `autumn_meter.ts:61`).
+- **Global config first** for the budget; add a per-org `managed_budget` column only when
+  top-ups need to differ.
+- **Enablement = provision-on-first-use** (lazy), Managed offered to all in the UI — that's
+  what actually removes the per-org conditional enablement (vs pre-minting 482 keys).
+  Slice 2 below.
+
+## 7b. Slices
+
+- **Slice 1 (decouple + make safe) — DONE:** dropped the `billing_provider` refusal
+  (`model_billing.ts`); `budgetFor` mints non-autumn keys at the fixed `$10` budget
+  (`MANAGED_DEFAULT_BUDGET_USD`); fenced the meter (debit/halt/cap) to autumn-only
+  (`model_meter.ts` early-return). Tests updated + non-autumn cases added (21/21 green,
+  tsc clean). After this, *any* org can be enabled with bounded exposure and zero
+  wrongful halts. *Still requires the per-org enable step — that's Slice 2.*
+- **Slice 2 (remove per-org enablement):** provision-on-first-use so Managed "just works"
+  for any org with no operator action, and surface it to all in the UI. One UX seam to
+  settle: provision when the user selects Managed, or silently on the first Managed turn.
 
 ## 8. Non-goals
 

--- a/.agents/work/managed-keys-for-everyone.md
+++ b/.agents/work/managed-keys-for-everyone.md
@@ -1,8 +1,13 @@
 # Managed keys for everyone — decouple Managed from billing
 
-Status: **Slice 1 implemented (2026-06-29); Slice 2 pending.** Builds on the shipped
-Managed work (`token-billing.md`, PRs #445 + sessions-api #34). Governing principle:
+Status: **Slices 1 + 2 implemented (2026-06-29) on `feat/managed-keys-for-everyone`
+(PR #452); pending review + deploy.** Builds on the shipped Managed work
+(`token-billing.md`, PRs #445 + sessions-api #34). Governing principle:
 `oc-bg-agents/.agents/conventions/shift-left-over-feature-flags.md`.
+
+**Step 0 resolved:** there ARE two org-create paths — the edge signup handler AND the
+Go/WorkOS cell path (`oauth_handlers.go` → `store.go:1620 INSERT INTO orgs` → D1). So the
+reconcile sweep is required (path-agnostic); the signup hook is immediacy-only.
 
 ## 1. Objective
 
@@ -120,10 +125,13 @@ customers (pro + active Stripe sub): **33 on legacy** (all `model_billing_status
   (`model_meter.ts` early-return). Tests updated + non-autumn cases added (21/21 green,
   tsc clean). After this, *any* org can be enabled with bounded exposure and zero
   wrongful halts. *Still requires the per-org enable step — that's Slice 2.*
-- **Slice 2 (make Managed an invariant + kill `managedAvailable`):** No new endpoint, no
-  sessions-api→edge trigger, no hot-path fork. `enableManagedBilling` /
-  `reconcileManagedBilling` already mint+bind idempotently; we just make *every* org carry
-  a managed credential (like every org carries an Autumn customer).
+- **Slice 2 (make Managed an invariant + kill `managedAvailable`) — DONE (PR #452):**
+  `runManagedProvisioner` sweep (edge `scheduled()`, batched, idempotent) drains every
+  unprovisioned org via `enableManagedBilling`; signup hook provisions at org birth for
+  immediacy; `managedAvailable` deleted from edge `/billing` + web (`Agents.tsx`,
+  `AgentDetail.tsx`, `schemas.ts`) → Managed always offered; no sessions-api change. Edge
+  + web tsc clean, 22/22 edge tests (incl. the sweep test). No new endpoint, no
+  cross-service trigger, no hot-path fork. Below is the design as built:
   - **Provision at org birth:** add `enableManagedBilling(orgID)` in the edge signup
     handler, beside the existing `createAutumnCustomer` call (`index.ts:~1251`,
     best-effort — don't fail signup on a provisioning hiccup; the sweep heals it).

--- a/.agents/work/managed-keys-for-everyone.md
+++ b/.agents/work/managed-keys-for-everyone.md
@@ -145,9 +145,13 @@ customers (pro + active Stripe sub): **33 on legacy** (all `model_billing_status
     (`core/credentials.ts`) — if the org has no managed credential, sign the enable call
     with `OC_MANAGED_CRED_HMAC_SECRET` (scheme `${ts}.${body}`, `X-Timestamp`/`X-Signature`)
     and POST `OPENCOMPUTER_API_URL/internal/model-billing/enable`; the edge mints + binds
-    back; confirm bound. Called synchronously from agent-create (`core/agents.ts`, the
-    `credential: managed` branch); throws on failure so we never create a Managed agent
-    that can't run. Idempotent. tsc green.
+    back; confirm bound. Called at agent-create (`core/agents.ts`, explicit
+    `credential: managed`) for early provisioning, AND at **session-resolve**
+    (`resolveCredentialForSession` — both the explicit-managed path and the
+    org-default→Managed fallback) so omitted/patched/flipped agents are covered (the
+    contract's "omit → Managed if no BYO default"). Provisions exactly when Managed is the
+    resolved credential, never for BYO/default-BYO. Idempotent; throws so we never run a
+    Managed agent that can't resolve. tsc green.
   - **Must deploy together** — flag removal (edge/web) + agent-create provisioning
     (sessions-api) are one rollout, else Managed is offered but unprovisioned.
   - **No backfill needed** — existing orgs provision when they next create a Managed

--- a/.agents/work/managed-keys-for-everyone.md
+++ b/.agents/work/managed-keys-for-everyone.md
@@ -1,13 +1,18 @@
 # Managed keys for everyone — decouple Managed from billing
 
-Status: **Slices 1 + 2 implemented (2026-06-29) on `feat/managed-keys-for-everyone`
-(PR #452); pending review + deploy.** Builds on the shipped Managed work
-(`token-billing.md`, PRs #445 + sessions-api #34). Governing principle:
-`oc-bg-agents/.agents/conventions/shift-left-over-feature-flags.md`.
+Status: **Implemented (2026-06-29); pending review + deploy.** Slice 1 (decouple) + Slice 2
+(provision at agent-create, kill `managedAvailable`). edge/web on
+`feat/managed-keys-for-everyone` (PR #452); sessions-api on a companion PR. Builds on the
+shipped Managed work (`token-billing.md`, PRs #445 + sessions-api #34). Governing
+principle: `oc-bg-agents/.agents/conventions/shift-left-over-feature-flags.md`.
 
-**Step 0 resolved:** there ARE two org-create paths — the edge signup handler AND the
-Go/WorkOS cell path (`oauth_handlers.go` → `store.go:1620 INSERT INTO orgs` → D1). So the
-reconcile sweep is required (path-agnostic); the signup hook is immediacy-only.
+**Design note (the path we landed on after review):** the first cut of Slice 2 used a
+background reconcile **sweep** + signup hook to provision every org ahead of time. That was
+async machinery whose only purpose was to avoid one cross-service call — it provisions
+*eventually* (2h drain), parks errors, and offers Managed before it's provisioned. Dropped
+it for **just-in-time provisioning at agent-create** (sessions-api → edge enable,
+synchronous, idempotent). Agent-create is the single chokepoint both create paths flow
+through, so it covers everything with no sweep, no flag, no window, no wasted keys.
 
 ## 1. Objective
 
@@ -110,12 +115,15 @@ customers (pro + active Stripe sub): **33 on legacy** (all `model_billing_status
   `autumn_meter.ts:61`).
 - **Global config first** for the budget; add a per-org `managed_budget` column only when
   top-ups need to differ.
-- **Enablement = make Managed an INVARIANT, not a conditional.** Every org has a managed
-  credential the same way every org has an Autumn customer — provisioned at org birth +
-  backfilled, never gated. No runtime "provision-if-needed" branch, no `managedAvailable`
-  flag. (Rejected: the per-org enable step, AND a lazy provision-on-first-use trigger —
-  both keep a fork in the hot path and a new cross-service call. Reuses the existing
-  `enableManagedBilling`; **no new endpoint**.)
+- **Enablement = provision at AGENT CREATE (just-in-time), no flag.** When an agent is
+  created with `credential: managed`, sessions-api ensures the org's OpenRouter key is
+  provisioned (idempotent) before the create returns — bound before any session resolves
+  it. Managed is offered to all (no `managedAvailable` flag); an org that never picks
+  Managed is simply never provisioned. (Rejected: the per-org enable step; AND the
+  background invariant sweep + signup hook — async machinery that only provisioned
+  *eventually*, parked errors, and existed solely to dodge one cross-service call.
+  Agent-create is synchronous → no window, no wasted keys, no cron. Reuses the existing
+  enable route — **no new endpoint**.)
 
 ## 7b. Slices
 
@@ -125,30 +133,27 @@ customers (pro + active Stripe sub): **33 on legacy** (all `model_billing_status
   (`model_meter.ts` early-return). Tests updated + non-autumn cases added (21/21 green,
   tsc clean). After this, *any* org can be enabled with bounded exposure and zero
   wrongful halts. *Still requires the per-org enable step — that's Slice 2.*
-- **Slice 2 (make Managed an invariant + kill `managedAvailable`) — DONE (PR #452):**
-  `runManagedProvisioner` sweep (edge `scheduled()`, batched, idempotent) drains every
-  unprovisioned org via `enableManagedBilling`; signup hook provisions at org birth for
-  immediacy; `managedAvailable` deleted from edge `/billing` + web (`Agents.tsx`,
-  `AgentDetail.tsx`, `schemas.ts`) → Managed always offered; no sessions-api change. Edge
-  + web tsc clean, 22/22 edge tests (incl. the sweep test). No new endpoint, no
-  cross-service trigger, no hot-path fork. Below is the design as built:
-  - **Provision at org birth:** add `enableManagedBilling(orgID)` in the edge signup
-    handler, beside the existing `createAutumnCustomer` call (`index.ts:~1251`,
-    best-effort — don't fail signup on a provisioning hiccup; the sweep heals it).
-  - **Backfill + self-heal via a reconcile sweep:** a small edge cron (mirrors the
-    model_meter / autumn_meter cron pattern) that ensures every org is provisioned.
-    Path-agnostic (also covers the Go/WorkOS `ProvisionOrgAndUser` create path → cell PG →
-    D1), subsumes the one-time backfill, and repairs any failed provision — with zero
-    hot-path code. *Step 0: verify whether the edge signup handler is the ONLY org-create
-    path; if it is, the org-birth hook + a one-shot backfill may suffice and the cron is
-    optional.*
-  - **Remove `managedAvailable`:** delete it from edge `/billing` (`dashboard.ts:996–1040`)
-    and the web (`AgentDetail.tsx`, `Agents.tsx`, `schemas.ts`) — Managed is always
-    offered. Must land WITH the provisioning, never before (else offer-then-fail).
-  - **sessions-api:** no trigger change — resolve "just works" because the credential is
-    always bound. (Verify `credentials.ts:328` resolve has no provider assumption.)
-  - **Tradeoff:** one OR key per org (free until used; $10 cap). Consistent with the
-    invariant choice; if key-count ever bites, fall back to lazy-at-first-use.
+- **Slice 2 (provision at agent-create + kill `managedAvailable`) — DONE:**
+  - **edge (PR #452):** removed the async (`runManagedProvisioner` sweep + signup hook);
+    the enable route (`/internal/model-billing/enable`) now *also* accepts the scoped
+    `OC_MANAGED_CRED_HMAC_SECRET` so sessions-api can call it (no new endpoint; no broad
+    `CF_ADMIN_SECRET` on sessions-api; `disable` stays admin-only). `managedAvailable`
+    deleted from `/billing` (`dashboard.ts`) + web (`Agents.tsx`, `AgentDetail.tsx`,
+    `schemas.ts`) → Managed always offered. Copy made provider-neutral (`Managed · no key
+    needed`). 26 edge tests + edge/web tsc green.
+  - **sessions-api (companion PR):** `ensureManagedProvisioned(owner)`
+    (`core/credentials.ts`) — if the org has no managed credential, sign the enable call
+    with `OC_MANAGED_CRED_HMAC_SECRET` (scheme `${ts}.${body}`, `X-Timestamp`/`X-Signature`)
+    and POST `OPENCOMPUTER_API_URL/internal/model-billing/enable`; the edge mints + binds
+    back; confirm bound. Called synchronously from agent-create (`core/agents.ts`, the
+    `credential: managed` branch); throws on failure so we never create a Managed agent
+    that can't run. Idempotent. tsc green.
+  - **Must deploy together** — flag removal (edge/web) + agent-create provisioning
+    (sessions-api) are one rollout, else Managed is offered but unprovisioned.
+  - **No backfill needed** — existing orgs provision when they next create a Managed
+    agent; no existing Managed agents sit on unprovisioned orgs (only `2f9094d9` had it).
+  - **Open:** P2 legacy→autumn upgrade should baseline `committed_micro` at the provider
+    flip (`autumn_webhook`) so prior fixed-budget usage isn't retro-debited. Not yet done.
 
 ## 8. Non-goals
 

--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -989,9 +989,9 @@ export async function handleDashboard(
       max_concurrent_sandboxes: number; billing_provider: string;
     }>();
     if (!org) return json({ error: "org not found" }, 404);
-    // Managed is a universal capability (every org is provisioned a managed credential by
-    // runManagedProvisioner), so there is no per-org "available" flag to read or return —
-    // the UI always offers Managed.
+    // Managed is a universal capability (every org gets a managed credential provisioned
+    // on demand at agent-create / first use), so there's no per-org "available" flag to
+    // read or return — the UI always offers Managed.
     // Cross-check against the live DO state — the D1 mirror gets written by
     // the DO after every debit but lags a touch, and on initial signup the
     // column reads its column-default (500) before the DO has ever been

--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -989,19 +989,9 @@ export async function handleDashboard(
       max_concurrent_sandboxes: number; billing_provider: string;
     }>();
     if (!org) return json({ error: "org not found" }, 404);
-    // Managed model access (token-billing §6.6) — read SEPARATELY + defensively so the
-    // critical billing read above never depends on the phase-9 column. If schema_phase9
-    // hasn't been applied yet (Worker deployed first), the column is missing → this
-    // throws → managedAvailable=false, and existing billing is unaffected (P0 ordering).
-    let managedAvailable = false;
-    try {
-      const m = await env.OPENCOMPUTER_DB.prepare(
-        `SELECT model_billing_status FROM orgs WHERE id = ?1`,
-      ).bind(caller.orgID).first<{ model_billing_status: string | null }>();
-      managedAvailable = m?.model_billing_status === "active";
-    } catch {
-      /* phase-9 not migrated yet → Managed simply unavailable */
-    }
+    // Managed is a universal capability (every org is provisioned a managed credential by
+    // runManagedProvisioner), so there is no per-org "available" flag to read or return —
+    // the UI always offers Managed.
     // Cross-check against the live DO state — the D1 mirror gets written by
     // the DO after every debit but lags a touch, and on initial signup the
     // column reads its column-default (500) before the DO has ever been
@@ -1033,11 +1023,6 @@ export async function handleDashboard(
       isHalted: !!org.is_halted,
       maxConcurrentSandboxes: org.max_concurrent_sandboxes,
       billingProvider: org.billing_provider,
-      // Managed model access (token-billing §6.6): the single gating authority the UI
-      // reads to offer the "Managed" credential option. True only once the edge has
-      // provisioned the org's OpenRouter key + bound it (model_billing_status='active').
-      // Read defensively above so a missing phase-9 column never breaks billing.
-      managedAvailable,
       // Upcoming-invoice + meters would come from Stripe API on demand;
       // surface stubs for now so the UI has stable keys to render against.
       upcomingInvoice: null,

--- a/cloudflare-workers/api-edge/src/index.test.ts
+++ b/cloudflare-workers/api-edge/src/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import worker, { type Env } from "./index";
 
 const orgID = "org-1";
@@ -260,5 +260,56 @@ describe("api-edge sandbox create", () => {
       2048,
       expect.any(Number),
     ]);
+  });
+});
+
+// The scoped-secret boundary added so sessions-api can ensure-provision Managed at
+// agent-create without holding the broad CF_ADMIN_SECRET. Asserts the auth gate only
+// (provisioning itself isn't exercised: getOrg → null → 500, which is still ≠ 401).
+describe("/internal/model-billing/enable — scoped-secret auth boundary", () => {
+  const ADMIN = "admin-secret";
+  const MANAGED = "managed-secret";
+  const authEnv = { ...env, CF_ADMIN_SECRET: ADMIN, OC_MANAGED_CRED_HMAC_SECRET: MANAGED } as unknown as Env;
+  // HMAC-SHA256 hex via Web Crypto — mirrors the edge's hmacHex (node:crypto isn't in the
+  // Worker tsconfig).
+  const sign = async (secret: string, ts: string, body: string): Promise<string> => {
+    const key = await crypto.subtle.importKey("raw", new TextEncoder().encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+    const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(`${ts}.${body}`));
+    return [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, "0")).join("");
+  };
+  const post = async (path: string, secret: string, o: { ts?: string; sig?: string } = {}) => {
+    const body = JSON.stringify({ org_id: "org-x" });
+    const ts = o.ts ?? Math.floor(Date.now() / 1000).toString();
+    const sig = o.sig ?? (await sign(secret, ts, body));
+    return worker.fetch(
+      new Request(`https://app.opencomputer.dev${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "X-Timestamp": ts, "X-Signature": sig },
+        body,
+      }),
+      authEnv,
+      ctx,
+    );
+  };
+
+  // Belt: if auth ever passes through to provisioning, fail fast instead of hitting the net.
+  beforeEach(() => vi.stubGlobal("fetch", vi.fn(async () => new Response("{}", { status: 502 }))));
+
+  it("managed secret authorizes enable (passes auth → not 401)", async () => {
+    expect((await post("/internal/model-billing/enable", MANAGED)).status).not.toBe(401);
+  });
+  it("managed secret CANNOT call disable → 401", async () => {
+    expect((await post("/internal/model-billing/disable", MANAGED)).status).toBe(401);
+  });
+  it("admin secret authorizes enable and disable (not 401)", async () => {
+    expect((await post("/internal/model-billing/enable", ADMIN)).status).not.toBe(401);
+    expect((await post("/internal/model-billing/disable", ADMIN)).status).not.toBe(401);
+  });
+  it("wrong signature → 401", async () => {
+    expect((await post("/internal/model-billing/enable", MANAGED, { sig: "deadbeef" })).status).toBe(401);
+  });
+  it("stale timestamp → 401", async () => {
+    const stale = (Math.floor(Date.now() / 1000) - 600).toString();
+    expect((await post("/internal/model-billing/enable", MANAGED, { ts: stale })).status).toBe(401);
   });
 });

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -26,7 +26,7 @@ import {
   createAutumnCustomer,
 } from "./autumn_webhook";
 import { runAutumnMeter } from "./autumn_meter";
-import { disableManagedBilling, enableManagedBilling } from "./model_billing";
+import { disableManagedBilling, enableManagedBilling, runManagedProvisioner } from "./model_billing";
 import { runModelMeter } from "./model_meter";
 import * as secretStores from "./secret_stores";
 import * as snapshots from "./snapshots";
@@ -1265,6 +1265,12 @@ async function authCallback(req: Request, env: Env): Promise<Response> {
     )
       .bind(orgID, userID, nowSec)
       .run();
+    // Managed is an invariant: provision the org's OpenRouter key at birth so it "just
+    // works" immediately. Best-effort — a hiccup must not break signup; the reconcile
+    // sweep (scheduled) backfills + heals, and also covers the Go/WorkOS create path.
+    await enableManagedBilling(env, orgID).catch((e) =>
+      console.error(`signup: managed provisioning failed for ${orgID} (sweep will retry)`, e),
+    );
   }
 
   // Mint session JWT — same signing secret as cap-token but a different
@@ -2143,6 +2149,11 @@ export default {
     if (env.OPENROUTER_PROVISIONING_KEY) {
       ctx.waitUntil(
         runModelMeter(env, Date.now()).catch((err) => console.error("model-meter: run failed", err)),
+      );
+      // Keep Managed an invariant: drain any org without a managed credential (backfill +
+      // new orgs from any create path + failed provisions). Idempotent, bounded per tick.
+      ctx.waitUntil(
+        runManagedProvisioner(env).catch((err) => console.error("managed-provisioner: run failed", err)),
       );
     }
   },

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -2142,16 +2142,21 @@ export default {
   // key's spend → debit Autumn `model_spend` → push the markup-correct cap + halt.
   // Dormant unless OPENROUTER_PROVISIONING_KEY is set + managed keys exist.
   async scheduled(_event: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
-    if (!env.AUTUMN_SECRET_KEY) return;
-    ctx.waitUntil(
-      runAutumnMeter(env, Date.now()).catch((err) => console.error("autumn-meter: run failed", err)),
-    );
-    if (env.OPENROUTER_PROVISIONING_KEY) {
+    // Autumn meter + the credit-debiting model meter are Autumn-specific.
+    if (env.AUTUMN_SECRET_KEY) {
       ctx.waitUntil(
-        runModelMeter(env, Date.now()).catch((err) => console.error("model-meter: run failed", err)),
+        runAutumnMeter(env, Date.now()).catch((err) => console.error("autumn-meter: run failed", err)),
       );
-      // Keep Managed an invariant: drain any org without a managed credential (backfill +
-      // new orgs from any create path + failed provisions). Idempotent, bounded per tick.
+      if (env.OPENROUTER_PROVISIONING_KEY) {
+        ctx.waitUntil(
+          runModelMeter(env, Date.now()).catch((err) => console.error("model-meter: run failed", err)),
+        );
+      }
+    }
+    // Managed provisioning is OpenRouter-only (decoupled from billing) — it must run
+    // even where Autumn is absent or disabled. Keeps Managed an invariant: drains any org
+    // without a managed credential (backfill + new orgs from any path + failed provisions).
+    if (env.OPENROUTER_PROVISIONING_KEY) {
       ctx.waitUntil(
         runManagedProvisioner(env).catch((err) => console.error("managed-provisioner: run failed", err)),
       );

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -26,7 +26,7 @@ import {
   createAutumnCustomer,
 } from "./autumn_webhook";
 import { runAutumnMeter } from "./autumn_meter";
-import { disableManagedBilling, enableManagedBilling, runManagedProvisioner } from "./model_billing";
+import { disableManagedBilling, enableManagedBilling } from "./model_billing";
 import { runModelMeter } from "./model_meter";
 import * as secretStores from "./secret_stores";
 import * as snapshots from "./snapshots";
@@ -1265,12 +1265,6 @@ async function authCallback(req: Request, env: Env): Promise<Response> {
     )
       .bind(orgID, userID, nowSec)
       .run();
-    // Managed is an invariant: provision the org's OpenRouter key at birth so it "just
-    // works" immediately. Best-effort — a hiccup must not break signup; the reconcile
-    // sweep (scheduled) backfills + heals, and also covers the Go/WorkOS create path.
-    await enableManagedBilling(env, orgID).catch((e) =>
-      console.error(`signup: managed provisioning failed for ${orgID} (sweep will retry)`, e),
-    );
   }
 
   // Mint session JWT — same signing secret as cap-token but a different
@@ -1810,8 +1804,15 @@ export default {
       const ts = req.headers.get("X-Timestamp") ?? "";
       const sig = req.headers.get("X-Signature") ?? "";
       const body = await req.text();
-      const expected = await hmacHex(env.CF_ADMIN_SECRET, `${ts}.${body}`);
-      if (!constantTimeEqual(expected, sig)) return json({ error: "signature mismatch" }, 401);
+      // CF_ADMIN_SECRET authorizes both ops. `enable` is additionally accepted with the
+      // scoped OC_MANAGED_CRED_HMAC_SECRET, so sessions-api can ensure-provision at
+      // agent-create without holding the broad admin secret. `disable` stays admin-only.
+      const adminOk = constantTimeEqual(await hmacHex(env.CF_ADMIN_SECRET, `${ts}.${body}`), sig);
+      const managedOk =
+        path === "/internal/model-billing/enable" && env.OC_MANAGED_CRED_HMAC_SECRET
+          ? constantTimeEqual(await hmacHex(env.OC_MANAGED_CRED_HMAC_SECRET, `${ts}.${body}`), sig)
+          : false;
+      if (!adminOk && !managedOk) return json({ error: "signature mismatch" }, 401);
       if (Math.abs(Math.floor(Date.now() / 1000) - Number(ts)) > 300) return json({ error: "timestamp out of window" }, 401);
       const parsed = JSON.parse(body) as { org_id?: string };
       if (!parsed.org_id) return json({ error: "org_id required" }, 400);
@@ -2142,23 +2143,13 @@ export default {
   // key's spend → debit Autumn `model_spend` → push the markup-correct cap + halt.
   // Dormant unless OPENROUTER_PROVISIONING_KEY is set + managed keys exist.
   async scheduled(_event: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
-    // Autumn meter + the credit-debiting model meter are Autumn-specific.
-    if (env.AUTUMN_SECRET_KEY) {
-      ctx.waitUntil(
-        runAutumnMeter(env, Date.now()).catch((err) => console.error("autumn-meter: run failed", err)),
-      );
-      if (env.OPENROUTER_PROVISIONING_KEY) {
-        ctx.waitUntil(
-          runModelMeter(env, Date.now()).catch((err) => console.error("model-meter: run failed", err)),
-        );
-      }
-    }
-    // Managed provisioning is OpenRouter-only (decoupled from billing) — it must run
-    // even where Autumn is absent or disabled. Keeps Managed an invariant: drains any org
-    // without a managed credential (backfill + new orgs from any path + failed provisions).
+    if (!env.AUTUMN_SECRET_KEY) return;
+    ctx.waitUntil(
+      runAutumnMeter(env, Date.now()).catch((err) => console.error("autumn-meter: run failed", err)),
+    );
     if (env.OPENROUTER_PROVISIONING_KEY) {
       ctx.waitUntil(
-        runManagedProvisioner(env).catch((err) => console.error("managed-provisioner: run failed", err)),
+        runModelMeter(env, Date.now()).catch((err) => console.error("model-meter: run failed", err)),
       );
     }
   },

--- a/cloudflare-workers/api-edge/src/model_billing.test.ts
+++ b/cloudflare-workers/api-edge/src/model_billing.test.ts
@@ -366,4 +366,3 @@ describe("disableManagedBilling (rollback / hard offboard)", () => {
     expect(db.orgs.get(orgId)!.model_billing_status).toBe("off");
   });
 });
-

--- a/cloudflare-workers/api-edge/src/model_billing.test.ts
+++ b/cloudflare-workers/api-edge/src/model_billing.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   disableManagedBilling,
   enableManagedBilling,
+  runManagedProvisioner,
   type ManagedModelKeyRow,
   type ModelBillingEnv,
   ownerIdForOrg,
@@ -65,6 +66,14 @@ class FakeStmt {
     if (this.sql.includes("FROM managed_model_keys")) {
       const orgId = this.args[0] as string;
       return { results: this.db.keys.filter((k) => k.org_id === orgId) as T[] };
+    }
+    // runManagedProvisioner: unprovisioned orgs (not active/error), bounded by LIMIT.
+    if (this.sql.includes("FROM orgs")) {
+      const rows = [...this.db.orgs.values()].filter(
+        (o) => !["active", "error"].includes(o.model_billing_status ?? "off"),
+      );
+      const limit = typeof this.args[0] === "number" ? this.args[0] : rows.length;
+      return { results: rows.slice(0, limit) as T[] };
     }
     return { results: [] };
   }
@@ -364,5 +373,25 @@ describe("disableManagedBilling (rollback / hard offboard)", () => {
     vi.stubGlobal("fetch", spy);
     await disableManagedBilling(makeEnv(db), orgId);
     expect(db.orgs.get(orgId)!.model_billing_status).toBe("off");
+  });
+});
+
+describe("runManagedProvisioner (Managed-as-invariant sweep)", () => {
+  it("provisions every unprovisioned org (any provider), leaving active/error alone", async () => {
+    const db = new FakeDb();
+    seedOrg(db, { id: "a", model_billing_status: "off" }); // autumn, fresh
+    seedOrg(db, { id: "b", model_billing_status: "active" }); // already provisioned
+    seedOrg(db, { id: "c", model_billing_status: "error" }); // parked — leave alone
+    seedOrg(db, { id: "d", billing_provider: "legacy" }); // non-autumn, off by default
+    const { spy } = makeFetch();
+    vi.stubGlobal("fetch", spy);
+
+    await runManagedProvisioner(makeEnv(db));
+
+    expect(db.orgs.get("a")!.model_billing_status).toBe("active");
+    expect(db.orgs.get("d")!.model_billing_status).toBe("active"); // legacy provisions too
+    expect(db.orgs.get("c")!.model_billing_status).toBe("error"); // untouched
+    expect(db.keys.some((k) => k.org_id === "a")).toBe(true);
+    expect(db.keys.some((k) => k.org_id === "c")).toBe(false); // never touched
   });
 });

--- a/cloudflare-workers/api-edge/src/model_billing.test.ts
+++ b/cloudflare-workers/api-edge/src/model_billing.test.ts
@@ -9,7 +9,6 @@ import {
 import {
   disableManagedBilling,
   enableManagedBilling,
-  runManagedProvisioner,
   type ManagedModelKeyRow,
   type ModelBillingEnv,
   ownerIdForOrg,
@@ -66,14 +65,6 @@ class FakeStmt {
     if (this.sql.includes("FROM managed_model_keys")) {
       const orgId = this.args[0] as string;
       return { results: this.db.keys.filter((k) => k.org_id === orgId) as T[] };
-    }
-    // runManagedProvisioner: unprovisioned orgs (not active/error), bounded by LIMIT.
-    if (this.sql.includes("FROM orgs")) {
-      const rows = [...this.db.orgs.values()].filter(
-        (o) => !["active", "error"].includes(o.model_billing_status ?? "off"),
-      );
-      const limit = typeof this.args[0] === "number" ? this.args[0] : rows.length;
-      return { results: rows.slice(0, limit) as T[] };
     }
     return { results: [] };
   }
@@ -376,22 +367,3 @@ describe("disableManagedBilling (rollback / hard offboard)", () => {
   });
 });
 
-describe("runManagedProvisioner (Managed-as-invariant sweep)", () => {
-  it("provisions every unprovisioned org (any provider), leaving active/error alone", async () => {
-    const db = new FakeDb();
-    seedOrg(db, { id: "a", model_billing_status: "off" }); // autumn, fresh
-    seedOrg(db, { id: "b", model_billing_status: "active" }); // already provisioned
-    seedOrg(db, { id: "c", model_billing_status: "error" }); // parked — leave alone
-    seedOrg(db, { id: "d", billing_provider: "legacy" }); // non-autumn, off by default
-    const { spy } = makeFetch();
-    vi.stubGlobal("fetch", spy);
-
-    await runManagedProvisioner(makeEnv(db));
-
-    expect(db.orgs.get("a")!.model_billing_status).toBe("active");
-    expect(db.orgs.get("d")!.model_billing_status).toBe("active"); // legacy provisions too
-    expect(db.orgs.get("c")!.model_billing_status).toBe("error"); // untouched
-    expect(db.keys.some((k) => k.org_id === "a")).toBe(true);
-    expect(db.keys.some((k) => k.org_id === "c")).toBe(false); // never touched
-  });
-});

--- a/cloudflare-workers/api-edge/src/model_billing.test.ts
+++ b/cloudflare-workers/api-edge/src/model_billing.test.ts
@@ -267,12 +267,19 @@ describe("enableManagedBilling state machine", () => {
     expect((create.body as { limit: number }).limit).toBeCloseTo(6 / 1.2, 5); // 5.0
   });
 
-  it("refuses non-autumn orgs", async () => {
+  it("non-autumn org provisions at the fixed default budget (decoupled from billing)", async () => {
     const db = new FakeDb();
     const orgId = seedOrg(db, { billing_provider: "legacy" });
-    vi.stubGlobal("fetch", makeFetch().spy);
-    await expect(enableManagedBilling(makeEnv(db), orgId)).rejects.toThrow(/not autumn/);
-    expect(db.orgs.get(orgId)!.model_billing_status).not.toBe("active");
+    const { spy, calls } = makeFetch();
+    vi.stubGlobal("fetch", spy);
+
+    const res = await enableManagedBilling(makeEnv(db), orgId);
+
+    expect(res.status).toBe("active");
+    expect(db.orgs.get(orgId)!.model_billing_status).toBe("active");
+    // Minted at the FIXED $10 budget (no credits lookup), not credits-derived.
+    const create = calls.find((c) => c.url.endsWith("/keys") && c.method === "POST")!;
+    expect((create.body as { limit: number }).limit).toBe(10);
   });
 
   it("is idempotent: a complete active row re-call mints nothing new", async () => {

--- a/cloudflare-workers/api-edge/src/model_billing.ts
+++ b/cloudflare-workers/api-edge/src/model_billing.ts
@@ -409,6 +409,35 @@ export async function reconcileManagedBilling(env: ModelBillingEnv, orgId: strin
   return enableManagedBilling(env, orgId);
 }
 
+// runManagedProvisioner makes "every org has a managed credential" an INVARIANT rather
+// than a per-org opt-in. It drains orgs that aren't provisioned yet — a bounded batch per
+// tick — via the idempotent enableManagedBilling. One mechanism covers the one-time
+// backfill, every new org (regardless of create path: edge signup OR the Go/WorkOS cell
+// path), and any half/failed provision — with zero hot-path code and no managedAvailable
+// flag. Orgs parked in 'error' (exhausted retries) are left alone.
+const PROVISION_BATCH = 20;
+export async function runManagedProvisioner(env: ModelBillingEnv): Promise<void> {
+  const res = await env.OPENCOMPUTER_DB.prepare(
+    `SELECT id FROM orgs WHERE COALESCE(model_billing_status,'off') NOT IN ('active','error')
+       ORDER BY created_at LIMIT ?1`,
+  )
+    .bind(PROVISION_BATCH)
+    .all<{ id: string }>();
+  const orgs = res.results ?? [];
+  if (orgs.length === 0) return;
+  let done = 0;
+  for (const { id } of orgs) {
+    try {
+      await enableManagedBilling(env, id);
+      done++;
+    } catch (e) {
+      // Best-effort: one org's failure never blocks the rest; the next tick retries.
+      console.error(`managed-provisioner: org ${id} failed`, e);
+    }
+  }
+  console.log(`managed-provisioner: ${done}/${orgs.length} provisioned this run`);
+}
+
 // disableManagedBilling is the rollback path: a synchronous HARD offboard. The
 // graceful-drain cron (§5.8 — keep polling until spend quiesces, final debit, then
 // delete) isn't built yet, so disable does the teardown directly: delete the OR

--- a/cloudflare-workers/api-edge/src/model_billing.ts
+++ b/cloudflare-workers/api-edge/src/model_billing.ts
@@ -409,35 +409,6 @@ export async function reconcileManagedBilling(env: ModelBillingEnv, orgId: strin
   return enableManagedBilling(env, orgId);
 }
 
-// runManagedProvisioner makes "every org has a managed credential" an INVARIANT rather
-// than a per-org opt-in. It drains orgs that aren't provisioned yet — a bounded batch per
-// tick — via the idempotent enableManagedBilling. One mechanism covers the one-time
-// backfill, every new org (regardless of create path: edge signup OR the Go/WorkOS cell
-// path), and any half/failed provision — with zero hot-path code and no managedAvailable
-// flag. Orgs parked in 'error' (exhausted retries) are left alone.
-const PROVISION_BATCH = 20;
-export async function runManagedProvisioner(env: ModelBillingEnv): Promise<void> {
-  const res = await env.OPENCOMPUTER_DB.prepare(
-    `SELECT id FROM orgs WHERE COALESCE(model_billing_status,'off') NOT IN ('active','error')
-       ORDER BY created_at LIMIT ?1`,
-  )
-    .bind(PROVISION_BATCH)
-    .all<{ id: string }>();
-  const orgs = res.results ?? [];
-  if (orgs.length === 0) return;
-  let done = 0;
-  for (const { id } of orgs) {
-    try {
-      await enableManagedBilling(env, id);
-      done++;
-    } catch (e) {
-      // Best-effort: one org's failure never blocks the rest; the next tick retries.
-      console.error(`managed-provisioner: org ${id} failed`, e);
-    }
-  }
-  console.log(`managed-provisioner: ${done}/${orgs.length} provisioned this run`);
-}
-
 // disableManagedBilling is the rollback path: a synchronous HARD offboard. The
 // graceful-drain cron (§5.8 — keep polling until spend quiesces, final debit, then
 // delete) isn't built yet, so disable does the teardown directly: delete the OR

--- a/cloudflare-workers/api-edge/src/model_billing.ts
+++ b/cloudflare-workers/api-edge/src/model_billing.ts
@@ -24,7 +24,13 @@ export interface ModelBillingEnv extends OpenRouterEnv, AutumnApiEnv {
   OC_MANAGED_CRED_HMAC_SECRET: string;
   // Optional env-default markup (basis points) when the org row's is 0. Org wins.
   OPENROUTER_MARKUP_BPS?: string;
+  // Fixed prepaid OR-key budget (USD) for non-autumn orgs, which are decoupled from
+  // billing (no metering/halt — the key limit IS the ceiling). Default $10.
+  MANAGED_DEFAULT_BUDGET_USD?: string;
 }
+
+// Fixed prepaid budget for a non-autumn (un-metered) managed org, in USD.
+const DEFAULT_MANAGED_BUDGET_USD = 10;
 
 // Bounded retries before parking the org in 'error' (§5.1).
 const MAX_PROVISION_ATTEMPTS = 5;
@@ -189,6 +195,24 @@ function initialCapUsd(remainingUsd: number, bps: number): number {
   return Math.max(0, remainingUsd / (1 + bps / 10000));
 }
 
+function defaultBudgetUsd(env: ModelBillingEnv): number {
+  const v = parseFloat(env.MANAGED_DEFAULT_BUDGET_USD ?? "");
+  return Number.isFinite(v) && v > 0 ? v : DEFAULT_MANAGED_BUDGET_USD;
+}
+
+// budgetFor returns the OR key's spend limit (USD) at provision. Autumn orgs are
+// metered against the shared credit pool, so their cap tracks remaining credits
+// (markup-adjusted) and the meter keeps it in sync. Non-autumn orgs are decoupled
+// from billing: they get a FIXED prepaid budget and are never metered/halted — the
+// OR key limit is the hard ceiling. Top-up = move them to autumn + grant credits.
+async function budgetFor(env: ModelBillingEnv, org: OrgBillingRow): Promise<number> {
+  if (org.billing_provider === "autumn") {
+    const remaining = await remainingCreditsUsd(env, org.id);
+    return initialCapUsd(remaining, markupBps(env, org));
+  }
+  return defaultBudgetUsd(env);
+}
+
 // ── edge → sessions-api hand-off (HMAC, §6.7.5) ─────────────────────────────
 
 async function hmacHex(secret: string, data: string): Promise<string> {
@@ -284,10 +308,10 @@ export interface EnableResult {
 export async function enableManagedBilling(env: ModelBillingEnv, orgId: string): Promise<EnableResult> {
   const org = await getOrg(env, orgId);
   if (!org) throw new Error(`model-billing: org ${orgId} not found`);
-  // Managed billing is autumn-only (§3 invariant 6).
-  if (org.billing_provider !== "autumn") {
-    throw new Error(`model-billing: org ${orgId} is '${org.billing_provider}', not autumn — refusing`);
-  }
+  // Managed is available to ANY org (decoupled from billing). Autumn orgs meter
+  // against the shared credit pool; non-autumn orgs run on a fixed OR-key budget
+  // (see budgetFor). The provider only changes the budget source, never whether
+  // Managed works.
 
   await setOrgStatus(env, orgId, "provisioning");
 
@@ -315,8 +339,7 @@ async function driveProvisioning(env: ModelBillingEnv, org: OrgBillingRow, row: 
     // Step 2: mint the OR key (once). Persist the hash before binding so a lost
     // bind response is recoverable.
     if (!row.or_key_hash) {
-      const remaining = await remainingCreditsUsd(env, org.id);
-      const limitUsd = initialCapUsd(remaining, markupBps(env, org));
+      const limitUsd = await budgetFor(env, org);
       const created = await createOrKey(env, { name: orKeyName(org.id), limitUsd });
       await updateRow(env, row.id, { or_key_hash: created.data.hash, attempts: 0, last_error: null });
       row.or_key_hash = created.data.hash;

--- a/cloudflare-workers/api-edge/src/model_meter.test.ts
+++ b/cloudflare-workers/api-edge/src/model_meter.test.ts
@@ -21,7 +21,7 @@ const gProject = projectOrg as unknown as ReturnType<typeof vi.fn>;
 
 // ── in-memory D1 for orgs + managed_model_keys ──────────────────────────────
 class FakeDb {
-  orgs = new Map<string, { id: string; model_markup_bps: number }>();
+  orgs = new Map<string, { id: string; model_markup_bps: number; billing_provider: string }>();
   keys: ManagedModelKeyRow[] = [];
   prepare(sql: string) {
     return new Stmt(this, sql);
@@ -88,7 +88,7 @@ afterEach(() => vi.clearAllMocks());
 describe("model_meter debit (persist-before-track, §7)", () => {
   it("debits new spend: persists interval, tracks micro-credits, advances watermark", async () => {
     const db = new FakeDb();
-    db.orgs.set("org1", { id: "org1", model_markup_bps: 0 });
+    db.orgs.set("org1", { id: "org1", model_markup_bps: 0, billing_provider: "autumn" });
     db.keys.push(key({ committed_micro: 0 }));
     gOrKey.mockResolvedValue(orKey(0.5)); // $0.50 cumulative
     gCust.mockResolvedValue({ id: "org1", balances: { credits: { remaining: 10 } } });
@@ -101,9 +101,22 @@ describe("model_meter debit (persist-before-track, §7)", () => {
     expect(db.keys[0].pending_idem).toBeNull(); // cleared after success
   });
 
+  it("skips non-autumn orgs entirely — no debit, no halt (decoupled; the fixed OR-key budget is the ceiling)", async () => {
+    const db = new FakeDb();
+    db.orgs.set("org1", { id: "org1", model_markup_bps: 0, billing_provider: "legacy" });
+    db.keys.push(key({ committed_micro: 0 }));
+    gOrKey.mockResolvedValue(orKey(0.5));
+    gCust.mockResolvedValue(null); // a legacy org has no Autumn customer
+
+    await runModelMeter(env(db), 0);
+
+    expect(gTrack).not.toHaveBeenCalled(); // not metered
+    expect(gProject).not.toHaveBeenCalled(); // not halted — a 0 credit read must NOT hibernate it
+  });
+
   it("applies markup to the debit value", async () => {
     const db = new FakeDb();
-    db.orgs.set("org1", { id: "org1", model_markup_bps: 2000 }); // +20%
+    db.orgs.set("org1", { id: "org1", model_markup_bps: 2000, billing_provider: "autumn" }); // +20%
     db.keys.push(key({ committed_micro: 0 }));
     gOrKey.mockResolvedValue(orKey(0.5));
     gCust.mockResolvedValue({ id: "org1", balances: { credits: { remaining: 10 } } });
@@ -114,7 +127,7 @@ describe("model_meter debit (persist-before-track, §7)", () => {
 
   it("retries a pending interval VERBATIM after a crash (never recompute against newer usage)", async () => {
     const db = new FakeDb();
-    db.orgs.set("org1", { id: "org1", model_markup_bps: 0 });
+    db.orgs.set("org1", { id: "org1", model_markup_bps: 0, billing_provider: "autumn" });
     // crashed mid-debit: pending [0,500000] persisted; OR usage has since grown to $1.
     db.keys.push(key({ committed_micro: 0, pending_from_micro: 0, pending_to_micro: 500000, pending_idem: "model_spend:org1:0:500000" }));
     gOrKey.mockResolvedValue(orKey(1.0)); // now $1.00
@@ -128,7 +141,7 @@ describe("model_meter debit (persist-before-track, §7)", () => {
 
   it("no track when usage hasn't advanced past the watermark", async () => {
     const db = new FakeDb();
-    db.orgs.set("org1", { id: "org1", model_markup_bps: 0 });
+    db.orgs.set("org1", { id: "org1", model_markup_bps: 0, billing_provider: "autumn" });
     db.keys.push(key({ committed_micro: 500000 }));
     gOrKey.mockResolvedValue(orKey(0.5)); // == committed
     gCust.mockResolvedValue({ id: "org1", balances: { credits: { remaining: 10 } } });
@@ -141,7 +154,7 @@ describe("model_meter debit (persist-before-track, §7)", () => {
 describe("model_meter cap + halt (§5.4/§7)", () => {
   it("active-key cap = usage + remaining/(1+markup)", async () => {
     const db = new FakeDb();
-    db.orgs.set("org1", { id: "org1", model_markup_bps: 0 });
+    db.orgs.set("org1", { id: "org1", model_markup_bps: 0, billing_provider: "autumn" });
     db.keys.push(key({ committed_micro: 500000 }));
     gOrKey.mockResolvedValue(orKey(0.5, 1)); // usage 0.5, limit 1
     gCust.mockResolvedValue({ id: "org1", balances: { credits: { remaining: 10 } } });
@@ -153,7 +166,7 @@ describe("model_meter cap + halt (§5.4/§7)", () => {
 
   it("rotation: superseded key frozen at usage+ε, active gets the rest", async () => {
     const db = new FakeDb();
-    db.orgs.set("org1", { id: "org1", model_markup_bps: 0 });
+    db.orgs.set("org1", { id: "org1", model_markup_bps: 0, billing_provider: "autumn" });
     db.keys.push(key({ id: "mmk_old", or_key_hash: "old", status: "superseded", committed_micro: 2000000 }));
     db.keys.push(key({ id: "mmk_new", or_key_hash: "new", status: "active", committed_micro: 1000000 }));
     gOrKey.mockImplementation(async (_e: unknown, h: string) => (h === "old" ? orKey(2.0, 5) : orKey(1.0, 5)));
@@ -167,7 +180,7 @@ describe("model_meter cap + halt (§5.4/§7)", () => {
 
   it("halts the org when balance ≤ 0", async () => {
     const db = new FakeDb();
-    db.orgs.set("org1", { id: "org1", model_markup_bps: 0 });
+    db.orgs.set("org1", { id: "org1", model_markup_bps: 0, billing_provider: "autumn" });
     db.keys.push(key({ committed_micro: 500000 }));
     gOrKey.mockResolvedValue(orKey(0.5));
     gCust.mockResolvedValue({ id: "org1", balances: { credits: { remaining: 0 } } });

--- a/cloudflare-workers/api-edge/src/model_meter.ts
+++ b/cloudflare-workers/api-edge/src/model_meter.ts
@@ -30,6 +30,7 @@ const CAP_MIN_DELTA_USD = 0.01;
 interface OrgMeterRow {
   id: string;
   model_markup_bps: number;
+  billing_provider: string;
 }
 
 function markupBps(env: ModelMeterEnv, org: OrgMeterRow): number {
@@ -72,11 +73,18 @@ export async function runModelMeter(env: ModelMeterEnv, _nowMs: number): Promise
 
 async function meterOrg(env: ModelMeterEnv, orgId: string, keys: ManagedModelKeyRow[]): Promise<boolean> {
   const org = await env.OPENCOMPUTER_DB.prepare(
-    "SELECT id, model_markup_bps FROM orgs WHERE id = ?1",
+    "SELECT id, model_markup_bps, billing_provider FROM orgs WHERE id = ?1",
   )
     .bind(orgId)
     .first<OrgMeterRow>();
   if (!org) return false;
+  // Decoupled billing: only autumn orgs are on the shared credit pool, so only they
+  // are metered, capped-to-credits, and halted. Non-autumn orgs run on the FIXED OR
+  // key budget set at provision — the key limit is the ceiling; we never debit or
+  // halt them. This guard is also a correctness requirement, not just a skip: with
+  // no Autumn customer, `remaining` below would read 0 and wrongly halt the org
+  // (hibernate its boxes). Top-up = move the org to autumn + grant credits.
+  if (org.billing_provider !== "autumn") return false;
   const bps = markupBps(env, org);
 
   // Read each key's current OpenRouter usage once (reused for debit + cap).

--- a/sdks/typescript/src/agents/agents.ts
+++ b/sdks/typescript/src/agents/agents.ts
@@ -10,7 +10,7 @@ export interface CreateAgentParams {
   runtime?: Runtime;
   /** Model provider key for the runtime (Anthropic for `claude`, OpenAI for `codex`), stored as a sealed credential. Mutually exclusive with `credential`. */
   key?: string;
-  /** Model source: `"managed"` (run via OpenComputer, billed to credits) or a `cred_…` id. Omit for the org default. Mutually exclusive with `key`. */
+  /** Model source: `"managed"` (run via OpenComputer, no provider key) or a `cred_…` id. Omit for the org default. Mutually exclusive with `key`. */
   credential?: CredentialRef;
   limits?: Limits;
 }

--- a/sdks/typescript/src/agents/types.ts
+++ b/sdks/typescript/src/agents/types.ts
@@ -18,7 +18,7 @@ export type Runtime = "claude" | "codex" | (string & {});
 // checkable while still accepting any concrete id.
 export type CredentialId = `cred_${string}`;
 // How an agent picks its model source: the reserved "managed" sentinel (run via
-// OpenComputer, billed to credits) or a specific BYO credential id. Omit/null to
+// OpenComputer, no provider key) or a specific BYO credential id. Omit/null to
 // inherit the org default.
 export type CredentialRef = "managed" | CredentialId;
 

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -192,10 +192,6 @@ export const BillingStateSchema = z.object({
   hasPaymentMethod: z.boolean(),
   freeCreditsRemainingCents: z.number(),
   billingProvider: z.string().optional(),
-  // Managed model access (token-billing §6.6): the single gating authority for
-  // offering the "Managed · billed to credits" credential option. Optional so an
-  // older edge without the field validates (treated as unavailable).
-  managedAvailable: z.boolean().optional(),
 })
 
 export const AutumnAutoTopupSchema = z.object({

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -10,7 +10,6 @@ import {
   createSession,
   getCredentials,
   createCredential,
-  getBilling,
   type Agent,
 } from '@/api/client'
 import type { Session } from '@/api/schemas'
@@ -63,9 +62,6 @@ export default function AgentDetail() {
     queryKey: ['credentials'],
     queryFn: getCredentials,
   })
-  // Managed availability gates the "Managed" entry (token-billing §6.6/§6.8.C).
-  const { data: billing } = useQuery({ queryKey: ['billing'], queryFn: getBilling })
-  const managedAvailable = billing?.managedAvailable ?? false
   // Model list + credential provider follow the agent's runtime (immutable after
   // create): claude→anthropic, codex→openai. Falls back to claude while loading.
   const rt = getRuntime(agent?.runtime)
@@ -181,14 +177,10 @@ export default function AgentDetail() {
   const credSelectValue = credNew
     ? NEW_CRED
     : (agent?.credential_id ?? ORG_DEFAULT)
-  // Show Managed when it's available, or when this agent already runs Managed (so the
-  // current value renders even if availability later changes). It carries no provider.
-  const showManaged = managedAvailable || agent?.credential_id === MANAGED
+  // Managed is always offered (every org carries a managed credential); it has no provider.
   const credOptions = [
     { value: ORG_DEFAULT, label: 'Org default (no pinned credential)' },
-    ...(showManaged
-      ? [{ value: MANAGED, label: 'Managed · billed to credits' }]
-      : []),
+    { value: MANAGED, label: 'Managed · billed to credits' },
     ...providerCreds.map((c) => ({ value: c.id, label: credLabel(c.id) })),
     { value: NEW_CRED, label: '＋ New credential…' },
   ]

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -33,7 +33,7 @@ import { getRuntime } from '@/lib/runtimes'
 // credential provider come from the agent's runtime (see @/lib/runtimes).
 const ORG_DEFAULT = '__default__' // no pinned credential → org default resolves
 const NEW_CRED = '__new__' // create one inline
-const MANAGED = 'managed' // run via OpenComputer, billed to credits (token-billing §6.6)
+const MANAGED = 'managed' // run via OpenComputer, no BYO key (token-billing §6.6)
 
 export default function AgentDetail() {
   const { agentId = '' } = useParams()
@@ -180,7 +180,7 @@ export default function AgentDetail() {
   // Managed is always offered (every org carries a managed credential); it has no provider.
   const credOptions = [
     { value: ORG_DEFAULT, label: 'Org default (no pinned credential)' },
-    { value: MANAGED, label: 'Managed · billed to credits' },
+    { value: MANAGED, label: 'Managed · no key needed' },
     ...providerCreds.map((c) => ({ value: c.id, label: credLabel(c.id) })),
     { value: NEW_CRED, label: '＋ New credential…' },
   ]

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -8,7 +8,6 @@ import {
   createAgent,
   getCredentials,
   createCredential,
-  getBilling,
   type Agent,
 } from '@/api/client'
 import { PageHeader } from '@/components/page-header'
@@ -51,10 +50,6 @@ export default function Agents() {
     queryKey: ['credentials'],
     queryFn: getCredentials,
   })
-  // Managed availability gates the "Managed" picker entry (the single authority —
-  // token-billing §6.6/§6.8.C). Absent/false → only BYO credentials are offered.
-  const { data: billing } = useQuery({ queryKey: ['billing'], queryFn: getBilling })
-  const managedAvailable = billing?.managedAvailable ?? false
   const [showCreate, setShowCreate] = useState(false)
   const [name, setName] = useState('')
   const [prompt, setPrompt] = useState('')
@@ -76,10 +71,9 @@ export default function Agents() {
   const hasDefault = providerCreds.some((c) => c.is_default)
 
   // Lowest-friction default, mirroring backend resolution (token-billing §6.6):
-  // a BYO org default wins; else Managed (when available); else first BYO; else "new".
+  // a BYO org default wins; else Managed (always available to every org).
   const defaultCredFor = (creds: typeof providerCreds) =>
-    creds.find((c) => c.is_default)?.id ??
-    (managedAvailable ? MANAGED : creds[0]?.id ?? NEW_CRED)
+    creds.find((c) => c.is_default)?.id ?? MANAGED
 
   const resetForm = () => {
     setName('')
@@ -114,9 +108,7 @@ export default function Agents() {
   // Build options: Managed (if available, billed to credits — no provider filter, it
   // has no provider) + this runtime's provider creds + "New credential…".
   const credOptions = [
-    ...(managedAvailable
-      ? [{ value: MANAGED, label: 'Managed · billed to credits' }]
-      : []),
+    { value: MANAGED, label: 'Managed · billed to credits' },
     ...providerCreds.map((c) => ({
       value: c.id,
       label: `${c.name || 'Unnamed'}${c.last4 ? ` ·· ${c.last4}` : ''}${

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -34,7 +34,8 @@ import {
 // Sentinels for the non-credential choices in the credential picker. The model
 // list + credential provider both follow the chosen runtime (see @/lib/runtimes).
 const NEW_CRED = '__new__'
-// "Managed" model access: run via OpenComputer, billed to credits (no BYO key).
+// "Managed" model access: run via OpenComputer with no BYO key. Billing varies by org
+// (Autumn → credits; otherwise a fixed OpenRouter key cap), so the label stays neutral.
 // Sent to the API as the reserved credential value "managed" (token-billing §6.6).
 const MANAGED = 'managed'
 
@@ -105,10 +106,10 @@ export default function Agents() {
     setNewCredKey('')
   }
 
-  // Build options: Managed (if available, billed to credits — no provider filter, it
-  // has no provider) + this runtime's provider creds + "New credential…".
+  // Build options: Managed (always offered, no provider — runs without a BYO key) +
+  // this runtime's provider creds + "New credential…".
   const credOptions = [
-    { value: MANAGED, label: 'Managed · billed to credits' },
+    { value: MANAGED, label: 'Managed · no key needed' },
     ...providerCreds.map((c) => ({
       value: c.id,
       label: `${c.name || 'Unnamed'}${c.last4 ? ` ·· ${c.last4}` : ''}${
@@ -125,7 +126,7 @@ export default function Agents() {
       //  - else     → pin the chosen existing credential.
       let credentialId: string | undefined
       if (credChoice === MANAGED) {
-        credentialId = MANAGED // run via OpenComputer, billed to credits — no key
+        credentialId = MANAGED // run via OpenComputer, no BYO key
       } else if (credChoice === NEW_CRED) {
         const cred = await createCredential({
           key: newCredKey.trim(),


### PR DESCRIPTION
Makes **Managed model keys work for every org** by removing both forks: the billing-provider coupling and the per-org availability flag. Working doc: `.agents/work/managed-keys-for-everyone.md`. Companion: **sessions-api #35**.

## Slice 1 — decouple Managed from billing
- Dropped the `billing_provider!=='autumn'` refusal — any org can provision; `budgetFor()` mints non-autumn keys at a fixed **$10** (`MANAGED_DEFAULT_BUDGET_USD`), autumn keeps its credits-derived cap.
- **Fenced the meter to autumn** — non-autumn orgs are never debited/halted/capped (the OR-key limit is the ceiling). Also a correctness fix: otherwise a provisioned non-autumn org reads `remaining=0` and wrongly halts.
- Kept the autumn credit-runout halt (the top-up nudge).

## Slice 2 — provision at agent-create, kill `managedAvailable`
Provisioning is **just-in-time at agent-create** (in #35), not a background sweep. This PR is the edge/web half:
- **Removed the async** I'd first built (the `runManagedProvisioner` sweep + signup hook) — it only provisioned *eventually*, parked errors, and existed solely to dodge one cross-service call.
- The enable route now **also accepts the scoped `OC_MANAGED_CRED_HMAC_SECRET`** (enable only; `disable` stays admin-only) so sessions-api can ensure-provision without the broad `CF_ADMIN_SECRET`. No new endpoint.
- **Removed `managedAvailable`** from `/billing` + web (`Agents.tsx`, `AgentDetail.tsx`, `schemas.ts`) → Managed always offered. Copy made provider-neutral (`Managed · no key needed`).

## Why
`shift-left-over-feature-flags`: one runtime path, billing demoted to best-effort accounting, OR-key budget as the boundary. Agent-create provisioning = no flag, no cron, no offer-then-fail window, no wasted keys.

## Deploy / verification
- **Deploy with sessions-api #35** (flag removal without the provisioning would offer Managed before it's set up).
- No backfill needed (existing orgs provision on next Managed agent-create; no Managed agents sit on unprovisioned orgs).
- 31 edge tests (incl. the scoped-secret auth-boundary suite) + edge/web `tsc` green.
- Independent follow-up: markup still 0 (`OPENROUTER_MARKUP_BPS`); and baseline `committed_micro` at legacy→autumn flip so prior fixed-budget usage isn't retro-debited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)