### PR TITLE
Dashboard UX nits: agent-sessions naming, steer-input keyboard, pause copy

### DIFF
--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -60,7 +60,7 @@ const NAV: NavGroup[] = [
       { to: '/agents', label: 'Agents', icon: Bot, preview: true },
       {
         to: '/sessions',
-        label: 'Sessions',
+        label: 'Agent sessions',
         icon: MessagesSquare,
         preview: true,
       },
@@ -244,7 +244,8 @@ function HaltBanner() {
   if (!halted || location.pathname.startsWith('/billing')) return null
   return (
     <div className="border-status-pending/20 bg-status-pending-bg text-status-pending border-b px-4 py-2.5 text-center text-sm sm:px-8">
-      Your sandboxes are paused — you&apos;re out of prepaid credits.{' '}
+      Your agent sessions and sandboxes are paused — you&apos;re out of prepaid
+      credits.{' '}
       <Link
         to="/billing"
         className="font-semibold underline underline-offset-2"

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -60,7 +60,7 @@ const NAV: NavGroup[] = [
       { to: '/agents', label: 'Agents', icon: Bot, preview: true },
       {
         to: '/sessions',
-        label: 'Agent sessions',
+        label: 'Sessions',
         icon: MessagesSquare,
         preview: true,
       },

--- a/web/src/pages/Billing.tsx
+++ b/web/src/pages/Billing.tsx
@@ -306,7 +306,8 @@ function PrepaidPlan() {
         {halted ? (
           <p className="text-status-error mt-2 flex items-center gap-1.5 text-sm">
             <CircleAlert className="size-4 shrink-0" />
-            Credits exhausted — top up to resume your sandboxes
+            Credits exhausted — top up to resume your agent sessions and
+            sandboxes
           </p>
         ) : null}
 

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -196,13 +196,13 @@ export default function Dashboard() {
         <div className="space-y-6">
           <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
             <MetricCard
-              label="Active sessions"
+              label="Active agent sessions"
               value={
                 loadingSessions ? '—' : activeSessions.length.toLocaleString()
               }
             />
             <MetricCard
-              label="Sessions today"
+              label="Agent sessions today"
               value={loadingSessions ? '—' : sessionsToday.toLocaleString()}
             />
             <MetricCard
@@ -221,7 +221,7 @@ export default function Dashboard() {
 
           <Panel className="overflow-hidden">
             <PanelHeader>
-              <PanelTitle>Recent sessions</PanelTitle>
+              <PanelTitle>Recent agent sessions</PanelTitle>
               <Link
                 to="/sessions"
                 className="text-muted-foreground hover:text-foreground text-xs underline-offset-4 hover:underline"

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -211,6 +211,8 @@ export default function SessionDetail() {
               </p>
             ) : null}
             <ApiHint
+              method="GET"
+              path="/v3/sessions/:id"
               sdk="oc.sessions.get()"
               docs="https://docs.opencomputer.dev/agent-sessions/sessions"
             />

--- a/web/src/pages/Sessions.tsx
+++ b/web/src/pages/Sessions.tsx
@@ -113,7 +113,7 @@ export default function Sessions() {
   return (
     <div>
       <PageHeader
-        title="Sessions"
+        title="Agent sessions"
         description="Durable agent runs — an append-only event log you can steer."
         api={{
           method: 'POST',


### PR DESCRIPTION
Small dashboard polish.

**Naming — "agent sessions" not "sessions"** (where it stands alone and "sessions" is unclear): Sessions page title, dashboard metrics/panel (Active agent sessions · Agent sessions today · Recent agent sessions). Sidebar **keeps "Sessions"** — it's nested under the Agents section, so the context is already there.

**Session detail hint** shows the endpoint: `GET /v3/sessions/:id · oc.sessions.get()` (was SDK-only).

**Pause copy includes agent sessions** — a credit halt pauses sessions too, but copy said only "sandboxes": HaltBanner + billing credits-exhausted line now say "your agent sessions and sandboxes." (Plan concurrency limit + per-sandbox usage table left as-is — genuinely sandbox-level.)

**Steer input keyboard** — the box was a Textarea in a form, so Enter did nothing (send was button-only). Now: **Enter (and ⌘/Ctrl+Enter) sends, Shift+Enter inserts a newline**, Enter mid-IME-composition is ignored (CJK/accents), with empty/archived/in-flight guards. Send button gets a shortcut tooltip.

web tsc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)