### PR TITLE
Steer input: auto-grow + keyboard send

### DIFF
--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, Send, Wrench } from 'lucide-react'
@@ -56,6 +56,7 @@ export default function SessionDetail() {
   const { sessionId = '' } = useParams()
   const queryClient = useQueryClient()
   const [draft, setDraft] = useState('')
+  const draftRef = useRef<HTMLTextAreaElement>(null)
   const [level, setLevel] = useState<LevelFilter>('all')
   const [confirmCancel, setConfirmCancel] = useState(false)
   const [liveEvents, setLiveEvents] = useState<SessionEvent[]>([])
@@ -105,6 +106,15 @@ export default function SessionDetail() {
     es.onerror = () => setStreamOk(false) // EventSource retries on its own
     return () => es.close()
   }, [sessionId])
+
+  // Auto-grow the steer box with its content (up to ~6 rows, then scroll), and
+  // shrink back when it's cleared after a send.
+  useLayoutEffect(() => {
+    const el = draftRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = `${Math.min(el.scrollHeight, 160)}px`
+  }, [draft])
 
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: ['session', sessionId] })
@@ -298,19 +308,35 @@ export default function SessionDetail() {
             }}
           >
             <Textarea
+              ref={draftRef}
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                // Enter (or ⌘/Ctrl+Enter) sends; Shift+Enter inserts a newline.
+                // Ignore Enter mid-IME-composition so CJK/accent input isn't cut off.
+                if (
+                  e.key === 'Enter' &&
+                  !e.shiftKey &&
+                  !e.nativeEvent.isComposing
+                ) {
+                  e.preventDefault()
+                  if (draft.trim() && canSteer && !steerMutation.isPending) {
+                    steerMutation.mutate()
+                  }
+                }
+              }}
               placeholder={
                 canSteer
                   ? 'Send a message to steer the session…'
                   : 'Session archived'
               }
               disabled={!canSteer}
-              className="min-h-10 flex-1"
+              className="min-h-10 max-h-40 flex-1 overflow-y-auto"
               rows={1}
             />
             <Button
               type="submit"
+              title="Enter to send · Shift+Enter for newline"
               disabled={!draft.trim() || !canSteer || steerMutation.isPending}
             >
               <Send className="size-4" />


### PR DESCRIPTION
Two improvements to the session steer input.

**Auto-grow** — the box was a fixed ~1-row `resize-none` Textarea, cramped for multi-line steer instructions. It now grows with content up to ~6 rows (160px) then scrolls, and shrinks back after a send clears it. Implemented with a ref + `useLayoutEffect` (measures before paint, no flicker); the ref reaches the native `<textarea>` through the `@/components/form` wrapper via React 19 prop-spread (no component change).

**Keyboard send** — **Enter (and ⌘/Ctrl+Enter) sends; Shift+Enter inserts a newline**; Enter mid-IME-composition is ignored (CJK/accents); empty/archived/in-flight guards; Send button gets a shortcut tooltip.

> Note: the keyboard half was committed on #453's branch but its commit got **orphaned by the merge** (the merge's parent was the previous commit) and never reached `main` — so it's re-applied here.

web tsc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)