### PR TITLE
Shared ChatTextarea: auto-grow + Enter-to-send across all send boxes

### DIFF
--- a/web/src/components/chat-textarea.tsx
+++ b/web/src/components/chat-textarea.tsx
@@ -1,0 +1,50 @@
+import { useLayoutEffect, useRef, type ComponentProps } from 'react'
+import { Textarea } from '@/components/form'
+import { cn } from '@/lib/utils'
+
+type ChatTextareaProps = ComponentProps<typeof Textarea> & {
+  /** Fired when the user presses Enter (or ⌘/Ctrl+Enter). Shift+Enter inserts a
+   *  newline. The caller decides whether to actually send (e.g. guard on
+   *  non-empty / not in-flight); a disabled textarea never fires this. */
+  onSend?: () => void
+}
+
+/** Chat-style textarea: auto-grows with its content (up to ~6 rows, then
+ *  scrolls) and sends on Enter, newline on Shift+Enter. One home for the
+ *  keyboard + sizing semantics so every "send a message" box — steer, start
+ *  session — behaves the same. (Not for multi-field forms, where Enter must not
+ *  submit; use the plain Textarea there.) */
+export function ChatTextarea({
+  onSend,
+  value,
+  onKeyDown,
+  className,
+  ...props
+}: ChatTextareaProps) {
+  const ref = useRef<HTMLTextAreaElement>(null)
+  // Grow to fit content (cap, then scroll); shrink back when cleared after send.
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = `${Math.min(el.scrollHeight, 160)}px`
+  }, [value])
+  return (
+    <Textarea
+      ref={ref}
+      value={value}
+      rows={1}
+      onKeyDown={(e) => {
+        onKeyDown?.(e)
+        // Enter (or ⌘/Ctrl+Enter) sends; Shift+Enter is a newline. Skip Enter
+        // mid-IME-composition so CJK/accent input isn't cut off.
+        if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+          e.preventDefault()
+          onSend?.()
+        }
+      }}
+      className={cn('max-h-40 overflow-y-auto', className)}
+      {...props}
+    />
+  )
+}

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/panel'
 import { Button } from '@/components/ui/button'
 import { Field, Input, Select, Textarea } from '@/components/form'
+import { ChatTextarea } from '@/components/chat-textarea'
 import { StatusBadge } from '@/components/status-badge'
 import { EmptyState } from '@/components/empty-state'
 import { ResourceTable, type Column } from '@/components/resource-table'
@@ -423,9 +424,14 @@ export default function AgentDetail() {
                   if (task.trim()) startMutation.mutate()
                 }}
               >
-                <Textarea
+                <ChatTextarea
                   value={task}
                   onChange={(e) => setTask(e.target.value)}
+                  onSend={() => {
+                    if (task.trim() && !startMutation.isPending) {
+                      startMutation.mutate()
+                    }
+                  }}
                   placeholder="Give this agent a task — it runs durably as a new session…"
                   className="min-h-20"
                 />
@@ -433,6 +439,7 @@ export default function AgentDetail() {
                   <Button
                     type="submit"
                     size="sm"
+                    title="Enter to start · Shift+Enter for newline"
                     disabled={startMutation.isPending || !task.trim()}
                   >
                     <Send className="size-4" />

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -14,7 +14,7 @@ import {
 import { SessionEventSchema } from '@/api/schemas'
 import { Panel } from '@/components/panel'
 import { Button } from '@/components/ui/button'
-import { Textarea } from '@/components/form'
+import { ChatTextarea } from '@/components/chat-textarea'
 import { Skeleton } from '@/components/ui/skeleton'
 import { StatusBadge } from '@/components/status-badge'
 import { EmptyState } from '@/components/empty-state'
@@ -297,9 +297,14 @@ export default function SessionDetail() {
               if (draft.trim() && canSteer) steerMutation.mutate()
             }}
           >
-            <Textarea
+            <ChatTextarea
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
+              onSend={() => {
+                if (draft.trim() && canSteer && !steerMutation.isPending) {
+                  steerMutation.mutate()
+                }
+              }}
               placeholder={
                 canSteer
                   ? 'Send a message to steer the session…'
@@ -307,10 +312,10 @@ export default function SessionDetail() {
               }
               disabled={!canSteer}
               className="min-h-10 flex-1"
-              rows={1}
             />
             <Button
               type="submit"
+              title="Enter to send · Shift+Enter for newline"
               disabled={!draft.trim() || !canSteer || steerMutation.isPending}
             >
               <Send className="size-4" />

--- a/web/src/pages/Sessions.tsx
+++ b/web/src/pages/Sessions.tsx
@@ -16,7 +16,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Field, Label, Select, Textarea } from '@/components/form'
+import { Field, Label, Select } from '@/components/form'
+import { ChatTextarea } from '@/components/chat-textarea'
 import { StatusBadge } from '@/components/status-badge'
 import { EmptyState } from '@/components/empty-state'
 import { ResourceTable, type Column } from '@/components/resource-table'
@@ -197,10 +198,15 @@ export default function Sessions() {
                 htmlFor="start-message"
                 description="What should the agent do? (required)"
               >
-                <Textarea
+                <ChatTextarea
                   id="start-message"
                   value={message}
                   onChange={(e) => setMessage(e.target.value)}
+                  onSend={() => {
+                    if (agentId && message.trim() && !startMutation.isPending) {
+                      startMutation.mutate()
+                    }
+                  }}
                   placeholder="Review PR #412 and open a follow-up if anything needs fixing."
                   className="min-h-24"
                 />


### PR DESCRIPTION
Generalizes the steer-input behavior from #454 into one `ChatTextarea` and applies it to every place a message is "sent", so they're consistent — and removes the now-redundant inline implementation.

**`ChatTextarea`** — auto-grows with content (up to ~6 rows, then scrolls; shrinks back after send), **Enter (and ⌘/Ctrl+Enter) sends, Shift+Enter = newline**, Enter mid-IME-composition ignored (CJK/accents). Callers pass `onSend` and keep their own guards (non-empty / not in-flight); a disabled box never fires.

**Applied to all three chat-like inputs:**
- SessionDetail — steer (refactored from #454's inline version onto the shared component; `draftRef` + the inline `useLayoutEffect`/`useRef` are gone)
- AgentDetail — "Start session" (give the agent a task)
- Sessions — start dialog (first task)

**Deliberately left as plain `Textarea`** (multi-field forms where Enter must not submit): the two "System prompt" editors (Agents create, AgentDetail edit).

Builds on #454 (merged); merged main in and resolved SessionDetail to the shared-component version. web tsc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)