### PR TITLE
Polish Browser Sessions launch UI

### DIFF
--- a/sdks/python/opencomputer/browser.py
+++ b/sdks/python/opencomputer/browser.py
@@ -1,4 +1,4 @@
-"""Browser entity for OpenComputer's Kernel-backed browser API."""
+"""Browser entity for OpenComputer's browser API."""
 
 from __future__ import annotations
 
@@ -18,7 +18,7 @@ def _resolve_browser_api_url(api_url: str | None) -> str:
 
 @dataclass
 class Browser:
-    """Kernel-backed browser session managed through OpenComputer."""
+    """Browser session managed through OpenComputer."""
 
     id: str
     provider: str
@@ -60,7 +60,7 @@ class Browser:
         chrome_policy: dict[str, Any] | None = None,
         telemetry: dict[str, Any] | None = None,
     ) -> Browser:
-        """Create a browser session and return Kernel's direct connection URLs."""
+        """Create a browser session and return direct connection URLs."""
         url = _resolve_browser_api_url(api_url)
         key = api_key or os.environ.get("OPENCOMPUTER_API_KEY", "")
         client = httpx.AsyncClient(base_url=url, headers=_headers(key), timeout=30.0)

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -71,9 +71,14 @@ const NAV: NavGroup[] = [
         icon: KeySquare,
         preview: true,
       },
+    ],
+  },
+  {
+    label: 'Browser Sessions',
+    items: [
       {
         to: '/browsers',
-        label: 'Browsers',
+        label: 'Browser sessions',
         icon: Monitor,
         preview: true,
       },

--- a/web/src/pages/Browsers.tsx
+++ b/web/src/pages/Browsers.tsx
@@ -31,11 +31,6 @@ function browserMode(browser: BrowserSession) {
   return browser.headless ? 'Headless' : 'Headful'
 }
 
-function openExternal(url?: string | null) {
-  if (!url) return
-  window.open(url, '_blank', 'noopener,noreferrer')
-}
-
 export default function Browsers() {
   const queryClient = useQueryClient()
   const [status, setStatus] = useState('')
@@ -149,24 +144,36 @@ export default function Browsers() {
         <div className="flex h-8 items-center justify-end gap-1">
           {browser.live_view_url ? (
             <Button
+              asChild
               variant="ghost"
               size="icon"
               title="Open live view"
               aria-label="Open live view"
-              onClick={() => openExternal(browser.live_view_url)}
             >
-              <ExternalLink className="size-4" />
+              <a
+                href={browser.live_view_url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ExternalLink className="size-4" />
+              </a>
             </Button>
           ) : null}
           {browser.replay_view_url ? (
             <Button
+              asChild
               variant="ghost"
               size="icon"
               title="Open replay"
               aria-label="Open replay"
-              onClick={() => openExternal(browser.replay_view_url)}
             >
-              <Monitor className="size-4" />
+              <a
+                href={browser.replay_view_url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Monitor className="size-4" />
+              </a>
             </Button>
           ) : null}
           {canDeleteBrowser(browser) ? (
@@ -190,7 +197,7 @@ export default function Browsers() {
     <div>
       <PageHeader
         title="Browser sessions"
-        description="Kernel-backed browser sessions, live views, and recordings."
+        description="Browser sessions, live views, and recordings."
         api={{
           method: 'POST',
           path: '/v1/browsers',
@@ -253,7 +260,7 @@ export default function Browsers() {
         open={toDelete !== null}
         onOpenChange={(open) => !open && setToDelete(null)}
         title={`Delete browser ${toDelete?.id ?? ''}?`}
-        description="The browser session will be stopped. Existing replay links remain available when Kernel recorded the session."
+        description="The browser session will be stopped. Existing replay links remain available when recording was enabled."
         confirmLabel="Delete browser"
         destructive
         pending={deleteMutation.isPending}
@@ -333,7 +340,7 @@ function ProfilesTable({
     },
     {
       key: 'provider',
-      header: 'Kernel profile',
+      header: 'Provider profile',
       cell: (profile) => (
         <span className="text-muted-foreground font-mono text-xs">
           {profile.provider_profile_id}


### PR DESCRIPTION
## Summary
- move Browser Sessions into its own dashboard sidebar section
- make live view and replay actions real external links
- remove provider-specific Kernel wording from visible UI and Python SDK docstrings

## Validation
- npm run typecheck