### PR TITLE
Install gh (GitHub CLI) in the default sandbox rootfs

### DIFF
--- a/deploy/firecracker/rootfs/Dockerfile.default
+++ b/deploy/firecracker/rootfs/Dockerfile.default
@@ -79,6 +79,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libfuse3-3 \
     && rm -rf /var/lib/apt/lists/*
 
+# ── GitHub CLI (gh) ──────────────────────────────────────────────────────────
+# Agents do GitHub operations (PRs, issues, auth) via `gh`. It isn't in Ubuntu's
+# default repos, so add GitHub's apt source (keyring fetched with curl, installed
+# above). The signed-by keyring means no apt-key / gnupg is needed, and
+# dpkg --print-architecture keeps it correct on both amd64 and arm64 VMs.
+RUN install -d -m 755 /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install rclone from upstream so we track current backend support. The
 # version pinned into the rootfs is whatever was current at image build
 # time; sandboxes surface it via `mounts.list().rcloneVersion` for ops triage.


### PR DESCRIPTION
**Papercut:** agents hit "cannot connect to github" — `gh` isn't available in the sandbox.

`gh` isn't in Ubuntu's default apt repos, so this adds GitHub's apt source (signed-by keyring fetched with `curl`, which the main package block already installs) and installs `gh` in a dedicated `RUN`, matching how rclone/nodesource are added. arch-agnostic via `dpkg --print-architecture` (amd64/arm64). Lands in `Dockerfile.default` — the image all agent sandboxes run on.

Validated by inspection against GitHub's documented install; the rootfs build runs in CI (`scripts/build-rootfs.sh`), not locally. Follow-up (optional): same block for the `node`/`python`/`ubuntu` templates if agents use them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)