### PR TITLE
Agent Revisions: SDK revisions resource + oc deploy CLI (v1)

### DIFF
--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@opencomputer/sdk",
       "version": "0.9.4",
       "license": "MIT",
+      "dependencies": {
+        "smol-toml": "^1.7.0"
+      },
       "devDependencies": {
         "@types/node": "^25.3.0",
         "tsx": "^4.21.0",
@@ -1607,6 +1610,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/source-map-js": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "oc": "dist/cli.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -54,5 +57,8 @@
     "tsx": "^4.21.0",
     "typescript": "^5.4.0",
     "vitest": "^1.6.0"
+  },
+  "dependencies": {
+    "smol-toml": "^1.7.0"
   }
 }

--- a/sdks/typescript/src/agents/agents.ts
+++ b/sdks/typescript/src/agents/agents.ts
@@ -1,5 +1,6 @@
 import type { Http, Query } from "./http.js";
 import type { Agent, CredentialRef, Limits, Runtime } from "./types.js";
+import { AgentRevisions } from "./revisions.js";
 
 export interface CreateAgentParams {
   name: string;
@@ -54,7 +55,17 @@ export interface ConnectSlackParams {
 
 /** Reusable agents — the "what" a session runs. */
 export class Agents {
-  constructor(private readonly http: Http) {}
+  /** Per-agent revision lifecycle (deploy / list / get / activate); methods take the agent id. */
+  readonly revisions: AgentRevisions;
+
+  constructor(private readonly http: Http) {
+    this.revisions = new AgentRevisions(http);
+  }
+
+  /** Roll back (or promote) an agent to an earlier revision — sugar for `revisions.activate`. */
+  rollback(agentId: string, ref: string | number): Promise<{ activeRevisionId: string }> {
+    return this.revisions.activate(agentId, ref);
+  }
 
   create(params: CreateAgentParams): Promise<Agent> {
     // Idempotent by name server-side → safe to auto-retry transient failures.

--- a/sdks/typescript/src/agents/index.ts
+++ b/sdks/typescript/src/agents/index.ts
@@ -12,6 +12,11 @@ export type {
   CreateAgentParams, UpdateAgentParams, Page,
   SlackManifest, SlackConnection, ConnectSlackParams,
 } from "./agents.js";
+export { AgentRevisions } from "./revisions.js";
+export type {
+  SkillFileInput, DeployParams, DeployResult, RevisionRef, RevisionSummary,
+  Revision, SkillManifestEntry, DeployEvent, Activation,
+} from "./revisions.js";
 export { Repos, GitHub, GitHubApps, GitHubInstallations } from "./repos.js";
 export type {
   CreateRepoParams, UpdateRepoParams, Repo,

--- a/sdks/typescript/src/agents/node-deploy.test.ts
+++ b/sdks/typescript/src/agents/node-deploy.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readManifest, readPrompt, readSkills } from "./node-deploy.js";
+
+let dir: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "oc-agentdir-"));
+  writeFileSync(join(dir, "agent.toml"), [
+    'name  = "issue-fixer"',
+    'model = "anthropic/claude-sonnet-4-6"',
+    "",
+    "[runtime]",
+    'family = "claude"',
+    'type   = "default"',
+    "",
+    "[limits]",
+    "turns = 24",
+  ].join("\n"));
+  writeFileSync(join(dir, "prompt.md"), "You fix issues.\n");
+  mkdirSync(join(dir, "skills/triage"), { recursive: true });
+  writeFileSync(join(dir, "skills/triage/SKILL.md"), "# Triage\n");
+  writeFileSync(join(dir, "skills/triage/run.sh"), "#!/bin/sh\necho hi\n");
+  chmodSync(join(dir, "skills/triage/run.sh"), 0o755);
+});
+
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("deployAgentDir directory reading", () => {
+  it("parses agent.toml (smol-toml): name/model/runtime/type/limits", () => {
+    const m = readManifest(dir);
+    expect(m.name).toBe("issue-fixer");
+    expect(m.model).toBe("anthropic/claude-sonnet-4-6");
+    expect(m.runtime).toBe("claude");
+    expect(m.runtimeType).toBe("default");
+    expect(m.limits).toEqual({ turns: 24 });
+  });
+
+  it("requires name + model", () => {
+    const bad = mkdtempSync(join(tmpdir(), "oc-bad-"));
+    writeFileSync(join(bad, "agent.toml"), 'model = "anthropic/x"');
+    expect(() => readManifest(bad)).toThrow(/name/);
+    rmSync(bad, { recursive: true, force: true });
+  });
+
+  it("reads prompt.md", () => {
+    expect(readPrompt(dir)).toBe("You fix issues.\n");
+  });
+
+  it("walks skills/ with skill-root-relative paths + exec → 0755", () => {
+    const skills = readSkills(dir).sort((a, b) => (a.path < b.path ? -1 : 1));
+    expect(skills.map((s) => s.path)).toEqual(["triage/SKILL.md", "triage/run.sh"]);
+    const run = skills.find((s) => s.path === "triage/run.sh")!;
+    const md = skills.find((s) => s.path === "triage/SKILL.md")!;
+    expect(run.mode).toBe(0o755);
+    expect(md.mode).toBe(0o644);
+    expect(md.content).toBe("# Triage\n");
+  });
+
+  it("absent skills/ → empty array", () => {
+    const noskills = mkdtempSync(join(tmpdir(), "oc-noskills-"));
+    expect(readSkills(noskills)).toEqual([]);
+    rmSync(noskills, { recursive: true, force: true });
+  });
+});

--- a/sdks/typescript/src/agents/node-deploy.ts
+++ b/sdks/typescript/src/agents/node-deploy.ts
@@ -1,0 +1,88 @@
+// Node-only: bundle an agent DIRECTORY into a deploy (design 009 §4/§13). "An agent is a
+// directory": agent.toml (manifest) + prompt.md + skills/. Reads the tree, ensures the agent
+// exists (idempotent by name), and deploys a revision. NOT browser-safe (fs) — exported from
+// `@opencomputer/sdk/node`, never the browser entry.
+
+import { readFileSync, existsSync, statSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+import { parse as parseToml } from "smol-toml";
+import type { OpenComputer } from "./client.js";
+import type { Runtime } from "./types.js";
+import type { DeployResult, SkillFileInput } from "./revisions.js";
+
+export interface AgentManifest {
+  name: string;
+  model: string;
+  runtime: Runtime;        // [runtime] family (claude | codex)
+  runtimeType: "default" | "custom";
+  limits?: Record<string, unknown>;
+}
+
+/** Parse agent.toml (the manifest). Requires `name` + `model`; defaults runtime to claude/default. */
+export function readManifest(dir: string): AgentManifest {
+  const path = join(dir, "agent.toml");
+  if (!existsSync(path)) throw new Error(`no agent.toml in ${dir} — an agent directory needs a manifest`);
+  const t = parseToml(readFileSync(path, "utf8")) as Record<string, any>;
+  const name = typeof t.name === "string" ? t.name : undefined;
+  const model = typeof t.model === "string" ? t.model : undefined;
+  if (!name) throw new Error("agent.toml: `name` is required");
+  if (!model) throw new Error("agent.toml: `model` is required");
+  const runtime = (t.runtime?.family ?? "claude") as Runtime;
+  const runtimeType = (t.runtime?.type ?? "default") as "default" | "custom";
+  return { name, model, runtime, runtimeType, limits: t.limits as Record<string, unknown> | undefined };
+}
+
+/** Read prompt.md (the system prompt). Required. */
+export function readPrompt(dir: string): string {
+  const path = join(dir, "prompt.md");
+  if (!existsSync(path)) throw new Error(`no prompt.md in ${dir}`);
+  return readFileSync(path, "utf8");
+}
+
+/** Walk skills/ → SkillFileInput[] with SKILL-ROOT-relative paths (the leading `skills/` stripped),
+ *  mode 0755 for executable files else 0644. Absent skills/ ⇒ []. */
+export function readSkills(dir: string): SkillFileInput[] {
+  const root = join(dir, "skills");
+  if (!existsSync(root)) return [];
+  const out: SkillFileInput[] = [];
+  const walk = (d: string) => {
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      const full = join(d, entry.name);
+      if (entry.isDirectory()) { walk(full); continue; }
+      if (!entry.isFile()) continue; // skip symlinks/sockets — not transported
+      const st = statSync(full);
+      out.push({
+        path: relative(root, full).split("\\").join("/"),
+        content: readFileSync(full, "utf8"),
+        mode: st.mode & 0o111 ? 0o755 : 0o644,
+      });
+    }
+  };
+  walk(root);
+  return out;
+}
+
+export interface DeployAgentDirOptions { activate?: boolean; gitSha?: string; }
+export interface DeployAgentDirResult { agentId: string; agentName: string; manifest: AgentManifest; deploy: DeployResult; }
+
+/**
+ * Deploy an agent directory: ensure the agent exists (create-or-get, idempotent by name), then
+ * deploy a revision carrying prompt.md + skills/. Note: a brand-new agent's create makes
+ * revision #1 (prompt only); the subsequent deploy adds skills as the next revision (a no-skills
+ * deploy dedups to a no-op). Returns the agent + the deploy result.
+ */
+export async function deployAgentDir(oc: OpenComputer, dir: string, opts: DeployAgentDirOptions = {}): Promise<DeployAgentDirResult> {
+  const manifest = readManifest(dir);
+  const prompt = readPrompt(dir);
+  const skills = readSkills(dir);
+  const agent = await oc.agents.create({ name: manifest.name, prompt, model: manifest.model, runtime: manifest.runtime });
+  const deploy = await oc.agents.revisions.create(agent.id, {
+    prompt,
+    model: manifest.model,
+    skills,
+    runtime: { type: manifest.runtimeType },
+    activate: opts.activate ?? true,
+    source: { via: "cli", path: dir, gitSha: opts.gitSha },
+  });
+  return { agentId: agent.id, agentName: agent.name, manifest, deploy };
+}

--- a/sdks/typescript/src/agents/revisions.ts
+++ b/sdks/typescript/src/agents/revisions.ts
@@ -1,0 +1,88 @@
+import type { Http } from "./http.js";
+
+// Agent Revisions (design 009) — the deploy lifecycle of an agent's behavior. A revision is an
+// immutable, content-addressed payload {prompt, model, skills, …}; the active revision is the
+// production pointer; rollback re-points it. Browser-safe REST (the directory→deploy bundler is
+// Node-only — see `@opencomputer/sdk/node`'s `deployAgentDir`).
+
+/** A skill file in a deploy payload. `mode` is an octal int (0o644 default | 0o755). */
+export interface SkillFileInput { path: string; content: string; mode?: number; }
+
+export interface DeployParams {
+  /** The system prompt (required by the deploy API; the directory bundler fills it from prompt.md). */
+  prompt?: string;
+  /** `provider/model` id; omit for the runtime default. */
+  model?: string;
+  /** The skill file tree (skill-root-relative paths). Omit for no skills. v1: claude runtime only. */
+  skills?: SkillFileInput[];
+  /** Reserved — rejected in v1 (`not_supported_v1`). */
+  mcp?: Record<string, unknown> | null;
+  /** v1: only `{ type: "default" }`; `custom` is rejected (v2). */
+  runtime?: { type: "default" | "custom" };
+  /** Auto-activate (move the production pointer). Default true. */
+  activate?: boolean;
+  /** Provenance only (not part of the behavior digest). */
+  source?: { via?: string; repoId?: string; path?: string; gitSha?: string };
+}
+
+export interface RevisionRef { id: string; number: number; digest: string; active: boolean; }
+export interface DeployResult {
+  deployId: string;
+  state: "ready";
+  result: "created" | "deduped";
+  revision: RevisionRef;
+}
+
+export interface RevisionSummary { id: string; number: number; digest: string; createdAt: string; active: boolean; }
+export interface SkillManifestEntry { path: string; mode: number; size: number; sha256: string; }
+export interface Revision {
+  id: string;
+  number: number;
+  digest: string;
+  prompt: string;
+  model: string | null;
+  skillBundleDigest: string | null;
+  runtimeRef: { mode: "floating" | "pinned"; buildId?: string };
+  createdAt: string;
+  files: SkillManifestEntry[];
+}
+export interface DeployEvent {
+  id: string;
+  state: string;
+  result: string | null;
+  source: Record<string, unknown> | null;
+  actor: string | null;
+  revisionId: string | null;
+  createdAt: string;
+}
+export interface Activation { from: string | null; to: string; actor: string | null; reason: string; createdAt: string; }
+
+/** Per-agent revision lifecycle. Reached via `oc.agents.revisions`; methods take the agent id. */
+export class AgentRevisions {
+  constructor(private readonly http: Http) {}
+
+  /** Deploy = create (and, by default, activate) a revision. Idempotent by behavior digest. */
+  create(agentId: string, params: DeployParams): Promise<DeployResult> {
+    return this.http.request("POST", `/agents/${agentId}/revisions`, { body: params, idempotent: true });
+  }
+  /** Revision history (newest first). */
+  list(agentId: string): Promise<{ data: RevisionSummary[] }> {
+    return this.http.request("GET", `/agents/${agentId}/revisions`);
+  }
+  /** A single revision (by `rev_…` id or number) + its skill manifest. */
+  get(agentId: string, ref: string | number): Promise<Revision> {
+    return this.http.request("GET", `/agents/${agentId}/revisions/${ref}`);
+  }
+  /** Promote / roll back to a revision (by id or number) — moves the production pointer. */
+  activate(agentId: string, ref: string | number): Promise<{ activeRevisionId: string }> {
+    return this.http.request("POST", `/agents/${agentId}/revisions/${ref}/activate`, { body: {}, idempotent: true });
+  }
+  /** Deploy timeline (provenance + state). */
+  deploys(agentId: string): Promise<{ data: DeployEvent[] }> {
+    return this.http.request("GET", `/agents/${agentId}/deploys`);
+  }
+  /** Activation history (pointer audit). */
+  activations(agentId: string): Promise<{ data: Activation[] }> {
+    return this.http.request("GET", `/agents/${agentId}/activations`);
+  }
+}

--- a/sdks/typescript/src/agents/types.ts
+++ b/sdks/typescript/src/agents/types.ts
@@ -35,6 +35,9 @@ export interface Agent {
   model: string;
   runtime: Runtime;
   revision?: number;
+  /** The active revision pointer (design 009). prompt/model are sourced from it. */
+  activeRevisionId?: string | null;
+  activeRevision?: { id: string; number: number; digest: string } | null;
   credentialId?: CredentialRef | null;
   limits?: Limits;
   createdAt?: string;

--- a/sdks/typescript/src/cli.ts
+++ b/sdks/typescript/src/cli.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// `oc` — a thin CLI over the Agent Revisions deploy API (design 009 §10/§13). Everything it does
+// is available via the SDK; this is sugar for the "an agent is a directory" workflow.
+//
+//   oc deploy [dir=.] [--no-activate]   bundle agent.toml + prompt.md + skills/ → deploy a revision
+//   oc rollback <agent> <ref>           activate an earlier revision (id or number)
+//   oc revisions <agent> [get <ref>]    list revisions (or show one)
+//
+// Auth: OPENCOMPUTER_API_KEY (required). Base URL: OPENCOMPUTER_BASE_URL (default /v3 prod).
+
+import { OpenComputer } from "./agents/client.js";
+import { deployAgentDir } from "./agents/node-deploy.js";
+
+function client(): OpenComputer {
+  const apiKey = process.env.OPENCOMPUTER_API_KEY;
+  if (!apiKey) fail("OPENCOMPUTER_API_KEY is not set");
+  return new OpenComputer({ apiKey: apiKey!, baseUrl: process.env.OPENCOMPUTER_BASE_URL });
+}
+
+function fail(msg: string): never {
+  console.error(`oc: ${msg}`);
+  process.exit(1);
+}
+
+async function main() {
+  const [cmd, ...rest] = process.argv.slice(2);
+  switch (cmd) {
+    case "deploy": {
+      const args = rest.filter((a) => !a.startsWith("-"));
+      const dir = args[0] ?? ".";
+      const activate = !rest.includes("--no-activate");
+      const r = await deployAgentDir(client(), dir, { activate });
+      const rev = r.deploy.revision;
+      console.log(`deployed ${r.agentName} (${r.agentId}) → rev #${rev.number} ${rev.digest.slice(0, 19)} [${r.deploy.result}]${rev.active ? " active" : " (not activated)"}`);
+      break;
+    }
+    case "rollback": {
+      const [agent, ref] = rest;
+      if (!agent || !ref) fail("usage: oc rollback <agent> <ref>");
+      const r = await client().agents.rollback(agent, /^\d+$/.test(ref) ? Number(ref) : ref);
+      console.log(`active revision → ${r.activeRevisionId}`);
+      break;
+    }
+    case "revisions": {
+      const [agent, sub, ref] = rest;
+      if (!agent) fail("usage: oc revisions <agent> [get <ref>]");
+      const oc = client();
+      if (sub === "get") {
+        if (!ref) fail("usage: oc revisions <agent> get <ref>");
+        const rev = await oc.agents.revisions.get(agent, /^\d+$/.test(ref) ? Number(ref) : ref);
+        console.log(JSON.stringify(rev, null, 2));
+      } else {
+        const { data } = await oc.agents.revisions.list(agent);
+        for (const r of data) console.log(`#${r.number}\t${r.id}\t${r.digest.slice(0, 19)}\t${r.active ? "active" : ""}`);
+      }
+      break;
+    }
+    default:
+      console.log("usage: oc <deploy|rollback|revisions> …");
+      process.exit(cmd ? 1 : 0);
+  }
+}
+
+main().catch((e) => fail(e instanceof Error ? e.message : String(e)));

--- a/sdks/typescript/src/node.ts
+++ b/sdks/typescript/src/node.ts
@@ -1,3 +1,8 @@
 export * from "./index.js";
 export { Image, type ImageManifest, type ImageStep } from "./image.js";
 export { Snapshots, type SnapshotInfo, type CreateSnapshotOpts } from "./snapshot.js";
+// Agent Revisions: directory → deploy (Node-only; reads agent.toml + prompt.md + skills/).
+export {
+  deployAgentDir, readManifest, readPrompt, readSkills,
+  type AgentManifest, type DeployAgentDirOptions, type DeployAgentDirResult,
+} from "./agents/node-deploy.js";


### PR DESCRIPTION
Adds the **Agent Revisions** deploy surface to `@opencomputer/sdk` (design 009, v1 = skills-only). Pairs with the sessions-api `/v3` revisions API (separate PR).

## What
- **`oc.agents.revisions`** (browser-safe REST): `create` (deploy), `list`, `get`, `activate`, `deploys`, `activations`. `oc.agents.rollback(agentId, ref)` is sugar for `activate`. `Agent` gains `activeRevisionId` / `activeRevision`.
- **`deployAgentDir(oc, dir)`** (Node-only, `@opencomputer/sdk/node`) — "an agent is a directory": parses `agent.toml` (smol-toml) + `prompt.md` + `skills/` (skill-root-relative paths, exec→0755), create-or-gets the agent, deploys a revision.
- **`oc` CLI** (`bin`): `oc deploy [dir] [--no-activate]`, `oc rollback <agent> <ref>`, `oc revisions <agent> [get <ref>]`. Auth via `OPENCOMPUTER_API_KEY`.
- Adds **smol-toml** (first runtime dep; used only on the Node deploy path, tree-shaken from the browser entry). SDK **0.9.4 → 0.9.5** (publish fires on version change).

## Verify
- `tsc` build green; `vitest` 25/25 (incl. new directory-reading tests: TOML parse, required name/model, skills walk + modes, absent-skills empty).

## Notes
- A brand-new agent's `create` makes revision #1 (prompt only); the subsequent `deploy` adds skills as the next revision (a no-skills deploy dedups to a no-op).
- Gated by the server rollout: skills only take effect once the materialization runtime is the floating latest (see the sessions-api PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)