### PR TITLE
Dashboard: Agent Revisions panel (history, active pointer, rollback)

### DIFF
--- a/docs/agent-sessions/agents.mdx
+++ b/docs/agent-sessions/agents.mdx
@@ -4,7 +4,7 @@ title: "Agents"
 description: "Reusable agent configuration"
 ---
 
-An **agent** is reusable configuration: `name`, `prompt`, `model`, and [`runtime`](/agent-sessions/runtimes). Every [session](/agent-sessions/sessions) runs on an agent, so create one first, then start as many sessions on it as you like.
+An **agent** is reusable configuration: `name`, `prompt`, `model`, [`runtime`](/agent-sessions/runtimes), and optional [**skills**](/agent-sessions/revisions). Every [session](/agent-sessions/sessions) runs on an agent, so create one first, then start as many sessions on it as you like. The behavior (`prompt`/`model`/`skills`) is versioned as [**revisions**](/agent-sessions/revisions): every edit deploys a new one, and you can roll back.
 
 <Note>You can create and edit agents in the [dashboard](https://app.opencomputer.dev) too — the create dialog also lets you pick or add a [credential](/agent-sessions/credentials) inline.</Note>
 
@@ -46,7 +46,7 @@ Pass your model `key` inline and it's stored as a [credential](/agent-sessions/c
 
 ## Session-pinned config
 
-When a session is created it **freezes** the agent's `prompt`, `model`, `runtime`, and `revision` (a number that bumps on every edit) into the session — and pins the resolved credential too. Editing the named agent afterwards never changes a running or resumed session — its behavior is pinned for its whole life. Update an agent freely: existing sessions keep what they started with, new sessions pick up the change. (Rotating a credential's **key value** is the exception — that flows to running sessions, so a compromised key can be replaced; see [credentials](/agent-sessions/credentials).)
+When a session is created it **freezes** the agent's **active [revision](/agent-sessions/revisions)** — `prompt`, `model`, `runtime`, and `skills` — into the session, and pins the resolved credential too. Editing the named agent afterwards never changes a running or resumed session — its behavior is pinned for its whole life. Update an agent freely: existing sessions keep what they started with, new sessions pick up the change. (Rotating a credential's **key value** is the exception — that flows to running sessions, so a compromised key can be replaced; see [credentials](/agent-sessions/credentials).)
 
 ## Model
 

--- a/docs/agent-sessions/overview.mdx
+++ b/docs/agent-sessions/overview.mdx
@@ -37,7 +37,7 @@ Create an agent, start a session, stream its event log, steer it with messages, 
 
 <Steps>
   <Step title="Define an agent">
-    Create a reusable `{ name, model, prompt, runtime }` from your backend — `runtime: "claude"` (Anthropic models) or `"codex"` (OpenAI models). Run **Managed** (`credential: "managed"`, billed to your OpenComputer credits — no key) or pass your own model `key` inline / reference a saved [credential](/agent-sessions/credentials). ([Agents](/agent-sessions/agents))
+    Create a reusable `{ name, model, prompt, runtime }` from your backend — `runtime: "claude"` (Anthropic models) or `"codex"` (OpenAI models). Run **Managed** (`credential: "managed"`, billed to your OpenComputer credits — no key) or pass your own model `key` inline / reference a saved [credential](/agent-sessions/credentials). Every edit is versioned as a [revision](/agent-sessions/revisions), and you can attach [skills](/agent-sessions/revisions#skills). ([Agents](/agent-sessions/agents))
   </Step>
   <Step title="Start a session">
     Start a session with `{ agent, input }`. The agent starts immediately and returns a browser-safe `client_token`.

--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -315,6 +315,12 @@ After checkout, the agent works with ordinary files. It can inspect, edit, test,
 make local commits. Anything needing GitHub credentials runs outside the agent sandbox, so
 the agent never runs authenticated `git`/`gh` and never sees a token.
 
+<Warning>
+Opening PRs from the agent (`github_publish_pull_request`) is **temporarily unavailable**
+while the runtime is being updated — checkout (read) works today; the agent-driven PR-open
+described below will be re-enabled in an upcoming runtime release.
+</Warning>
+
 To open a pull request, the agent calls the
 [`github_publish_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool —
 it is **not** an SDK method; the agent invokes it from inside the sandbox. It takes the

--- a/docs/agent-sessions/revisions.mdx
+++ b/docs/agent-sessions/revisions.mdx
@@ -85,7 +85,7 @@ GET  /v3/agents/agt_123/activations      # pointer-move audit log
 
 ## Skills
 
-A **skill** is a folder containing a `SKILL.md` (with YAML frontmatter — `name` + `description` — followed by instructions Claude Code loads at turn start) plus any helper files it references. An agent can have several. Skills are materialized into the runtime when a session runs, so the agent can use them.
+A **skill** is a folder containing a `SKILL.md` (with YAML frontmatter — `name` + `description` — followed by instructions the agent loads at the start of a turn) plus any helper files it references. An agent can have several. Skills are materialized into the runtime when a session runs, so the agent can use them.
 
 Manage them as a sub-resource of the agent. **List** the active revision's skills:
 

--- a/docs/agent-sessions/revisions.mdx
+++ b/docs/agent-sessions/revisions.mdx
@@ -1,0 +1,140 @@
+---
+mode: "wide"
+title: "Revisions & skills"
+description: "Versioned agent behavior — deploy, roll back, and manage skills"
+---
+
+An agent's behavior — its `prompt`, `model`, and **skills** — is versioned as **revisions**. Every change is a **deploy** that appends a new immutable revision; the agent's **active revision** is what new [sessions](/agent-sessions/sessions) use. Rolling back is just re-activating an earlier revision.
+
+<Note>Revisions are **linear**: each deploy is a new revision (like a deployment on Vercel/Fly), and the number only goes up. Re-activating an older revision (rollback) moves the **active pointer** back, but never deletes or rewrites history. In-flight sessions keep the revision they started on; only new sessions pick up the change.</Note>
+
+## What's on a revision
+
+| Field | |
+|---|---|
+| `number` | Monotonic per agent (`1, 2, 3, …`). |
+| `prompt` / `model` | The behavior at deploy time. |
+| `skill_bundle_digest` | Points at the skill files (a content-addressed bundle); `null` when the agent has no skills. |
+| `digest` | A content hash of the behavior — two revisions with the same behavior share a digest (the bundle is also deduplicated in storage), but each deploy is still its own revision. |
+
+The agent row keeps only **identity + bindings** (`name`, `runtime`, `credential`, `limits`) plus a pointer to the active revision. `prompt`/`model` are served from that revision.
+
+## Deploy a revision
+
+Editing an agent's `prompt` or `model` deploys a revision automatically (the response shape of [`PATCH /agents/:id`](/agent-sessions/agents) is unchanged):
+
+```http REST API
+PATCH https://api.opencomputer.dev/v3/agents/agt_123
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+Content-Type: application/json
+
+{ "prompt": "You are a meticulous reviewer. Run the tests." }
+```
+
+For a full behavior payload (prompt + model + skills in one go), deploy directly. This is the **complete** behavior — omitted fields are not inherited (`prompt` is required; omitted `skills` means *no skills*).
+
+```http REST API
+POST https://api.opencomputer.dev/v3/agents/agt_123/revisions
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+Content-Type: application/json
+
+{
+  "prompt": "You triage pull requests.",
+  "model": "anthropic/claude-opus-4-8",
+  "skills": [
+    { "path": "triage/SKILL.md", "content": "---\nname: triage\ndescription: Triage a PR\n---\nSummarize the diff…" }
+  ],
+  "activate": true
+}
+```
+
+```json Response (201)
+{
+  "deploy_id": "dep_…",
+  "state": "ready",
+  "result": "created",
+  "revision": { "id": "rev_…", "number": 5, "digest": "sha256:…", "active": true }
+}
+```
+
+`activate` defaults to `true` (deploy straight to production). Pass `activate: false` to stage a revision without changing what new sessions use.
+
+## Roll back / promote
+
+Re-activate any earlier revision by **number** or `rev_…` id — this moves the active pointer. Running sessions are unaffected; new sessions use it.
+
+```http REST API
+POST https://api.opencomputer.dev/v3/agents/agt_123/revisions/3/activate
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+```
+
+```json Response (200)
+{ "active_revision_id": "rev_…" }
+```
+
+## Inspect history
+
+```http REST API
+GET  /v3/agents/agt_123/revisions        # history (newest first; `active` flags the current one)
+GET  /v3/agents/agt_123/revisions/5      # one revision + its skill file manifest
+GET  /v3/agents/agt_123/deploys          # deploy timeline (provenance + state)
+GET  /v3/agents/agt_123/activations      # pointer-move audit log
+```
+
+`GET /agents/:id` also includes an `active_revision` summary (`id`, `number`, `digest`).
+
+## Skills
+
+A **skill** is a folder containing a `SKILL.md` (with YAML frontmatter — `name` + `description` — followed by instructions Claude Code loads at turn start) plus any helper files it references. An agent can have several. Skills are materialized into the runtime when a session runs, so the agent can use them.
+
+Manage them as a sub-resource of the agent. **List** the active revision's skills:
+
+```http REST API
+GET https://api.opencomputer.dev/v3/agents/agt_123/skills
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+```
+
+```json Response (200)
+{
+  "revision": { "id": "rev_…", "number": 5, "digest": "sha256:…" },
+  "skill_bundle_digest": "sha256:…",
+  "skills": [
+    { "name": "triage", "description": "Triage a PR", "files": [{ "path": "triage/SKILL.md", "mode": 420, "size": 812 }] }
+  ]
+}
+```
+
+**Upload** a `.zip` of your skills — the API unzips, validates, and deploys a new revision with those skills (keeping the agent's current prompt + model). The zip body is sent raw:
+
+```http REST API
+PUT https://api.opencomputer.dev/v3/agents/agt_123/skills
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+Content-Type: application/zip
+
+<binary .zip>
+```
+
+The zip should contain **one folder per skill**, each with a `SKILL.md`:
+
+```
+triage/
+  SKILL.md
+  checklist.md
+pr-review/
+  SKILL.md
+```
+
+A top-level `skills/` wrapper is fine too (it's stripped). **Remove** all skills (deploys a revision with none):
+
+```http REST API
+DELETE https://api.opencomputer.dev/v3/agents/agt_123/skills
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+```
+
+Uploading and removing are both **deploys** — each is a new revision (not a rollback). Limits: up to 64 files, 256 KiB total, UTF-8 text only, modes `0644`/`0755`.
+
+<Note>**v1 supports skills on the `claude` runtime only.** Skills on a `codex` agent are rejected; custom runtimes and MCP servers are not yet supported.</Note>
+
+## Dashboard
+
+Everything here is in the [dashboard](https://app.opencomputer.dev) on the agent page: a **Revisions** panel (history, the active revision, one-click rollback) and a **Skills** panel (the current skills with descriptions, plus upload-a-`.zip` and remove).

--- a/docs/agent-sessions/runtime-tools.mdx
+++ b/docs/agent-sessions/runtime-tools.mdx
@@ -32,6 +32,12 @@ The agent's final `say` is the session result. `ask` ends the turn with `yield_r
 
 ## GitHub tools
 
+<Warning>
+`github_publish_pull_request` is **temporarily unavailable** — the current agent runtime
+does not expose it yet, while the runtime is being updated. The description below is the
+intended behavior; the tool will be re-enabled in an upcoming runtime release.
+</Warning>
+
 | Tool | What it does |
 | --- | --- |
 | `github_publish_pull_request` | Open a pull request from a checked-out [Repo](/agent-sessions/repos) source. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -73,6 +73,7 @@
           "agent-sessions/overview",
           "agent-sessions/quickstart",
           "agent-sessions/agents",
+          "agent-sessions/revisions",
           "agent-sessions/sessions",
           "agent-sessions/credentials",
           "agent-sessions/repos",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,6 +17,7 @@
         "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "jszip": "^3.10.1",
         "lucide-react": "^1.21.0",
         "posthog-js": "^1.395.0",
         "radix-ui": "^1.6.0",
@@ -47,6 +48,9 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.0",
         "vite": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4570,6 +4574,12 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -6488,6 +6498,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6519,7 +6535,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -7259,6 +7274,18 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7311,6 +7338,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -8194,6 +8230,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8542,6 +8584,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -8893,6 +8941,27 @@
         }
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/recast": {
       "version": "0.23.12",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.12.tgz",
@@ -9133,6 +9202,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -9292,6 +9367,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -9541,6 +9622,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-width": {
@@ -10229,7 +10319,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-name": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,7 +17,6 @@
         "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "jszip": "^3.10.1",
         "lucide-react": "^1.21.0",
         "posthog-js": "^1.395.0",
         "radix-ui": "^1.6.0",
@@ -4574,12 +4573,6 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
-    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -6498,12 +6491,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "license": "MIT"
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6535,6 +6522,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -7274,18 +7262,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/jszip": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "dependencies": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "^1.0.5"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7338,15 +7314,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -8230,12 +8197,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8584,12 +8545,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -8941,27 +8896,6 @@
         }
       }
     },
-    "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
     "node_modules/recast": {
       "version": "0.23.12",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.12.tgz",
@@ -9202,12 +9136,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -9367,12 +9295,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -9622,15 +9544,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-width": {
@@ -10319,6 +10232,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-name": {

--- a/web/package.json
+++ b/web/package.json
@@ -26,7 +26,6 @@
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "jszip": "^3.10.1",
     "lucide-react": "^1.21.0",
     "posthog-js": "^1.395.0",
     "radix-ui": "^1.6.0",

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "jszip": "^3.10.1",
     "lucide-react": "^1.21.0",
     "posthog-js": "^1.395.0",
     "radix-ui": "^1.6.0",

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -29,7 +29,7 @@ export type {
   BrowserProfile,
   Agent,
   AgentRevision,
-  AgentRevisionDetail,
+  AgentSkills,
   SkillManifestEntry,
   AgentDeploy,
   Session,
@@ -451,26 +451,23 @@ export const activateRevision = (agentId: string, rev: string | number) =>
     S.ActivateRevisionSchema,
   )
 
-// A single revision + its skill manifest (file list, no bytes).
-export const getAgentRevision = (agentId: string, rev: string | number) =>
-  apiFetch(`/v3/agents/${agentId}/revisions/${rev}`, {}, S.AgentRevisionDetailSchema)
+// Skills sub-resource (design 009 §8) — the API owns zip → validate → bundle, so the
+// dashboard is a thin consumer: read the file list, upload a .zip, or clear.
+export const getAgentSkills = (agentId: string) =>
+  apiFetch(`/v3/agents/${agentId}/skills`, {}, S.AgentSkillsSchema)
 
-// Deploy a revision (create + activate by default). The body is the FULL behavior
-// payload — prompt is required, so callers pass the agent's current prompt/model when
-// only the skills change. `skills` is the complete set (a deploy replaces, not merges).
-export const deployAgentRevision = (
-  agentId: string,
-  body: {
-    prompt: string
-    model?: string
-    skills?: { path: string; content: string; mode?: number }[]
-  },
-) =>
+// Upload a .zip of skills → the API unzips + deploys a new revision (active behavior with
+// skills replaced). The raw file is the body; no client-side parsing.
+export const putAgentSkills = (agentId: string, zip: File | Blob) =>
   apiFetch(
-    `/v3/agents/${agentId}/revisions`,
-    { method: 'POST', body: JSON.stringify(body) },
+    `/v3/agents/${agentId}/skills`,
+    { method: 'PUT', body: zip, headers: { 'Content-Type': 'application/zip' } },
     S.DeployResultSchema,
   )
+
+// Remove all skills → deploys a revision from the active behavior with no skills.
+export const deleteAgentSkills = (agentId: string) =>
+  apiFetch(`/v3/agents/${agentId}/skills`, { method: 'DELETE' }, S.DeployResultSchema)
 
 // Slack — an agent's BYO Slack app (1 app ⟷ 1 agent ⟷ 1 workspace). Two-step
 // connect: START (manifest) returns the app manifest + guided steps; COMPLETE

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -30,7 +30,7 @@ export type {
   Agent,
   AgentRevision,
   AgentSkills,
-  SkillManifestEntry,
+  SkillItem,
   AgentDeploy,
   Session,
   SessionEvent,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -29,6 +29,8 @@ export type {
   BrowserProfile,
   Agent,
   AgentRevision,
+  AgentRevisionDetail,
+  SkillManifestEntry,
   AgentDeploy,
   Session,
   SessionEvent,
@@ -447,6 +449,27 @@ export const activateRevision = (agentId: string, rev: string | number) =>
     `/v3/agents/${agentId}/revisions/${rev}/activate`,
     { method: 'POST', body: JSON.stringify({}) },
     S.ActivateRevisionSchema,
+  )
+
+// A single revision + its skill manifest (file list, no bytes).
+export const getAgentRevision = (agentId: string, rev: string | number) =>
+  apiFetch(`/v3/agents/${agentId}/revisions/${rev}`, {}, S.AgentRevisionDetailSchema)
+
+// Deploy a revision (create + activate by default). The body is the FULL behavior
+// payload — prompt is required, so callers pass the agent's current prompt/model when
+// only the skills change. `skills` is the complete set (a deploy replaces, not merges).
+export const deployAgentRevision = (
+  agentId: string,
+  body: {
+    prompt: string
+    model?: string
+    skills?: { path: string; content: string; mode?: number }[]
+  },
+) =>
+  apiFetch(
+    `/v3/agents/${agentId}/revisions`,
+    { method: 'POST', body: JSON.stringify(body) },
+    S.DeployResultSchema,
   )
 
 // Slack — an agent's BYO Slack app (1 app ⟷ 1 agent ⟷ 1 workspace). Two-step

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -28,6 +28,8 @@ export type {
   BrowserSession,
   BrowserProfile,
   Agent,
+  AgentRevision,
+  AgentDeploy,
   Session,
   SessionEvent,
   Turn,
@@ -425,6 +427,26 @@ export const updateAgent = (
     `/v3/agents/${id}`,
     { method: 'PATCH', body: JSON.stringify(body) },
     S.AgentSchema,
+  )
+
+// Agent Revisions (design 009) — the deploy history of an agent's behavior. List
+// endpoints wrap rows in { data: [...] }; callers want the array. Rollback = activate
+// an earlier revision (by id or number); it moves the production pointer.
+export const getAgentRevisions = (agentId: string) =>
+  apiFetch(`/v3/agents/${agentId}/revisions`, {}, S.AgentRevisionListSchema).then(
+    (r) => r.data,
+  )
+
+export const getAgentDeploys = (agentId: string) =>
+  apiFetch(`/v3/agents/${agentId}/deploys`, {}, S.AgentDeployListSchema).then(
+    (r) => r.data,
+  )
+
+export const activateRevision = (agentId: string, rev: string | number) =>
+  apiFetch(
+    `/v3/agents/${agentId}/revisions/${rev}/activate`,
+    { method: 'POST', body: JSON.stringify({}) },
+    S.ActivateRevisionSchema,
   )
 
 // Slack — an agent's BYO Slack app (1 app ⟷ 1 agent ⟷ 1 workspace). Two-step

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -381,15 +381,12 @@ export const SkillManifestEntrySchema = z.object({
   size: z.number(),
   sha256: z.string(),
 })
-// A single revision with its skill manifest (GET …/revisions/:rev).
-export const AgentRevisionDetailSchema = z.object({
-  id: z.string(),
-  number: z.number(),
-  digest: z.string(),
-  prompt: z.string().nullish(),
-  model: z.string().nullish(),
+// The agent's skills (GET …/skills) — the active revision's skill files.
+export const AgentSkillsSchema = z.object({
+  revision: z
+    .object({ id: z.string(), number: z.number(), digest: z.string() })
+    .nullish(),
   skill_bundle_digest: z.string().nullish(),
-  created_at: z.string(),
   files: z.array(SkillManifestEntrySchema).default([]),
 })
 // The deploy-shaped response from POST …/revisions.
@@ -532,7 +529,7 @@ export const DeliverySchema = z.object({
 
 export type Agent = z.infer<typeof AgentSchema>
 export type AgentRevision = z.infer<typeof AgentRevisionSchema>
-export type AgentRevisionDetail = z.infer<typeof AgentRevisionDetailSchema>
+export type AgentSkills = z.infer<typeof AgentSkillsSchema>
 export type SkillManifestEntry = z.infer<typeof SkillManifestEntrySchema>
 export type AgentDeploy = z.infer<typeof AgentDeploySchema>
 export type Credential = z.infer<typeof CredentialSchema>

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -374,20 +374,25 @@ export const AgentDeployListSchema = z.object({
 export const ActivateRevisionSchema = z.object({
   active_revision_id: z.string(),
 })
-// A skill file in a bundle manifest (no bytes — path/mode/size/sha256).
-export const SkillManifestEntrySchema = z.object({
+// A file within a skill (path/mode/size).
+export const SkillFileSchema = z.object({
   path: z.string(),
   mode: z.number(),
   size: z.number(),
-  sha256: z.string(),
 })
-// The agent's skills (GET …/skills) — the active revision's skill files.
+// A skill — the domain unit: a folder with a SKILL.md (name + description from frontmatter).
+export const SkillItemSchema = z.object({
+  name: z.string(),
+  description: z.string().nullish(),
+  files: z.array(SkillFileSchema).default([]),
+})
+// The agent's skills (GET …/skills) — the active revision's skills, enumerated.
 export const AgentSkillsSchema = z.object({
   revision: z
     .object({ id: z.string(), number: z.number(), digest: z.string() })
     .nullish(),
   skill_bundle_digest: z.string().nullish(),
-  files: z.array(SkillManifestEntrySchema).default([]),
+  skills: z.array(SkillItemSchema).default([]),
 })
 // The deploy-shaped response from POST …/revisions.
 export const DeployResultSchema = z.object({
@@ -530,7 +535,7 @@ export const DeliverySchema = z.object({
 export type Agent = z.infer<typeof AgentSchema>
 export type AgentRevision = z.infer<typeof AgentRevisionSchema>
 export type AgentSkills = z.infer<typeof AgentSkillsSchema>
-export type SkillManifestEntry = z.infer<typeof SkillManifestEntrySchema>
+export type SkillItem = z.infer<typeof SkillItemSchema>
 export type AgentDeploy = z.infer<typeof AgentDeploySchema>
 export type Credential = z.infer<typeof CredentialSchema>
 export type SlackConnection = z.infer<typeof SlackConnectionSchema>

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -331,6 +331,11 @@ export const AgentSchema = z.object({
   runtime: z.string(),
   credential_id: z.string().nullable().optional(),
   revision: z.number().optional(),
+  // Agent Revisions (design 009): the active production pointer + a summary of it.
+  active_revision_id: z.string().nullish(),
+  active_revision: z
+    .object({ id: z.string(), number: z.number(), digest: z.string() })
+    .nullish(),
   limits: record.nullish(),
   created_at: z.string(),
 })
@@ -368,6 +373,33 @@ export const AgentDeployListSchema = z.object({
 // The pointer-move response from POST …/revisions/:rev/activate.
 export const ActivateRevisionSchema = z.object({
   active_revision_id: z.string(),
+})
+// A skill file in a bundle manifest (no bytes — path/mode/size/sha256).
+export const SkillManifestEntrySchema = z.object({
+  path: z.string(),
+  mode: z.number(),
+  size: z.number(),
+  sha256: z.string(),
+})
+// A single revision with its skill manifest (GET …/revisions/:rev).
+export const AgentRevisionDetailSchema = z.object({
+  id: z.string(),
+  number: z.number(),
+  digest: z.string(),
+  prompt: z.string().nullish(),
+  model: z.string().nullish(),
+  skill_bundle_digest: z.string().nullish(),
+  created_at: z.string(),
+  files: z.array(SkillManifestEntrySchema).default([]),
+})
+// The deploy-shaped response from POST …/revisions.
+export const DeployResultSchema = z.object({
+  deploy_id: z.string(),
+  state: z.string(),
+  result: z.string().nullish(),
+  revision: z
+    .object({ id: z.string(), number: z.number(), digest: z.string(), active: z.boolean() })
+    .nullish(),
 })
 
 // Credentials — the reusable model-provider keys an agent/session resolves. The
@@ -500,6 +532,8 @@ export const DeliverySchema = z.object({
 
 export type Agent = z.infer<typeof AgentSchema>
 export type AgentRevision = z.infer<typeof AgentRevisionSchema>
+export type AgentRevisionDetail = z.infer<typeof AgentRevisionDetailSchema>
+export type SkillManifestEntry = z.infer<typeof SkillManifestEntrySchema>
 export type AgentDeploy = z.infer<typeof AgentDeploySchema>
 export type Credential = z.infer<typeof CredentialSchema>
 export type SlackConnection = z.infer<typeof SlackConnectionSchema>

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -340,6 +340,36 @@ export const AgentListSchema = z.object({
   next_cursor: z.string().nullish(),
 })
 
+// Agent Revisions (design 009) — immutable deployed versions of an agent's behavior.
+// `active` flags the production pointer; rollback = activate an earlier revision.
+export const AgentRevisionSchema = z.object({
+  id: z.string(),
+  number: z.number(),
+  digest: z.string(),
+  created_at: z.string(),
+  active: z.boolean(),
+})
+export const AgentRevisionListSchema = z.object({
+  data: z.array(AgentRevisionSchema),
+})
+// A deploy event (provenance + state); one revision can be produced by many deploys.
+export const AgentDeploySchema = z.object({
+  id: z.string(),
+  state: z.string(), // validating | uploading | ready | failed
+  result: z.string().nullish(), // created | deduped | failed
+  source: record.nullish(), // { via, repo_id?, path?, git_sha? }
+  actor: z.string().nullish(),
+  revision_id: z.string().nullish(),
+  created_at: z.string(),
+})
+export const AgentDeployListSchema = z.object({
+  data: z.array(AgentDeploySchema),
+})
+// The pointer-move response from POST …/revisions/:rev/activate.
+export const ActivateRevisionSchema = z.object({
+  active_revision_id: z.string(),
+})
+
 // Credentials — the reusable model-provider keys an agent/session resolves. The
 // raw key is write-only; the API returns only metadata (last4 for display).
 export const CredentialSchema = z.object({
@@ -469,6 +499,8 @@ export const DeliverySchema = z.object({
 })
 
 export type Agent = z.infer<typeof AgentSchema>
+export type AgentRevision = z.infer<typeof AgentRevisionSchema>
+export type AgentDeploy = z.infer<typeof AgentDeploySchema>
 export type Credential = z.infer<typeof CredentialSchema>
 export type SlackConnection = z.infer<typeof SlackConnectionSchema>
 export type SlackManifestResponse = z.infer<typeof SlackManifestResponseSchema>

--- a/web/src/components/agent-revisions.tsx
+++ b/web/src/components/agent-revisions.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { History } from 'lucide-react'
+import { History, RotateCcw, ArrowUp } from 'lucide-react'
 import { notifyError } from '@/lib/errors'
 import {
   getAgentRevisions,
@@ -100,21 +100,30 @@ export function AgentRevisions({ agentId }: { agentId: string }) {
       key: 'action',
       header: '',
       align: 'right',
-      cell: (r) =>
-        r.active ? (
-          <StatusBadge status="active" />
-        ) : (
+      cell: (r) => {
+        if (r.active) return <StatusBadge status="active" />
+        // Activating an older revision is a rollback; a newer one is a promote. Show just the
+        // icon (it repeats down the column); the label slides in on hover so it stays legible.
+        const isRollback = !!revisions[0] && r.number < revisions[0].number
+        const Icon = isRollback ? RotateCcw : ArrowUp
+        const label = isRollback ? 'Roll back' : 'Activate'
+        return (
           <Button
             variant="ghost"
             size="xs"
-            className="text-muted-foreground hover:text-foreground"
+            aria-label={label}
+            title={label}
+            className="group text-muted-foreground hover:text-foreground gap-0"
             disabled={activateMutation.isPending}
             onClick={() => setPending(r)}
           >
-            {/* Activating an older revision is a rollback; a newer one is a promote. */}
-            {revisions[0] && r.number < revisions[0].number ? 'Roll back' : 'Activate'}
+            <Icon className="size-3.5 shrink-0" />
+            <span className="max-w-0 overflow-hidden whitespace-nowrap opacity-0 transition-all duration-200 ease-out group-hover:ml-1.5 group-hover:max-w-[6rem] group-hover:opacity-100 motion-reduce:transition-none motion-reduce:group-hover:ml-1.5">
+              {label}
+            </span>
           </Button>
-        ),
+        )
+      },
     },
   ]
 

--- a/web/src/components/agent-revisions.tsx
+++ b/web/src/components/agent-revisions.tsx
@@ -95,8 +95,9 @@ export function AgentRevisions({ agentId }: { agentId: string }) {
           <StatusBadge status="active" />
         ) : (
           <Button
-            variant="outline"
-            size="sm"
+            variant="ghost"
+            size="xs"
+            className="text-muted-foreground hover:text-foreground"
             disabled={activateMutation.isPending}
             onClick={() => setPending(r)}
           >

--- a/web/src/components/agent-revisions.tsx
+++ b/web/src/components/agent-revisions.tsx
@@ -7,14 +7,8 @@ import {
   getAgentDeploys,
   activateRevision,
   type AgentRevision,
-  type AgentDeploy,
 } from '@/api/client'
-import {
-  Panel,
-  PanelContent,
-  PanelHeader,
-  PanelTitle,
-} from '@/components/panel'
+import { Panel, PanelHeader, PanelTitle } from '@/components/panel'
 import { ResourceTable, type Column } from '@/components/resource-table'
 import { StatusBadge } from '@/components/status-badge'
 import { Button } from '@/components/ui/button'
@@ -39,10 +33,17 @@ export function AgentRevisions({ agentId }: { agentId: string }) {
     queryKey: ['agent-revisions', agentId],
     queryFn: () => getAgentRevisions(agentId),
   })
-  const { data: deploys = [], isLoading: loadingDeploys } = useQuery({
+  const { data: deploys = [] } = useQuery({
     queryKey: ['agent-deploys', agentId],
     queryFn: () => getAgentDeploys(agentId),
   })
+  // A revision's provenance lives on the deploy that CREATED it (one revision, many
+  // deploys — source is a deploy field). Fold source.via into the revisions table so
+  // we don't need a second, near-duplicate table.
+  const createdVia = new Map<string, string>()
+  for (const d of deploys) {
+    if (d.revision_id && d.result === 'created') createdVia.set(d.revision_id, sourceVia(d.source))
+  }
 
   const activateMutation = useMutation({
     mutationFn: (rev: AgentRevision) => activateRevision(agentId, rev.number),
@@ -66,6 +67,15 @@ export function AgentRevisions({ agentId }: { agentId: string }) {
       header: 'Revision',
       cell: (r) => (
         <span className="text-foreground font-mono text-[13px]">#{r.number}</span>
+      ),
+    },
+    {
+      key: 'source',
+      header: 'Source',
+      cell: (r) => (
+        <span className="text-muted-foreground text-xs capitalize">
+          {createdVia.get(r.id) ?? '—'}
+        </span>
       ),
     },
     {
@@ -108,40 +118,6 @@ export function AgentRevisions({ agentId }: { agentId: string }) {
     },
   ]
 
-  const deployColumns: Column<AgentDeploy>[] = [
-    {
-      key: 'via',
-      header: 'Source',
-      cell: (d) => (
-        <span className="text-foreground text-xs capitalize">{sourceVia(d.source)}</span>
-      ),
-    },
-    {
-      key: 'result',
-      header: 'Result',
-      cell: (d) => (
-        <span className="text-muted-foreground font-mono text-xs">
-          {d.result ?? '—'}
-        </span>
-      ),
-    },
-    {
-      key: 'state',
-      header: 'State',
-      cell: (d) => <StatusBadge status={d.state} />,
-    },
-    {
-      key: 'when',
-      header: 'When',
-      align: 'right',
-      cell: (d) => (
-        <span className="text-muted-foreground font-mono text-xs">
-          {new Date(d.created_at).toLocaleString()}
-        </span>
-      ),
-    },
-  ]
-
   return (
     <Panel className="overflow-hidden">
       <PanelHeader>
@@ -164,20 +140,6 @@ export function AgentRevisions({ agentId }: { agentId: string }) {
           />
         }
       />
-
-      {/* Deploy history — provenance + state, newest first. */}
-      {deploys.length > 0 || loadingDeploys ? (
-        <PanelContent className="border-t">
-          <p className="text-muted-foreground mb-2 text-xs font-medium">Deploy history</p>
-          <ResourceTable
-            columns={deployColumns}
-            rows={deploys.slice(0, 8)}
-            rowKey={(d) => d.id}
-            loading={loadingDeploys}
-            skeletonRows={3}
-          />
-        </PanelContent>
-      ) : null}
 
       <ConfirmDialog
         open={pending !== null}

--- a/web/src/components/agent-revisions.tsx
+++ b/web/src/components/agent-revisions.tsx
@@ -1,0 +1,192 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { History } from 'lucide-react'
+import { notifyError } from '@/lib/errors'
+import {
+  getAgentRevisions,
+  getAgentDeploys,
+  activateRevision,
+  type AgentRevision,
+  type AgentDeploy,
+} from '@/api/client'
+import {
+  Panel,
+  PanelContent,
+  PanelHeader,
+  PanelTitle,
+} from '@/components/panel'
+import { ResourceTable, type Column } from '@/components/resource-table'
+import { StatusBadge } from '@/components/status-badge'
+import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+import { EmptyState } from '@/components/empty-state'
+
+// Short, legible digest (e.g. "sha256:a14f940d82") for the table.
+const shortDigest = (d: string) => d.slice(0, 19)
+const sourceVia = (s?: Record<string, unknown> | null) =>
+  (s && typeof s.via === 'string' && s.via) || 'api'
+
+/**
+ * Agent Revisions panel (design 009 §13): the deploy history of an agent's behavior,
+ * the active production pointer made visible, one-click rollback (activate an earlier
+ * revision), and a compact deploy timeline (provenance + state).
+ */
+export function AgentRevisions({ agentId }: { agentId: string }) {
+  const queryClient = useQueryClient()
+  const [pending, setPending] = useState<AgentRevision | null>(null)
+
+  const { data: revisions = [], isLoading } = useQuery({
+    queryKey: ['agent-revisions', agentId],
+    queryFn: () => getAgentRevisions(agentId),
+  })
+  const { data: deploys = [], isLoading: loadingDeploys } = useQuery({
+    queryKey: ['agent-deploys', agentId],
+    queryFn: () => getAgentDeploys(agentId),
+  })
+
+  const activateMutation = useMutation({
+    mutationFn: (rev: AgentRevision) => activateRevision(agentId, rev.number),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['agent-revisions', agentId] })
+      void queryClient.invalidateQueries({ queryKey: ['agent-deploys', agentId] })
+      // prompt/model are sourced from the active revision → refresh the agent too.
+      void queryClient.invalidateQueries({ queryKey: ['agent', agentId] })
+      void queryClient.invalidateQueries({ queryKey: ['agents'] })
+      setPending(null)
+    },
+    onError: (e) => {
+      notifyError("Couldn't activate that revision.", e)
+      setPending(null)
+    },
+  })
+
+  const revisionColumns: Column<AgentRevision>[] = [
+    {
+      key: 'number',
+      header: 'Revision',
+      cell: (r) => (
+        <span className="text-foreground font-mono text-[13px]">#{r.number}</span>
+      ),
+    },
+    {
+      key: 'digest',
+      header: 'Digest',
+      cell: (r) => (
+        <span className="text-muted-foreground font-mono text-xs">
+          {shortDigest(r.digest)}
+        </span>
+      ),
+    },
+    {
+      key: 'created',
+      header: 'Created',
+      cell: (r) => (
+        <span className="text-muted-foreground font-mono text-xs">
+          {new Date(r.created_at).toLocaleString()}
+        </span>
+      ),
+    },
+    {
+      key: 'action',
+      header: '',
+      align: 'right',
+      cell: (r) =>
+        r.active ? (
+          <StatusBadge status="active" />
+        ) : (
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={activateMutation.isPending}
+            onClick={() => setPending(r)}
+          >
+            {/* Activating an older revision is a rollback; a newer one is a promote. */}
+            {revisions[0] && r.number < revisions[0].number ? 'Roll back' : 'Activate'}
+          </Button>
+        ),
+    },
+  ]
+
+  const deployColumns: Column<AgentDeploy>[] = [
+    {
+      key: 'via',
+      header: 'Source',
+      cell: (d) => (
+        <span className="text-foreground text-xs capitalize">{sourceVia(d.source)}</span>
+      ),
+    },
+    {
+      key: 'result',
+      header: 'Result',
+      cell: (d) => (
+        <span className="text-muted-foreground font-mono text-xs">
+          {d.result ?? '—'}
+        </span>
+      ),
+    },
+    {
+      key: 'state',
+      header: 'State',
+      cell: (d) => <StatusBadge status={d.state} />,
+    },
+    {
+      key: 'when',
+      header: 'When',
+      align: 'right',
+      cell: (d) => (
+        <span className="text-muted-foreground font-mono text-xs">
+          {new Date(d.created_at).toLocaleString()}
+        </span>
+      ),
+    },
+  ]
+
+  return (
+    <Panel className="overflow-hidden">
+      <PanelHeader>
+        <PanelTitle>Revisions</PanelTitle>
+        <span className="text-muted-foreground text-xs">
+          Each deploy is an immutable revision. Rolling back re-points the active one.
+        </span>
+      </PanelHeader>
+
+      <ResourceTable
+        columns={revisionColumns}
+        rows={revisions}
+        rowKey={(r) => r.id}
+        loading={isLoading}
+        empty={
+          <EmptyState
+            icon={History}
+            title="No revisions yet"
+            description="Editing the prompt or model, or deploying an agent directory, creates a revision."
+          />
+        }
+      />
+
+      {/* Deploy history — provenance + state, newest first. */}
+      {deploys.length > 0 || loadingDeploys ? (
+        <PanelContent className="border-t">
+          <p className="text-muted-foreground mb-2 text-xs font-medium">Deploy history</p>
+          <ResourceTable
+            columns={deployColumns}
+            rows={deploys.slice(0, 8)}
+            rowKey={(d) => d.id}
+            loading={loadingDeploys}
+            skeletonRows={3}
+          />
+        </PanelContent>
+      ) : null}
+
+      <ConfirmDialog
+        open={pending !== null}
+        onOpenChange={(open) => !open && setPending(null)}
+        title={`Activate revision #${pending?.number ?? ''}?`}
+        description="New sessions will use this revision. In-flight sessions keep the revision they started with."
+        confirmLabel="Activate"
+        pending={activateMutation.isPending}
+        onConfirm={() => pending && activateMutation.mutate(pending)}
+      />
+    </Panel>
+  )
+}

--- a/web/src/components/agent-skills.tsx
+++ b/web/src/components/agent-skills.tsx
@@ -58,11 +58,21 @@ export function AgentSkills({ agentId }: { agentId: string }) {
       </PanelHeader>
       <PanelContent className="space-y-4">
         {!isLoading && skills.length === 0 ? (
-          <EmptyState
-            icon={FileArchive}
-            title="No skills deployed"
-            description="Upload a .zip with one folder per skill, each containing a SKILL.md."
-          />
+          <div className="space-y-3">
+            <EmptyState
+              icon={FileArchive}
+              title="No skills yet"
+              description="A skill is a folder with a SKILL.md. Upload a .zip shaped like:"
+            />
+            <pre className="text-muted-foreground/70 mx-auto w-fit text-left font-mono text-xs leading-relaxed">
+{`skills/
+├─ triage/
+│  └─ SKILL.md
+└─ pr-review/
+   ├─ SKILL.md
+   └─ run.sh`}
+            </pre>
+          </div>
         ) : (
           <ul className="divide-border divide-y rounded-md border">
             {skills.map((s) => (
@@ -83,14 +93,6 @@ export function AgentSkills({ agentId }: { agentId: string }) {
             ))}
           </ul>
         )}
-
-        <p className="text-muted-foreground text-xs">
-          A skill is a folder with a <span className="font-mono">SKILL.md</span> (its{' '}
-          <span className="font-mono">name</span> + <span className="font-mono">description</span> go
-          in the frontmatter). Upload a <span className="font-mono">.zip</span> with one folder per
-          skill (e.g. <span className="font-mono">triage/SKILL.md</span>), or a{' '}
-          <span className="font-mono">skills/</span> folder wrapping them.
-        </p>
 
         <div className="flex items-center gap-3">
           <input

--- a/web/src/components/agent-skills.tsx
+++ b/web/src/components/agent-skills.tsx
@@ -47,9 +47,8 @@ export function AgentSkills({ agentId }: { agentId: string }) {
     mutationFn: () => deleteAgentSkills(agentId),
     onSuccess: (r) => {
       invalidate()
-      // Removing skills re-activates the matching no-skills revision (content-addressed), which
-      // may be an EARLIER number — name it so the pointer move is obvious, not surprising.
-      notifySuccess(`Skills removed${r.revision ? ` — now on revision #${r.revision.number}` : ''}`)
+      // Removing skills deploys a new forward revision (no skills); name it for clear feedback.
+      notifySuccess(`Skills removed${r.revision ? ` — revision #${r.revision.number} active` : ''}`)
     },
     onError: (e) => notifyError("Couldn't remove the skills.", e),
   })

--- a/web/src/components/agent-skills.tsx
+++ b/web/src/components/agent-skills.tsx
@@ -1,0 +1,134 @@
+import { useRef } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { FileArchive, Upload } from 'lucide-react'
+import JSZip from 'jszip'
+import { notifyError } from '@/lib/errors'
+import { getAgentRevision, deployAgentRevision, type Agent } from '@/api/client'
+import {
+  Panel,
+  PanelContent,
+  PanelHeader,
+  PanelTitle,
+} from '@/components/panel'
+import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/empty-state'
+
+const fmtBytes = (n: number) => (n < 1024 ? `${n} B` : `${(n / 1024).toFixed(1)} KiB`)
+
+/**
+ * Parse a skills .zip into the deploy `skills[]` payload (path/content/mode). Strips a single
+ * common top-level wrapper dir (so zipping `skills/` or `my-agent/` both work), skips macOS +
+ * dotfiles, and marks `.sh` / exec-bit files 0755. The API validates limits (64 files / 256 KiB /
+ * UTF-8 text) and 400s on violation.
+ */
+async function zipToSkills(file: File): Promise<{ path: string; content: string; mode: number }[]> {
+  const zip = await JSZip.loadAsync(file)
+  const entries = Object.values(zip.files)
+    .filter((f) => !f.dir)
+    .filter((f) => !f.name.startsWith('__MACOSX/') && !f.name.split('/').some((s) => s.startsWith('.')))
+  if (entries.length === 0) throw new Error('The zip has no files.')
+  const tops = entries.map((f) => f.name.split('/')[0])
+  const commonTop = entries.every((f) => f.name.includes('/')) && tops.every((t) => t === tops[0]) ? tops[0] : null
+  const skills: { path: string; content: string; mode: number }[] = []
+  for (const f of entries) {
+    const path = commonTop ? f.name.slice(commonTop.length + 1) : f.name
+    if (!path) continue
+    const content = await f.async('string')
+    const execBit = (typeof f.unixPermissions === 'number' ? f.unixPermissions : 0) & 0o111
+    skills.push({ path, content, mode: execBit || /\.sh$/.test(path) ? 0o755 : 0o644 })
+  }
+  return skills
+}
+
+/**
+ * Skills panel — shows the active revision's skill files and lets you upload a .zip to deploy a
+ * new revision with those skills (the deploy is a full behavior payload, so we carry the agent's
+ * current prompt + model; skills[] is the complete set — an upload replaces, it doesn't merge).
+ */
+export function AgentSkills({ agentId, agent }: { agentId: string; agent: Agent }) {
+  const queryClient = useQueryClient()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const activeNumber = agent.active_revision?.number
+
+  const { data: revision } = useQuery({
+    queryKey: ['agent-revision-detail', agentId, activeNumber],
+    queryFn: () => getAgentRevision(agentId, activeNumber!),
+    enabled: activeNumber != null,
+  })
+  const files = revision?.files ?? []
+
+  const uploadMutation = useMutation({
+    mutationFn: async (file: File) => {
+      const skills = await zipToSkills(file)
+      return deployAgentRevision(agentId, { prompt: agent.prompt ?? '', model: agent.model, skills })
+    },
+    onSuccess: () => {
+      // A skills deploy creates a new active revision — refresh the dependent views.
+      void queryClient.invalidateQueries({ queryKey: ['agent-revisions', agentId] })
+      void queryClient.invalidateQueries({ queryKey: ['agent-deploys', agentId] })
+      void queryClient.invalidateQueries({ queryKey: ['agent-revision-detail', agentId] })
+      void queryClient.invalidateQueries({ queryKey: ['agent', agentId] })
+    },
+    onError: (e) => notifyError("Couldn't deploy the skills.", e),
+  })
+
+  const canUpload = !!agent.prompt && !uploadMutation.isPending
+
+  return (
+    <Panel className="overflow-hidden">
+      <PanelHeader>
+        <PanelTitle>Skills</PanelTitle>
+        <span className="text-muted-foreground text-xs">
+          Files Claude Code loads for this agent.
+        </span>
+      </PanelHeader>
+      <PanelContent className="space-y-4">
+        {files.length === 0 ? (
+          <EmptyState
+            icon={FileArchive}
+            title="No skills deployed"
+            description="Upload a .zip of your skills folder to deploy a revision with them."
+          />
+        ) : (
+          <ul className="divide-border divide-y rounded-md border">
+            {files.map((f) => (
+              <li key={f.path} className="flex items-center justify-between px-3 py-2">
+                <span className="text-foreground font-mono text-xs">{f.path}</span>
+                <span className="text-muted-foreground font-mono text-xs">
+                  {(f.mode & 0o777).toString(8)} · {fmtBytes(f.size)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="flex items-center gap-3">
+          <input
+            ref={inputRef}
+            type="file"
+            accept=".zip,application/zip"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0]
+              if (f) uploadMutation.mutate(f)
+              e.target.value = '' // allow re-selecting the same file
+            }}
+          />
+          <Button size="sm" disabled={!canUpload} onClick={() => inputRef.current?.click()}>
+            <Upload className="size-4" />
+            {uploadMutation.isPending
+              ? 'Deploying…'
+              : files.length
+                ? 'Replace skills (.zip)'
+                : 'Upload skills (.zip)'}
+          </Button>
+          <p className="text-muted-foreground text-xs">
+            {agent.prompt
+              ? 'Deploys a new revision; prompt & model unchanged.'
+              : 'Set a system prompt first.'}
+          </p>
+        </div>
+      </PanelContent>
+    </Panel>
+  )
+}

--- a/web/src/components/agent-skills.tsx
+++ b/web/src/components/agent-skills.tsx
@@ -10,7 +10,6 @@ import {
   PanelTitle,
 } from '@/components/panel'
 import { Button } from '@/components/ui/button'
-import { EmptyState } from '@/components/empty-state'
 
 const fmtBytes = (n: number) => (n < 1024 ? `${n} B` : `${(n / 1024).toFixed(1)} KiB`)
 
@@ -58,13 +57,17 @@ export function AgentSkills({ agentId }: { agentId: string }) {
       </PanelHeader>
       <PanelContent className="space-y-4">
         {!isLoading && skills.length === 0 ? (
-          <div className="space-y-3">
-            <EmptyState
-              icon={FileArchive}
-              title="No skills yet"
-              description="A skill is a folder with a SKILL.md. Upload a .zip shaped like:"
-            />
-            <pre className="text-muted-foreground/70 mx-auto w-fit text-left font-mono text-xs leading-relaxed">
+          <div className="flex items-center justify-between gap-6 rounded-md border border-dashed px-5 py-6">
+            <div className="space-y-1.5">
+              <div className="text-foreground flex items-center gap-2 text-sm font-medium">
+                <FileArchive className="text-muted-foreground size-5" />
+                No skills yet
+              </div>
+              <p className="text-muted-foreground max-w-xs text-xs">
+                A skill is a folder with a SKILL.md. Upload a .zip shaped like the example.
+              </p>
+            </div>
+            <pre className="text-muted-foreground/70 shrink-0 text-left font-mono text-xs leading-relaxed">
 {`skills/
 ├─ triage/
 │  └─ SKILL.md

--- a/web/src/components/agent-skills.tsx
+++ b/web/src/components/agent-skills.tsx
@@ -63,8 +63,8 @@ export function AgentSkills({ agentId }: { agentId: string }) {
                 <FileArchive className="text-muted-foreground size-5" />
                 No skills yet
               </div>
-              <p className="text-muted-foreground max-w-xs text-xs">
-                A skill is a folder with a SKILL.md. Upload a .zip shaped like the example.
+              <p className="text-muted-foreground text-xs">
+                A skill is a folder with a SKILL.md — upload a .zip like this:
               </p>
             </div>
             <pre className="text-muted-foreground/70 shrink-0 text-left font-mono text-xs leading-relaxed">

--- a/web/src/components/agent-skills.tsx
+++ b/web/src/components/agent-skills.tsx
@@ -109,28 +109,30 @@ export function AgentSkills({ agentId }: { agentId: string }) {
               e.target.value = '' // allow re-selecting the same file
             }}
           />
-          <Button size="sm" disabled={busy} onClick={() => inputRef.current?.click()}>
-            <Upload className="size-4" />
-            {upload.isPending
-              ? 'Uploading…'
-              : skills.length
-                ? 'Replace skills (.zip)'
-                : 'Upload skills (.zip)'}
-          </Button>
-          {skills.length > 0 ? (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="text-muted-foreground hover:text-foreground"
-              disabled={busy}
-              onClick={() => remove.mutate()}
-            >
-              {remove.isPending ? 'Removing…' : 'Remove all'}
-            </Button>
-          ) : null}
-          <p className="text-muted-foreground ml-auto text-xs">
+          <p className="text-muted-foreground text-xs">
             Deploys a new revision; prompt &amp; model unchanged.
           </p>
+          <div className="ml-auto flex items-center gap-2">
+            {skills.length > 0 ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-muted-foreground hover:text-foreground"
+                disabled={busy}
+                onClick={() => remove.mutate()}
+              >
+                {remove.isPending ? 'Removing…' : 'Remove all'}
+              </Button>
+            ) : null}
+            <Button size="sm" disabled={busy} onClick={() => inputRef.current?.click()}>
+              <Upload className="size-4" />
+              {upload.isPending
+                ? 'Uploading…'
+                : skills.length
+                  ? 'Replace skills (.zip)'
+                  : 'Upload skills (.zip)'}
+            </Button>
+          </div>
         </div>
       </PanelContent>
     </Panel>

--- a/web/src/components/agent-skills.tsx
+++ b/web/src/components/agent-skills.tsx
@@ -59,7 +59,7 @@ export function AgentSkills({ agentId }: { agentId: string }) {
       <PanelHeader>
         <PanelTitle>Skills</PanelTitle>
         <span className="text-muted-foreground text-xs">
-          Files Claude Code loads for this agent.
+          Skill files the agent loads at run time.
         </span>
       </PanelHeader>
       <PanelContent className="space-y-4">

--- a/web/src/components/agent-skills.tsx
+++ b/web/src/components/agent-skills.tsx
@@ -1,9 +1,8 @@
 import { useRef } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { FileArchive, Upload } from 'lucide-react'
-import JSZip from 'jszip'
 import { notifyError } from '@/lib/errors'
-import { getAgentRevision, deployAgentRevision, type Agent } from '@/api/client'
+import { getAgentSkills, putAgentSkills, deleteAgentSkills } from '@/api/client'
 import {
   Panel,
   PanelContent,
@@ -16,63 +15,38 @@ import { EmptyState } from '@/components/empty-state'
 const fmtBytes = (n: number) => (n < 1024 ? `${n} B` : `${(n / 1024).toFixed(1)} KiB`)
 
 /**
- * Parse a skills .zip into the deploy `skills[]` payload (path/content/mode). Strips a single
- * common top-level wrapper dir (so zipping `skills/` or `my-agent/` both work), skips macOS +
- * dotfiles, and marks `.sh` / exec-bit files 0755. The API validates limits (64 files / 256 KiB /
- * UTF-8 text) and 400s on violation.
+ * Skills panel — a thin consumer of the agent skills sub-resource (design 009 §8). The API owns
+ * unzip + validate + canonicalize + bundle: we just GET the file list, PUT a raw .zip to deploy a
+ * new revision (active behavior, skills replaced), or DELETE to clear. No client-side parsing.
  */
-async function zipToSkills(file: File): Promise<{ path: string; content: string; mode: number }[]> {
-  const zip = await JSZip.loadAsync(file)
-  const entries = Object.values(zip.files)
-    .filter((f) => !f.dir)
-    .filter((f) => !f.name.startsWith('__MACOSX/') && !f.name.split('/').some((s) => s.startsWith('.')))
-  if (entries.length === 0) throw new Error('The zip has no files.')
-  const tops = entries.map((f) => f.name.split('/')[0])
-  const commonTop = entries.every((f) => f.name.includes('/')) && tops.every((t) => t === tops[0]) ? tops[0] : null
-  const skills: { path: string; content: string; mode: number }[] = []
-  for (const f of entries) {
-    const path = commonTop ? f.name.slice(commonTop.length + 1) : f.name
-    if (!path) continue
-    const content = await f.async('string')
-    const execBit = (typeof f.unixPermissions === 'number' ? f.unixPermissions : 0) & 0o111
-    skills.push({ path, content, mode: execBit || /\.sh$/.test(path) ? 0o755 : 0o644 })
-  }
-  return skills
-}
-
-/**
- * Skills panel — shows the active revision's skill files and lets you upload a .zip to deploy a
- * new revision with those skills (the deploy is a full behavior payload, so we carry the agent's
- * current prompt + model; skills[] is the complete set — an upload replaces, it doesn't merge).
- */
-export function AgentSkills({ agentId, agent }: { agentId: string; agent: Agent }) {
+export function AgentSkills({ agentId }: { agentId: string }) {
   const queryClient = useQueryClient()
   const inputRef = useRef<HTMLInputElement>(null)
-  const activeNumber = agent.active_revision?.number
 
-  const { data: revision } = useQuery({
-    queryKey: ['agent-revision-detail', agentId, activeNumber],
-    queryFn: () => getAgentRevision(agentId, activeNumber!),
-    enabled: activeNumber != null,
+  const { data, isLoading } = useQuery({
+    queryKey: ['agent-skills', agentId],
+    queryFn: () => getAgentSkills(agentId),
   })
-  const files = revision?.files ?? []
+  const files = data?.files ?? []
 
-  const uploadMutation = useMutation({
-    mutationFn: async (file: File) => {
-      const skills = await zipToSkills(file)
-      return deployAgentRevision(agentId, { prompt: agent.prompt ?? '', model: agent.model, skills })
-    },
-    onSuccess: () => {
-      // A skills deploy creates a new active revision — refresh the dependent views.
-      void queryClient.invalidateQueries({ queryKey: ['agent-revisions', agentId] })
-      void queryClient.invalidateQueries({ queryKey: ['agent-deploys', agentId] })
-      void queryClient.invalidateQueries({ queryKey: ['agent-revision-detail', agentId] })
-      void queryClient.invalidateQueries({ queryKey: ['agent', agentId] })
-    },
-    onError: (e) => notifyError("Couldn't deploy the skills.", e),
+  // A skills change deploys a new active revision — refresh the dependent views.
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ['agent-skills', agentId] })
+    void queryClient.invalidateQueries({ queryKey: ['agent-revisions', agentId] })
+    void queryClient.invalidateQueries({ queryKey: ['agent-deploys', agentId] })
+    void queryClient.invalidateQueries({ queryKey: ['agent', agentId] })
+  }
+  const upload = useMutation({
+    mutationFn: (zip: File) => putAgentSkills(agentId, zip),
+    onSuccess: invalidate,
+    onError: (e) => notifyError("Couldn't upload the skills.", e),
   })
-
-  const canUpload = !!agent.prompt && !uploadMutation.isPending
+  const remove = useMutation({
+    mutationFn: () => deleteAgentSkills(agentId),
+    onSuccess: invalidate,
+    onError: (e) => notifyError("Couldn't remove the skills.", e),
+  })
+  const busy = upload.isPending || remove.isPending
 
   return (
     <Panel className="overflow-hidden">
@@ -83,7 +57,7 @@ export function AgentSkills({ agentId, agent }: { agentId: string; agent: Agent 
         </span>
       </PanelHeader>
       <PanelContent className="space-y-4">
-        {files.length === 0 ? (
+        {!isLoading && files.length === 0 ? (
           <EmptyState
             icon={FileArchive}
             title="No skills deployed"
@@ -110,22 +84,31 @@ export function AgentSkills({ agentId, agent }: { agentId: string; agent: Agent 
             className="hidden"
             onChange={(e) => {
               const f = e.target.files?.[0]
-              if (f) uploadMutation.mutate(f)
+              if (f) upload.mutate(f)
               e.target.value = '' // allow re-selecting the same file
             }}
           />
-          <Button size="sm" disabled={!canUpload} onClick={() => inputRef.current?.click()}>
+          <Button size="sm" disabled={busy} onClick={() => inputRef.current?.click()}>
             <Upload className="size-4" />
-            {uploadMutation.isPending
-              ? 'Deploying…'
+            {upload.isPending
+              ? 'Uploading…'
               : files.length
                 ? 'Replace skills (.zip)'
                 : 'Upload skills (.zip)'}
           </Button>
-          <p className="text-muted-foreground text-xs">
-            {agent.prompt
-              ? 'Deploys a new revision; prompt & model unchanged.'
-              : 'Set a system prompt first.'}
+          {files.length > 0 ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-muted-foreground hover:text-foreground"
+              disabled={busy}
+              onClick={() => remove.mutate()}
+            >
+              {remove.isPending ? 'Removing…' : 'Remove all'}
+            </Button>
+          ) : null}
+          <p className="text-muted-foreground ml-auto text-xs">
+            Deploys a new revision; prompt &amp; model unchanged.
           </p>
         </div>
       </PanelContent>

--- a/web/src/components/agent-skills.tsx
+++ b/web/src/components/agent-skills.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { FileArchive, Upload } from 'lucide-react'
-import { notifyError } from '@/lib/errors'
+import { notifyError, notifySuccess } from '@/lib/errors'
 import { getAgentSkills, putAgentSkills, deleteAgentSkills } from '@/api/client'
 import {
   Panel,
@@ -37,12 +37,20 @@ export function AgentSkills({ agentId }: { agentId: string }) {
   }
   const upload = useMutation({
     mutationFn: (zip: File) => putAgentSkills(agentId, zip),
-    onSuccess: invalidate,
+    onSuccess: (r) => {
+      invalidate()
+      notifySuccess(`Skills deployed${r.revision ? ` — revision #${r.revision.number} active` : ''}`)
+    },
     onError: (e) => notifyError("Couldn't upload the skills.", e),
   })
   const remove = useMutation({
     mutationFn: () => deleteAgentSkills(agentId),
-    onSuccess: invalidate,
+    onSuccess: (r) => {
+      invalidate()
+      // Removing skills re-activates the matching no-skills revision (content-addressed), which
+      // may be an EARLIER number — name it so the pointer move is obvious, not surprising.
+      notifySuccess(`Skills removed${r.revision ? ` — now on revision #${r.revision.number}` : ''}`)
+    },
     onError: (e) => notifyError("Couldn't remove the skills.", e),
   })
   const busy = upload.isPending || remove.isPending

--- a/web/src/components/agent-skills.tsx
+++ b/web/src/components/agent-skills.tsx
@@ -27,7 +27,7 @@ export function AgentSkills({ agentId }: { agentId: string }) {
     queryKey: ['agent-skills', agentId],
     queryFn: () => getAgentSkills(agentId),
   })
-  const files = data?.files ?? []
+  const skills = data?.skills ?? []
 
   // A skills change deploys a new active revision — refresh the dependent views.
   const invalidate = () => {
@@ -57,24 +57,40 @@ export function AgentSkills({ agentId }: { agentId: string }) {
         </span>
       </PanelHeader>
       <PanelContent className="space-y-4">
-        {!isLoading && files.length === 0 ? (
+        {!isLoading && skills.length === 0 ? (
           <EmptyState
             icon={FileArchive}
             title="No skills deployed"
-            description="Upload a .zip of your skills folder to deploy a revision with them."
+            description="Upload a .zip with one folder per skill, each containing a SKILL.md."
           />
         ) : (
           <ul className="divide-border divide-y rounded-md border">
-            {files.map((f) => (
-              <li key={f.path} className="flex items-center justify-between px-3 py-2">
-                <span className="text-foreground font-mono text-xs">{f.path}</span>
-                <span className="text-muted-foreground font-mono text-xs">
-                  {(f.mode & 0o777).toString(8)} · {fmtBytes(f.size)}
-                </span>
+            {skills.map((s) => (
+              <li key={s.name} className="px-3 py-2.5">
+                <div className="flex items-baseline justify-between gap-3">
+                  <span className="text-foreground font-mono text-[13px]">{s.name}</span>
+                  <span className="text-muted-foreground shrink-0 text-xs">
+                    {s.files.length} file{s.files.length === 1 ? '' : 's'} ·{' '}
+                    {fmtBytes(s.files.reduce((n, f) => n + f.size, 0))}
+                  </span>
+                </div>
+                {s.description ? (
+                  <p className="text-muted-foreground mt-0.5 text-xs">{s.description}</p>
+                ) : (
+                  <p className="text-muted-foreground/70 mt-0.5 text-xs italic">no description</p>
+                )}
               </li>
             ))}
           </ul>
         )}
+
+        <p className="text-muted-foreground text-xs">
+          A skill is a folder with a <span className="font-mono">SKILL.md</span> (its{' '}
+          <span className="font-mono">name</span> + <span className="font-mono">description</span> go
+          in the frontmatter). Upload a <span className="font-mono">.zip</span> with one folder per
+          skill (e.g. <span className="font-mono">triage/SKILL.md</span>), or a{' '}
+          <span className="font-mono">skills/</span> folder wrapping them.
+        </p>
 
         <div className="flex items-center gap-3">
           <input
@@ -92,11 +108,11 @@ export function AgentSkills({ agentId }: { agentId: string }) {
             <Upload className="size-4" />
             {upload.isPending
               ? 'Uploading…'
-              : files.length
+              : skills.length
                 ? 'Replace skills (.zip)'
                 : 'Upload skills (.zip)'}
           </Button>
-          {files.length > 0 ? (
+          {skills.length > 0 ? (
             <Button
               variant="ghost"
               size="sm"

--- a/web/src/lib/errors.ts
+++ b/web/src/lib/errors.ts
@@ -16,3 +16,8 @@ export function notifyError(message: string, error?: unknown): void {
     detail && detail !== message ? { description: detail } : undefined,
   )
 }
+
+/** Show a brief success toast (e.g. confirming a deploy + which revision is now active). */
+export function notifySuccess(message: string, description?: string): void {
+  toast.success(message, description ? { description } : undefined)
+}

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -96,6 +96,9 @@ export default function AgentDetail() {
   const settleAgent = () => {
     void queryClient.invalidateQueries({ queryKey: ['agent', agentId] })
     void queryClient.invalidateQueries({ queryKey: ['agents'] })
+    // A prompt/model save creates a new revision → refresh the Revisions panel too.
+    void queryClient.invalidateQueries({ queryKey: ['agent-revisions', agentId] })
+    void queryClient.invalidateQueries({ queryKey: ['agent-deploys', agentId] })
   }
   const optimistic = async (patch: Partial<Agent>) => {
     await queryClient.cancelQueries({ queryKey: ['agent', agentId] })

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -410,7 +410,7 @@ export default function AgentDetail() {
           <SlackConnect agentId={agent.id} agentName={agent.name} />
 
           {/* Skills — current files + upload-a-zip to deploy a new revision */}
-          <AgentSkills agentId={agent.id} agent={agent} />
+          <AgentSkills agentId={agent.id} />
 
           {/* Revisions — deploy history + active pointer + rollback */}
           <AgentRevisions agentId={agent.id} />

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -28,6 +28,7 @@ import { EmptyState } from '@/components/empty-state'
 import { ResourceTable, type Column } from '@/components/resource-table'
 import { Skeleton } from '@/components/ui/skeleton'
 import { SlackConnect } from '@/components/slack-connect'
+import { AgentRevisions } from '@/components/agent-revisions'
 import { getRuntime } from '@/lib/runtimes'
 
 // Sentinels for the non-credential choices in the picker. The model list +
@@ -403,6 +404,9 @@ export default function AgentDetail() {
 
           {/* Slack — kept above Sessions so it's visible without scrolling */}
           <SlackConnect agentId={agent.id} agentName={agent.name} />
+
+          {/* Revisions — deploy history + active pointer + rollback */}
+          <AgentRevisions agentId={agent.id} />
 
           {/* Sessions */}
           <Panel className="overflow-hidden">

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -272,9 +272,9 @@ export default function AgentDetail() {
               <span className="text-foreground font-mono">{agent.id}</span>
               <span>Runtime</span>
               <span className="text-foreground capitalize">{agent.runtime}</span>
-              <span>Revision</span>
+              <span>Active revision</span>
               <span className="text-foreground font-mono">
-                {agent.revision ?? 1}
+                #{agent.active_revision?.number ?? agent.revision ?? 1}
               </span>
               <span>Created</span>
               <span className="text-foreground">

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -28,6 +28,7 @@ import { EmptyState } from '@/components/empty-state'
 import { ResourceTable, type Column } from '@/components/resource-table'
 import { Skeleton } from '@/components/ui/skeleton'
 import { SlackConnect } from '@/components/slack-connect'
+import { AgentSkills } from '@/components/agent-skills'
 import { AgentRevisions } from '@/components/agent-revisions'
 import { getRuntime } from '@/lib/runtimes'
 
@@ -407,6 +408,9 @@ export default function AgentDetail() {
 
           {/* Slack — kept above Sessions so it's visible without scrolling */}
           <SlackConnect agentId={agent.id} agentName={agent.name} />
+
+          {/* Skills — current files + upload-a-zip to deploy a new revision */}
+          <AgentSkills agentId={agent.id} agent={agent} />
 
           {/* Revisions — deploy history + active pointer + rollback */}
           <AgentRevisions agentId={agent.id} />

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -185,11 +185,11 @@ export default function Agents() {
     },
     {
       key: 'revision',
-      header: 'Revision',
+      header: 'Active revision',
       align: 'right',
       cell: (a) => (
         <span className="text-muted-foreground font-mono text-xs">
-          {a.revision ?? 1}
+          #{a.active_revision?.number ?? a.revision ?? 1}
         </span>
       ),
     },


### PR DESCRIPTION
Surfaces the now-live `/v3` Agent Revisions API in the dashboard (design 009 §13). Phase 1 of the UI work; deploy-from-GitHub (the connect-repo flow) is phase 2.

## What
A **Revisions** panel on the per-agent view (`/agents/:id`, between Slack and Sessions):
- **Revision history** — number, short digest, created-at.
- **Active production pointer** shown as an "Active" badge on the current revision.
- **One-click rollback / activate** — a non-active revision shows a "Roll back"/"Activate" button → ConfirmDialog → `POST /v3/agents/:id/revisions/:rev/activate` → invalidates the agent + revisions + deploys queries.
- **Deploy timeline** — compact provenance list (source via, result created/deduped, state, when) from `GET /v3/agents/:id/deploys`.

## Files
- `web/src/components/agent-revisions.tsx` (new)
- `web/src/api/schemas.ts` — `AgentRevision` / `AgentDeploy` / `ActivateRevision` Zod schemas + types
- `web/src/api/client.ts` — `getAgentRevisions`, `getAgentDeploys`, `activateRevision`
- `web/src/pages/AgentDetail.tsx` — render `<AgentRevisions>`

## Notes
- Reuses the existing Panel / ResourceTable / StatusBadge / ConfirmDialog primitives + tanstack-query patterns; cookie-auth through the api-edge `/v3` proxy. `tsc -b` + `vite build` green.
- Remaining: a visual pass against the live dashboard (couldn't screenshot the authenticated SPA from here). The API path is verified end-to-end on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)