### PR TITLE
Add template delete CLI

### DIFF
--- a/cmd/oc/internal/commands/root.go
+++ b/cmd/oc/internal/commands/root.go
@@ -65,6 +65,7 @@ func init() {
 	rootCmd.AddCommand(execCmd)
 	rootCmd.AddCommand(shellCmd)
 	rootCmd.AddCommand(checkpointCmd)
+	rootCmd.AddCommand(templateCmd)
 	rootCmd.AddCommand(patchCmd)
 	rootCmd.AddCommand(previewCmd)
 	rootCmd.AddCommand(mountsCmd)

--- a/cmd/oc/internal/commands/template.go
+++ b/cmd/oc/internal/commands/template.go
@@ -1,0 +1,128 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/opensandbox/opensandbox/cmd/oc/internal/client"
+	"github.com/spf13/cobra"
+)
+
+// TemplateInfo matches the API response for named snapshots.
+type TemplateInfo struct {
+	ID           string          `json:"id"`
+	OrgID        string          `json:"orgId"`
+	ContentHash  string          `json:"contentHash"`
+	CheckpointID string          `json:"checkpointId,omitempty"`
+	Name         string          `json:"name,omitempty"`
+	Manifest     json.RawMessage `json:"manifest"`
+	Status       string          `json:"status"`
+	CreatedAt    time.Time       `json:"createdAt"`
+	LastUsedAt   time.Time       `json:"lastUsedAt"`
+}
+
+var templateCmd = &cobra.Command{
+	Use:     "template",
+	Aliases: []string{"templates", "snapshot", "snapshots"},
+	Short:   "Manage declarative sandbox templates",
+}
+
+var templateListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List templates",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := client.FromContext(cmd.Context())
+
+		var templates []TemplateInfo
+		if err := c.Get(cmd.Context(), "/snapshots", &templates); err != nil {
+			return err
+		}
+
+		printer.Print(templates, func() {
+			if len(templates) == 0 {
+				fmt.Println("No templates found.")
+				return
+			}
+			headers := []string{"NAME", "STATUS", "CHECKPOINT", "LAST USED", "CREATED"}
+			var rows [][]string
+			for _, tmpl := range templates {
+				checkpointID := tmpl.CheckpointID
+				if checkpointID == "" {
+					checkpointID = "-"
+				}
+				rows = append(rows, []string{
+					tmpl.Name,
+					tmpl.Status,
+					checkpointID,
+					formatTemplateTime(tmpl.LastUsedAt),
+					formatTemplateTime(tmpl.CreatedAt),
+				})
+			}
+			printer.Table(headers, rows)
+		})
+		return nil
+	},
+}
+
+var templateGetCmd = &cobra.Command{
+	Use:   "get <name>",
+	Short: "Get template details",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := client.FromContext(cmd.Context())
+		name := args[0]
+
+		var tmpl TemplateInfo
+		if err := c.Get(cmd.Context(), "/snapshots/"+url.PathEscape(name), &tmpl); err != nil {
+			return err
+		}
+
+		printer.Print(tmpl, func() {
+			fmt.Printf("Name:       %s\n", tmpl.Name)
+			fmt.Printf("Status:     %s\n", tmpl.Status)
+			fmt.Printf("ID:         %s\n", tmpl.ID)
+			fmt.Printf("Checkpoint: %s\n", valueOrDash(tmpl.CheckpointID))
+			fmt.Printf("Created:    %s\n", formatTemplateTime(tmpl.CreatedAt))
+			fmt.Printf("Last used:  %s\n", formatTemplateTime(tmpl.LastUsedAt))
+		})
+		return nil
+	},
+}
+
+var templateDeleteCmd = &cobra.Command{
+	Use:   "delete <name>",
+	Short: "Delete a template",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c := client.FromContext(cmd.Context())
+		name := args[0]
+		if err := c.DeleteIgnoreNotFound(cmd.Context(), "/snapshots/"+url.PathEscape(name)); err != nil {
+			return err
+		}
+		fmt.Printf("Template %s deleted.\n", name)
+		return nil
+	},
+}
+
+func formatTemplateTime(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.Format(time.RFC3339)
+}
+
+func valueOrDash(v string) string {
+	if v == "" {
+		return "-"
+	}
+	return v
+}
+
+func init() {
+	templateCmd.AddCommand(templateListCmd)
+	templateCmd.AddCommand(templateGetCmd)
+	templateCmd.AddCommand(templateDeleteCmd)
+}

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -1360,3 +1360,26 @@ func (s *Server) dashboardDeleteImage(c echo.Context) error {
 
 	return c.NoContent(http.StatusNoContent)
 }
+
+// dashboardDeleteSnapshot deletes a named template/snapshot for the authenticated org.
+func (s *Server) dashboardDeleteSnapshot(c echo.Context) error {
+	if s.store == nil {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "database not configured"})
+	}
+
+	orgID, ok := auth.GetOrgID(c)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "org context required"})
+	}
+
+	name := c.Param("name")
+	ic, _ := s.store.GetImageCacheByName(c.Request().Context(), orgID, name)
+	if err := s.store.DeleteImageCacheByName(c.Request().Context(), orgID, name); err != nil {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": err.Error()})
+	}
+	if ic != nil {
+		s.publishImageCacheEvent(c.Request().Context(), "image_cache_deleted", ic.ID, orgID, nil)
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -361,6 +361,7 @@ func NewServer(mgr sandbox.Manager, ptyMgr *sandbox.PTYManager, apiKey string, o
 		// Proxy these here so dashboard can render per-cell image lists.
 		idash.GET("/images", s.dashboardListImages)
 		idash.DELETE("/images/:id", s.dashboardDeleteImage)
+		idash.DELETE("/snapshots/:name", s.dashboardDeleteSnapshot)
 		// Agents — currently proxied to an external service from each cell.
 		// Easier to keep that wiring intact than reimplement on the edge.
 		idash.Any("/agents", s.dashboardAgentsProxy)
@@ -657,6 +658,7 @@ func NewServer(mgr sandbox.Manager, ptyMgr *sandbox.PTYManager, apiKey string, o
 		dash.DELETE("/checkpoints/:id", s.dashboardDeleteCheckpoint)
 		dash.GET("/images", s.dashboardListImages)
 		dash.DELETE("/images/:id", s.dashboardDeleteImage)
+		dash.DELETE("/snapshots/:name", s.dashboardDeleteSnapshot)
 
 		// Organization members and invitations
 		dash.GET("/org/members", s.dashboardListOrgMembers)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -188,6 +188,9 @@ export const getImages = (all = false) =>
 export const deleteImage = (id: string) =>
   apiFetch<void>(`/images/${id}`, { method: 'DELETE' })
 
+export const deleteSnapshot = (name: string) =>
+  apiFetch<void>(`/snapshots/${encodeURIComponent(name)}`, { method: 'DELETE' })
+
 export const getSandboxDetail = (sandboxId: string) =>
   apiFetch(`/sessions/${sandboxId}`, {}, S.SandboxDetailSchema)
 

--- a/web/src/pages/Templates.tsx
+++ b/web/src/pages/Templates.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Package } from 'lucide-react'
 import { notifyError } from '@/lib/errors'
-import { deleteImage, getImages, type ImageCacheItem } from '@/api/client'
+import { deleteSnapshot, getImages, type ImageCacheItem } from '@/api/client'
 import { PageHeader } from '@/components/page-header'
 import { Panel } from '@/components/panel'
 import { Button } from '@/components/ui/button'
@@ -58,14 +58,14 @@ export default function Templates() {
   })
 
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => deleteImage(id),
+    mutationFn: (name: string) => deleteSnapshot(name),
     onError: (error) => notifyError("Couldn't delete the template.", error),
     onSettled: () => queryClient.invalidateQueries({ queryKey: ['images'] }),
   })
 
   const confirmDelete = () => {
-    if (!toDelete) return
-    deleteMutation.mutate(toDelete.id, { onSuccess: () => setToDelete(null) })
+    if (!toDelete?.name) return
+    deleteMutation.mutate(toDelete.name, { onSuccess: () => setToDelete(null) })
   }
 
   const columns: Column<ImageCacheItem>[] = [


### PR DESCRIPTION
Adds an oc template command group for listing, inspecting, and deleting templates by name. Also fixes dashboard template deletion to call the name-based snapshots endpoint instead of the UUID image delete endpoint.