### PR TITLE
fix: skills .zip upload (binary body) + auto-refresh after connecting a repo

### DIFF
--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -854,7 +854,7 @@ async function proxyToV3(
 
   const init: RequestInit = { method: req.method, headers, redirect: "manual" };
   if (req.method !== "GET" && req.method !== "HEAD") {
-    init.body = await req.text();
+    init.body = await req.arrayBuffer(); // binary-safe — req.text() UTF-8-mangles zip/binary uploads
   }
   return fetch(target, init);
 }
@@ -884,7 +884,7 @@ async function proxyToBrowserAPI(
 
   const init: RequestInit = { method: req.method, headers, redirect: "manual" };
   if (req.method !== "GET" && req.method !== "HEAD") {
-    init.body = await req.text();
+    init.body = await req.arrayBuffer(); // binary-safe — req.text() UTF-8-mangles zip/binary uploads
   }
 
   return fetch(target, init);

--- a/web/src/components/agent-deploy-source.tsx
+++ b/web/src/components/agent-deploy-source.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState } from 'react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from '@tanstack/react-query'
 import { Unplug, ExternalLink, RotateCw } from 'lucide-react'
 import { notifyError, notifySuccess } from '@/lib/errors'
 import {
@@ -14,6 +19,28 @@ import { Button } from '@/components/ui/button'
 import { Input, Select } from '@/components/form'
 
 // GitHub mark (lucide's brand `Github` icon is deprecated/unexported — inline the SVG).
+// A connect / redeploy kicks off a GitHub deploy that runs ASYNC — the new revision (prompt +
+// skills) isn't live until it activates. Poll the source until the deploy lands
+// (active_deployed_sha caught up to latest_seen_sha), keeping the card in step, then refresh the
+// dependent views so the Overview + Skills update without a manual page reload. Bounded (~60s).
+async function pollDeployUntilActive(agentId: string, queryClient: QueryClient) {
+  for (let i = 0; i < 24; i++) {
+    await new Promise((r) => setTimeout(r, 2500))
+    try {
+      const src = (await getDeploymentSource(agentId)).source
+      queryClient.setQueryData(['agent-deploy-source', agentId], src)
+      if (src?.active_deployed_sha && src.active_deployed_sha === src.latest_seen_sha) {
+        void queryClient.invalidateQueries({ queryKey: ['agent', agentId] })
+        void queryClient.invalidateQueries({ queryKey: ['agent-skills', agentId] })
+        void queryClient.invalidateQueries({ queryKey: ['agent-revisions', agentId] })
+        return
+      }
+    } catch {
+      return
+    }
+  }
+}
+
 function GithubMark({ className }: { className?: string }) {
   return (
     <svg viewBox="0 0 16 16" fill="currentColor" className={className} aria-hidden="true">
@@ -100,6 +127,7 @@ export function AgentDeploySource({
     void queryClient.invalidateQueries({
       queryKey: ['agent-revisions', agentId],
     })
+    void queryClient.invalidateQueries({ queryKey: ['agent-skills', agentId] })
     void queryClient.invalidateQueries({ queryKey: ['agent', agentId] })
   }
 
@@ -120,9 +148,11 @@ export function AgentDeploySource({
       } else {
         notifySuccess(
           source
-            ? 'Updated — creating a revision from the latest commit.'
+            ? 'Redeploying — pulling the latest commit into a new revision.'
             : 'Connected — creating the first revision.',
         )
+        // The GitHub deploy runs async — refresh the prompt + skills once it activates.
+        void pollDeployUntilActive(agentId, queryClient)
       }
     },
     onError: (e) => notifyError("Couldn't connect the repo.", e),


### PR DESCRIPTION
Two dashboard/edge fixes for the deploy-from-GitHub flow.

## 1. Skills `.zip` upload silently produced no skills
The edge dashboard proxy (`proxyToV3`, and `proxyToBrowserAPI`) forwarded request bodies via `await req.text()`, which UTF-8-decodes the bytes and **corrupts binary uploads**. A skills `.zip` PUT (`PUT /v3/agents/:id/skills`) arrived mangled at sessions-api, which then silently created a revision with **zero skills** — `201`, no error, nothing shown. JSON bodies were unaffected, so everything else worked.

**Fix:** forward raw bytes via `req.arrayBuffer()` (binary-safe; JSON identical). Confirmed the engine is fine via a direct `/v3` upload.

## 2. Prompt + skills didn't refresh after connecting a repo
Connecting a repo starts an **async** GitHub deploy, so the immediate cache-invalidate ran before the new revision was live — the Overview prompt + Skills card stayed stale until a manual page reload (and `agent-skills` was never invalidated at all).

**Fix:** after connect/redeploy, poll the source until the deploy activates (`active_deployed_sha == latest_seen_sha`), then refresh agent + skills + revisions; also invalidate `agent-skills` on link/unlink.

Both deployed to `opencomputer-edge-prod` ahead of merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
