### PR TITLE
Watches + working repo: dashboard picker, SDK & CLI, docs (design 010)

### DIFF
--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -854,7 +854,7 @@ async function proxyToV3(
 
   const init: RequestInit = { method: req.method, headers, redirect: "manual" };
   if (req.method !== "GET" && req.method !== "HEAD") {
-    init.body = await req.text();
+    init.body = await req.arrayBuffer(); // binary-safe — req.text() UTF-8-mangles zip/binary uploads
   }
   return fetch(target, init);
 }
@@ -884,7 +884,7 @@ async function proxyToBrowserAPI(
 
   const init: RequestInit = { method: req.method, headers, redirect: "manual" };
   if (req.method !== "GET" && req.method !== "HEAD") {
-    init.body = await req.text();
+    init.body = await req.arrayBuffer(); // binary-safe — req.text() UTF-8-mangles zip/binary uploads
   }
 
   return fetch(target, init);

--- a/cmd/oc/internal/commands/session_watch.go
+++ b/cmd/oc/internal/commands/session_watch.go
@@ -1,0 +1,164 @@
+package commands
+
+// `oc session watch|watches|unwatch` — PR watches (design 010). A watch wakes the
+// session when a PR it opened changes (checks finish, a review/comment lands, it
+// merges/closes). Only PRs the same session opened, on OpenComputer-App repos.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type Watch struct {
+	ID             string `json:"id"`
+	Type           string `json:"type"`
+	Repo           string `json:"repo"`
+	PR             int    `json:"pr"`
+	WakeOn         string `json:"wake_on"`
+	Intent         string `json:"intent,omitempty"`
+	Status         string `json:"status"`
+	Origin         string `json:"origin"`
+	LastSnapshotAt string `json:"last_snapshot_at,omitempty"`
+	ExpiresAt      string `json:"expires_at,omitempty"`
+	CreatedAt      string `json:"created_at"`
+}
+
+type WatchEnvelope struct {
+	Watch Watch `json:"watch"`
+}
+
+type WatchList struct {
+	Data []Watch `json:"data"`
+}
+
+var wakeOns = []string{"checks", "review", "comment", "merge"}
+
+var sessionWatchCmd = &cobra.Command{
+	Use:   "watch <id>",
+	Short: "Watch a PR the session opened (wake it on PR changes)",
+	Long: "Declare a watch: OpenComputer wakes the session when the watched PR changes.\n\n" +
+		"wake_on picks the condition — checks (CI finishes, default), review (a review\n" +
+		"decision), comment (a new comment), or merge (the PR merges/closes). --repo/--pr\n" +
+		"are optional; omitted, they resolve to the PR this session opened.",
+	Example: "  oc session watch ses_123 --wake-on review --intent \"address review feedback\"\n" +
+		"  oc session watch ses_123                     # wake_on=checks (default)",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+		wakeOn, _ := cmd.Flags().GetString("wake-on")
+		if !contains(wakeOns, wakeOn) {
+			return fmt.Errorf("--wake-on must be one of %s", strings.Join(wakeOns, ", "))
+		}
+		repo, _ := cmd.Flags().GetString("repo")
+		pr, _ := cmd.Flags().GetInt("pr")
+		intent, _ := cmd.Flags().GetString("intent")
+
+		body := map[string]interface{}{"type": "github_pr", "wake_on": wakeOn}
+		if repo != "" {
+			body["repo"] = repo
+		}
+		if pr > 0 {
+			body["pr"] = pr
+		}
+		if intent != "" {
+			body["intent"] = intent
+		}
+		var env WatchEnvelope
+		if err := sc.Post(cmd.Context(), "/v3/sessions/"+args[0]+"/watches", body, &env); err != nil {
+			return err
+		}
+		printer.Print(env.Watch, func() {
+			w := env.Watch
+			fmt.Printf("Watching %s#%d — wake on %s (%s)\n", w.Repo, w.PR, w.WakeOn, w.Status)
+			fmt.Printf("Watch id: %s\n", w.ID)
+			if w.Status == "auth_required" {
+				fmt.Println("Note: the OpenComputer GitHub App needs its watch permissions re-accepted; re-declare once fixed.")
+			}
+		})
+		return nil
+	},
+}
+
+var sessionWatchesCmd = &cobra.Command{
+	Use:     "watches <id>",
+	Short:   "List a session's watches",
+	Args:    cobra.ExactArgs(1),
+	Aliases: []string{"watch-list"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+		var resp WatchList
+		if err := sc.Get(cmd.Context(), "/v3/sessions/"+args[0]+"/watches", &resp); err != nil {
+			return err
+		}
+		printer.Print(resp.Data, func() {
+			if len(resp.Data) == 0 {
+				fmt.Println("No watches.")
+				return
+			}
+			headers := []string{"ID", "REPO", "PR", "WAKE ON", "STATUS", "INTENT"}
+			var rows [][]string
+			for _, w := range resp.Data {
+				rows = append(rows, []string{w.ID, w.Repo, fmt.Sprintf("%d", w.PR), w.WakeOn, w.Status, truncStr(w.Intent, 40)})
+			}
+			printer.Table(headers, rows)
+		})
+		return nil
+	},
+}
+
+var sessionUnwatchCmd = &cobra.Command{
+	Use:     "unwatch <id> <watch-id>",
+	Short:   "Remove a watch",
+	Example: "  oc session unwatch ses_123 wch_abc",
+	Args:    cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+		if err := sc.Delete(cmd.Context(), "/v3/sessions/"+args[0]+"/watches/"+args[1]); err != nil {
+			return err
+		}
+		fmt.Printf("Removed watch %s\n", args[1])
+		return nil
+	},
+}
+
+func contains(xs []string, x string) bool {
+	for _, v := range xs {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}
+
+func truncStr(s string, n int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}
+
+func init() {
+	sessionWatchCmd.Flags().String("wake-on", "checks", "Wake condition: checks | review | comment | merge")
+	sessionWatchCmd.Flags().String("repo", "", "owner/repo (default: the PR this session opened)")
+	sessionWatchCmd.Flags().Int("pr", 0, "PR number (default: the session's sole owned PR)")
+	sessionWatchCmd.Flags().String("intent", "", "Freeform note (\"why\"), replayed to the agent on wake")
+
+	sessionCmd.AddCommand(sessionWatchCmd)
+	sessionCmd.AddCommand(sessionWatchesCmd)
+	sessionCmd.AddCommand(sessionUnwatchCmd)
+}

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -219,7 +219,7 @@ Body: `{ text, idempotency_key? }` or `{ envelope }`. Returns `202` (or `200` on
 
 ## Watches
 
-*Watches are managed via REST (no SDK method or `oc` command yet); the agent-facing path is the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool. Authenticate with your **org API key** (server-side). Full guide: [Watches](/agent-sessions/watches).*
+*Managed with the SDK (`session.watches.create/list/delete`), the CLI (`oc session watch/watches/unwatch`), or REST — authenticate with your **org API key** (server-side). The agent-facing path is the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool. Full guide: [Watches](/agent-sessions/watches).*
 
 | Method · Path | Purpose |
 | --- | --- |

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -219,7 +219,7 @@ Body: `{ text, idempotency_key? }` or `{ envelope }`. Returns `202` (or `200` on
 
 ## Watches
 
-*Watches are managed via REST (no SDK method or `oc` command yet); the agent-facing path is the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool. Authenticate with the org key or a client token. Full guide: [Watches](/agent-sessions/watches).*
+*Watches are managed via REST (no SDK method or `oc` command yet); the agent-facing path is the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool. Authenticate with your **org API key** (server-side). Full guide: [Watches](/agent-sessions/watches).*
 
 | Method · Path | Purpose |
 | --- | --- |
@@ -239,9 +239,9 @@ Body: `{ text, idempotency_key? }` or `{ envelope }`. Returns `202` (or `200` on
 | `intent?` | freeform note ("why"), replayed on wake |
 | `status` | `active · closed · revoked · auth_required` |
 | `origin` | how it was declared (runtime tool / management API) |
-| `last_snapshot_at?` `created_at` | last authoritative PR re-read · timestamp |
+| `last_snapshot_at?` `expires_at` `created_at` | last authoritative PR re-read · 30-day TTL lapse · timestamp |
 
-**Delivered events** — appended into the session log at level `user` with `source: "github"`, carrying a normalized summary (not the raw webhook): `github.pr.checks_completed` · `github.pr.review_submitted` · `github.pr.review_comment` · `github.pr.comment` · `github.pr.merged` · `github.pr.closed` · `github.pr.reopened`.
+**Delivered events** — appended into the session log at level `user` with `source: "github"`, carrying a normalized summary (not the raw webhook): `github.pr.checks_completed` · `github.pr.review_submitted` · `github.pr.comment` · `github.pr.merged` · `github.pr.closed`.
 
 ## Agents
 

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -123,8 +123,8 @@ A turn's **`yield_reason`** tells you why it stopped:
 
 | Variant | Shape |
 |---|---|
-| registered | `{ repo, ref, sha, name? }` — `repo` is a `repo_…` id or `"owner/repo"`; App-backed auth |
-| inline | `{ url, ref, sha, name?, auth }` — `auth = { type:"risky_short_lived_token", token, expires_at }` (can't refresh) |
+| registered | `{ repo, ref, sha?, name? }` — `repo` is a `repo_…` id or `"owner/repo"`; App-backed auth. `sha` is **optional** (omit → control plane resolves `ref`→HEAD and pins it at create) |
+| inline | `{ url, ref, sha, name?, auth }` — `sha` **required**; `auth = { type:"risky_short_lived_token", token, expires_at }` (can't refresh) |
 
 **`SourceSummary`** (sanitized; on create + `GET …/sources`)
 
@@ -216,6 +216,33 @@ Filter by `type` (exact or `prefix.*`), `turn_id`, `limit`. `after` resumes from
 </Tabs>
 
 Body: `{ text, idempotency_key? }` or `{ envelope }`. Returns `202` (or `200` on idempotent replay) with `{ event: { id, seq }, session: { id, status, head } }`.
+
+## Watches
+
+*Watches are managed via REST (no SDK method or `oc` command yet); the agent-facing path is the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool. Authenticate with the org key or a client token. Full guide: [Watches](/agent-sessions/watches).*
+
+| Method · Path | Purpose |
+| --- | --- |
+| `POST /sessions/:id/watches` | Declare a watch → `201 { watch }`. Body: `{ type:"github_pr", repo?, pr?, goal, intent?, events? }`. |
+| `GET /sessions/:id/watches` | List watches → `{ data: [watch] }`. |
+| `DELETE /sessions/:id/watches/:watchId` | Remove a watch → `{ ok: true }`. |
+
+`repo`/`pr` are optional — omitted, they resolve to the PR this session opened. A watch fires only on PRs the **same session** opened, on Connected-App (`oc_app`) repos. Limits: **10** active watches per session, **30-day** TTL (and never outlives the PR).
+
+**`Watch`**
+
+| Field | Notes |
+|---|---|
+| `id` `type` | `wch_…`; `type` = `github_pr` |
+| `repo` `pr` | watched repo · PR number |
+| `goal` | `wait_for_checks` (default) · `wait_for_review` · `wait_for_merge` · `respond_to_comments` |
+| `intent?` | freeform note, replayed on wake |
+| `events` | delivered event types this watch subscribes to |
+| `status` | `pending_snapshot · active · expired · closed · revoked · auth_required · app_suspended` |
+| `origin` | how it was declared (runtime tool / management API) |
+| `last_snapshot_at?` `created_at` | last authoritative PR re-read · timestamp |
+
+**Delivered events** — appended into the session log at level `user` with `source: "github"`, carrying a normalized summary (not the raw webhook): `github.pr.checks_completed` · `github.pr.review_submitted` · `github.pr.review_comment` · `github.pr.comment` · `github.pr.merged` · `github.pr.closed` · `github.pr.reopened`.
 
 ## Agents
 

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -237,7 +237,7 @@ Body: `{ text, idempotency_key? }` or `{ envelope }`. Returns `202` (or `200` on
 | `repo` `pr` | watched repo · PR number |
 | `wake_on` | wake condition: `checks` (default) · `review` (a review decision) · `comment` · `merge` (merged/closed) |
 | `intent?` | freeform note ("why"), replayed on wake |
-| `status` | `pending_snapshot · active · expired · closed · revoked · auth_required · app_suspended` |
+| `status` | `active · closed · revoked · auth_required` |
 | `origin` | how it was declared (runtime tool / management API) |
 | `last_snapshot_at?` `created_at` | last authoritative PR re-read · timestamp |
 

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -223,11 +223,11 @@ Body: `{ text, idempotency_key? }` or `{ envelope }`. Returns `202` (or `200` on
 
 | Method · Path | Purpose |
 | --- | --- |
-| `POST /sessions/:id/watches` | Declare a watch → `201 { watch }`. Body: `{ type:"github_pr", repo?, pr?, goal, intent?, events? }`. |
+| `POST /sessions/:id/watches` | Declare a watch → `201 { watch }`. Body: `{ type:"github_pr", repo?, pr?, wake_on, intent? }`. |
 | `GET /sessions/:id/watches` | List watches → `{ data: [watch] }`. |
 | `DELETE /sessions/:id/watches/:watchId` | Remove a watch → `{ ok: true }`. |
 
-`repo`/`pr` are optional — omitted, they resolve to the PR this session opened. A watch fires only on PRs the **same session** opened, on Connected-App (`oc_app`) repos. Limits: **10** active watches per session, **30-day** TTL (and never outlives the PR).
+`wake_on` is the wake condition (`checks` default · `review` · `comment` · `merge`); `intent` is the freeform "why," replayed on wake. `repo`/`pr` are optional — omitted, they resolve to the PR this session opened. A watch fires only on PRs the **same session** opened, on Connected-App (`oc_app`) repos. Limits: **10** active watches per session, **30-day** TTL (and never outlives the PR).
 
 **`Watch`**
 
@@ -235,9 +235,8 @@ Body: `{ text, idempotency_key? }` or `{ envelope }`. Returns `202` (or `200` on
 |---|---|
 | `id` `type` | `wch_…`; `type` = `github_pr` |
 | `repo` `pr` | watched repo · PR number |
-| `goal` | `wait_for_checks` (default) · `wait_for_review` · `wait_for_merge` · `respond_to_comments` |
-| `intent?` | freeform note, replayed on wake |
-| `events` | delivered event types this watch subscribes to |
+| `wake_on` | wake condition: `checks` (default) · `review` (a review decision) · `comment` · `merge` (merged/closed) |
+| `intent?` | freeform note ("why"), replayed on wake |
 | `status` | `pending_snapshot · active · expired · closed · revoked · auth_required · app_suspended` |
 | `origin` | how it was declared (runtime tool / management API) |
 | `last_snapshot_at?` `created_at` | last authoritative PR re-read · timestamp |

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -82,7 +82,7 @@ oc agent deploy        # deploy the agent directory in the cwd
 - `key?` — get-or-create (one session per key). Keyless: an `Idempotency-Key` header makes create retry-safe.
 - `metadata?` — opaque routing state (≤ 16 KB); on get/list + **verbatim in webhooks**; never sent to the model, not indexed.
 - `limits?` `{ tokens, turn_seconds, turns }` — non-monetary; tripping one ends the turn (matching `yield_reason`).
-- `sources?` — repos checked out before turn 1 (the token never enters the sandbox; see [GitHub](#github-apps-and-repos)). Each `{ repo, ref, sha, name? }` or inline `{ url, ref, sha, name?, auth }`; `ref` + `sha` required.
+- `sources?` — repos checked out before turn 1 (the token never enters the sandbox; see [GitHub](#github-apps-and-repos)). Each registered `{ repo, ref, sha?, name? }` or inline `{ url, ref, sha, name?, auth }`. `ref` is required; `sha` is required for inline sources but **optional for a registered repo** — omit it and the control plane resolves `ref`→HEAD and pins that commit at create.
 - Client tokens: `scopes?` (`read`/`steer`), `ttl?` 60–86400 s (SDK `ttlSeconds`).
 
 A session pins the agent's active revision for its whole life — editing the agent later never affects a running one.

--- a/docs/agent-sessions/events.mdx
+++ b/docs/agent-sessions/events.mdx
@@ -51,9 +51,8 @@ When a session [watches](/agent-sessions/watches) a PR it opened, OpenComputer w
 | `type` | Fires on |
 | --- | --- |
 | `github.pr.checks_completed` | check suites finished (coalesced) |
-| `github.pr.review_submitted` | a review was submitted |
-| `github.pr.review_comment` | a review (diff) comment landed |
-| `github.pr.comment` | an issue-style comment landed on the PR |
+| `github.pr.review_submitted` | a review decision landed (approved / changes requested) |
+| `github.pr.comment` | a comment landed on the PR — issue-style or review (diff) comment |
 | `github.pr.merged` | the PR merged |
 | `github.pr.closed` | the PR closed without merging |
 | `github.pr.reopened` | a closed PR reopened |

--- a/docs/agent-sessions/events.mdx
+++ b/docs/agent-sessions/events.mdx
@@ -46,7 +46,7 @@ Treat **`type`** as the stable discriminator. Unknown types should render from t
 
 ### GitHub PR events
 
-When a session declares a [watch](/agent-sessions/watches) on a PR it opened, OpenComputer wakes it with a normalized PR event — level `user`, `source: "github"`, `body` a concise summary (e.g. author + comment text + url), never the raw webhook.
+When a session [watches](/agent-sessions/watches) a PR it opened, OpenComputer wakes it with a normalized event — level `user`, `source: "github"`, `body` a summary (author, text, url), never the raw webhook.
 
 | `type` | Fires on |
 | --- | --- |

--- a/docs/agent-sessions/events.mdx
+++ b/docs/agent-sessions/events.mdx
@@ -44,6 +44,20 @@ Treat **`type`** as the stable discriminator. Unknown types should render from t
 | `exec.completed` | `{ command, exit_code, summary, content_ref?, bytes? }` | a finished command |
 | `error.runtime` · `error.model` · `error.task` | `{ code, message, retriable? }` | a failure |
 
+### GitHub PR events
+
+When a session declares a [watch](/agent-sessions/watches) on a PR it opened, OpenComputer wakes it with a normalized PR event — level `user`, `source: "github"`, `body` a concise summary (e.g. author + comment text + url), never the raw webhook.
+
+| `type` | Fires on |
+| --- | --- |
+| `github.pr.checks_completed` | check suites finished (coalesced) |
+| `github.pr.review_submitted` | a review was submitted |
+| `github.pr.review_comment` | a review (diff) comment landed |
+| `github.pr.comment` | an issue-style comment landed on the PR |
+| `github.pr.merged` | the PR merged |
+| `github.pr.closed` | the PR closed without merging |
+| `github.pr.reopened` | a closed PR reopened |
+
 ## Visibility levels
 
 Every event carries a `level`; use it to choose how much detail each client receives.

--- a/docs/agent-sessions/events.mdx
+++ b/docs/agent-sessions/events.mdx
@@ -50,12 +50,11 @@ When a session [watches](/agent-sessions/watches) a PR it opened, OpenComputer w
 
 | `type` | Fires on |
 | --- | --- |
-| `github.pr.checks_completed` | check suites finished (coalesced) |
+| `github.pr.checks_completed` | GitHub check runs/suites for the head commit finished (coalesced) |
 | `github.pr.review_submitted` | a review decision landed (approved / changes requested) |
 | `github.pr.comment` | a comment landed on the PR — issue-style or review (diff) comment |
 | `github.pr.merged` | the PR merged |
 | `github.pr.closed` | the PR closed without merging |
-| `github.pr.reopened` | a closed PR reopened |
 
 ## Visibility levels
 

--- a/docs/agent-sessions/quickstart.mdx
+++ b/docs/agent-sessions/quickstart.mdx
@@ -108,6 +108,18 @@ Response:
 }
 ```
 
+<Tip>**Working on a repo?** Pass [`sources`](/agent-sessions/repos) to check code out before turn 1 — the GitHub token never enters the sandbox. For a registered repo, `sha` is optional (OpenComputer resolves `ref`→HEAD and pins it):</Tip>
+
+```ts
+const session = await oc.sessions.create({
+  agent: agent.id,
+  input: "Fix the failing test on this branch, then open a PR.",
+  sources: [{ repo: "acme/web", ref: "main" }],
+});
+```
+
+The agent can then open a PR with `github_publish_pull_request` and [watch](/agent-sessions/watches) it — waking when checks finish or a reviewer comments.
+
 ## 3. Stream events
 
 Use the `client_token` in the browser. Ask for `progress` for a good activity feed, or `internal` for an operator/debug view.

--- a/docs/agent-sessions/quickstart.mdx
+++ b/docs/agent-sessions/quickstart.mdx
@@ -110,7 +110,9 @@ Response:
 
 <Tip>**Working on a repo?** Pass [`sources`](/agent-sessions/repos) to check code out before turn 1 — the GitHub token never enters the sandbox. For a registered repo, `sha` is optional (OpenComputer resolves `ref`→HEAD and pins it):</Tip>
 
-```ts
+<CodeGroup>
+
+```ts TypeScript SDK
 const session = await oc.sessions.create({
   agent: agent.id,
   input: "Fix the failing test on this branch, then open a PR.",
@@ -118,7 +120,21 @@ const session = await oc.sessions.create({
 });
 ```
 
-The agent can then open a PR with `github_publish_pull_request` and [watch](/agent-sessions/watches) it — waking when checks finish or a reviewer comments.
+```http REST API
+POST https://api.opencomputer.dev/v3/sessions
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+Content-Type: application/json
+
+{
+  "agent": "agt_...",
+  "input": "Fix the failing test on this branch, then open a PR.",
+  "sources": [{ "repo": "acme/web", "ref": "main" }]
+}
+```
+
+</CodeGroup>
+
+The agent can then open a PR with `github_publish_pull_request` and [watch](/agent-sessions/watches) it — it wakes when checks finish or a reviewer comments.
 
 ## 3. Stream events
 

--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -326,16 +326,15 @@ agent's edits to an `oc/<session>/<source>-<id>` branch and opens the PR with a
 just-in-time, write-scoped token. This requires a **configured GitHub App** — the inline
 `risky_short_lived_token` path is checkout-only and **cannot** open PRs.
 
-**Check out more repos mid-session.** The agent can call
-[`add_source(repo, ref, name?)`](/agent-sessions/runtime-tools#github-tools) to check out an
-additional Connected-App repo into `/workspace/sources/<name>` after the first turn — the
-same zero-credential model as the initial checkout.
+**More repos mid-session.**
+[`add_source(repo, ref, name?)`](/agent-sessions/runtime-tools#github-tools) checks out an
+additional Connected-App repo into `/workspace/sources/<name>` after the first turn — same
+zero-credential model as the initial checkout.
 
-**React to PR events.** After opening a PR, the agent can declare a
-[watch](/agent-sessions/watches) on it with `watch_pull_request`: OpenComputer wakes the
-session when checks finish, a review or comment lands, or it merges, so the agent can respond
-(e.g. push a fix onto the branch). Watches cover PRs the same session opened, on Connected-App
-repos only.
+**React to PR events.** After opening a PR, the agent can
+[watch](/agent-sessions/watches) it with `watch_pull_request`; OpenComputer wakes the session
+when checks finish, a review or comment lands, or it merges, so the agent can respond (e.g.
+push a fix). Own-PR only, Connected-App repos only.
 
 ## Guarantees
 

--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -131,6 +131,8 @@ for checkout, write only to publish) — the agent never holds one.
 Use your own GitHub App so PRs, comments, and statuses come from **your** identity. OpenComputer
 stores the key encrypted and signs the same per-operation tokens with it.
 
+<Note>[Watches](/agent-sessions/watches) currently require PRs opened through the **OpenComputer** App — a PR published with a bring-your-own App isn't watchable yet.</Note>
+
 **Create one** — `createManifestUrl` returns a link; open it and GitHub walks you through
 creating the App, then OpenComputer captures the key and registers it. (Creating an App is a
 GitHub-UI flow, so it's a link to open, not a pure API call.)

--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -285,7 +285,9 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 
 - **`ref`** (required) — the fetch ref (a branch or `refs/pull/N/head`); a private SHA
   can't be fetched directly.
-- **`sha`** (required) — the exact commit, pinned and verified after fetch.
+- **`sha`** — the exact commit, pinned and verified after fetch. **Optional for a
+  registered repo** (omit it and the control plane resolves `ref`→HEAD and pins that commit
+  at create); **required for inline sources**.
 
 You can also reference `"owner/repo"` directly instead of a registered id. A session can
 list several immutable sources, such as a PR's base and head.
@@ -315,12 +317,6 @@ After checkout, the agent works with ordinary files. It can inspect, edit, test,
 make local commits. Anything needing GitHub credentials runs outside the agent sandbox, so
 the agent never runs authenticated `git`/`gh` and never sees a token.
 
-<Warning>
-Opening PRs from the agent (`github_publish_pull_request`) is **temporarily unavailable**
-while the runtime is being updated — checkout (read) works today; the agent-driven PR-open
-described below will be re-enabled in an upcoming runtime release.
-</Warning>
-
 To open a pull request, the agent calls the
 [`github_publish_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool —
 it is **not** an SDK method; the agent invokes it from inside the sandbox. It takes the
@@ -329,6 +325,17 @@ source's checked-out ref), and `draft`, and returns the PR URL. OpenComputer com
 agent's edits to an `oc/<session>/<source>-<id>` branch and opens the PR with a
 just-in-time, write-scoped token. This requires a **configured GitHub App** — the inline
 `risky_short_lived_token` path is checkout-only and **cannot** open PRs.
+
+**Check out more repos mid-session.** The agent can call
+[`add_source(repo, ref, name?)`](/agent-sessions/runtime-tools#github-tools) to check out an
+additional Connected-App repo into `/workspace/sources/<name>` after the first turn — the
+same zero-credential model as the initial checkout.
+
+**React to PR events.** After opening a PR, the agent can declare a
+[watch](/agent-sessions/watches) on it with `watch_pull_request`: OpenComputer wakes the
+session when checks finish, a review or comment lands, or it merges, so the agent can respond
+(e.g. push a fix onto the branch). Watches cover PRs the same session opened, on Connected-App
+repos only.
 
 ## Guarantees
 

--- a/docs/agent-sessions/runtime-tools.mdx
+++ b/docs/agent-sessions/runtime-tools.mdx
@@ -61,28 +61,25 @@ inline (`risky_short_lived_token`) auth, which is **checkout-only** — see
 </Note>
 
 `add_source(repo, ref, name?)` checks out an **additional** repo into
-`/workspace/sources/<name>` mid-session — for pulling in a second repo after the first turn.
-`repo` is `"owner/repo"` (or a `repo_…` id), `ref` is a branch or `refs/pull/N/head`, and
-`name` defaults to the repo name. It uses the same zero-credential model as the initial
-checkout: a Git operations sandbox mints a just-in-time, read-only token and the agent never
-sees it. **Connected-App (`oc_app`) repos only** — inline-token sources can't be added this
-way.
+`/workspace/sources/<name>` mid-session. `repo` is `"owner/repo"` (or a `repo_…` id), `ref` a
+branch or `refs/pull/N/head`, `name` defaults to the repo name. Same zero-credential model as
+the initial checkout — a Git operations sandbox mints a just-in-time, read-only token; the
+agent never sees it. **Connected-App (`oc_app`) repos only.**
 
 `watch_pull_request(goal?, repo?, pr?, intent?)` subscribes the session to events on a PR it
-opened; OpenComputer **wakes the session** when checks finish, a review or comment lands, or
-the PR merges. It does **not** block — call it, then finish the turn.
+opened; OpenComputer wakes the session when checks finish, a review or comment lands, or the
+PR merges. It does **not** block — call it, then finish the turn.
 
 | Argument | Required | What it is |
 | --- | --- | --- |
 | `goal` | no | What to wait for: `wait_for_checks` (default), `wait_for_review`, `wait_for_merge`, `respond_to_comments`. |
 | `repo` | no | The watched repo. Defaults to the most recent PR the session opened. |
 | `pr` | no | The PR number. Defaults with `repo`. |
-| `intent` | no | Freeform note replayed on wake, so the agent knows why it woke. |
+| `intent` | no | Freeform note replayed on wake. |
 
-You can only watch a PR the **same session** opened, on **Connected-App (`oc_app`) repos
-only**. `unwatch_pull_request(repo?, pr?)` stops watching; both args default to the session's
-only active watch. Full flow, statuses, and delivered event types:
-[Watches](/agent-sessions/watches).
+Watches cover PRs the **same session** opened, on **Connected-App (`oc_app`) repos only**.
+`unwatch_pull_request(repo?, pr?)` stops watching; both args default to the session's only
+active watch. Full flow, statuses, and delivered events: [Watches](/agent-sessions/watches).
 
 ## External systems
 

--- a/docs/agent-sessions/runtime-tools.mdx
+++ b/docs/agent-sessions/runtime-tools.mdx
@@ -55,10 +55,34 @@ just-in-time, write-scoped token — outside the agent sandbox. It returns the P
 
 <Note>
 `github_publish_pull_request` requires a **configured GitHub App** (the OpenComputer App or
-a [bring-your-own App](/agent-sessions/repos#github-app-modes)). It does **not** work with
+a [bring-your-own App](/agent-sessions/repos#bring-your-own-app)). It does **not** work with
 inline (`risky_short_lived_token`) auth, which is **checkout-only** — see
 [Repos & GitHub](/agent-sessions/repos#inline-short-lived-token).
 </Note>
+
+`add_source(repo, ref, name?)` checks out an **additional** repo into
+`/workspace/sources/<name>` mid-session — for pulling in a second repo after the first turn.
+`repo` is `"owner/repo"` (or a `repo_…` id), `ref` is a branch or `refs/pull/N/head`, and
+`name` defaults to the repo name. It uses the same zero-credential model as the initial
+checkout: a Git operations sandbox mints a just-in-time, read-only token and the agent never
+sees it. **Connected-App (`oc_app`) repos only** — inline-token sources can't be added this
+way.
+
+`watch_pull_request(goal?, repo?, pr?, intent?)` subscribes the session to events on a PR it
+opened; OpenComputer **wakes the session** when checks finish, a review or comment lands, or
+the PR merges. It does **not** block — call it, then finish the turn.
+
+| Argument | Required | What it is |
+| --- | --- | --- |
+| `goal` | no | What to wait for: `wait_for_checks` (default), `wait_for_review`, `wait_for_merge`, `respond_to_comments`. |
+| `repo` | no | The watched repo. Defaults to the most recent PR the session opened. |
+| `pr` | no | The PR number. Defaults with `repo`. |
+| `intent` | no | Freeform note replayed on wake, so the agent knows why it woke. |
+
+You can only watch a PR the **same session** opened, on **Connected-App (`oc_app`) repos
+only**. `unwatch_pull_request(repo?, pr?)` stops watching; both args default to the session's
+only active watch. Full flow, statuses, and delivered event types:
+[Watches](/agent-sessions/watches).
 
 ## External systems
 

--- a/docs/agent-sessions/runtime-tools.mdx
+++ b/docs/agent-sessions/runtime-tools.mdx
@@ -32,15 +32,12 @@ The agent's final `say` is the session result. `ask` ends the turn with `yield_r
 
 ## GitHub tools
 
-<Warning>
-`github_publish_pull_request` is **temporarily unavailable** — the current agent runtime
-does not expose it yet, while the runtime is being updated. The description below is the
-intended behavior; the tool will be re-enabled in an upcoming runtime release.
-</Warning>
-
 | Tool | What it does |
 | --- | --- |
 | `github_publish_pull_request` | Open a pull request from a checked-out [Repo](/agent-sessions/repos) source. |
+| `add_source` | Check out an additional repo into `/workspace/sources/<name>` mid-session. |
+| `watch_pull_request` | Subscribe to events on a PR the session opened — the session is woken when checks finish, a review or comment lands, or it merges. |
+| `unwatch_pull_request` | Stop watching a PR. |
 
 `github_publish_pull_request` lets the agent open a PR **without ever holding a GitHub
 credential**. The agent edits files in `/workspace/sources/<source>` and makes local

--- a/docs/agent-sessions/runtime-tools.mdx
+++ b/docs/agent-sessions/runtime-tools.mdx
@@ -66,16 +66,16 @@ branch or `refs/pull/N/head`, `name` defaults to the repo name. Same zero-creden
 the initial checkout — a Git operations sandbox mints a just-in-time, read-only token; the
 agent never sees it. **Connected-App (`oc_app`) repos only.**
 
-`watch_pull_request(goal?, repo?, pr?, intent?)` subscribes the session to events on a PR it
-opened; OpenComputer wakes the session when checks finish, a review or comment lands, or the
-PR merges. It does **not** block — call it, then finish the turn.
+`watch_pull_request(wake_on?, repo?, pr?, intent?)` subscribes the session to a PR it opened;
+OpenComputer wakes the session when the wake condition is met. It does **not** block — call it,
+then finish the turn.
 
 | Argument | Required | What it is |
 | --- | --- | --- |
-| `goal` | no | What to wait for: `wait_for_checks` (default), `wait_for_review`, `wait_for_merge`, `respond_to_comments`. |
+| `wake_on` | no | The wake condition: `checks` (default), `review` (a review decision), `comment` (a new comment), `merge` (merged/closed). |
 | `repo` | no | The watched repo. Defaults to the most recent PR the session opened. |
 | `pr` | no | The PR number. Defaults with `repo`. |
-| `intent` | no | Freeform note replayed on wake. |
+| `intent` | no | Freeform note (the *why*), replayed on wake. |
 
 Watches cover PRs the **same session** opened, on **Connected-App (`oc_app`) repos only**.
 `unwatch_pull_request(repo?, pr?)` stops watching; both args default to the session's only

--- a/docs/agent-sessions/sessions.mdx
+++ b/docs/agent-sessions/sessions.mdx
@@ -10,7 +10,7 @@ A **session** is an [agent](/agent-sessions/agents) run with an append-only [eve
 
 ## Session flow
 
-1. You create a session from an [agent](/agent-sessions/agents). It **pins the agent's active [revision](/agent-sessions/revisions)** (prompt / model / skills) for its whole life — editing the agent later never affects a running session. Pass `revision` to pin a specific one instead (e.g. to test a [staged](/agent-sessions/revisions#staging-vs-activating) revision before promoting). The model runs **Managed** (billed to your credits, no key — the default) or on a [model credential](/agent-sessions/credentials) you supply. The session starts immediately.
+1. You create a session from an [agent](/agent-sessions/agents). It **pins the agent's active [revision](/agent-sessions/revisions)** (prompt / model / skills) for its whole life — editing the agent later never affects a running session. Pass `revision` to pin a specific one instead (e.g. to test a [staged](/agent-sessions/revisions#staging-vs-activating) revision before promoting). The model runs **Managed** (billed to your credits, no key — the default) or on a [model credential](/agent-sessions/credentials) you supply. Pass [`sources`](/agent-sessions/repos) to check repos out into `/workspace/sources/` before turn 1 — the GitHub token never enters the sandbox. The session starts immediately.
 2. The [runtime](/agent-sessions/runtimes) executes the agent in a sandbox, appending [events](/agent-sessions/events) to the log as it works.
 3. With nothing left to do, the session goes **idle** and the sandbox **hibernates**.
 4. A [steer](/agent-sessions/messaging) message wakes it; it resumes with its prior context. Repeat.

--- a/docs/agent-sessions/watches.mdx
+++ b/docs/agent-sessions/watches.mdx
@@ -4,28 +4,28 @@ title: "Watches"
 description: "Wake a session when a PR it opened gets checks, reviews, comments, or merges"
 ---
 
-A **watch** closes the loop after a session [opens a pull request](/agent-sessions/repos#what-the-agent-can-do). The agent opens a PR, declares a watch on it, and finishes the turn; when CI finishes, a review or comment lands, or the PR merges, OpenComputer **wakes the session** with a concise, normalized event so the agent reacts — the "open a PR, then respond to CI and reviews" loop, without you polling GitHub.
+A **watch** wakes a session when a PR it opened changes. The agent opens a PR, declares a watch, and ends the turn; when checks finish, a review or comment lands, or the PR merges, OpenComputer appends a normalized event and wakes the session to react. This is the open-a-PR-then-respond-to-CI loop without polling GitHub.
 
 <Note>**Preview** — APIs may change before general availability.</Note>
 
-A watch is declared from inside the sandbox with the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool, or managed from your backend with the REST endpoints [below](#management-api). The agent-facing path is the runtime tool.
+Declare a watch from inside the sandbox with the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool, or from your backend with the REST endpoints [below](#management-api).
 
 ## How it works
 
-A watch is a standing **wake trigger**, not a session state. The session just goes **idle** after the turn that declared it; when a real transition happens on the PR, OpenComputer appends an event and wakes the session exactly like a [steer](/agent-sessions/messaging). Four properties make this reliable:
+Declaring a watch doesn't change session state — the session goes **idle** after the turn like any other. On a PR transition, OpenComputer appends an event and wakes the session, the same path as a [steer](/agent-sessions/messaging).
 
-- **Snapshot is truth.** A webhook is only a *hint*. Before waking the session, OpenComputer re-reads the authoritative PR state from GitHub and wakes with that snapshot — so late, duplicate, or out-of-order webhooks all converge to the correct state.
-- **One wake per real transition.** Bursts are coalesced: a wave of check events for one commit becomes a single `checks_completed` wake, not one per check.
-- **Loop-suppressed.** The session's own comments, pushes, and activity never wake it — only third-party transitions do, so the agent can't spin against itself.
-- **Wake like a steer.** The delivered event is appended into the session log (level `user`, `source: "github"`) and the session resumes with its prior context, just as if you had steered it.
+- **Authoritative re-read.** A webhook is a hint. Before waking, OpenComputer re-reads PR state from GitHub and wakes with that snapshot, so late, duplicate, or out-of-order webhooks converge.
+- **Coalesced.** One wake per transition — a burst of check events for a commit is a single `checks_completed` wake.
+- **Loop-suppressed.** The session's own comments and pushes don't wake it; only third-party changes do.
+- **Delivered as `user` events.** The event is appended at level `user` (`source: "github"`) and the session resumes with prior context.
 
 <Warning>
-A watch lets the agent **react** to a PR event — it does not give the agent a GitHub write path back. There is no comment-write tool: the agent reads the delivered event and responds by, for example, [pushing a fix](/agent-sessions/repos#what-the-agent-can-do) to the branch or opening a follow-up PR. It cannot post a reply comment to GitHub.
+A watch lets the agent react; it doesn't grant a GitHub write path. There is no comment-write tool — the agent reads the event and responds by [pushing a fix](/agent-sessions/repos#what-the-agent-can-do) to the branch or opening a follow-up PR. It cannot post a reply comment to GitHub.
 </Warning>
 
 ## Ownership gate
 
-You can only watch a PR the **same session** opened, via [`github_publish_pull_request`](/agent-sessions/runtime-tools#github-tools). Watches are supported on **Connected-App (`oc_app`) repos only** — sources checked out with an inline `risky_short_lived_token` aren't watchable (that token is checkout-only and purged, so there's no durable, write-capable identity to poll or react with).
+You can only watch a PR the **same session** opened via [`github_publish_pull_request`](/agent-sessions/runtime-tools#github-tools). Connected-App (`oc_app`) repos only — inline `risky_short_lived_token` sources aren't watchable (the token is checkout-only and purged).
 
 <Note>
 **Owner-side prerequisite.** The OpenComputer GitHub App needs **Pull requests: Read**, **Checks: Read**, and **Issues: Read**, plus event subscriptions to **`pull_request`**, **`pull_request_review`**, **`pull_request_review_comment`**, **`check_suite`**, and **`issue_comment`**. Existing installs must **re-accept the new permissions**. Until they do, a watch is created but declares as `auth_required` and won't deliver events.
@@ -33,18 +33,18 @@ You can only watch a PR the **same session** opened, via [`github_publish_pull_r
 
 ## Goals
 
-A watch's `goal` tells the agent what it's waiting for; it's replayed on wake so the agent knows why it woke.
+The `goal` records what the watch waits for; it's replayed on wake.
 
 | `goal` | Waits for |
 | --- | --- |
-| `wait_for_checks` | CI / check suites to finish (**default**). |
+| `wait_for_checks` | Check suites to finish (**default**). |
 | `wait_for_review` | A review to be submitted. |
 | `wait_for_merge` | The PR to merge. |
-| `respond_to_comments` | New review comments or issue comments. |
+| `respond_to_comments` | New review or issue comments. |
 
 ## Runtime tools
 
-The agent declares and clears watches from inside the sandbox. Full signatures live in [Runtime tools](/agent-sessions/runtime-tools#github-tools).
+The agent declares and clears watches from inside the sandbox. Full signatures: [Runtime tools](/agent-sessions/runtime-tools#github-tools).
 
 | Tool | What it does |
 | --- | --- |
@@ -53,9 +53,9 @@ The agent declares and clears watches from inside the sandbox. Full signatures l
 
 ## Management API
 
-Watches are also managed over REST — public, authenticated with your **org API key** or a session [client token](/agent-sessions/authentication#client-tokens). `repo`/`pr` are optional: omit them and OpenComputer resolves the watch to the PR this session owns.
+REST management, authenticated with your **org API key** or a session [client token](/agent-sessions/authentication#client-tokens). `repo`/`pr` are optional — omitted, they resolve to the PR this session opened.
 
-<Note>There is **no SDK method and no `oc` CLI command** for watches yet — use the REST endpoints here, or the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool from inside the sandbox.</Note>
+<Note>No SDK method or `oc` CLI command for watches yet — use these REST endpoints, or the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool from inside the sandbox.</Note>
 
 **Create a watch:**
 
@@ -100,10 +100,10 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 | `repo` `pr` | the watched repo and PR number |
 | `goal` | what it's waiting for (table above) |
 | `intent?` | freeform note, replayed on wake |
-| `events` | the delivered event types this watch subscribes to |
+| `events` | delivered event types this watch subscribes to |
 | `status` | lifecycle status (below) |
-| `origin` | how it was declared (runtime tool vs. management API) |
-| `last_snapshot_at?` | when OpenComputer last re-read the authoritative PR state |
+| `origin` | how it was declared (runtime tool or management API) |
+| `last_snapshot_at?` | last authoritative PR re-read |
 | `created_at` | timestamp |
 
 ### Statuses
@@ -120,7 +120,7 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 
 ### Delivered events
 
-On each real transition, OpenComputer appends one event into the session log at level `user` with `source: "github"`. The `body` is a **concise, normalized summary** (e.g. a comment event carries the author, comment text, and URL) — never the raw webhook.
+One event per transition, appended at level `user` with `source: "github"`. The `body` is a normalized summary (a comment event carries author, text, and URL), never the raw webhook.
 
 | `type` | Fires on |
 | --- | --- |
@@ -137,11 +137,11 @@ These join the standard session [event types](/agent-sessions/events#event-types
 ## Limits
 
 - Max **10** active watches per session.
-- **30-day** TTL. A watch also never outlives its PR — it ends when the PR closes or merges.
+- **30-day** TTL, and never outlives the PR — the watch ends when the PR closes or merges.
 
-## Worked example
+## Example
 
-1. The agent edits a checked-out source and calls `github_publish_pull_request("web", "Refactor auth")`. OpenComputer commits to an `oc/<session>/web-<id>` branch and returns the PR URL.
-2. The agent calls `watch_pull_request(goal: "wait_for_review", intent: "Address review feedback")` and ends the turn with a `say`. The session goes **idle**.
-3. A reviewer leaves a comment. GitHub sends a webhook; OpenComputer re-reads the PR (**snapshot is truth**), confirms the transition, and appends a `github.pr.review_comment` event (level `user`, `source: "github"`) carrying the reviewer, the comment text, and its URL — then **wakes the session**.
-4. The agent wakes with the comment and its original `intent`, edits the source to address it, and calls `github_publish_pull_request` again to push the fix onto the same branch. (Its own push is **loop-suppressed** and won't wake it.) The watch keeps running until the PR merges or the 30-day TTL expires.
+1. Agent calls `github_publish_pull_request("web", "Refactor auth")` → PR opened on branch `oc/<session>/web-<id>`.
+2. Agent calls `watch_pull_request(goal: "wait_for_review", intent: "Address review feedback")`, `say`s, ends the turn. Session goes idle.
+3. Reviewer comments. OpenComputer re-reads the PR, appends `github.pr.review_comment` (author, text, URL) at level `user`, and wakes the session.
+4. Agent edits the source and calls `github_publish_pull_request` again to push onto the same branch. Its own push is loop-suppressed. The watch runs until the PR merges or the TTL expires.

--- a/docs/agent-sessions/watches.mdx
+++ b/docs/agent-sessions/watches.mdx
@@ -25,10 +25,10 @@ A watch lets the agent react; it doesn't grant a GitHub write path. There is no 
 
 ## What you can watch
 
-A session can only watch a PR it opened itself via [`github_publish_pull_request`](/agent-sessions/runtime-tools#github-tools). Connected-App (`oc_app`) repos only — inline `risky_short_lived_token` sources aren't watchable (the token is checkout-only and purged).
+A session can only watch a PR it opened itself via [`github_publish_pull_request`](/agent-sessions/runtime-tools#github-tools). The PR must have been opened through the **OpenComputer GitHub App** (`oc_app` sources) — that App's webhook and read token are what drive the watch. Inline `risky_short_lived_token` sources aren't watchable (the token is checkout-only and purged).
 
 <Note>
-**Owner-side prerequisite.** The OpenComputer GitHub App needs **Pull requests: Read**, **Checks: Read**, and **Issues: Read**, plus event subscriptions to **`pull_request`**, **`pull_request_review`**, **`pull_request_review_comment`**, **`check_suite`**, and **`issue_comment`**. Existing installs must **re-accept the new permissions**. Until they do, a watch is created but declares as `auth_required` and won't deliver events.
+**Owner-side prerequisite.** The OpenComputer GitHub App needs **Pull requests: Read**, **Checks: Read**, and **Issues: Read**, plus event subscriptions to **`pull_request`**, **`pull_request_review`**, **`pull_request_review_comment`**, **`check_suite`**, **`check_run`**, and **`issue_comment`**. Existing installs must **re-accept the new permissions**. Until they do, a watch is created but declares as `auth_required` and won't deliver events.
 </Note>
 
 ## Wake conditions
@@ -59,7 +59,7 @@ The agent declares and clears watches from inside the sandbox. Full signatures: 
 
 ## Management API
 
-REST management, authenticated with your **org API key** or a session [client token](/agent-sessions/authentication#client-tokens). `repo`/`pr` are optional — omitted, they resolve to the PR this session opened.
+REST management, authenticated with your **org API key** (server-side). `repo`/`pr` are optional — omitted, they resolve to the PR this session opened.
 
 <Note>No SDK method or `oc` CLI command for watches yet — use these REST endpoints, or the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool from inside the sandbox.</Note>
 
@@ -108,6 +108,7 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 | `status` | lifecycle status (below) |
 | `origin` | how it was declared (runtime tool or management API) |
 | `last_snapshot_at?` | last authoritative PR re-read |
+| `expires_at` | when the 30-day TTL lapses; past this the watch stops firing (status stays `active`) |
 | `created_at` | timestamp |
 
 ### Statuses
@@ -128,12 +129,10 @@ One event per transition, appended at level `user` with `source: "github"`. The 
 | `type` | Fires on |
 | --- | --- |
 | `github.pr.checks_completed` | Check suites for the head commit finished (coalesced). |
-| `github.pr.review_submitted` | A review was submitted. |
-| `github.pr.review_comment` | A review (diff) comment landed. |
-| `github.pr.comment` | An issue-style comment landed on the PR. |
+| `github.pr.review_submitted` | A review decision was submitted (approved / changes requested). |
+| `github.pr.comment` | A comment landed on the PR — issue-style **or** review (diff) comment. |
 | `github.pr.merged` | The PR merged. |
 | `github.pr.closed` | The PR closed without merging. |
-| `github.pr.reopened` | A closed PR reopened. |
 
 These join the standard session [event types](/agent-sessions/events#event-types) — switch on `type`, don't parse prose.
 

--- a/docs/agent-sessions/watches.mdx
+++ b/docs/agent-sessions/watches.mdx
@@ -23,9 +23,9 @@ Declaring a watch doesn't change session state — the session goes **idle** aft
 A watch lets the agent react; it doesn't grant a GitHub write path. There is no comment-write tool — the agent reads the event and responds by [pushing a fix](/agent-sessions/repos#what-the-agent-can-do) to the branch or opening a follow-up PR. It cannot post a reply comment to GitHub.
 </Warning>
 
-## Ownership gate
+## What you can watch
 
-You can only watch a PR the **same session** opened via [`github_publish_pull_request`](/agent-sessions/runtime-tools#github-tools). Connected-App (`oc_app`) repos only — inline `risky_short_lived_token` sources aren't watchable (the token is checkout-only and purged).
+A session can only watch a PR it opened itself via [`github_publish_pull_request`](/agent-sessions/runtime-tools#github-tools). Connected-App (`oc_app`) repos only — inline `risky_short_lived_token` sources aren't watchable (the token is checkout-only and purged).
 
 <Note>
 **Owner-side prerequisite.** The OpenComputer GitHub App needs **Pull requests: Read**, **Checks: Read**, and **Issues: Read**, plus event subscriptions to **`pull_request`**, **`pull_request_review`**, **`pull_request_review_comment`**, **`check_suite`**, and **`issue_comment`**. Existing installs must **re-accept the new permissions**. Until they do, a watch is created but declares as `auth_required` and won't deliver events.
@@ -115,7 +115,7 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 | `expired` | Hit the 30-day TTL. |
 | `closed` | The PR closed/merged, so the watch ended with it. |
 | `revoked` | Removed via `unwatch_pull_request` or `DELETE`. |
-| `auth_required` | The App lacks the required permissions or event subscriptions — [re-accept them](#ownership-gate). |
+| `auth_required` | The App lacks the required permissions or event subscriptions — [re-accept them](#what-you-can-watch). |
 | `app_suspended` | The GitHub App installation is suspended. |
 
 ### Delivered events

--- a/docs/agent-sessions/watches.mdx
+++ b/docs/agent-sessions/watches.mdx
@@ -31,16 +31,22 @@ A session can only watch a PR it opened itself via [`github_publish_pull_request
 **Owner-side prerequisite.** The OpenComputer GitHub App needs **Pull requests: Read**, **Checks: Read**, and **Issues: Read**, plus event subscriptions to **`pull_request`**, **`pull_request_review`**, **`pull_request_review_comment`**, **`check_suite`**, and **`issue_comment`**. Existing installs must **re-accept the new permissions**. Until they do, a watch is created but declares as `auth_required` and won't deliver events.
 </Note>
 
-## Goals
+## Wake conditions
 
-The `goal` records what the watch waits for; it's replayed on wake.
+`wake_on` is the **wake condition** — the PR state change that wakes the session. It's *what* the watch waits for; the *why* is [`intent`](#intent-why), replayed on wake.
 
-| `goal` | Waits for |
+| `wake_on` | Wakes when |
 | --- | --- |
-| `wait_for_checks` | Check suites to finish (**default**). |
-| `wait_for_review` | A review to be submitted. |
-| `wait_for_merge` | The PR to merge. |
-| `respond_to_comments` | New review or issue comments. |
+| `checks` | CI / check suites finish (**default**). |
+| `review` | A review **decision** lands — approved or changes-requested (not plain comments). |
+| `comment` | A new comment on the PR (review comment or issue comment). |
+| `merge` | The PR reaches a terminal state — merged, or closed without merging. |
+
+`events` is **derived** from `wake_on`; it is not part of the create request.
+
+### intent (why)
+
+`intent` is a freeform note — *why* the agent is watching (e.g. "Fix CI if it fails"). It doesn't affect *when* the session wakes; it's replayed back to the agent on wake so it knows what to do.
 
 ## Runtime tools
 
@@ -48,7 +54,7 @@ The agent declares and clears watches from inside the sandbox. Full signatures: 
 
 | Tool | What it does |
 | --- | --- |
-| `watch_pull_request(goal?, repo?, pr?, intent?)` | Subscribe to events on a PR the session opened. Does **not** block — call it, then finish the turn. Defaults to the most recent PR the session opened; `goal` defaults to `wait_for_checks`. `intent` is a freeform note replayed on wake. |
+| `watch_pull_request(wake_on?, repo?, pr?, intent?)` | Subscribe to a PR the session opened. Does **not** block — call it, then finish the turn. Defaults to the most recent PR the session opened; `wake_on` defaults to `checks`. `intent` is a freeform note replayed on wake. |
 | `unwatch_pull_request(repo?, pr?)` | Stop watching. Defaults to the only active watch. |
 
 ## Management API
@@ -68,11 +74,10 @@ Content-Type: application/json
   "type": "github_pr",
   "repo": "acme/web",
   "pr": 42,
-  "goal": "wait_for_review",
-  "intent": "Address review feedback on the auth refactor.",
-  "events": ["github.pr.review_submitted", "github.pr.review_comment"]
+  "wake_on": "review",
+  "intent": "Address review feedback on the auth refactor."
 }
-// → 201 { "watch": { … } }
+// → 201 { "watch": { … } }  ·  repo/pr optional (resolve to the session's owned PR)
 ```
 
 **List watches:**
@@ -98,9 +103,8 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 | `id` | `wch_…` |
 | `type` | `github_pr` |
 | `repo` `pr` | the watched repo and PR number |
-| `goal` | what it's waiting for (table above) |
+| `wake_on` | the wake condition (table above) |
 | `intent?` | freeform note, replayed on wake |
-| `events` | delivered event types this watch subscribes to |
 | `status` | lifecycle status (below) |
 | `origin` | how it was declared (runtime tool or management API) |
 | `last_snapshot_at?` | last authoritative PR re-read |
@@ -142,6 +146,6 @@ These join the standard session [event types](/agent-sessions/events#event-types
 ## Example
 
 1. Agent calls `github_publish_pull_request("web", "Refactor auth")` → PR opened on branch `oc/<session>/web-<id>`.
-2. Agent calls `watch_pull_request(goal: "wait_for_review", intent: "Address review feedback")`, `say`s, ends the turn. Session goes idle.
+2. Agent calls `watch_pull_request(wake_on: "review", intent: "Address review feedback")`, `say`s, ends the turn. Session goes idle.
 3. Reviewer comments. OpenComputer re-reads the PR, appends `github.pr.review_comment` (author, text, URL) at level `user`, and wakes the session.
 4. Agent edits the source and calls `github_publish_pull_request` again to push onto the same branch. Its own push is loop-suppressed. The watch runs until the PR merges or the TTL expires.

--- a/docs/agent-sessions/watches.mdx
+++ b/docs/agent-sessions/watches.mdx
@@ -114,13 +114,12 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 
 | Status | Meaning |
 | --- | --- |
-| `pending_snapshot` | Created; taking the first authoritative snapshot. |
 | `active` | Watching; delivering events. |
-| `expired` | Hit the 30-day TTL. |
-| `closed` | The PR closed/merged, so the watch ended with it. |
+| `closed` | The PR merged or closed, so the watch ended with it. |
 | `revoked` | Removed via `unwatch_pull_request` or `DELETE`. |
-| `auth_required` | The App lacks the required permissions or event subscriptions — [re-accept them](#what-you-can-watch). |
-| `app_suspended` | The GitHub App installation is suspended. |
+| `auth_required` | The App lacks the required permissions or event subscriptions — [re-accept them](#what-you-can-watch). Re-declare the watch once fixed. |
+
+A watch that hits its 30-day TTL simply stops firing (its `expires_at` passes) — re-declare to renew it.
 
 ### Delivered events
 

--- a/docs/agent-sessions/watches.mdx
+++ b/docs/agent-sessions/watches.mdx
@@ -37,7 +37,7 @@ A session can only watch a PR it opened itself via [`github_publish_pull_request
 
 | `wake_on` | Wakes when |
 | --- | --- |
-| `checks` | CI / check suites finish (**default**). |
+| `checks` | GitHub **check runs/suites** for the head commit finish (**default**). Legacy commit *statuses* aren't watched. |
 | `review` | A review **decision** lands — approved or changes-requested (not plain comments). |
 | `comment` | A new comment on the PR (review comment or issue comment). |
 | `merge` | The PR reaches a terminal state — merged, or closed without merging. |
@@ -184,5 +184,5 @@ These join the standard session [event types](/agent-sessions/events#event-types
 
 1. Agent calls `github_publish_pull_request("web", "Refactor auth")` → PR opened on branch `oc/<session>/web-<id>`.
 2. Agent calls `watch_pull_request(wake_on: "review", intent: "Address review feedback")`, `say`s, ends the turn. Session goes idle.
-3. Reviewer comments. OpenComputer re-reads the PR, appends `github.pr.review_comment` (author, text, URL) at level `user`, and wakes the session.
+3. Reviewer comments. OpenComputer re-reads the PR, appends `github.pr.comment` (author, text, URL) at level `user`, and wakes the session.
 4. Agent edits the source and calls `github_publish_pull_request` again to push onto the same branch. Its own push is loop-suppressed. The watch runs until the PR merges or the TTL expires.

--- a/docs/agent-sessions/watches.mdx
+++ b/docs/agent-sessions/watches.mdx
@@ -1,0 +1,147 @@
+---
+mode: "wide"
+title: "Watches"
+description: "Wake a session when a PR it opened gets checks, reviews, comments, or merges"
+---
+
+A **watch** closes the loop after a session [opens a pull request](/agent-sessions/repos#what-the-agent-can-do). The agent opens a PR, declares a watch on it, and finishes the turn; when CI finishes, a review or comment lands, or the PR merges, OpenComputer **wakes the session** with a concise, normalized event so the agent reacts — the "open a PR, then respond to CI and reviews" loop, without you polling GitHub.
+
+<Note>**Preview** — APIs may change before general availability.</Note>
+
+A watch is declared from inside the sandbox with the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool, or managed from your backend with the REST endpoints [below](#management-api). The agent-facing path is the runtime tool.
+
+## How it works
+
+A watch is a standing **wake trigger**, not a session state. The session just goes **idle** after the turn that declared it; when a real transition happens on the PR, OpenComputer appends an event and wakes the session exactly like a [steer](/agent-sessions/messaging). Four properties make this reliable:
+
+- **Snapshot is truth.** A webhook is only a *hint*. Before waking the session, OpenComputer re-reads the authoritative PR state from GitHub and wakes with that snapshot — so late, duplicate, or out-of-order webhooks all converge to the correct state.
+- **One wake per real transition.** Bursts are coalesced: a wave of check events for one commit becomes a single `checks_completed` wake, not one per check.
+- **Loop-suppressed.** The session's own comments, pushes, and activity never wake it — only third-party transitions do, so the agent can't spin against itself.
+- **Wake like a steer.** The delivered event is appended into the session log (level `user`, `source: "github"`) and the session resumes with its prior context, just as if you had steered it.
+
+<Warning>
+A watch lets the agent **react** to a PR event — it does not give the agent a GitHub write path back. There is no comment-write tool: the agent reads the delivered event and responds by, for example, [pushing a fix](/agent-sessions/repos#what-the-agent-can-do) to the branch or opening a follow-up PR. It cannot post a reply comment to GitHub.
+</Warning>
+
+## Ownership gate
+
+You can only watch a PR the **same session** opened, via [`github_publish_pull_request`](/agent-sessions/runtime-tools#github-tools). Watches are supported on **Connected-App (`oc_app`) repos only** — sources checked out with an inline `risky_short_lived_token` aren't watchable (that token is checkout-only and purged, so there's no durable, write-capable identity to poll or react with).
+
+<Note>
+**Owner-side prerequisite.** The OpenComputer GitHub App needs **Pull requests: Read**, **Checks: Read**, and **Issues: Read**, plus event subscriptions to **`pull_request`**, **`pull_request_review`**, **`pull_request_review_comment`**, **`check_suite`**, and **`issue_comment`**. Existing installs must **re-accept the new permissions**. Until they do, a watch is created but declares as `auth_required` and won't deliver events.
+</Note>
+
+## Goals
+
+A watch's `goal` tells the agent what it's waiting for; it's replayed on wake so the agent knows why it woke.
+
+| `goal` | Waits for |
+| --- | --- |
+| `wait_for_checks` | CI / check suites to finish (**default**). |
+| `wait_for_review` | A review to be submitted. |
+| `wait_for_merge` | The PR to merge. |
+| `respond_to_comments` | New review comments or issue comments. |
+
+## Runtime tools
+
+The agent declares and clears watches from inside the sandbox. Full signatures live in [Runtime tools](/agent-sessions/runtime-tools#github-tools).
+
+| Tool | What it does |
+| --- | --- |
+| `watch_pull_request(goal?, repo?, pr?, intent?)` | Subscribe to events on a PR the session opened. Does **not** block — call it, then finish the turn. Defaults to the most recent PR the session opened; `goal` defaults to `wait_for_checks`. `intent` is a freeform note replayed on wake. |
+| `unwatch_pull_request(repo?, pr?)` | Stop watching. Defaults to the only active watch. |
+
+## Management API
+
+Watches are also managed over REST — public, authenticated with your **org API key** or a session [client token](/agent-sessions/authentication#client-tokens). `repo`/`pr` are optional: omit them and OpenComputer resolves the watch to the PR this session owns.
+
+<Note>There is **no SDK method and no `oc` CLI command** for watches yet — use the REST endpoints here, or the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool from inside the sandbox.</Note>
+
+**Create a watch:**
+
+```http
+POST https://api.opencomputer.dev/v3/sessions/ses_.../watches
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+Content-Type: application/json
+
+{
+  "type": "github_pr",
+  "repo": "acme/web",
+  "pr": 42,
+  "goal": "wait_for_review",
+  "intent": "Address review feedback on the auth refactor.",
+  "events": ["github.pr.review_submitted", "github.pr.review_comment"]
+}
+// → 201 { "watch": { … } }
+```
+
+**List watches:**
+
+```http
+GET https://api.opencomputer.dev/v3/sessions/ses_.../watches
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+// → { "data": [ { … } ] }
+```
+
+**Delete a watch:**
+
+```http
+DELETE https://api.opencomputer.dev/v3/sessions/ses_.../watches/wch_...
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+// → { "ok": true }
+```
+
+## The watch object
+
+| Field | Notes |
+| --- | --- |
+| `id` | `wch_…` |
+| `type` | `github_pr` |
+| `repo` `pr` | the watched repo and PR number |
+| `goal` | what it's waiting for (table above) |
+| `intent?` | freeform note, replayed on wake |
+| `events` | the delivered event types this watch subscribes to |
+| `status` | lifecycle status (below) |
+| `origin` | how it was declared (runtime tool vs. management API) |
+| `last_snapshot_at?` | when OpenComputer last re-read the authoritative PR state |
+| `created_at` | timestamp |
+
+### Statuses
+
+| Status | Meaning |
+| --- | --- |
+| `pending_snapshot` | Created; taking the first authoritative snapshot. |
+| `active` | Watching; delivering events. |
+| `expired` | Hit the 30-day TTL. |
+| `closed` | The PR closed/merged, so the watch ended with it. |
+| `revoked` | Removed via `unwatch_pull_request` or `DELETE`. |
+| `auth_required` | The App lacks the required permissions or event subscriptions — [re-accept them](#ownership-gate). |
+| `app_suspended` | The GitHub App installation is suspended. |
+
+### Delivered events
+
+On each real transition, OpenComputer appends one event into the session log at level `user` with `source: "github"`. The `body` is a **concise, normalized summary** (e.g. a comment event carries the author, comment text, and URL) — never the raw webhook.
+
+| `type` | Fires on |
+| --- | --- |
+| `github.pr.checks_completed` | Check suites for the head commit finished (coalesced). |
+| `github.pr.review_submitted` | A review was submitted. |
+| `github.pr.review_comment` | A review (diff) comment landed. |
+| `github.pr.comment` | An issue-style comment landed on the PR. |
+| `github.pr.merged` | The PR merged. |
+| `github.pr.closed` | The PR closed without merging. |
+| `github.pr.reopened` | A closed PR reopened. |
+
+These join the standard session [event types](/agent-sessions/events#event-types) — switch on `type`, don't parse prose.
+
+## Limits
+
+- Max **10** active watches per session.
+- **30-day** TTL. A watch also never outlives its PR — it ends when the PR closes or merges.
+
+## Worked example
+
+1. The agent edits a checked-out source and calls `github_publish_pull_request("web", "Refactor auth")`. OpenComputer commits to an `oc/<session>/web-<id>` branch and returns the PR URL.
+2. The agent calls `watch_pull_request(goal: "wait_for_review", intent: "Address review feedback")` and ends the turn with a `say`. The session goes **idle**.
+3. A reviewer leaves a comment. GitHub sends a webhook; OpenComputer re-reads the PR (**snapshot is truth**), confirms the transition, and appends a `github.pr.review_comment` event (level `user`, `source: "github"`) carrying the reviewer, the comment text, and its URL — then **wakes the session**.
+4. The agent wakes with the comment and its original `intent`, edits the source to address it, and calls `github_publish_pull_request` again to push the fix onto the same branch. (Its own push is **loop-suppressed** and won't wake it.) The watch keeps running until the PR merges or the 30-day TTL expires.

--- a/docs/agent-sessions/watches.mdx
+++ b/docs/agent-sessions/watches.mdx
@@ -59,42 +59,81 @@ The agent declares and clears watches from inside the sandbox. Full signatures: 
 
 ## Management API
 
-REST management, authenticated with your **org API key** (server-side). `repo`/`pr` are optional — omitted, they resolve to the PR this session opened.
-
-<Note>No SDK method or `oc` CLI command for watches yet — use these REST endpoints, or the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool from inside the sandbox.</Note>
+Manage watches from your backend with the SDK, the `oc` CLI, or REST — authenticated with your **org API key** (server-side). `repo`/`pr` are optional; omitted, they resolve to the PR this session opened.
 
 **Create a watch:**
 
-```http
+<CodeGroup>
+
+```ts TypeScript SDK
+const session = await oc.sessions.get("ses_...");
+const watch = await session.watches.create({
+  repo: "acme/web",          // optional — defaults to the PR this session opened
+  pr: 42,                    // optional
+  wakeOn: "review",          // checks (default) · review · comment · merge
+  intent: "Address review feedback on the auth refactor.",
+});
+// → { id: "wch_...", status: "active", ... }
+```
+
+```bash oc CLI
+oc session watch ses_... \
+  --repo acme/web --pr 42 \
+  --wake-on review \
+  --intent "Address review feedback on the auth refactor."
+```
+
+```http REST
 POST https://api.opencomputer.dev/v3/sessions/ses_.../watches
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 Content-Type: application/json
 
-{
-  "type": "github_pr",
-  "repo": "acme/web",
-  "pr": 42,
-  "wake_on": "review",
-  "intent": "Address review feedback on the auth refactor."
-}
-// → 201 { "watch": { … } }  ·  repo/pr optional (resolve to the session's owned PR)
+{ "type": "github_pr", "repo": "acme/web", "pr": 42,
+  "wake_on": "review", "intent": "Address review feedback on the auth refactor." }
+// → 201 { "watch": { … } }
 ```
+
+</CodeGroup>
 
 **List watches:**
 
-```http
+<CodeGroup>
+
+```ts TypeScript SDK
+const watches = await session.watches.list();
+```
+
+```bash oc CLI
+oc session watches ses_...
+```
+
+```http REST
 GET https://api.opencomputer.dev/v3/sessions/ses_.../watches
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 // → { "data": [ { … } ] }
 ```
 
+</CodeGroup>
+
 **Delete a watch:**
 
-```http
+<CodeGroup>
+
+```ts TypeScript SDK
+await session.watches.delete("wch_...");
+```
+
+```bash oc CLI
+oc session unwatch ses_... wch_...
+```
+
+```http REST
 DELETE https://api.opencomputer.dev/v3/sessions/ses_.../watches/wch_...
 Authorization: Bearer $OPENCOMPUTER_API_KEY
 // → { "ok": true }
 ```
+
+</CodeGroup>
 
 ## The watch object
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -85,6 +85,7 @@
           "agent-sessions/slack",
           "agent-sessions/runtimes",
           "agent-sessions/runtime-tools",
+          "agent-sessions/watches",
           "agent-sessions/api-reference",
           {
             "group": "Labs",

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/agents/index.ts
+++ b/sdks/typescript/src/agents/index.ts
@@ -30,6 +30,8 @@ export { Credentials } from "./credentials.js";
 export type { CreateCredentialParams } from "./credentials.js";
 export { Destinations, Deliveries } from "./destinations.js";
 export type { CreateDestinationParams, UpdateDestinationParams } from "./destinations.js";
+export { Watches } from "./watches.js";
+export type { Watch, WatchStatus, WakeOn, CreateWatchParams } from "./watches.js";
 export { verifyWebhook, WebhookVerificationError } from "./webhooks.js";
 export type { WebhookDelivery, VerifyWebhookOptions } from "./webhooks.js";
 

--- a/sdks/typescript/src/agents/sessions.ts
+++ b/sdks/typescript/src/agents/sessions.ts
@@ -2,6 +2,7 @@ import type { Http, Query } from "./http.js";
 import type { Event, Level, Limits, LastTurn, SessionData, SessionStatus, Turn } from "./types.js";
 import { parseEventStream } from "./sse.js";
 import { Destinations, Deliveries } from "./destinations.js";
+import { Watches } from "./watches.js";
 
 export type Envelope = { text?: string; [k: string]: unknown };
 
@@ -235,6 +236,8 @@ export class Session extends ClientSession {
   /** Webhook destinations + delivery records for this session (org key). */
   readonly destinations: Destinations;
   readonly deliveries: Deliveries;
+  /** PR watches for this session — wake it when a PR it opened changes (org key). */
+  readonly watches: Watches;
   private data: SessionData;
   private _sources: SourceSummary[];
 
@@ -244,6 +247,7 @@ export class Session extends ClientSession {
     this._sources = sources ?? [];
     this.destinations = new Destinations(http, data.id);
     this.deliveries = new Deliveries(http, data.id);
+    this.watches = new Watches(http, data.id);
   }
 
   get status(): SessionStatus { return this.data.status; }

--- a/sdks/typescript/src/agents/sessions.ts
+++ b/sdks/typescript/src/agents/sessions.ts
@@ -54,10 +54,13 @@ export interface RegisteredRepoSource {
   repo: string;
   url?: never;
   auth?: never;
-  /** Required fetch ref (branch or `refs/pull/N/head`). */
+  /** Fetch ref (branch or `refs/pull/N/head`). */
   ref: string;
-  /** Required exact commit; fetched, then pinned + verified. */
-  sha: string;
+  /**
+   * Exact commit to pin. OPTIONAL for a registered repo: omit it and the control plane resolves
+   * `ref`→HEAD and pins that sha at create. Pass it to pin an exact commit yourself.
+   */
+  sha?: string;
   /** Checkout slug → `/workspace/sources/<name>`. Defaults to the repo name. */
   name?: string;
 }

--- a/sdks/typescript/src/agents/watches.ts
+++ b/sdks/typescript/src/agents/watches.ts
@@ -1,0 +1,73 @@
+import type { Http } from "./http.js";
+
+/** The wake condition — the PR state change that wakes the session. */
+export type WakeOn = "checks" | "review" | "comment" | "merge";
+
+/** Watch lifecycle status. */
+export type WatchStatus = "active" | "closed" | "revoked" | "auth_required";
+
+export interface CreateWatchParams {
+  /** Only `"github_pr"` today (the default). */
+  type?: string;
+  /** `"owner/repo"` — omitted, resolves to the PR this session opened. */
+  repo?: string;
+  /** PR number — omitted, resolves to the session's sole owned PR. */
+  pr?: number;
+  /** Wake condition. Default `"checks"`. */
+  wakeOn?: WakeOn;
+  /** Freeform note ("why"), replayed to the agent on wake. */
+  intent?: string;
+}
+
+export interface Watch {
+  id: string;
+  /** `"github_pr"`. */
+  type: string;
+  /** Watched repo (`"owner/repo"`). */
+  repo: string;
+  /** Watched PR number. */
+  pr: number;
+  wakeOn: WakeOn;
+  /** Freeform note, replayed on wake. */
+  intent?: string;
+  status: WatchStatus;
+  /** How it was declared (runtime tool / management API). */
+  origin: string;
+  /** Last authoritative PR re-read. */
+  lastSnapshotAt?: string;
+  /** When the 30-day TTL lapses; past this the watch stops firing (status stays `active`). */
+  expiresAt: string;
+  createdAt: string;
+}
+
+/**
+ * Watches for one session — wake the session when a PR it opened changes (checks finish, a review
+ * or comment lands, the PR merges/closes). Management surface; needs the org key.
+ *
+ * A watch only fires on a PR the **same session** opened via `github_publish_pull_request`, on
+ * OpenComputer-App (`oc_app`) repos. See the [Watches guide](https://docs.opencomputer.dev/agent-sessions/watches).
+ */
+export class Watches {
+  constructor(private readonly http: Http, private readonly sessionId: string) {}
+
+  /** Declare a watch. `repo`/`pr` omitted → the PR this session opened. */
+  async create(params: CreateWatchParams = {}): Promise<Watch> {
+    const r = await this.http.request<{ watch: Watch }>(
+      "POST", `/sessions/${this.sessionId}/watches`, { body: params },
+    );
+    return r.watch;
+  }
+
+  /** List this session's watches. */
+  async list(): Promise<Watch[]> {
+    const r = await this.http.request<{ data?: Watch[] } | Watch[]>(
+      "GET", `/sessions/${this.sessionId}/watches`,
+    );
+    return Array.isArray(r) ? r : r.data ?? [];
+  }
+
+  /** Remove a watch (equivalent to the agent's `unwatch_pull_request`). */
+  delete(id: string): Promise<void> {
+    return this.http.request("DELETE", `/sessions/${this.sessionId}/watches/${id}`);
+  }
+}

--- a/sdks/typescript/src/agents/watches.ts
+++ b/sdks/typescript/src/agents/watches.ts
@@ -8,7 +8,7 @@ export type WatchStatus = "active" | "closed" | "revoked" | "auth_required";
 
 export interface CreateWatchParams {
   /** Only `"github_pr"` today (the default). */
-  type?: string;
+  type?: "github_pr";
   /** `"owner/repo"` — omitted, resolves to the PR this session opened. */
   repo?: string;
   /** PR number — omitted, resolves to the session's sole owned PR. */

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -610,10 +610,16 @@ export const getSessions = (
 export const getSession = (id: string) =>
   apiFetch(`/v3/sessions/${id}`, {}, S.SessionSchema)
 
-// The API wants { agent: <id>, input } (input required). The response is an envelope
+// The API wants { agent: <id>, input } (input required). An optional `sources[]` attaches
+// a WORKING repo the agent checks out + opens PRs from — the control plane pins the ref's
+// HEAD when `sha` is omitted (design 010 §24.0). The response is an envelope
 // { session, client_token } — return the session.
 export const createSession = (
-  body: { agent: string; input: string },
+  body: {
+    agent: string
+    input: string
+    sources?: { repo: string; ref: string; name?: string }[]
+  },
   idempotencyKey?: string,
 ) =>
   apiFetch(

--- a/web/src/components/agent-deploy-source.tsx
+++ b/web/src/components/agent-deploy-source.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState } from 'react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from '@tanstack/react-query'
 import { Unplug, ExternalLink, RotateCw } from 'lucide-react'
 import { notifyError, notifySuccess } from '@/lib/errors'
 import {
@@ -14,6 +19,28 @@ import { Button } from '@/components/ui/button'
 import { Input, Select } from '@/components/form'
 
 // GitHub mark (lucide's brand `Github` icon is deprecated/unexported — inline the SVG).
+// A connect / redeploy kicks off a GitHub deploy that runs ASYNC — the new revision (prompt +
+// skills) isn't live until it activates. Poll the source until the deploy lands
+// (active_deployed_sha caught up to latest_seen_sha), keeping the card in step, then refresh the
+// dependent views so the Overview + Skills update without a manual page reload. Bounded (~60s).
+async function pollDeployUntilActive(agentId: string, queryClient: QueryClient) {
+  for (let i = 0; i < 24; i++) {
+    await new Promise((r) => setTimeout(r, 2500))
+    try {
+      const src = (await getDeploymentSource(agentId)).source
+      queryClient.setQueryData(['agent-deploy-source', agentId], src)
+      if (src?.active_deployed_sha && src.active_deployed_sha === src.latest_seen_sha) {
+        void queryClient.invalidateQueries({ queryKey: ['agent', agentId] })
+        void queryClient.invalidateQueries({ queryKey: ['agent-skills', agentId] })
+        void queryClient.invalidateQueries({ queryKey: ['agent-revisions', agentId] })
+        return
+      }
+    } catch {
+      return
+    }
+  }
+}
+
 function GithubMark({ className }: { className?: string }) {
   return (
     <svg viewBox="0 0 16 16" fill="currentColor" className={className} aria-hidden="true">
@@ -100,6 +127,7 @@ export function AgentDeploySource({
     void queryClient.invalidateQueries({
       queryKey: ['agent-revisions', agentId],
     })
+    void queryClient.invalidateQueries({ queryKey: ['agent-skills', agentId] })
     void queryClient.invalidateQueries({ queryKey: ['agent', agentId] })
   }
 
@@ -120,9 +148,11 @@ export function AgentDeploySource({
       } else {
         notifySuccess(
           source
-            ? 'Updated — creating a revision from the latest commit.'
+            ? 'Redeploying — pulling the latest commit into a new revision.'
             : 'Connected — creating the first revision.',
         )
+        // The GitHub deploy runs async — refresh the prompt + skills once it activates.
+        void pollDeployUntilActive(agentId, queryClient)
       }
     },
     onError: (e) => notifyError("Couldn't connect the repo.", e),

--- a/web/src/components/agent-deploy-source.tsx
+++ b/web/src/components/agent-deploy-source.tsx
@@ -17,8 +17,8 @@ import {
 import { Panel, PanelContent } from '@/components/panel'
 import { Button } from '@/components/ui/button'
 import { Input, Select } from '@/components/form'
+import { GithubMark } from '@/components/github-mark'
 
-// GitHub mark (lucide's brand `Github` icon is deprecated/unexported — inline the SVG).
 // A connect / redeploy kicks off a GitHub deploy that runs ASYNC — the new revision (prompt +
 // skills) isn't live until it activates. Poll the source until the deploy lands
 // (active_deployed_sha caught up to latest_seen_sha), keeping the card in step, then refresh the
@@ -39,14 +39,6 @@ async function pollDeployUntilActive(agentId: string, queryClient: QueryClient) 
       return
     }
   }
-}
-
-function GithubMark({ className }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 16 16" fill="currentColor" className={className} aria-hidden="true">
-      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-    </svg>
-  )
 }
 
 /**

--- a/web/src/components/github-mark.tsx
+++ b/web/src/components/github-mark.tsx
@@ -1,0 +1,14 @@
+// GitHub wordmark glyph. lucide's `Github` icon is deprecated/unexported, so we inline the
+// official mark path. Inherits color via `currentColor`; size via className (e.g. `size-4`).
+export function GithubMark({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  )
+}

--- a/web/src/components/working-repo-field.tsx
+++ b/web/src/components/working-repo-field.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { GitBranch, X, ExternalLink } from 'lucide-react'
+import { getDeployApp } from '@/api/client'
+import { Button } from '@/components/ui/button'
+import { Input, Select } from '@/components/form'
+
+// The WORKING repo a session checks out and opens PRs from (design 010 §2). It is deliberately
+// SEPARATE from the agent's config/"connected" repo (where prompt + skills come from) — an agent
+// is typically configured from one repo and works across others, so this never defaults to the
+// connected repo. Optional: a session starts fine with none (chat/analysis need no repo); when
+// set, the agent can publish + (later) watch PRs against it.
+
+export interface WorkingRepo {
+  repo: string // "owner/repo"
+  ref: string // branch
+}
+
+const lastKey = (agentId: string) => `oc.workingRepo.${agentId}`
+
+/** Remember the last working repo chosen FOR THIS AGENT — offered as a suggestion next time,
+ *  never auto-applied (a working repo is always an explicit choice). Best-effort; ignore quota. */
+function readLast(agentId: string): WorkingRepo | null {
+  try {
+    const raw = localStorage.getItem(lastKey(agentId))
+    if (!raw) return null
+    const v = JSON.parse(raw) as Partial<WorkingRepo>
+    return v.repo && v.ref ? { repo: v.repo, ref: v.ref } : null
+  } catch {
+    return null
+  }
+}
+export function rememberWorkingRepo(agentId: string, wr: WorkingRepo): void {
+  try {
+    localStorage.setItem(lastKey(agentId), JSON.stringify(wr))
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Inline, secondary working-repo control for the session composer. Unset → a quiet ghost chip
+ * ("Working repo"); starting works empty. Set → a solid removable chip (owner/repo · branch).
+ * Clicking either opens a lightweight picker over the repos the OpenComputer App can reach.
+ */
+export function WorkingRepoField({
+  agentId,
+  value,
+  onChange,
+}: {
+  agentId: string
+  value: WorkingRepo | null
+  onChange: (v: WorkingRepo | null) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const { data: app, isLoading } = useQuery({
+    queryKey: ['deploy-app'],
+    queryFn: getDeployApp,
+    enabled: open,
+    staleTime: 30_000,
+  })
+
+  const repoOptions = useMemo(
+    () => (app?.repositories ?? []).map((r) => ({ value: r.full_name, label: r.full_name })),
+    [app],
+  )
+  const suggestion = useMemo(() => readLast(agentId), [agentId, open])
+
+  // Draft state while the picker is open.
+  const [repo, setRepo] = useState('')
+  const [branch, setBranch] = useState('')
+  useEffect(() => {
+    if (open) {
+      setRepo(value?.repo ?? '')
+      setBranch(value?.ref ?? '')
+    }
+  }, [open, value])
+
+  const pickRepo = (fullName: string) => {
+    setRepo(fullName)
+    const r = app?.repositories.find((x) => x.full_name === fullName)
+    setBranch((b) => b || r?.default_branch || 'main')
+  }
+
+  const apply = () => {
+    if (!repo || !branch.trim()) return
+    const wr = { repo, ref: branch.trim() }
+    rememberWorkingRepo(agentId, wr)
+    onChange(wr)
+    setOpen(false)
+  }
+
+  // ── The chip (collapsed state) ──────────────────────────────────────────────
+  if (!open) {
+    if (value) {
+      return (
+        <span className="border-border bg-panel-2 inline-flex items-center gap-1.5 rounded-full border py-1 pr-1 pl-2.5 text-xs">
+          <button
+            type="button"
+            className="text-foreground hover:text-foreground/80 inline-flex items-center gap-1.5"
+            title="Change working repo"
+            onClick={() => setOpen(true)}
+          >
+            <GitBranch className="size-3 shrink-0" />
+            <span className="font-mono">
+              {value.repo} · {value.ref}
+            </span>
+          </button>
+          <button
+            type="button"
+            title="Remove working repo"
+            className="text-muted-foreground hover:text-foreground hover:bg-accent rounded-full p-0.5"
+            onClick={() => onChange(null)}
+          >
+            <X className="size-3" />
+          </button>
+        </span>
+      )
+    }
+    return (
+      <button
+        type="button"
+        className="border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 inline-flex items-center gap-1.5 rounded-full border border-dashed px-2.5 py-1 text-xs transition-colors"
+        title="Attach a repo for the agent to work in and open PRs from (optional)"
+        onClick={() => setOpen(true)}
+      >
+        <GitBranch className="size-3 shrink-0" />
+        Working repo
+      </button>
+    )
+  }
+
+  // ── The picker (expanded state) ─────────────────────────────────────────────
+  return (
+    <div className="border-border bg-panel-2 w-full max-w-md space-y-2 rounded-md border p-2.5 text-xs">
+      <div className="flex items-center justify-between">
+        <span className="text-foreground font-medium">Working repo</span>
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground"
+          onClick={() => setOpen(false)}
+          title="Close"
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+      <p className="text-muted-foreground">
+        The repo this session checks out and opens PRs from. Separate from where the agent gets
+        its prompt + skills.
+      </p>
+
+      {isLoading ? (
+        <p className="text-muted-foreground">Loading repos…</p>
+      ) : !app?.installed ? (
+        <div className="space-y-2">
+          <p className="text-muted-foreground">
+            Connect the OpenComputer GitHub App to pick a repo.
+          </p>
+          {app?.install_url ? (
+            <Button size="sm" variant="outline" asChild>
+              <a href={app.install_url} target="_blank" rel="noreferrer">
+                <ExternalLink className="size-3.5" />
+                Connect GitHub
+              </a>
+            </Button>
+          ) : null}
+        </div>
+      ) : (
+        <>
+          {suggestion && suggestion.repo !== repo ? (
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 underline-offset-2 hover:underline"
+              onClick={() => {
+                setRepo(suggestion.repo)
+                setBranch(suggestion.ref)
+              }}
+            >
+              Recently used: <span className="font-mono">{suggestion.repo}</span>
+            </button>
+          ) : null}
+          <Select
+            value={repo}
+            onValueChange={pickRepo}
+            placeholder={repoOptions.length ? 'Select a repo' : 'No repos available'}
+            disabled={repoOptions.length === 0}
+            options={repoOptions}
+          />
+          <div className="flex items-center gap-2">
+            <Input
+              value={branch}
+              onChange={(e) => setBranch(e.target.value)}
+              placeholder="main"
+              className="max-w-40"
+              aria-label="Branch"
+            />
+            <div className="ml-auto flex gap-2">
+              <Button size="sm" variant="ghost" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button size="sm" disabled={!repo || !branch.trim()} onClick={apply}>
+                Use repo
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/working-repo-field.tsx
+++ b/web/src/components/working-repo-field.tsx
@@ -17,16 +17,6 @@ export interface WorkingRepo {
   ref: string // branch
 }
 
-/** Remember the last working repo chosen FOR THIS AGENT (used as a suggestion in a later slice;
- *  never auto-applied — a working repo is always an explicit choice). Best-effort. */
-export function rememberWorkingRepo(agentId: string, wr: WorkingRepo): void {
-  try {
-    localStorage.setItem(`oc.workingRepo.${agentId}`, JSON.stringify(wr))
-  } catch {
-    /* ignore quota */
-  }
-}
-
 function splitRepo(full: string): [owner: string, name: string] {
   const i = full.indexOf('/')
   return i === -1 ? ['', full] : [full.slice(0, i), full.slice(i + 1)]
@@ -40,15 +30,18 @@ function splitRepo(full: string): [owner: string, name: string] {
  * on the Radix primitive (no new dependency) so it reads as a deliberate control, not stock.
  */
 export function WorkingRepoField({
-  agentId,
   value,
   onChange,
 }: {
-  agentId: string
   value: WorkingRepo | null
   onChange: (v: WorkingRepo | null) => void
 }) {
-  const { data: app, isLoading } = useQuery({
+  const {
+    data: app,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery({
     queryKey: ['deploy-app'],
     queryFn: getDeployApp,
     staleTime: 30_000,
@@ -61,9 +54,22 @@ export function WorkingRepoField({
     const r = repoOptions.find((x) => x.full_name === fullName)
     // Keep the current branch when re-picking the same repo; else the repo's default.
     const ref = value?.repo === fullName ? value.ref : r?.default_branch || 'main'
-    const wr = { repo: fullName, ref }
-    rememberWorkingRepo(agentId, wr)
-    onChange(wr)
+    onChange({ repo: fullName, ref })
+  }
+
+  // Load failed → an explicit retry, not a silent "No repos available" dead-end.
+  if (isError) {
+    return (
+      <button
+        type="button"
+        onClick={() => void refetch()}
+        className="border-border inline-flex h-8 items-center gap-2 rounded-md border border-dashed px-2.5 text-sm text-red-600 transition-colors hover:border-red-400 dark:text-red-500"
+        title="Couldn't load your repos — click to retry"
+      >
+        <GithubMark className="size-3.5" />
+        Couldn’t load repos — retry
+      </button>
+    )
   }
 
   // Not installed → a quiet connect affordance instead of a dead control.

--- a/web/src/components/working-repo-field.tsx
+++ b/web/src/components/working-repo-field.tsx
@@ -1,47 +1,43 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { GitBranch, X, ExternalLink } from 'lucide-react'
+import { Select as SelectPrimitive } from 'radix-ui'
+import { Check, ChevronDown, GitBranch, X } from 'lucide-react'
 import { getDeployApp } from '@/api/client'
-import { Button } from '@/components/ui/button'
-import { Input, Select } from '@/components/form'
+import { GithubMark } from '@/components/github-mark'
+import { markFloatingLayerPointerDismiss } from '@/components/ui/floating-layer'
+import { cn } from '@/lib/utils'
 
-// The WORKING repo a session checks out and opens PRs from (design 010 §2). It is deliberately
-// SEPARATE from the agent's config/"connected" repo (where prompt + skills come from) — an agent
-// is typically configured from one repo and works across others, so this never defaults to the
-// connected repo. Optional: a session starts fine with none (chat/analysis need no repo); when
-// set, the agent can publish + (later) watch PRs against it.
+// The WORKING repo a session checks out and opens PRs from (design 010 §2). Deliberately SEPARATE
+// from the agent's config/"connected" repo (prompt + skills) — an agent is typically configured
+// from one repo and works across others, so this never defaults to the connected repo. Optional:
+// a session starts fine with none; when set, the agent can publish (and later watch) PRs.
 
 export interface WorkingRepo {
   repo: string // "owner/repo"
   ref: string // branch
 }
 
-const lastKey = (agentId: string) => `oc.workingRepo.${agentId}`
-
-/** Remember the last working repo chosen FOR THIS AGENT — offered as a suggestion next time,
- *  never auto-applied (a working repo is always an explicit choice). Best-effort; ignore quota. */
-function readLast(agentId: string): WorkingRepo | null {
-  try {
-    const raw = localStorage.getItem(lastKey(agentId))
-    if (!raw) return null
-    const v = JSON.parse(raw) as Partial<WorkingRepo>
-    return v.repo && v.ref ? { repo: v.repo, ref: v.ref } : null
-  } catch {
-    return null
-  }
-}
+/** Remember the last working repo chosen FOR THIS AGENT (used as a suggestion in a later slice;
+ *  never auto-applied — a working repo is always an explicit choice). Best-effort. */
 export function rememberWorkingRepo(agentId: string, wr: WorkingRepo): void {
   try {
-    localStorage.setItem(lastKey(agentId), JSON.stringify(wr))
+    localStorage.setItem(`oc.workingRepo.${agentId}`, JSON.stringify(wr))
   } catch {
-    /* ignore */
+    /* ignore quota */
   }
+}
+
+function splitRepo(full: string): [owner: string, name: string] {
+  const i = full.indexOf('/')
+  return i === -1 ? ['', full] : [full.slice(0, i), full.slice(i + 1)]
 }
 
 /**
- * Inline, secondary working-repo control for the session composer. Unset → a quiet ghost chip
- * ("Working repo"); starting works empty. Set → a solid removable chip (owner/repo · branch).
- * Clicking either opens a lightweight picker over the repos the OpenComputer App can reach.
+ * Inline, secondary working-repo control for the session composer. A compact, GitHub-marked
+ * dropdown — unselected by default (short "Working repo" placeholder); starting a session works
+ * empty. Selecting a repo reveals a branch pill (prefilled with the repo's default branch) and a
+ * clear (✕). Repos come from what the OpenComputer App can reach (getDeployApp). Custom-styled
+ * on the Radix primitive (no new dependency) so it reads as a deliberate control, not stock.
  */
 export function WorkingRepoField({
   agentId,
@@ -52,159 +48,122 @@ export function WorkingRepoField({
   value: WorkingRepo | null
   onChange: (v: WorkingRepo | null) => void
 }) {
-  const [open, setOpen] = useState(false)
   const { data: app, isLoading } = useQuery({
     queryKey: ['deploy-app'],
     queryFn: getDeployApp,
-    enabled: open,
     staleTime: 30_000,
   })
-
-  const repoOptions = useMemo(
-    () => (app?.repositories ?? []).map((r) => ({ value: r.full_name, label: r.full_name })),
-    [app],
-  )
-  const suggestion = useMemo(() => readLast(agentId), [agentId, open])
-
-  // Draft state while the picker is open.
-  const [repo, setRepo] = useState('')
-  const [branch, setBranch] = useState('')
-  useEffect(() => {
-    if (open) {
-      setRepo(value?.repo ?? '')
-      setBranch(value?.ref ?? '')
-    }
-  }, [open, value])
+  const repoOptions = useMemo(() => app?.repositories ?? [], [app])
+  const installed = app?.installed !== false // treat "still loading" as installed
+  const disabled = !installed || repoOptions.length === 0
 
   const pickRepo = (fullName: string) => {
-    setRepo(fullName)
-    const r = app?.repositories.find((x) => x.full_name === fullName)
-    setBranch((b) => b || r?.default_branch || 'main')
-  }
-
-  const apply = () => {
-    if (!repo || !branch.trim()) return
-    const wr = { repo, ref: branch.trim() }
+    const r = repoOptions.find((x) => x.full_name === fullName)
+    // Keep the current branch when re-picking the same repo; else the repo's default.
+    const ref = value?.repo === fullName ? value.ref : r?.default_branch || 'main'
+    const wr = { repo: fullName, ref }
     rememberWorkingRepo(agentId, wr)
     onChange(wr)
-    setOpen(false)
   }
 
-  // ── The chip (collapsed state) ──────────────────────────────────────────────
-  if (!open) {
-    if (value) {
-      return (
-        <span className="border-border bg-panel-2 inline-flex items-center gap-1.5 rounded-full border py-1 pr-1 pl-2.5 text-xs">
-          <button
-            type="button"
-            className="text-foreground hover:text-foreground/80 inline-flex items-center gap-1.5"
-            title="Change working repo"
-            onClick={() => setOpen(true)}
-          >
-            <GitBranch className="size-3 shrink-0" />
-            <span className="font-mono">
-              {value.repo} · {value.ref}
-            </span>
-          </button>
-          <button
-            type="button"
-            title="Remove working repo"
-            className="text-muted-foreground hover:text-foreground hover:bg-accent rounded-full p-0.5"
-            onClick={() => onChange(null)}
-          >
-            <X className="size-3" />
-          </button>
-        </span>
-      )
-    }
+  // Not installed → a quiet connect affordance instead of a dead control.
+  if (installed === false && app?.install_url) {
     return (
-      <button
-        type="button"
-        className="border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 inline-flex items-center gap-1.5 rounded-full border border-dashed px-2.5 py-1 text-xs transition-colors"
-        title="Attach a repo for the agent to work in and open PRs from (optional)"
-        onClick={() => setOpen(true)}
+      <a
+        href={app.install_url}
+        target="_blank"
+        rel="noreferrer"
+        className="border-border text-muted-foreground hover:text-foreground hover:border-foreground/25 inline-flex h-8 items-center gap-2 rounded-md border border-dashed px-2.5 text-sm transition-colors"
+        title="Connect the OpenComputer GitHub App to work in a repo"
       >
-        <GitBranch className="size-3 shrink-0" />
-        Working repo
-      </button>
+        <GithubMark className="size-3.5" />
+        Connect GitHub
+      </a>
     )
   }
 
-  // ── The picker (expanded state) ─────────────────────────────────────────────
-  return (
-    <div className="border-border bg-panel-2 w-full max-w-md space-y-2 rounded-md border p-2.5 text-xs">
-      <div className="flex items-center justify-between">
-        <span className="text-foreground font-medium">Working repo</span>
-        <button
-          type="button"
-          className="text-muted-foreground hover:text-foreground"
-          onClick={() => setOpen(false)}
-          title="Close"
-        >
-          <X className="size-3.5" />
-        </button>
-      </div>
-      <p className="text-muted-foreground">
-        The repo this session checks out and opens PRs from. Separate from where the agent gets
-        its prompt + skills.
-      </p>
+  const [owner, name] = value ? splitRepo(value.repo) : ['', '']
 
-      {isLoading ? (
-        <p className="text-muted-foreground">Loading repos…</p>
-      ) : !app?.installed ? (
-        <div className="space-y-2">
-          <p className="text-muted-foreground">
-            Connect the OpenComputer GitHub App to pick a repo.
-          </p>
-          {app?.install_url ? (
-            <Button size="sm" variant="outline" asChild>
-              <a href={app.install_url} target="_blank" rel="noreferrer">
-                <ExternalLink className="size-3.5" />
-                Connect GitHub
-              </a>
-            </Button>
-          ) : null}
-        </div>
-      ) : (
-        <>
-          {suggestion && suggestion.repo !== repo ? (
-            <button
-              type="button"
-              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 underline-offset-2 hover:underline"
-              onClick={() => {
-                setRepo(suggestion.repo)
-                setBranch(suggestion.ref)
-              }}
-            >
-              Recently used: <span className="font-mono">{suggestion.repo}</span>
-            </button>
-          ) : null}
-          <Select
-            value={repo}
-            onValueChange={pickRepo}
-            placeholder={repoOptions.length ? 'Select a repo' : 'No repos available'}
-            disabled={repoOptions.length === 0}
-            options={repoOptions}
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <SelectPrimitive.Root value={value?.repo ?? ''} onValueChange={pickRepo} disabled={disabled}>
+        <SelectPrimitive.Trigger
+          aria-label="Working repo"
+          title="Optional — the repo the agent works in and opens PRs from"
+          className={cn(
+            'border-border bg-panel-2 hover:border-foreground/25 focus-visible:border-foreground/40 data-[state=open]:border-foreground/35 group inline-flex h-8 max-w-64 min-w-40 items-center gap-2 rounded-md border px-2.5 text-sm outline-none transition-colors disabled:cursor-not-allowed disabled:opacity-60',
+          )}
+        >
+          <GithubMark className="text-muted-foreground group-hover:text-foreground/70 size-3.5 shrink-0 transition-colors" />
+          <span className="min-w-0 flex-1 truncate text-left">
+            {value ? (
+              <span className="font-medium">
+                <span className="text-muted-foreground">{owner}/</span>
+                {name}
+              </span>
+            ) : (
+              <span className="text-muted-foreground">
+                {disabled ? (isLoading ? 'Loading repos…' : 'No repos available') : 'Working repo'}
+              </span>
+            )}
+          </span>
+          <ChevronDown className="text-muted-foreground/50 size-3.5 shrink-0" />
+        </SelectPrimitive.Trigger>
+        <SelectPrimitive.Portal>
+          <SelectPrimitive.Content
+            position="popper"
+            sideOffset={5}
+            onPointerDownOutside={markFloatingLayerPointerDismiss}
+            className="bg-popover text-popover-foreground ring-foreground/10 shadow-overlay data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 z-50 max-h-(--radix-select-content-available-height) min-w-(--radix-select-trigger-width) origin-(--radix-select-content-transform-origin) overflow-hidden rounded-lg p-1 ring-1 duration-100"
+          >
+            <SelectPrimitive.Viewport>
+              {repoOptions.map((r) => {
+                const [o, n] = splitRepo(r.full_name)
+                return (
+                  <SelectPrimitive.Item
+                    key={r.full_name}
+                    value={r.full_name}
+                    className="focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2 text-sm outline-hidden select-none"
+                  >
+                    <GithubMark className="text-muted-foreground size-3.5 shrink-0" />
+                    <SelectPrimitive.ItemText>
+                      <span className="text-muted-foreground">{o}/</span>
+                      {n}
+                    </SelectPrimitive.ItemText>
+                    <span className="absolute right-2 flex items-center">
+                      <SelectPrimitive.ItemIndicator>
+                        <Check className="size-4" />
+                      </SelectPrimitive.ItemIndicator>
+                    </span>
+                  </SelectPrimitive.Item>
+                )
+              })}
+            </SelectPrimitive.Viewport>
+          </SelectPrimitive.Content>
+        </SelectPrimitive.Portal>
+      </SelectPrimitive.Root>
+
+      {value ? (
+        <span className="border-border bg-panel-2 focus-within:border-foreground/40 inline-flex h-8 items-center gap-1 rounded-md border pr-1 pl-2 transition-colors">
+          <GitBranch className="text-muted-foreground size-3.5 shrink-0" />
+          <input
+            value={value.ref}
+            onChange={(e) => onChange({ ...value, ref: e.target.value })}
+            placeholder="main"
+            aria-label="Branch"
+            spellCheck={false}
+            className="w-24 bg-transparent font-mono text-xs outline-none"
           />
-          <div className="flex items-center gap-2">
-            <Input
-              value={branch}
-              onChange={(e) => setBranch(e.target.value)}
-              placeholder="main"
-              className="max-w-40"
-              aria-label="Branch"
-            />
-            <div className="ml-auto flex gap-2">
-              <Button size="sm" variant="ghost" onClick={() => setOpen(false)}>
-                Cancel
-              </Button>
-              <Button size="sm" disabled={!repo || !branch.trim()} onClick={apply}>
-                Use repo
-              </Button>
-            </div>
-          </div>
-        </>
-      )}
+          <button
+            type="button"
+            title="Clear working repo"
+            className="text-muted-foreground hover:text-foreground hover:bg-accent rounded p-0.5"
+            onClick={() => onChange(null)}
+          >
+            <X className="size-3.5" />
+          </button>
+        </span>
+      ) : null}
     </div>
   )
 }

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -31,6 +31,10 @@ import { SlackConnect } from '@/components/slack-connect'
 import { AgentSkills } from '@/components/agent-skills'
 import { AgentDeploySource } from '@/components/agent-deploy-source'
 import { AgentRevisions } from '@/components/agent-revisions'
+import {
+  WorkingRepoField,
+  type WorkingRepo,
+} from '@/components/working-repo-field'
 import { ApiHint, type ApiRef } from '@/components/api-hint'
 import { getRuntime } from '@/lib/runtimes'
 
@@ -113,10 +117,19 @@ export default function AgentDetail() {
 
   // ── Start a session (used by the Sessions tab composer) ────────────────────
   const [task, setTask] = useState('')
+  // Optional working repo — the repo the agent checks out + opens PRs from. Explicitly chosen,
+  // never derived from the connected/config repo (design 010 §2).
+  const [workingRepo, setWorkingRepo] = useState<WorkingRepo | null>(null)
   const startMutation = useMutation({
     mutationFn: () =>
       createSession(
-        { agent: agentId, input: task.trim() },
+        {
+          agent: agentId,
+          input: task.trim(),
+          ...(workingRepo
+            ? { sources: [{ repo: workingRepo.repo, ref: workingRepo.ref }] }
+            : {}),
+        },
         crypto.randomUUID(),
       ),
     onSuccess: (session) => {
@@ -452,12 +465,18 @@ export default function AgentDetail() {
                   placeholder="Give this agent a task — it runs durably as a new session…"
                   className="min-h-20"
                 />
-                <div className="flex justify-end">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <WorkingRepoField
+                    agentId={agentId}
+                    value={workingRepo}
+                    onChange={setWorkingRepo}
+                  />
                   <Button
                     type="submit"
                     size="sm"
                     title="Enter to start · Shift+Enter for newline"
                     disabled={startMutation.isPending || !task.trim()}
+                    className="ml-auto"
                   >
                     <Send className="size-4" />
                     {startMutation.isPending ? 'Starting…' : 'Start session'}

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -467,7 +467,6 @@ export default function AgentDetail() {
                 />
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <WorkingRepoField
-                    agentId={agentId}
                     value={workingRepo}
                     onChange={setWorkingRepo}
                   />

--- a/web/src/pages/Sessions.tsx
+++ b/web/src/pages/Sessions.tsx
@@ -229,7 +229,6 @@ export default function Sessions() {
               </Field>
               {agentId ? (
                 <WorkingRepoField
-                  agentId={agentId}
                   value={workingRepo}
                   onChange={setWorkingRepo}
                 />

--- a/web/src/pages/Sessions.tsx
+++ b/web/src/pages/Sessions.tsx
@@ -17,6 +17,10 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Field, Label, Select } from '@/components/form'
+import {
+  WorkingRepoField,
+  type WorkingRepo,
+} from '@/components/working-repo-field'
 import { ChatTextarea } from '@/components/chat-textarea'
 import { StatusBadge } from '@/components/status-badge'
 import { EmptyState } from '@/components/empty-state'
@@ -39,17 +43,26 @@ export default function Sessions() {
   const [showStart, setShowStart] = useState(false)
   const [agentId, setAgentId] = useState('')
   const [message, setMessage] = useState('')
+  // Optional working repo — explicitly chosen, per-agent (cleared when the agent changes).
+  const [workingRepo, setWorkingRepo] = useState<WorkingRepo | null>(null)
 
   const openStart = () => {
     setAgentId(agents?.[0]?.id ?? '')
     setMessage('')
+    setWorkingRepo(null)
     setShowStart(true)
   }
 
   const startMutation = useMutation({
     mutationFn: () =>
       createSession(
-        { agent: agentId, input: message.trim() },
+        {
+          agent: agentId,
+          input: message.trim(),
+          ...(workingRepo
+            ? { sources: [{ repo: workingRepo.repo, ref: workingRepo.ref }] }
+            : {}),
+        },
         crypto.randomUUID(),
       ),
     onSuccess: (session) => {
@@ -186,7 +199,10 @@ export default function Sessions() {
                 <Select
                   id="start-agent"
                   value={agentId}
-                  onValueChange={setAgentId}
+                  onValueChange={(v) => {
+                    setAgentId(v)
+                    setWorkingRepo(null) // a working repo is per-agent
+                  }}
                   options={(agents ?? []).map((a) => ({
                     value: a.id,
                     label: a.name,
@@ -211,6 +227,18 @@ export default function Sessions() {
                   className="min-h-24"
                 />
               </Field>
+              {agentId ? (
+                <div className="flex items-center gap-2">
+                  <WorkingRepoField
+                    agentId={agentId}
+                    value={workingRepo}
+                    onChange={setWorkingRepo}
+                  />
+                  <span className="text-muted-foreground text-xs">
+                    optional — repo to work in &amp; open PRs from
+                  </span>
+                </div>
+              ) : null}
               <DialogFooter className="mt-2">
                 <Button
                   type="button"

--- a/web/src/pages/Sessions.tsx
+++ b/web/src/pages/Sessions.tsx
@@ -228,16 +228,11 @@ export default function Sessions() {
                 />
               </Field>
               {agentId ? (
-                <div className="flex items-center gap-2">
-                  <WorkingRepoField
-                    agentId={agentId}
-                    value={workingRepo}
-                    onChange={setWorkingRepo}
-                  />
-                  <span className="text-muted-foreground text-xs">
-                    optional — repo to work in &amp; open PRs from
-                  </span>
-                </div>
+                <WorkingRepoField
+                  agentId={agentId}
+                  value={workingRepo}
+                  onChange={setWorkingRepo}
+                />
               ) : null}
               <DialogFooter className="mt-2">
                 <Button


### PR DESCRIPTION
Client side + docs for **watches** (design 010) and the **working-repo selector** (S0). The server/runtime core shipped in sessions-api #43 (merged). `main` is merged in, so this targets `main` directly and merges clean.

### Working repo (S0)
- Working-repo **picker** in the session composer (AgentDetail → Sessions tab + the global Start-session dialog): optional, GitHub-marked, single-line control on the Radix Select we already depend on; unselected by default; branch pill once a repo is picked. `createSession` now carries `sources:[{repo, ref}]`; the CP pins the ref's HEAD. Deliberately **separate** from the agent's connected/config repo — never defaults to it (§2). Shared `github-mark.tsx`.

### Watches — SDK + CLI + docs
- **SDK**: `session.watches.create/list/delete` (new `agents/watches.ts` sub-resource; `wakeOn ∈ checks|review|comment|merge`; camelCase↔snake wire; `Watch`/`WatchStatus`/`WakeOn`/`CreateWatchParams` exported). `RegisteredRepoSource.sha` now optional. **`@opencomputer/sdk` → 0.11.0** — note this **publishes to npm on merge**.
- **CLI**: `oc session watch | watches | unwatch` (`--wake-on/--repo/--pr/--intent`).
- **Docs**: full `watches.mdx` + updates to `events`, `api-reference`, `runtime-tools`, `repos`, `quickstart`, `sessions`, `docs.json`. Reflects the settled contract: `wake_on` (not `goal`), 4 statuses, emitted events (no `reopened`/`review_comment`), **org-key** management, `expires_at`, `checks` = GitHub Checks API only, SDK/CLI/REST tabs per op.

### Review hardening (3 rounds)
Doc/type accuracy fixes landed alongside the sessions-api rounds: `goal`→`wake_on`, status trim to 4, event-type/permission corrections, `type: "github_pr"`, "most recent PR" wording.

Includes a merge of `main` (resolved `agent-deploy-source.tsx`: kept the shared `GithubMark` component; main's async-deploy poller preserved).
