### PR TITLE
Proxy browser replays inline

### DIFF
--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -881,6 +881,8 @@ async function proxyToBrowserAPI(
   if (ct) headers.set("content-type", ct);
   const accept = req.headers.get("accept");
   if (accept) headers.set("accept", accept);
+  const range = req.headers.get("range");
+  if (range) headers.set("range", range);
 
   const init: RequestInit = { method: req.method, headers, redirect: "manual" };
   if (req.method !== "GET" && req.method !== "HEAD") {
@@ -915,6 +917,17 @@ export async function handleDashboard(
 
   // ── Browser Sessions — proxy to the dedicated browser Worker ───────────
   if (sub === "/browsers" && method === "GET") return proxyToBrowserAPI(req, env, caller, "/v1/browsers");
+  {
+    const m = sub.match(/^\/browsers\/([^/]+)\/replays\/([^/]+)$/);
+    if (m && method === "GET") {
+      return proxyToBrowserAPI(
+        req,
+        env,
+        caller,
+        `/v1/browsers/${encodeURIComponent(m[1])}/replays/${encodeURIComponent(m[2])}`,
+      );
+    }
+  }
   {
     const m = sub.match(/^\/browsers\/([^/]+)$/);
     if (m && (method === "GET" || method === "DELETE")) {

--- a/web/src/pages/Browsers.tsx
+++ b/web/src/pages/Browsers.tsx
@@ -181,7 +181,7 @@ export default function Browsers() {
               <ExternalLink className="size-4" />
             </Button>
           ) : null}
-          {browser.replay_view_url ? (
+          {browser.replay_id ? (
             <Button
               variant="ghost"
               size="icon"
@@ -194,7 +194,7 @@ export default function Browsers() {
                 toggleViewer({
                   browserId: browser.id,
                   kind: 'replay',
-                  url: browser.replay_view_url ?? '',
+                  url: `/api/dashboard/browsers/${encodeURIComponent(browser.id)}/replays/${encodeURIComponent(browser.replay_id ?? '')}`,
                 })
               }
             >
@@ -335,12 +335,20 @@ function InlineBrowserViewer({
         </Button>
       </div>
       <div className="bg-muted overflow-hidden rounded-md border">
-        <iframe
-          title={`${viewer.kind} for ${browser.id}`}
-          src={viewer.url}
-          className="block h-[520px] w-full bg-black"
-          allow="clipboard-read; clipboard-write; fullscreen"
-        />
+        {viewer.kind === 'replay' ? (
+          <video
+            src={viewer.url}
+            controls
+            className="block h-[520px] w-full bg-black"
+          />
+        ) : (
+          <iframe
+            title={`${viewer.kind} for ${browser.id}`}
+            src={viewer.url}
+            className="block h-[520px] w-full bg-black"
+            allow="clipboard-read; clipboard-write; fullscreen"
+          />
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- render Browser Sessions replays inline with a video player instead of navigating to provider viewer URLs
- proxy replay media through api-edge to the browser Worker
- forward Range headers so browser video playback and seeking work

## Validation
- npm test -- --run in cloudflare-workers/api-edge
- npm run typecheck in web

## Rollout
Deploy after the oc-browser replay media endpoint PR.