### PR TITLE
docs(AGENTS): SDK publish is version-gated (bump + lock in same PR)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,10 @@ just a refactor.
   think through both sides of the boundary.
 - **SDKs and CLI are public surfaces.** Prefer preserving behavior over
   rearranging internals for neatness.
+- **SDK publish is version-gated.** The `publish-ts-sdk` workflow only fires on a
+  version change, so any change under `sdks/typescript/` MUST bump `package.json`
+  **and** sync `package-lock.json` in the **same PR** — otherwise the change
+  silently never ships. One bump per PR, relative to the last-published version.
 - **Docs navigation is explicit.** Adding a page without wiring it into
   `docs/docs.json` leaves it effectively invisible.
 - **User-facing docs describe the product, not the implementation.**


### PR DESCRIPTION
## What
Codify a recurring release gotcha in `AGENTS.md` (Architecture boundaries): the `publish-ts-sdk` workflow only fires on a version change, so any change under `sdks/typescript/` must bump `package.json` **and** sync `package-lock.json` in the **same PR** — else it silently never publishes (bit us: #398 forgot the bump → didn't ship until #399).

Docs-only; migrated from agent memory into the repo so any contributor sees it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)