### PR TITLE
docs: Run Flue agents (Labs preview)

### DIFF
--- a/docs/agent-sessions/custom-runtimes.mdx
+++ b/docs/agent-sessions/custom-runtimes.mdx
@@ -4,7 +4,9 @@ title: "Custom runtimes"
 description: "Package your own agent harness as a runtime"
 ---
 
-<Note>**Labs preview.** Custom runtimes are not part of the stable Durable Sessions API. Production sessions use the built-in [runtimes](/agent-sessions/runtimes): `claude` and `codex`.</Note>
+<Note>**Labs preview.** Custom runtimes are not part of the stable Durable Sessions API. Production sessions use the built-in [runtimes](/agent-sessions/runtimes): `claude`, `codex`, and `pi`.</Note>
+
+Building on the [Flue framework](https://flueframework.com)? There's a supported path that skips all of this: [Run Flue agents](/agent-sessions/flue) deploys your Flue app onto the platform's brain contract directly. Custom runtimes remain the general escape hatch for any other harness.
 
 A custom runtime lets you run your own agent harness on Durable Agent Sessions. Once registered, select it on an agent with `runtime: "<name>"`; sessions, events, steering, webhooks, recovery, and sandbox tools use the same public API as built-in runtimes.
 

--- a/docs/agent-sessions/flue.mdx
+++ b/docs/agent-sessions/flue.mdx
@@ -4,19 +4,17 @@ title: "Run Flue agents"
 description: "Deploy a Flue app to OpenComputer as a durable session"
 ---
 
-<Note>**Labs preview.** Flue support is experimental and intentionally
-constrained — the supported profile below will widen. Flue itself is pre-1.0;
-each deploy pins your exact Flue version inside the artifact, so upstream
-changes never break a deployed agent.</Note>
+<Note>**Experimental.** The supported profile below is intentionally
+constrained and will widen. Flue is pre-1.0; each deploy bundles **your exact
+Flue version** into the artifact, so upstream releases never break a deployed
+agent — only new builds pick them up.</Note>
 
 [Flue](https://flueframework.com) is a TypeScript agent framework by the Astro
-team. OpenComputer runs Flue apps as [durable sessions](/agent-sessions/overview):
-your agent keeps its conversation across crashes and restarts, hibernates
-between turns, executes file/shell tools in an isolated workspace sandbox, and
-wakes on messages or [GitHub watches](/agent-sessions/watches) — with model
-usage on [Managed billing](/agent-sessions/credentials) or your Anthropic key.
+team. OpenComputer runs a Flue app as the resident process of a
+[durable session](/agent-sessions/overview) — same sessions API, events,
+steering, and watches as every other [runtime](/agent-sessions/runtimes).
 
-Your app stays plain Flue. The integration is one entry file:
+Your app stays plain Flue. You add one file:
 
 ```ts src/oc.ts
 import { serveOC } from '@opencomputer/flue';
@@ -25,7 +23,7 @@ import agent from './agents/support-triage.ts';
 serveOC(agent);
 ```
 
-Start from the template: [`diggerhq/oc-flue-starter`](https://github.com/diggerhq/oc-flue-starter).
+Template: [`diggerhq/oc-flue-starter`](https://github.com/diggerhq/oc-flue-starter).
 
 ## Quickstart
 
@@ -36,8 +34,7 @@ npm install
 # create the agent (name must match agent.toml)
 oc agent create support-triage --runtime flue --model anthropic/claude-sonnet-5
 
-# build + deploy: bundles your app, uploads the artifact, verifies it boots,
-# activates a new revision
+# build + upload + boot-verify + activate a revision
 oc agent deploy
 
 # talk to it
@@ -45,78 +42,124 @@ oc session create --input "Customer says order 1042 hasn't arrived — what do I
 oc session logs <session-id>
 ```
 
-Reply to an agent's question with `oc session steer <session-id> "..."`, or
-chat in the [dashboard](https://app.opencomputer.dev). Skills in your app's
-`src/skills/**` ship with every deploy — no extra steps. To give the agent a
-**codebase to work on**, attach a repo as a session source
-(`oc session create --input "..." --source owner/repo`); any
-`.agents/skills/**` that repo carries becomes available too.
+Answer the agent's questions with `oc session steer <session-id> "..."` or in
+the [dashboard](https://app.opencomputer.dev).
 
-## The supported profile
+## What changes vs a stock Flue app
 
-`oc agent deploy` validates these — violations fail at build or deploy, never
-mid-conversation.
+Everything below is validated at build or deploy — violations fail before a
+session can exist.
 
-| Works today | Not yet |
-| --- | --- |
-| One agent per app, exported via `serveOC` | Multiple agents per app |
-| `anthropic/…` models (Managed or your key) | Other providers |
-| Custom `defineTool` tools + subagents (run in-process with your app) | Flue channels (Slack/Discord ingress) |
-| App skills (`src/skills/**` — ship with each deploy) and workspace skills from attached sources | Packaged skill imports (`with { type: 'skill' }`) |
-| GitHub watches as input events | Flue workflows / `?wait=result` |
+| | Stock Flue | On OpenComputer |
+| --- | --- | --- |
+| Entry | Flue's generated server (`flue build --target node`) | Add `src/oc.ts` calling `serveOC(agent)`. Your agent code is untouched; `flue dev` keeps working locally |
+| Sandbox | You pick one (`local()`, containers, …) | **Leave `sandbox:` unset** — the session's workspace sandbox is supplied. Setting one fails the deploy |
+| Persistence | `db.ts` (or volatile in-memory default) | **No `db.ts`** — the conversation is stored durably in the session's state; survives restarts and hibernation |
+| Model credentials | Env keys or `registerProvider` in code | **No keys anywhere in the app.** Managed billing or an [OC credential](/agent-sessions/credentials); routing is injected at run time |
+| Model choice | In code | Still in code — but declared three times total (`defineAgent`, `agent.toml`, the OC agent) and all three **must be equal**; the deploy rejects divergence |
+| Skills | Packaged imports (`with {type:'skill'}`) or workspace files | **`src/skills/<name>/SKILL.md`** — ships with every deploy. Packaged imports are a build error (for now) |
+| Asking the user | No human-in-the-loop primitive | Your agent gets an **`ask` tool**: the session yields, waits at zero compute, resumes with the answer |
+| Channels / workflows | Slack/Discord ingress, `defineWorkflow` | Not supported — inbound is session messages + [GitHub watches](/agent-sessions/watches) |
+| Tool names | Anything | `bash`, `read`, `write`, `edit`, `ls`, `say`, `ask` are **reserved** (build error) |
 
-Rules the deploy enforces:
+## What `@opencomputer/flue` does
 
-- **Model declared once, everywhere the same**: `model` in your agent code,
-  `agent.toml`, and the OC agent record must be equal.
-- **Don't set `sandbox:`** — OpenComputer supplies the session's sandbox.
-- **No `db.ts`** — conversation durability is provided by the platform.
-- **Reserved tool names**: `bash`, `read`, `write`, `edit`, `ls`, `say`,
-  `ask` — a custom tool can't use these.
-- **No keys in the repo or bundle** — model credentials come from your
-  OpenComputer account.
+`serveOC(agent)` runs your app as the session's brain and wires the platform
+in — this is everything the package does, so you don't have to:
+
+- **Durable conversation, zero config.** It opens Flue's conversation store
+  on the session's persistent state volume. Your agent resumes with full
+  context after hibernation, crashes, or machine moves. (This is why `db.ts`
+  is rejected — a second store would fork the source of truth.)
+- **Sandbox wiring.** Flue's built-in `read`/`write`/`edit`/`bash` tools
+  execute on the session's **workspace sandbox** — a separate machine from
+  your app process, where attached repos are checked out. Your **custom
+  `defineTool` code runs in-process** with your app (see the note on network
+  access below).
+- **Two injected tools**: `say` (surface a message to the user mid-run) and
+  `ask` (ask and wait — the session yields `needs_input`, hibernates, and
+  your agent continues when the user replies).
+- **Model routing.** At run time it registers the Anthropic provider against
+  OpenComputer's credential system — managed metering or your key — so the
+  model string in your code just works and no secret ever enters your bundle
+  or repo.
+- **Turn integration.** Each session turn is admitted into Flue's engine
+  idempotently (safe under platform retries) and every step — model text,
+  your custom tool calls, sandbox operations — lands in the session's
+  [event log](/agent-sessions/events).
+- **Engine subordination.** Flue's internal retry/timeout knobs are pinned
+  under the platform's turn budget, so the platform's cancel/retry/deadline
+  semantics are the only ones you reason about.
+
+`oc-flue-build` (the package's build command, run by `oc agent deploy`)
+bundles `src/oc.ts` with **your** installed Flue version via esbuild, collects
+`src/skills/**` into the artifact, and stamps the metadata (`model`, versions)
+the deploy validates against.
+
+## Custom tools
+
+Plain `defineTool` — typed with valibot, running in-process:
+
+```ts src/tools/lookup-order.ts
+import { defineTool } from '@flue/runtime';
+import * as v from 'valibot';
+import orders from '../data/orders.json' with { type: 'json' };
+
+export const lookupOrder = defineTool({
+  name: 'lookup_order',
+  description: 'Look up an order by id.',
+  input: v.object({ order_id: v.string() }),
+  run({ input }) {
+    return (orders as Record<string, unknown>)[input.order_id] ?? { found: false };
+  },
+});
+```
+
+Two rules that follow from tools running inside the deployed artifact:
+
+- **Anything a tool needs at run time must be bundled** — `import` fixture
+  data and templates (as above); the repo checkout is not on the app's
+  filesystem.
+- **Outbound network**: custom tools currently have unrestricted outbound
+  access from the agent's sandbox; this will move behind an egress policy.
+  Don't bake secrets into the bundle to call your APIs — that egress story
+  is coming; keep v0 tools self-contained where you can.
+
+## Skills
+
+Put the agent's own skills at `src/skills/<name>/SKILL.md`
+([SKILL.md format](/agent-sessions/skills)). They ride the artifact and are
+placed into the agent's workspace at run time, where Flue's native discovery
+picks them up — updating a skill is a redeploy, and rollback rolls the skills
+back too. Separately, any repo you attach as a session source contributes its
+own `.agents/skills/**` (that convention means "skills for agents working on
+that repo"); on a name clash, your app's skill wins.
 
 ## Models
 
-Use `anthropic/<model>` with the same ids as the other runtimes —
-`anthropic/claude-sonnet-5` (balanced, the template default),
-`anthropic/claude-opus-4-8` (most capable), `anthropic/claude-haiku-4-5`
-(fastest/cheapest). Managed billing routes and meters usage exactly like the
-`claude` and `pi` runtimes; bring-your-own Anthropic keys work unchanged via
-[credentials](/agent-sessions/credentials).
+`anthropic/<id>`, same ids as the other runtimes — `anthropic/claude-sonnet-5`
+(the template default), `anthropic/claude-opus-4-8`,
+`anthropic/claude-haiku-4-5`. Managed billing and BYO keys behave exactly as
+on `claude`/`pi`; see [credentials](/agent-sessions/credentials).
 
-## Deploys and revisions
+## Deploying
 
-`oc agent deploy` builds your app with **your** Flue version into a
-content-addressed artifact, uploads it, **boot-verifies it** in a scratch
-sandbox (a bundle that can't start never activates), and creates an immutable
-[revision](/agent-sessions/revisions). Sessions pin their revision at create:
-a new deploy affects new sessions, in-flight sessions keep theirs, and
-rollback is repointing the active revision.
-
-## How it runs
-
-Your artifact is the session's **resident brain** — it stays warm across
-turns and hibernates with the session. File and shell tools execute on a
-separate **workspace sandbox**, not on the box holding credentials; every
-step, tool call, and answer lands in the session's durable
-[event log](/agent-sessions/events). Custom `defineTool` code runs in-process
-with your app: it executes inside your agent's sandbox with **unrestricted
-outbound network access in this release** — this will move behind an egress
-policy. Model traffic always routes through OpenComputer's credential proxy
-(your key is never inside the sandbox).
+`oc agent deploy` = build (`oc-flue-build`) → upload the content-addressed
+artifact → **boot-verify it in a scratch sandbox** (your app is imported and
+initialized; a bundle that can't start never activates) → create and activate
+an immutable [revision](/agent-sessions/revisions). Sessions pin their
+revision at create; rollback is repointing.
 
 ## Troubleshooting
 
-- **Deploy fails at verification** — your bundle didn't boot. The deploy
-  output includes the probe error; the usual causes are a profile violation
-  (`sandbox:` set, packaged-skill import, reserved tool name) or a top-level
-  crash in your app code.
-- **Model rejected at deploy** — the three model declarations diverge, or the
-  model isn't `anthropic/…`.
+- **Deploy fails at verification** — the bundle didn't boot; the deploy
+  output carries the probe error. Usual causes: `sandbox:` set, a
+  packaged-skill import, a reserved tool name, or a top-level crash in your
+  code.
+- **Model rejected at deploy** — the three model declarations diverge, or
+  the model isn't `anthropic/…`.
 - **`provider 401` on the first turn** — no usable model credential: enable
-  Managed billing or attach an Anthropic credential to the agent.
-- **Skill not loading** — the agent's own skills belong in
-  `src/skills/<name>/SKILL.md` (they ship with the deploy); skills from a
-  codebase need that repo attached as a *session source* (`--source`) with
-  the files under `.agents/skills/<name>/`.
+  managed billing or attach an Anthropic credential to the agent.
+- **Skill not loading** — the agent's own skills go in
+  `src/skills/<name>/SKILL.md`; skills from a codebase require that repo
+  attached as a session source (`--source`).

--- a/docs/agent-sessions/flue.mdx
+++ b/docs/agent-sessions/flue.mdx
@@ -47,15 +47,17 @@ the [dashboard](https://app.opencomputer.dev).
 
 ## What changes vs a stock Flue app
 
-Everything below is validated at build or deploy — violations fail before a
-session can exist.
+The sandbox, persistence, model, skills, tool-name, and credential rows are
+enforced at build or deploy — violations fail before a session can exist.
+Channels and workflows aren't checked: code not imported by `src/oc.ts`
+isn't in the artifact.
 
 | | Stock Flue | On OpenComputer |
 | --- | --- | --- |
 | Entry | Flue's generated server (`flue build --target node`) | Add `src/oc.ts` calling `serveOC(agent)`. Your agent code is untouched; `flue dev` keeps working locally |
 | Sandbox | You pick one (`local()`, containers, …) | **Leave `sandbox:` unset** — the session's workspace sandbox is supplied. Setting one fails the deploy |
 | Persistence | `db.ts` (or volatile in-memory default) | **No `db.ts`** — the conversation is stored durably in the session's state; survives restarts and hibernation |
-| Model credentials | Env keys or `registerProvider` in code | **No keys anywhere in the app.** Managed billing or an [OC credential](/agent-sessions/credentials); routing is injected at run time |
+| Model credentials | Env keys or `registerProvider` in code | **No keys anywhere in the app** — the deploy scans the artifact for key-shaped strings and fails on a hit. Managed billing or an [OC credential](/agent-sessions/credentials); routing is injected at run time |
 | Model choice | In code | Still in code — but declared three times total (`defineAgent`, `agent.toml`, the OC agent) and all three **must be equal**; the deploy rejects divergence |
 | Skills | Packaged imports (`with {type:'skill'}`) or workspace files | **`src/skills/<name>/SKILL.md`** — ships with every deploy. Packaged imports are a build error (for now) |
 | Asking the user | No human-in-the-loop primitive | An **`ask` tool** is added: the session yields `needs_input` and hibernates until the user replies |

--- a/docs/agent-sessions/flue.mdx
+++ b/docs/agent-sessions/flue.mdx
@@ -18,9 +18,9 @@ usage on [Managed billing](/agent-sessions/credentials) or your Anthropic key.
 
 Your app stays plain Flue. The integration is one entry file:
 
-```ts oc.ts
+```ts src/oc.ts
 import { serveOC } from '@opencomputer/flue';
-import agent from './agents/support.ts';
+import agent from './agents/support-triage.ts';
 
 serveOC(agent);
 ```

--- a/docs/agent-sessions/flue.mdx
+++ b/docs/agent-sessions/flue.mdx
@@ -16,7 +16,7 @@ steering, and watches as every other [runtime](/agent-sessions/runtimes).
 
 Your app stays plain Flue. You add one file:
 
-```ts src/oc.ts
+```ts src/opencomputer.ts
 import { serveOC } from '@opencomputer/flue';
 import agent from './agents/support-triage.ts';
 
@@ -49,12 +49,12 @@ the [dashboard](https://app.opencomputer.dev).
 
 The sandbox, persistence, model, skills, tool-name, and credential rows are
 enforced at build or deploy — violations fail before a session can exist.
-Channels and workflows aren't checked: code not imported by `src/oc.ts`
+Channels and workflows aren't checked: code not imported by `src/opencomputer.ts`
 isn't in the artifact.
 
 | | Stock Flue | On OpenComputer |
 | --- | --- | --- |
-| Entry | Flue's generated server (`flue build --target node`) | Add `src/oc.ts` calling `serveOC(agent)`. Your agent code is untouched; `flue dev` keeps working locally |
+| Entry | Flue's generated server (`flue build --target node`) | Add `src/opencomputer.ts` calling `serveOC(agent)`. Your agent code is untouched; `flue dev` keeps working locally |
 | Sandbox | You pick one (`local()`, containers, …) | **Leave `sandbox:` unset** — the session's workspace sandbox is supplied. Setting one fails the deploy |
 | Persistence | `db.ts` (or volatile in-memory default) | **No `db.ts`** — the conversation is stored durably in the session's state; survives restarts and hibernation |
 | Model credentials | Env keys or `registerProvider` in code | **No keys anywhere in the app** — the deploy scans the artifact for key-shaped strings and fails on a hit. Managed billing or an [OC credential](/agent-sessions/credentials); routing is injected at run time |
@@ -92,7 +92,7 @@ connects it to the platform:
   behavior is the platform's; there is no second layer to reason about.
 
 `oc-flue-build` (the package's build command, run by `oc agent deploy`)
-bundles `src/oc.ts` with **your** installed Flue version via esbuild, collects
+bundles `src/opencomputer.ts` with **your** installed Flue version via esbuild, collects
 `src/skills/**` into the artifact, and stamps the metadata (`model`, versions)
 the deploy validates against.
 

--- a/docs/agent-sessions/flue.mdx
+++ b/docs/agent-sessions/flue.mdx
@@ -1,0 +1,118 @@
+---
+mode: "wide"
+title: "Run Flue agents"
+description: "Deploy a Flue app to OpenComputer as a durable session"
+---
+
+<Note>**Labs preview.** Flue support is experimental and intentionally
+constrained — the supported profile below will widen. Flue itself is pre-1.0;
+each deploy pins your exact Flue version inside the artifact, so upstream
+changes never break a deployed agent.</Note>
+
+[Flue](https://flueframework.com) is a TypeScript agent framework by the Astro
+team. OpenComputer runs Flue apps as [durable sessions](/agent-sessions/overview):
+your agent keeps its conversation across crashes and restarts, hibernates
+between turns, executes file/shell tools in an isolated workspace sandbox, and
+wakes on messages or [GitHub watches](/agent-sessions/watches) — with model
+usage on [Managed billing](/agent-sessions/credentials) or your Anthropic key.
+
+Your app stays plain Flue. The integration is one entry file:
+
+```ts oc.ts
+import { serveOC } from '@opencomputer/flue';
+import agent from './agents/support.ts';
+
+serveOC(agent);
+```
+
+Start from the template: [`diggerhq/oc-flue-starter`](https://github.com/diggerhq/oc-flue-starter).
+
+## Quickstart
+
+```sh
+git clone https://github.com/diggerhq/oc-flue-starter && cd oc-flue-starter
+npm install
+
+# create the agent (name must match agent.toml)
+oc agent create support-triage --runtime flue --model anthropic/claude-sonnet-5
+
+# build + deploy: bundles your app, uploads the artifact, verifies it boots,
+# activates a new revision
+oc agent deploy
+
+# talk to it
+oc session create --input "Customer says order 1042 hasn't arrived — what do I tell them?"
+oc session logs <session-id>
+```
+
+Reply to an agent's question with `oc session steer <session-id> "..."`, or
+chat in the [dashboard](https://app.opencomputer.dev). To let the agent load
+[skills](/agent-sessions/skills), attach a repo containing `.agents/skills/**`
+as a session source: `oc session create --input "..." --source owner/repo`.
+
+## The supported profile
+
+`oc agent deploy` validates these — violations fail at build or deploy, never
+mid-conversation.
+
+| Works today | Not yet |
+| --- | --- |
+| One agent per app, exported via `serveOC` | Multiple agents per app |
+| `anthropic/…` models (Managed or your key) | Other providers |
+| Custom `defineTool` tools + subagents (run in-process with your app) | Flue channels (Slack/Discord ingress) |
+| Workspace skills (`.agents/skills/**` via a session source) | Packaged skill imports (`with { type: 'skill' }`) |
+| GitHub watches as input events | Flue workflows / `?wait=result` |
+
+Rules the deploy enforces:
+
+- **Model declared once, everywhere the same**: `model` in your agent code,
+  `agent.toml`, and the OC agent record must be equal.
+- **Don't set `sandbox:`** — OpenComputer supplies the session's sandbox.
+- **No `db.ts`** — conversation durability is provided by the platform.
+- **Reserved tool names**: `bash`, `read`, `write`, `edit`, `ls`, `say`,
+  `ask` — a custom tool can't use these.
+- **No keys in the repo or bundle** — model credentials come from your
+  OpenComputer account.
+
+## Models
+
+Use `anthropic/<model>` with the same ids as the other runtimes —
+`anthropic/claude-sonnet-5` (balanced, the template default),
+`anthropic/claude-opus-4-8` (most capable), `anthropic/claude-haiku-4-5`
+(fastest/cheapest). Managed billing routes and meters usage exactly like the
+`claude` and `pi` runtimes; bring-your-own Anthropic keys work unchanged via
+[credentials](/agent-sessions/credentials).
+
+## Deploys and revisions
+
+`oc agent deploy` builds your app with **your** Flue version into a
+content-addressed artifact, uploads it, **boot-verifies it** in a scratch
+sandbox (a bundle that can't start never activates), and creates an immutable
+[revision](/agent-sessions/revisions). Sessions pin their revision at create:
+a new deploy affects new sessions, in-flight sessions keep theirs, and
+rollback is repointing the active revision.
+
+## How it runs
+
+Your artifact is the session's **resident brain** — it stays warm across
+turns and hibernates with the session. File and shell tools execute on a
+separate **workspace sandbox**, not on the box holding credentials; every
+step, tool call, and answer lands in the session's durable
+[event log](/agent-sessions/events). Custom `defineTool` code runs in-process
+with your app: it executes inside your agent's sandbox with **unrestricted
+outbound network access in this release** — this will move behind an egress
+policy. Model traffic always routes through OpenComputer's credential proxy
+(your key is never inside the sandbox).
+
+## Troubleshooting
+
+- **Deploy fails at verification** — your bundle didn't boot. The deploy
+  output includes the probe error; the usual causes are a profile violation
+  (`sandbox:` set, packaged-skill import, reserved tool name) or a top-level
+  crash in your app code.
+- **Model rejected at deploy** — the three model declarations diverge, or the
+  model isn't `anthropic/…`.
+- **`provider 401` on the first turn** — no usable model credential: enable
+  Managed billing or attach an Anthropic credential to the agent.
+- **Skill not loading** — workspace skills need the repo attached as a
+  *session source* (`--source`), and the files under `.agents/skills/<name>/`.

--- a/docs/agent-sessions/flue.mdx
+++ b/docs/agent-sessions/flue.mdx
@@ -14,7 +14,9 @@ team. OpenComputer runs a Flue app as the resident process of a
 [durable session](/agent-sessions/overview) — same sessions API, events,
 steering, and watches as every other [runtime](/agent-sessions/runtimes).
 
-Your app stays plain Flue. You add one file:
+Your app stays plain Flue. You add one file — yours, committed, nothing is
+generated or injected. It plays the role Flue's layout gives `cloudflare.ts`:
+an optional platform-specific entry module.
 
 ```ts src/opencomputer.ts
 import { serveOC } from '@opencomputer/flue';
@@ -22,6 +24,10 @@ import agent from './agents/support-triage.ts';
 
 serveOC(agent);
 ```
+
+A full Flue app — with `app.ts`, channels, workflows — can add this file
+unchanged and keep self-hosting: only what it imports ends up in the
+OpenComputer artifact.
 
 Template: [`diggerhq/oc-flue-starter`](https://github.com/diggerhq/oc-flue-starter).
 

--- a/docs/agent-sessions/flue.mdx
+++ b/docs/agent-sessions/flue.mdx
@@ -58,38 +58,36 @@ session can exist.
 | Model credentials | Env keys or `registerProvider` in code | **No keys anywhere in the app.** Managed billing or an [OC credential](/agent-sessions/credentials); routing is injected at run time |
 | Model choice | In code | Still in code — but declared three times total (`defineAgent`, `agent.toml`, the OC agent) and all three **must be equal**; the deploy rejects divergence |
 | Skills | Packaged imports (`with {type:'skill'}`) or workspace files | **`src/skills/<name>/SKILL.md`** — ships with every deploy. Packaged imports are a build error (for now) |
-| Asking the user | No human-in-the-loop primitive | Your agent gets an **`ask` tool**: the session yields, waits at zero compute, resumes with the answer |
+| Asking the user | No human-in-the-loop primitive | An **`ask` tool** is added: the session yields `needs_input` and hibernates until the user replies |
 | Channels / workflows | Slack/Discord ingress, `defineWorkflow` | Not supported — inbound is session messages + [GitHub watches](/agent-sessions/watches) |
 | Tool names | Anything | `bash`, `read`, `write`, `edit`, `ls`, `say`, `ask` are **reserved** (build error) |
 
 ## What `@opencomputer/flue` does
 
-`serveOC(agent)` runs your app as the session's brain and wires the platform
-in — this is everything the package does, so you don't have to:
+`serveOC(agent)` runs your agent as the session's resident process and
+connects it to the platform:
 
-- **Durable conversation, zero config.** It opens Flue's conversation store
-  on the session's persistent state volume. Your agent resumes with full
-  context after hibernation, crashes, or machine moves. (This is why `db.ts`
-  is rejected — a second store would fork the source of truth.)
-- **Sandbox wiring.** Flue's built-in `read`/`write`/`edit`/`bash` tools
-  execute on the session's **workspace sandbox** — a separate machine from
-  your app process, where attached repos are checked out. Your **custom
-  `defineTool` code runs in-process** with your app (see the note on network
-  access below).
-- **Two injected tools**: `say` (surface a message to the user mid-run) and
-  `ask` (ask and wait — the session yields `needs_input`, hibernates, and
-  your agent continues when the user replies).
-- **Model routing.** At run time it registers the Anthropic provider against
-  OpenComputer's credential system — managed metering or your key — so the
-  model string in your code just works and no secret ever enters your bundle
-  or repo.
-- **Turn integration.** Each session turn is admitted into Flue's engine
-  idempotently (safe under platform retries) and every step — model text,
-  your custom tool calls, sandbox operations — lands in the session's
-  [event log](/agent-sessions/events).
-- **Engine subordination.** Flue's internal retry/timeout knobs are pinned
-  under the platform's turn budget, so the platform's cancel/retry/deadline
-  semantics are the only ones you reason about.
+- **Conversation persistence.** Opens Flue's conversation store on the
+  session's state volume. History survives process restarts, hibernation,
+  and machine moves. A `db.ts` is rejected at deploy because a second store
+  would fork the conversation history.
+- **Sandbox.** Flue's built-in `read`/`write`/`edit`/`bash` tools execute on
+  the session's workspace sandbox — a separate machine from your app
+  process, where attached repos are checked out. Custom `defineTool` code
+  runs in-process with your app (see the network-access note below).
+- **Two added tools.** `say` posts a message to the user mid-run. `ask` asks
+  a question: the session yields `needs_input` and hibernates until the user
+  replies, then the run continues with the answer.
+- **Model credentials.** Registers the Anthropic provider with credentials
+  resolved from the platform — managed metering or your key. The bundle and
+  repo contain no credentials.
+- **Turn handling.** Each session turn is admitted into Flue's engine with
+  an idempotent id, so platform-level retries can't double-run it. Every
+  step — model text, custom tool calls, sandbox operations — is written to
+  the session's [event log](/agent-sessions/events).
+- **Retries and timeouts.** Flue's internal retry and timeout settings are
+  capped below the platform's turn deadline. Cancel, retry, and deadline
+  behavior is the platform's; there is no second layer to reason about.
 
 `oc-flue-build` (the package's build command, run by `oc agent deploy`)
 bundles `src/oc.ts` with **your** installed Flue version via esbuild, collects
@@ -121,19 +119,19 @@ Two rules that follow from tools running inside the deployed artifact:
   data and templates (as above); the repo checkout is not on the app's
   filesystem.
 - **Outbound network**: custom tools currently have unrestricted outbound
-  access from the agent's sandbox; this will move behind an egress policy.
-  Don't bake secrets into the bundle to call your APIs — that egress story
-  is coming; keep v0 tools self-contained where you can.
+  access from the agent's sandbox. An egress policy is planned; until it
+  exists, don't embed secrets in the bundle to call your own APIs — prefer
+  self-contained tools.
 
 ## Skills
 
 Put the agent's own skills at `src/skills/<name>/SKILL.md`
-([SKILL.md format](/agent-sessions/skills)). They ride the artifact and are
-placed into the agent's workspace at run time, where Flue's native discovery
-picks them up — updating a skill is a redeploy, and rollback rolls the skills
-back too. Separately, any repo you attach as a session source contributes its
-own `.agents/skills/**` (that convention means "skills for agents working on
-that repo"); on a name clash, your app's skill wins.
+([SKILL.md format](/agent-sessions/skills)). The build packages them into the
+artifact; at run time they are written into the agent's workspace, where
+Flue's normal discovery finds them. Changing a skill is a redeploy; a
+rollback also reverts skills. Separately, a repo attached as a session source
+contributes its own `.agents/skills/**` (that convention means "skills for
+agents working on that repo"); on a name clash, the app's skill wins.
 
 ## Models
 

--- a/docs/agent-sessions/flue.mdx
+++ b/docs/agent-sessions/flue.mdx
@@ -46,9 +46,11 @@ oc session logs <session-id>
 ```
 
 Reply to an agent's question with `oc session steer <session-id> "..."`, or
-chat in the [dashboard](https://app.opencomputer.dev). To let the agent load
-[skills](/agent-sessions/skills), attach a repo containing `.agents/skills/**`
-as a session source: `oc session create --input "..." --source owner/repo`.
+chat in the [dashboard](https://app.opencomputer.dev). Skills in your app's
+`src/skills/**` ship with every deploy — no extra steps. To give the agent a
+**codebase to work on**, attach a repo as a session source
+(`oc session create --input "..." --source owner/repo`); any
+`.agents/skills/**` that repo carries becomes available too.
 
 ## The supported profile
 
@@ -60,7 +62,7 @@ mid-conversation.
 | One agent per app, exported via `serveOC` | Multiple agents per app |
 | `anthropic/…` models (Managed or your key) | Other providers |
 | Custom `defineTool` tools + subagents (run in-process with your app) | Flue channels (Slack/Discord ingress) |
-| Workspace skills (`.agents/skills/**` via a session source) | Packaged skill imports (`with { type: 'skill' }`) |
+| App skills (`src/skills/**` — ship with each deploy) and workspace skills from attached sources | Packaged skill imports (`with { type: 'skill' }`) |
 | GitHub watches as input events | Flue workflows / `?wait=result` |
 
 Rules the deploy enforces:
@@ -114,5 +116,7 @@ policy. Model traffic always routes through OpenComputer's credential proxy
   model isn't `anthropic/…`.
 - **`provider 401` on the first turn** — no usable model credential: enable
   Managed billing or attach an Anthropic credential to the agent.
-- **Skill not loading** — workspace skills need the repo attached as a
-  *session source* (`--source`), and the files under `.agents/skills/<name>/`.
+- **Skill not loading** — the agent's own skills belong in
+  `src/skills/<name>/SKILL.md` (they ship with the deploy); skills from a
+  codebase need that repo attached as a *session source* (`--source`) with
+  the files under `.agents/skills/<name>/`.

--- a/docs/agent-sessions/runtimes.mdx
+++ b/docs/agent-sessions/runtimes.mdx
@@ -11,14 +11,14 @@ A **runtime** executes the agent loop: provider SDK, model calls, and tool use. 
 | `claude` | `anthropic/…` (e.g. `anthropic/claude-opus-4-8`) | Managed, or an Anthropic key |
 | `codex` | `openai/…` (e.g. `openai/gpt-5-codex`) | Managed, or an OpenAI key |
 | `pi` | `anthropic/…` today — the runtime is provider-agnostic by construction; more providers land next | Managed, or an Anthropic key |
-| `flue` <sup>Labs</sup> | `anthropic/…` today | Managed, or an Anthropic key |
+| `flue` <sup>experimental</sup> | `anthropic/…` today — bring your own [Flue](/agent-sessions/flue) app | Managed, or an Anthropic key |
 
 `model` is passed straight through to the provider, so any model that provider serves works — only the **`provider/` prefix** is validated against the runtime (a bad prefix is rejected at agent create, a model the provider doesn't recognize fails on the first turn). Common choices:
 
 - **`claude`:** `anthropic/claude-sonnet-5` (default, balanced), `anthropic/claude-opus-4-8` (most capable), `anthropic/claude-fable-5`, `anthropic/claude-haiku-4-5` (fastest/cheapest).
 - **`codex`:** `openai/gpt-5-codex`.
 - **`pi`:** the `anthropic/…` catalog above. The runtime itself is provider-agnostic; additional providers are next.
-- **`flue`** (Labs): the `anthropic/…` catalog above — but the model is declared in your app's code; see [Run Flue agents](/agent-sessions/flue).
+- **`flue`** (experimental): the `anthropic/…` catalog above — but the model is declared in your app's code; see [Run Flue agents](/agent-sessions/flue).
 
 Sessions, [events](/agent-sessions/events), [steering](/agent-sessions/messaging), [tools](/agent-sessions/runtime-tools), and [webhooks](/agent-sessions/webhooks) share the same API across runtimes. `runtime` is fixed once the agent exists; to switch engines, create a new agent.
 
@@ -78,7 +78,7 @@ Content-Type: application/json
 
 The provider is taken from the model's `provider/` prefix — so as more providers land, switching provider is just a different `model` on the same `pi` agent, not a separate runtime.
 
-## `flue` <sup>Labs</sup>
+## `flue` <sup>experimental</sup>
 
 Unlike the runtimes above, `flue` doesn't run a platform-provided harness —
 it runs **your app**, built with the [Flue framework](https://flueframework.com)

--- a/docs/agent-sessions/runtimes.mdx
+++ b/docs/agent-sessions/runtimes.mdx
@@ -11,12 +11,14 @@ A **runtime** executes the agent loop: provider SDK, model calls, and tool use. 
 | `claude` | `anthropic/…` (e.g. `anthropic/claude-opus-4-8`) | Managed, or an Anthropic key |
 | `codex` | `openai/…` (e.g. `openai/gpt-5-codex`) | Managed, or an OpenAI key |
 | `pi` | `anthropic/…` today — the runtime is provider-agnostic by construction; more providers land next | Managed, or an Anthropic key |
+| `flue` <sup>Labs</sup> | `anthropic/…` today | Managed, or an Anthropic key |
 
 `model` is passed straight through to the provider, so any model that provider serves works — only the **`provider/` prefix** is validated against the runtime (a bad prefix is rejected at agent create, a model the provider doesn't recognize fails on the first turn). Common choices:
 
 - **`claude`:** `anthropic/claude-sonnet-5` (default, balanced), `anthropic/claude-opus-4-8` (most capable), `anthropic/claude-fable-5`, `anthropic/claude-haiku-4-5` (fastest/cheapest).
 - **`codex`:** `openai/gpt-5-codex`.
 - **`pi`:** the `anthropic/…` catalog above. The runtime itself is provider-agnostic; additional providers are next.
+- **`flue`** (Labs): the `anthropic/…` catalog above — but the model is declared in your app's code; see [Run Flue agents](/agent-sessions/flue).
 
 Sessions, [events](/agent-sessions/events), [steering](/agent-sessions/messaging), [tools](/agent-sessions/runtime-tools), and [webhooks](/agent-sessions/webhooks) share the same API across runtimes. `runtime` is fixed once the agent exists; to switch engines, create a new agent.
 
@@ -75,6 +77,18 @@ Content-Type: application/json
 ```
 
 The provider is taken from the model's `provider/` prefix — so as more providers land, switching provider is just a different `model` on the same `pi` agent, not a separate runtime.
+
+## `flue` <sup>Labs</sup>
+
+Unlike the runtimes above, `flue` doesn't run a platform-provided harness —
+it runs **your app**, built with the [Flue framework](https://flueframework.com)
+and deployed with `oc agent deploy`. Your code defines the agent
+(instructions, typed tools, subagents); OpenComputer provides the durable
+session around it: the event log, sandbox tools, steering, hibernation, and
+recovery are the same as every other runtime. `anthropic/…` models today,
+Managed or your Anthropic key. Experimental — see
+[Run Flue agents](/agent-sessions/flue) for the supported profile and
+quickstart.
 
 The runtime, model, and credential have to agree. `claude` needs an `anthropic/…` model and an Anthropic key; `codex` needs an `openai/…` model and an OpenAI key; `pi` runs `anthropic/…` models today and needs an Anthropic key (or Managed). A mismatch is rejected when you create the agent, with a clear error — so a session never starts on a broken pairing. See [model credentials](/agent-sessions/credentials).
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -92,6 +92,7 @@
             "tag": "Labs",
             "expanded": true,
             "pages": [
+              "agent-sessions/flue",
               "agent-sessions/custom-runtimes",
               "agent-sessions/triggers",
               "agent-sessions/channels",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -88,11 +88,17 @@
           "agent-sessions/watches",
           "agent-sessions/api-reference",
           {
+            "group": "Frameworks",
+            "expanded": true,
+            "pages": [
+              "agent-sessions/flue"
+            ]
+          },
+          {
             "group": "Labs",
             "tag": "Labs",
             "expanded": true,
             "pages": [
-              "agent-sessions/flue",
               "agent-sessions/custom-runtimes",
               "agent-sessions/triggers",
               "agent-sessions/channels",


### PR DESCRIPTION
Aspirational user-facing docs for the Flue runtime slice — written **before implementation** (design 012 §11.12) so reviewers can stress-test the design at the user surface. Everything documented here is the intended shipped behavior of the first slice; nothing is live yet.

- new `docs/agent-sessions/flue.mdx`: quickstart (mirrors [diggerhq/oc-flue-starter](https://github.com/diggerhq/oc-flue-starter)), supported-profile table, deploy-enforced rules, models, deploy/revision semantics, the egress statement, troubleshooting
- `runtimes.mdx`: `flue` row + Labs section
- `custom-runtimes.mdx`: cross-link to the Flue path; fixed stale note (`claude` and `codex` → incl. `pi`)
- `docs.json`: nav entry under Labs

DO NOT MERGE until the slice ships — docs going live is the launch switch (work/flue-slice.md W6/W7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)