### PR TITLE
flue Lane D: CLI supply-chain/UX + docs drift

### DIFF
--- a/cmd/oc/internal/commands/agent_deploy.go
+++ b/cmd/oc/internal/commands/agent_deploy.go
@@ -304,6 +304,14 @@ func ensureAgentByName(cmd *cobra.Command, sc *client.Client, name, prompt, mode
 	}
 	for _, a := range list.Data {
 		if a.Name == name {
+			// Fail fast on a runtime-family mismatch. The server rejects the
+			// deployment anyway, but only after the build + artifact upload — a
+			// flue deploy onto an existing claude agent would waste both.
+			if runtime != "" && a.Runtime != "" && a.Runtime != runtime {
+				return "", false, fmt.Errorf(
+					"agent %q already exists with runtime %q, but this deploy is %q — rename the agent in agent.toml, or deploy the matching runtime",
+					name, a.Runtime, runtime)
+			}
 			return a.ID, false, nil
 		}
 	}

--- a/cmd/oc/internal/commands/agent_deploy_flue.go
+++ b/cmd/oc/internal/commands/agent_deploy_flue.go
@@ -51,12 +51,20 @@ func deployFlue(cmd *cobra.Command, sc *client.Client, dir string, m *manifest, 
 		return &ExitError{Code: 1}
 	}
 
-	// 2. Build the artifact with the app's own @opencomputer/flue devDependency.
+	// 2. Resolve the target agent (create with runtime=flue + no prompt if new).
+	//    Done before the build so a runtime-family mismatch fails fast — ahead
+	//    of the build and the artifact upload, not after a late server reject.
+	id, err := resolveDeployAgent(cmd, sc, m)
+	if err != nil {
+		return err
+	}
+
+	// 3. Build the artifact with the app's own @opencomputer/flue devDependency.
 	if err := runFlueBuild(cmd.Context(), dir); err != nil {
 		return err
 	}
 
-	// 3. Hash dist-oc/ into the content-addressed digest + canonical tar.gz.
+	// 4. Hash dist-oc/ into the content-addressed digest + canonical tar.gz.
 	outDir := filepath.Join(dir, flueBuildOutputDir)
 	files, err := readArtifactFiles(outDir)
 	if err != nil {
@@ -69,12 +77,6 @@ func deployFlue(cmd *cobra.Command, sc *client.Client, dir string, m *manifest, 
 	}
 	if len(tarGz) > flueArtifactMaxBytes {
 		return fmt.Errorf("artifact is %d bytes, over the %d MiB limit", len(tarGz), flueArtifactMaxBytes>>20)
-	}
-
-	// 4. Resolve the target agent (create with runtime=flue + no prompt if new).
-	id, err := resolveDeployAgent(cmd, sc, m)
-	if err != nil {
-		return err
 	}
 
 	// 5. Upload: presigned PUT (contract 3).
@@ -140,21 +142,23 @@ func resolveDeployAgent(cmd *cobra.Command, sc *client.Client, m *manifest) (str
 }
 
 // runFlueBuild runs the app's oc-flue-build (its own devDependency). Prefers the
-// locally-installed bin (avoids npx fetching an arbitrary package from the
-// registry); falls back to `npx oc-flue-build`. Build output goes to stderr so
-// stdout stays clean for --json.
+// locally-installed bin; falls back to `npx --no-install`, which runs the
+// package only if it is already in node_modules and NEVER fetches a same-named
+// package from the registry (a supply-chain hole). Build output goes to stderr
+// so stdout stays clean for --json.
 func runFlueBuild(ctx context.Context, dir string) error {
 	bin := filepath.Join(dir, "node_modules", ".bin", "oc-flue-build")
 	var c *exec.Cmd
 	if _, err := os.Stat(bin); err == nil {
 		c = exec.CommandContext(ctx, bin)
 	} else {
-		c = exec.CommandContext(ctx, "npx", "oc-flue-build")
+		c = exec.CommandContext(ctx, "npx", "--no-install", "oc-flue-build")
 	}
 	c.Dir = dir
 	c.Stdout = os.Stderr
 	c.Stderr = os.Stderr
-	c.Stdin = os.Stdin
+	// No stdin: oc-flue-build is a non-interactive bundler, and wiring the
+	// terminal through let an npx install prompt hijack it.
 	if err := c.Run(); err != nil {
 		return fmt.Errorf("oc-flue-build failed: %w\n(run `npm install` so @opencomputer/flue is available, node >= 22)", err)
 	}

--- a/docs/agent-sessions/flue.mdx
+++ b/docs/agent-sessions/flue.mdx
@@ -158,7 +158,8 @@ Two rules that follow from tools running inside the deployed artifact:
   data and templates (as above); the repo checkout is not on the app's
   filesystem.
 - **Outbound network**: custom tools currently have unrestricted outbound
-  access from the agent's sandbox. An egress policy is planned; until it
+  access from your app's process — where `defineTool` code runs, a separate
+  machine from the workspace sandbox. An egress policy is planned; until it
   exists, don't embed secrets in the bundle to call your own APIs — prefer
   self-contained tools.
 
@@ -234,8 +235,9 @@ at create; rollback is repointing.
   top-level crash in your code (something that only happens at import time).
 - **Model rejected at deploy** — the three model declarations diverge
   (`defineAgent`, `agent.toml`, the OC agent).
-- **`provider 401` on the first turn** — no usable model credential: enable
-  managed billing or attach an Anthropic credential to the agent.
+- **`provider 401` on the first turn** — no usable model credential. Managed
+  billing is the default, so this usually means the org's billing isn't set
+  up yet — set up billing, or attach a valid Anthropic credential to the agent.
 - **Skill not loading** — the agent's own skills go in
   `src/skills/<name>/SKILL.md`; skills from a codebase require that repo
   attached as a session source (`--source`).

--- a/docs/agent-sessions/runtimes.mdx
+++ b/docs/agent-sessions/runtimes.mdx
@@ -18,7 +18,7 @@ A **runtime** executes the agent loop: provider SDK, model calls, and tool use. 
 - **`claude`:** `anthropic/claude-sonnet-5` (default, balanced), `anthropic/claude-opus-4-8` (most capable), `anthropic/claude-fable-5`, `anthropic/claude-haiku-4-5` (fastest/cheapest).
 - **`codex`:** `openai/gpt-5-codex`.
 - **`pi`:** the `anthropic/…` catalog above. The runtime itself is provider-agnostic; additional providers are next.
-- **`flue`** (experimental): the `anthropic/…` catalog above — but the model is declared in your app's code; see [Run Flue agents](/agent-sessions/flue).
+- **`flue`** (experimental): an `anthropic/…` model, declared in your app's code — see [Run Flue agents](/agent-sessions/flue) for the supported ids.
 
 Sessions, [events](/agent-sessions/events), [steering](/agent-sessions/messaging), [tools](/agent-sessions/runtime-tools), and [webhooks](/agent-sessions/webhooks) share the same API across runtimes. `runtime` is fixed once the agent exists; to switch engines, create a new agent.
 


### PR DESCRIPTION
Lane D of the flue-slice review remediation. Targets `flue-slice` (draft, do not merge — Igor merges the whole slice). Files: `cmd/oc/**`, `docs/**`.

## CLI (`cmd/oc`)

- **npx supply-chain fallback** (`agent_deploy_flue.go`): `runFlueBuild` fell back to `npx oc-flue-build`, which auto-installs a same-named package from the registry (squattable) and ran with stdin wired to the terminal (an npx install prompt could hijack it). → `npx --no-install` (never fetches; runs only an already-installed package) + drop stdin (it's a non-interactive bundler).
- **Fail fast on runtime-family mismatch** (`agent_deploy.go` + `agent_deploy_flue.go`): `ensureAgentByName` ignored the family, so a flue deploy name-matching a claude agent did the full build + 10 MiB upload before the server rejected it. Added a client-side family check, and moved the agent resolve **before** the build in `deployFlue` so a mismatch fails ahead of both. Note: a brand-new flue agent is now created before the build — a correct intermediate state (artifact-less flue agent 422s on session-create until deploy completes; deploy is idempotent by name).

## Docs

- **flue.mdx custom-tool topology**: the network note said tools run "from the agent's sandbox" while the profile section says (correctly) `defineTool` runs in-process with your app. Fixed to "your app's process — a separate machine from the workspace sandbox." **Coordinator: please confirm the precise topology wording.**
- **flue.mdx billing troubleshooting**: "enable managed billing" was wrong — managed is the default. Reframed a `provider 401` as no usable credential / org billing not set up.
- **runtimes.mdx model reconcile**: it implied flue supports the full claude catalog (incl. `claude-fable-5`), contradicting flue.mdx (the single source, which omits it). runtimes.mdx now defers flue's ids to flue.mdx.

## Deferred (flagged, not done here)

- **`@opencomputer/flue` floor bump** and the **managed slug map** (`claude-sonnet-5` absent / `claude-sonnet-4-6` stale) are **not** in this PR — the slug map needs the coordinator's live-OpenRouter check (S1). The floor bump lives in the starter repo (separate PR); see note there re: 0.1.2 not yet published.

Verified: `go build`/`vet`/`test ./cmd/oc/...` green; gofmt clean; byte-scan clean.