### PR TITLE
Add Autumn concurrency override

### DIFF
--- a/cloudflare-workers/api-edge/src/autumn_webhook.ts
+++ b/cloudflare-workers/api-edge/src/autumn_webhook.ts
@@ -6,7 +6,8 @@
 // data.customer_id (= our org id). We then GET the customer from Autumn and
 // project the *authoritative* balance + plans into D1:
 //   - orgs.is_halted / halted_at        (credits balance <= 0)
-//   - orgs.max_concurrent_sandboxes     (highest active concurrency plan)
+//   - orgs.max_concurrent_sandboxes     (highest active concurrency plan,
+//                                        unless autumn_concurrency_override is set)
 // On a halt/resume transition we dispatch /admin/halt-org or /admin/resume-org
 // to the cells running the org's sandboxes (same HMAC scheme the DO used).
 //
@@ -211,13 +212,14 @@ export async function syncAutumnToD1(env: AutumnSyncEnv, orgID: string): Promise
 
   const creditsRemaining = cust.balances?.[CREDITS_FEATURE_ID]?.remaining ?? 0;
   const halted = creditsRemaining <= 0;
-  const maxConcurrent = maxConcurrency(cust.subscriptions ?? []);
+  const projectedMaxConcurrent = maxConcurrency(cust.subscriptions ?? []);
   const nowSec = Math.floor(Date.now() / 1000);
 
-  const prevRow = await env.OPENCOMPUTER_DB.prepare("SELECT is_halted FROM orgs WHERE id = ?1")
+  const prevRow = await env.OPENCOMPUTER_DB.prepare("SELECT is_halted, autumn_concurrency_override FROM orgs WHERE id = ?1")
     .bind(orgID)
-    .first<{ is_halted: number }>();
+    .first<{ is_halted: number; autumn_concurrency_override: number | null }>();
   const wasHalted = prevRow?.is_halted === 1;
+  const maxConcurrent = prevRow?.autumn_concurrency_override ?? projectedMaxConcurrent;
 
   await env.OPENCOMPUTER_DB.prepare(
     `UPDATE orgs SET is_halted = ?1, halted_at = ?2, max_concurrent_sandboxes = ?3, updated_at = ?4 WHERE id = ?5`,

--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -216,6 +216,7 @@ function cellToRegion(cellID: string): string {
 interface OrgRow {
   id: string; name: string; slug: string; plan: string;
   max_concurrent_sandboxes: number; max_sandbox_timeout_sec: number;
+  autumn_concurrency_override: number | null;
   created_at: number; updated_at: number;
   custom_domain: string | null; cf_hostname_id: string | null;
   domain_verification_status: string; domain_ssl_status: string;
@@ -231,6 +232,7 @@ function shapeOrg(r: OrgRow): Record<string, unknown> {
   return {
     id: r.id, name: r.name, slug: r.slug, plan: r.plan,
     maxConcurrentSandboxes: r.max_concurrent_sandboxes,
+    autumnConcurrencyOverride: r.autumn_concurrency_override ?? undefined,
     maxSandboxTimeoutSec: r.max_sandbox_timeout_sec,
     createdAt: epochToISORequired(r.created_at),
     updatedAt: epochToISORequired(r.updated_at),
@@ -1046,12 +1048,12 @@ export async function handleDashboard(
   // dashboard renders instead of 404-erroring on a missing route.
   if (sub === "/billing" && method === "GET") {
     const org = await env.OPENCOMPUTER_DB.prepare(
-      `SELECT plan, stripe_customer_id, stripe_subscription_id, free_credits_remaining_cents, credit_balance_cents, is_halted, max_concurrent_sandboxes, billing_provider
+      `SELECT plan, stripe_customer_id, stripe_subscription_id, free_credits_remaining_cents, credit_balance_cents, is_halted, max_concurrent_sandboxes, autumn_concurrency_override, billing_provider
          FROM orgs WHERE id = ?1`,
     ).bind(caller.orgID).first<{
       plan: string; stripe_customer_id: string | null; stripe_subscription_id: string | null;
       free_credits_remaining_cents: number; credit_balance_cents: number; is_halted: number;
-      max_concurrent_sandboxes: number; billing_provider: string;
+      max_concurrent_sandboxes: number; autumn_concurrency_override: number | null; billing_provider: string;
     }>();
     if (!org) return json({ error: "org not found" }, 404);
     // Managed is a universal capability (every org gets a managed credential provisioned
@@ -1087,6 +1089,7 @@ export async function handleDashboard(
       creditBalanceCents: org.credit_balance_cents,
       isHalted: !!org.is_halted,
       maxConcurrentSandboxes: org.max_concurrent_sandboxes,
+      autumnConcurrencyOverride: org.autumn_concurrency_override ?? undefined,
       billingProvider: org.billing_provider,
       // Upcoming-invoice + meters would come from Stripe API on demand;
       // surface stubs for now so the UI has stable keys to render against.

--- a/cloudflare-workers/schema_phase10_autumn_concurrency_override.sql
+++ b/cloudflare-workers/schema_phase10_autumn_concurrency_override.sql
@@ -1,0 +1,18 @@
+-- Phase 10: Autumn per-org concurrency override.
+--
+-- Autumn normally projects orgs.max_concurrent_sandboxes from the customer's
+-- active Autumn concurrency product:
+--   base=5, concurrency_pro=100, concurrency_pro_plus=600,
+--   concurrency_pro_plus_plus=1000.
+--
+-- Some migrated customers need a bespoke limit that should survive Autumn
+-- balance/concurrency projection. NULL means "follow Autumn plan"; a positive
+-- integer pins orgs.max_concurrent_sandboxes to that value whenever projection
+-- runs.
+--
+-- Apply with:
+--   wrangler d1 execute opencomputer-prod --remote --file cloudflare-workers/schema_phase10_autumn_concurrency_override.sql
+--
+-- SQLite/D1 has no ADD COLUMN IF NOT EXISTS, so this is one-shot.
+ALTER TABLE orgs ADD COLUMN autumn_concurrency_override INTEGER;
+


### PR DESCRIPTION
## Summary
- add a nullable D1 orgs.autumn_concurrency_override column for bespoke Autumn customer limits
- make Autumn projection preserve the override when writing max_concurrent_sandboxes
- expose the override in dashboard org/billing responses

## Rollout
Apply the D1 migration before deploying this Worker code, because the Worker reads the new column:

```sh
npx wrangler d1 execute opencomputer-prod --remote --file cloudflare-workers/schema_phase10_autumn_concurrency_override.sql
```

For NaironAI after the migration/deploy:

```sql
UPDATE orgs
SET billing_provider = 'autumn',
    autumn_concurrency_override = 50,
    max_concurrent_sandboxes = 50,
    updated_at = strftime('%s','now')
WHERE id = '694bc24c-26e7-481c-9b99-1f68885b40d7'
  AND billing_provider = 'legacy';
```

## Tests
- npm --prefix cloudflare-workers/api-edge test -- --run --cache=false
- npx tsc --noEmit

Note: tests were run in the main checkout with the same diff applied; the clean temp worktree used for this PR did not have node_modules installed.