### PR TITLE
docs: Schedules — cron for agents (doc-first, design 015)

### DIFF
--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -471,6 +471,68 @@ Linking deploys the current production HEAD immediately (unless `deploy_now: fal
 | `status` | `active`, or a problem: `path_missing`, `ref_missing` (production branch deleted), `auth_required`, `repo_not_selected`, `app_suspended`, `error` |
 | `latest_seen_sha?` `active_deployed_sha?` | newest sha observed · sha behind the active revision |
 
+## Schedules
+
+*Run an agent on a cron — each firing starts a session. Managed with the SDK, the `oc` CLI, or REST (org key). Full guide: [Schedules](/agent-sessions/schedules).*
+
+<Tabs>
+
+<Tab title="TypeScript SDK">
+
+| Call | Purpose |
+| --- | --- |
+| `oc.agents.schedules(id).create(params)` | Create a schedule (`{ name, cron, tz?, input, overlap? }`). |
+| `oc.agents.schedules(id).list()` · `.get(sid)` | List / fetch. |
+| `oc.agents.schedules(id).update(sid, params)` | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`. |
+| `oc.agents.schedules(id).del(sid)` | Delete (run history kept). |
+| `oc.agents.schedules(id).fire(sid)` | Fire now → a run; doesn't advance the cron. |
+| `oc.agents.schedules(id).runs(sid, { cursor?, limit? })` | Run history (each carries `sessionId`). |
+
+</Tab>
+
+<Tab title="REST API">
+
+| Method · Path | Purpose |
+| --- | --- |
+| `POST /agents/:id/schedules` | Create → `201 { schedule }`. Body `{ name, cron, tz?, input, overlap? }`. |
+| `GET /agents/:id/schedules` · `…/:sid` | List / fetch. |
+| `PATCH /agents/:id/schedules/:sid` | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`. |
+| `DELETE /agents/:id/schedules/:sid` | Delete → `204` (runs kept). |
+| `POST /agents/:id/schedules/:sid/fire` | Fire now → `202 { run }`; doesn't advance the cron. |
+| `GET /agents/:id/schedules/:sid/runs?cursor=&limit=` | Run history → `{ runs, next_cursor }`. |
+
+</Tab>
+
+<Tab title="oc CLI">
+
+| Command | Purpose |
+| --- | --- |
+| `oc agent schedule create <name> --agent <id> --cron <c> [--tz <z>] --input <s>` | Create a schedule. |
+| `oc agent schedules [--agent <id>]` · `oc agent schedule get <name>` | List / fetch. |
+| `oc agent schedule pause\|resume <name>` | Pause / resume. |
+| `oc agent schedule delete <name>` | Delete. |
+| `oc agent schedule fire <name>` | Fire now (prints the `ses_…`). |
+| `oc agent schedule runs <name>` | Run history. |
+
+</Tab>
+
+</Tabs>
+
+`cron` is a 5-field expression (**1-minute** floor); `tz` is an IANA name (UTC if omitted); `input` (**≤ 32 KiB**) is the first message of every run; `overlap` is `skip` (default) or `allow`. Schedules are also **synced from [`agent.toml`](/agent-sessions/schedules#agent-toml)** on deploy — a repo-driven agent rejects edits other than pause/resume (`409`). Max **20** per agent.
+
+**`Schedule`**
+
+| Field | Notes |
+|---|---|
+| `id` `agent_id` | `sch_…` · the owning agent |
+| `name` `cron` `tz?` `input` | handle (unique per agent) · 5-field cron · IANA tz · first message |
+| `overlap` | `skip` (default) · `allow` |
+| `state` | `active · paused · auto_paused` (five straight enactment failures auto-pause) |
+| `next_fire_at` `last_fired_at?` | next occurrence · last fire |
+| `consecutive_failures` `last_error?` | in-a-row enactment failures · last error (cleared on success) |
+
+**`Run`** — one per firing decision, newest-first: `srn_…` with `outcome` (`enacted` · `skipped` · `failed`), `scheduled_for?` (`null` for a manual fire), `fired_at`, `session_id?` (when enacted), `error?`. Chain `session_id` into `GET /sessions/:id`.
+
 ## Destinations
 
 *Webhooks are configured via SDK/REST (no `oc` command).*

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -481,12 +481,12 @@ Linking deploys the current production HEAD immediately (unless `deploy_now: fal
 
 | Call | Purpose |
 | --- | --- |
-| `oc.agents.schedules(id).create(params)` | Create a schedule (`{ name, cron, tz?, input, overlap? }`). |
-| `oc.agents.schedules(id).list()` · `.get(sid)` | List / fetch. |
-| `oc.agents.schedules(id).update(sid, params)` | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`. |
-| `oc.agents.schedules(id).del(sid)` | Delete (run history kept). |
-| `oc.agents.schedules(id).fire(sid)` | Fire now → a run; doesn't advance the cron. |
-| `oc.agents.schedules(id).runs(sid, { cursor?, limit? })` | Run history (each carries `sessionId`). |
+| `oc.agents.schedules.create(id, params)` | Create a schedule (`{ name, cron, tz?, input, overlap? }`). |
+| `oc.agents.schedules.list(id)` · `.get(id, sid)` | List / fetch. |
+| `oc.agents.schedules.update(id, sid, params)` | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`. |
+| `oc.agents.schedules.delete(id, sid)` | Delete (run history kept). |
+| `oc.agents.schedules.fire(id, sid)` | Fire now → a run; doesn't advance the cron. |
+| `oc.agents.schedules.runs(id, sid, { cursor?, limit? })` | Run history (each carries `sessionId`). |
 
 </Tab>
 
@@ -498,7 +498,7 @@ Linking deploys the current production HEAD immediately (unless `deploy_now: fal
 | `GET /agents/:id/schedules` · `…/:sid` | List / fetch. |
 | `PATCH /agents/:id/schedules/:sid` | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`. |
 | `DELETE /agents/:id/schedules/:sid` | Delete → `204` (runs kept). |
-| `POST /agents/:id/schedules/:sid/fire` | Fire now → `202 { run }`; doesn't advance the cron. |
+| `POST /agents/:id/schedules/:sid/fire` | Fire now → `201 { run }`; doesn't advance the cron. |
 | `GET /agents/:id/schedules/:sid/runs?cursor=&limit=` | Run history → `{ runs, next_cursor }`. |
 
 </Tab>
@@ -527,7 +527,7 @@ Linking deploys the current production HEAD immediately (unless `deploy_now: fal
 | `id` `agent_id` | `sch_…` · the owning agent |
 | `name` `cron` `tz?` `input` | handle (unique per agent) · 5-field cron · IANA tz · first message |
 | `overlap` | `skip` (default) · `allow` |
-| `state` | `active · paused · auto_paused` (five straight enactment failures auto-pause) |
+| `state` | `active · paused · auto_paused` (five straight scheduled-firing failures auto-pause) |
 | `next_fire_at` `last_fired_at?` | next occurrence · last fire |
 | `consecutive_failures` `last_error?` | in-a-row enactment failures · last error (cleared on success) |
 

--- a/docs/agent-sessions/schedules.mdx
+++ b/docs/agent-sessions/schedules.mdx
@@ -16,12 +16,12 @@ A platform tick runs every minute: it claims schedules whose `next_fire_at` has 
 
 | Mechanic | Behavior |
 | --- | --- |
-| **Cron** | 5 fields, 1-minute resolution (a seconds field is rejected). `tz` is an IANA name; omit for UTC. DST follows the cron library — a skipped or repeated wall-clock hour resolves to the next real occurrence. |
+| **Cron** | 5 fields, 1-minute resolution (a seconds field is rejected). `tz` is an IANA name; omit for UTC. DST follows the cron library — a match in a skipped hour fires at the next real occurrence; a repeated hour fires once. |
 | **Attribution** | The first `user.message` carries `actor { kind: "schedule", id, display }`; the session carries `metadata.schedule = { id, run_id, scheduled_for }`. |
 | **Idempotency** | One session per slot, keyed `sch_<id>:<slot>`. A tick that crashes and retries converges on the same session. |
 | **Overlap** | `skip` (default): if the previous run's session is still `queued`/`running`, record `skipped` and advance. `allow`: fire regardless. |
 | **Catch-up** | After downtime, fire **once** for the most recent missed slot, then advance past now — never replays a backlog. |
-| **Failure** | Five consecutive *enactment* failures (missing credential, no credit) → `auto_paused` with `last_error`. Session outcomes never change schedule state. |
+| **Failure** | Five consecutive scheduled-firing *enactment* failures (missing credential, no credit) → `auto_paused` with `last_error`. Session outcomes never change schedule state; neither do manual fires. |
 
 **Common crons** (`minute hour day-of-month month day-of-week`):
 
@@ -66,7 +66,7 @@ Org-key authenticated, server-side. Schedules are addressed under the agent.
 <CodeGroup>
 
 ```ts TypeScript SDK
-const schedule = await oc.agents.schedules("agt_...").create({
+const schedule = await oc.agents.schedules.create("agt_...", {
   name: "morning-docs-sweep",
   cron: "0 9 * * 1-5",
   tz: "Europe/London",       // optional — UTC if omitted
@@ -99,8 +99,8 @@ Content-Type: application/json
 <CodeGroup>
 
 ```ts TypeScript SDK
-const schedules = await oc.agents.schedules("agt_...").list();
-const schedule = await oc.agents.schedules("agt_...").get("sch_...");
+const schedules = await oc.agents.schedules.list("agt_...");
+const schedule = await oc.agents.schedules.get("agt_...", "sch_...");
 ```
 
 ```bash oc CLI
@@ -121,9 +121,9 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 <CodeGroup>
 
 ```ts TypeScript SDK
-await oc.agents.schedules("agt_...").update("sch_...", { cron: "0 7 * * *" });
-await oc.agents.schedules("agt_...").update("sch_...", { paused: true });   // pause
-await oc.agents.schedules("agt_...").update("sch_...", { paused: false });  // resume
+await oc.agents.schedules.update("agt_...", "sch_...", { cron: "0 7 * * *" });
+await oc.agents.schedules.update("agt_...", "sch_...", { paused: true });   // pause
+await oc.agents.schedules.update("agt_...", "sch_...", { paused: false });  // resume
 ```
 
 ```bash oc CLI
@@ -146,7 +146,7 @@ Content-Type: application/json
 <CodeGroup>
 
 ```ts TypeScript SDK
-await oc.agents.schedules("agt_...").del("sch_...");
+await oc.agents.schedules.delete("agt_...", "sch_...");
 ```
 
 ```bash oc CLI
@@ -161,12 +161,12 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 
 </CodeGroup>
 
-**Fire now** — enacts immediately in any state (paused included) and doesn't advance the cron. The test loop is `create` then `fire`.
+**Fire now** — enacts immediately in any state (paused included) and doesn't advance the cron. The test loop is `create` then `fire`. A failed manual fire returns the run with `outcome: "failed"` and updates `last_error`, but never changes the schedule's state or failure counter.
 
 <CodeGroup>
 
 ```ts TypeScript SDK
-const run = await oc.agents.schedules("agt_...").fire("sch_...");
+const run = await oc.agents.schedules.fire("agt_...", "sch_...");
 // → { id: "srn_...", outcome: "enacted", sessionId: "ses_..." }
 ```
 
@@ -178,7 +178,7 @@ oc agent schedule fire morning-docs-sweep --agent agt_...
 ```http REST
 POST https://api.opencomputer.dev/v3/agents/agt_.../schedules/sch_.../fire
 Authorization: Bearer $OPENCOMPUTER_API_KEY
-// → 202 { "run": { … } }
+// → 201 { "run": { … } }
 ```
 
 </CodeGroup>
@@ -188,7 +188,7 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 <CodeGroup>
 
 ```ts TypeScript SDK
-const { runs, nextCursor } = await oc.agents.schedules("agt_...").runs("sch_...", { limit: 50 });
+const { runs, nextCursor } = await oc.agents.schedules.runs("agt_...", "sch_...", { limit: 50 });
 ```
 
 ```bash oc CLI
@@ -233,7 +233,7 @@ Each firing decision appends a `srn_…` run, so the history shows why a slot di
 | --- | --- |
 | `enacted` | A session was created — `session_id` is set. |
 | `skipped` | The previous run was still going and `overlap` is `skip`. |
-| `failed` | Enactment errored; `error` is set and it counts toward auto-pause. |
+| `failed` | Enactment errored; `error` is set. Scheduled firings count toward auto-pause; manual fires don't. |
 
 Fields: `id` (`srn_…`), `scheduled_for?` (the slot; `null` for a manual fire), `fired_at`, `outcome`, `session_id?`, `error?`.
 

--- a/docs/agent-sessions/schedules.mdx
+++ b/docs/agent-sessions/schedules.mdx
@@ -1,0 +1,259 @@
+---
+mode: "wide"
+title: "Schedules"
+description: "Run an agent on a cron — each firing starts a new session"
+---
+
+A **schedule** fires an agent on a cron: each firing starts one [session](/agent-sessions/sessions) with a fixed first message, so a recurring job needs no scheduler of your own. The session is ordinary — same runtime, streaming, and [destinations](/agent-sessions/webhooks) as any other.
+
+<Note>**Preview** — APIs may change before general availability.</Note>
+
+Declare schedules in the agent's [`agent.toml`](#agent-toml), or manage them over the [SDK, CLI, or REST](#management-api). They live on the **agent**, not a session.
+
+## How it works
+
+A platform tick runs every minute: it claims schedules whose `next_fire_at` has passed, enacts each, and advances `next_fire_at` to the next occurrence. Enacting starts a session on the agent's **active [revision](/agent-sessions/revisions) at fire time** with `input` as the first message; everything downstream — boot, events, SSE, destinations — is the normal session path.
+
+| Mechanic | Behavior |
+| --- | --- |
+| **Cron** | 5 fields, 1-minute resolution (a seconds field is rejected). `tz` is an IANA name; omit for UTC. DST follows the cron library — a skipped or repeated wall-clock hour resolves to the next real occurrence. |
+| **Attribution** | The first `user.message` carries `actor { kind: "schedule", id, display }`; the session carries `metadata.schedule = { id, run_id, scheduled_for }`. |
+| **Idempotency** | One session per slot, keyed `sch_<id>:<slot>`. A tick that crashes and retries converges on the same session. |
+| **Overlap** | `skip` (default): if the previous run's session is still `queued`/`running`, record `skipped` and advance. `allow`: fire regardless. |
+| **Catch-up** | After downtime, fire **once** for the most recent missed slot, then advance past now — never replays a backlog. |
+| **Failure** | Five consecutive *enactment* failures (missing credential, no credit) → `auto_paused` with `last_error`. Session outcomes never change schedule state. |
+
+**Common crons** (`minute hour day-of-month month day-of-week`):
+
+| Cron | Fires |
+| --- | --- |
+| `*/15 * * * *` | every 15 minutes |
+| `0 9 * * 1-5` | 09:00 on weekdays |
+| `0 0 * * 0` | Sundays at midnight |
+| `0 0 1 * *` | first of the month |
+
+## agent.toml
+
+An agent can carry several schedules — the same behavior on different cadences and inputs — each a `[[schedules]]` entry keyed by a `name` unique to the agent.
+
+```toml
+[[schedules]]
+name  = "docs-sweep"
+cron  = "0 9 * * 1-5"        # weekdays 09:00
+tz    = "Europe/London"      # optional; UTC if omitted
+input = "Reconcile docs/ against changes since yesterday; open a draft PR if anything drifted."
+
+[[schedules]]
+name  = "dep-audit"
+cron  = "0 0 * * 0"          # Sundays 00:00 UTC
+input = "Audit dependencies for CVEs; file an issue per finding."
+```
+
+`input` is the entire first message and no human is in the loop, so write it as a self-contained instruction.
+
+Each deploy (`git push` or `oc agent deploy`) syncs the table: upsert by `name`, drop schedules no longer declared, preserve `paused`. Omitting the `[[schedules]]` table syncs nothing — existing schedules are left alone.
+
+A schedule is a binding, not behavior: it sits outside the [revision](/agent-sessions/revisions) digest, so editing one doesn't cut a revision and a rollback doesn't touch it.
+
+<Note>For a [repo-linked](/agent-sessions/revisions#deploy-from-a-repo) agent the `agent.toml` owns the schedules — the API and dashboard can pause/resume but reject other edits (`409`), same as `prompt`/`model`.</Note>
+
+## Management API
+
+Org-key authenticated, server-side. Schedules are addressed under the agent.
+
+**Create:**
+
+<CodeGroup>
+
+```ts TypeScript SDK
+const schedule = await oc.agents.schedules("agt_...").create({
+  name: "morning-docs-sweep",
+  cron: "0 9 * * 1-5",
+  tz: "Europe/London",       // optional — UTC if omitted
+  input: "Reconcile docs/ against changes since yesterday; open a draft PR if anything drifted.",
+  overlap: "skip",           // skip (default) · allow
+});
+// → { id: "sch_...", state: "active", nextFireAt: "2026-07-07T08:00:00Z", ... }
+```
+
+```bash oc CLI
+oc agent schedule create morning-docs-sweep --agent agt_... \
+  --cron "0 9 * * 1-5" --tz Europe/London \
+  --input "Reconcile docs/ against changes since yesterday; open a draft PR if anything drifted."
+```
+
+```http REST
+POST https://api.opencomputer.dev/v3/agents/agt_.../schedules
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+Content-Type: application/json
+
+{ "name": "morning-docs-sweep", "cron": "0 9 * * 1-5", "tz": "Europe/London",
+  "input": "Reconcile docs/ against changes since yesterday; open a draft PR if anything drifted." }
+// → 201 { "schedule": { … } }
+```
+
+</CodeGroup>
+
+**List and fetch:**
+
+<CodeGroup>
+
+```ts TypeScript SDK
+const schedules = await oc.agents.schedules("agt_...").list();
+const schedule = await oc.agents.schedules("agt_...").get("sch_...");
+```
+
+```bash oc CLI
+oc agent schedules --agent agt_...
+oc agent schedule get morning-docs-sweep --agent agt_...
+```
+
+```http REST
+GET https://api.opencomputer.dev/v3/agents/agt_.../schedules
+GET https://api.opencomputer.dev/v3/agents/agt_.../schedules/sch_...
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+```
+
+</CodeGroup>
+
+**Update, pause, resume.** `PATCH` accepts `cron`, `tz`, `input`, `overlap`, and `paused`. A `cron`/`tz` change recomputes `next_fire_at` from now; resume recomputes from now and resets the failure counter — the paused window never back-fires.
+
+<CodeGroup>
+
+```ts TypeScript SDK
+await oc.agents.schedules("agt_...").update("sch_...", { cron: "0 7 * * *" });
+await oc.agents.schedules("agt_...").update("sch_...", { paused: true });   // pause
+await oc.agents.schedules("agt_...").update("sch_...", { paused: false });  // resume
+```
+
+```bash oc CLI
+oc agent schedule pause  morning-docs-sweep --agent agt_...
+oc agent schedule resume morning-docs-sweep --agent agt_...
+```
+
+```http REST
+PATCH https://api.opencomputer.dev/v3/agents/agt_.../schedules/sch_...
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+Content-Type: application/json
+
+{ "cron": "0 7 * * *" }          // or { "paused": true } / { "paused": false }
+```
+
+</CodeGroup>
+
+**Delete** — removes the schedule; run history is retained.
+
+<CodeGroup>
+
+```ts TypeScript SDK
+await oc.agents.schedules("agt_...").del("sch_...");
+```
+
+```bash oc CLI
+oc agent schedule delete morning-docs-sweep --agent agt_...
+```
+
+```http REST
+DELETE https://api.opencomputer.dev/v3/agents/agt_.../schedules/sch_...
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+// → 204
+```
+
+</CodeGroup>
+
+**Fire now** — enacts immediately in any state (paused included) and doesn't advance the cron. The test loop is `create` then `fire`.
+
+<CodeGroup>
+
+```ts TypeScript SDK
+const run = await oc.agents.schedules("agt_...").fire("sch_...");
+// → { id: "srn_...", outcome: "enacted", sessionId: "ses_..." }
+```
+
+```bash oc CLI
+oc agent schedule fire morning-docs-sweep --agent agt_...
+# prints the ses_… → oc session logs ses_…
+```
+
+```http REST
+POST https://api.opencomputer.dev/v3/agents/agt_.../schedules/sch_.../fire
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+// → 202 { "run": { … } }
+```
+
+</CodeGroup>
+
+**Runs** — newest-first; each row carries `session_id` to chain into [`GET /sessions/:id`](/agent-sessions/api-reference#sessions).
+
+<CodeGroup>
+
+```ts TypeScript SDK
+const { runs, nextCursor } = await oc.agents.schedules("agt_...").runs("sch_...", { limit: 50 });
+```
+
+```bash oc CLI
+oc agent schedule runs morning-docs-sweep --agent agt_...
+```
+
+```http REST
+GET https://api.opencomputer.dev/v3/agents/agt_.../schedules/sch_.../runs?limit=50&cursor=…
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+// → { "runs": [ … ], "next_cursor": … }
+```
+
+</CodeGroup>
+
+## The schedule object
+
+| Field | Notes |
+| --- | --- |
+| `id` `agent_id` | `sch_…` · the agent whose active revision each run uses |
+| `name` | `^[a-z0-9][a-z0-9-]{0,63}$`, unique per agent — the `agent.toml` / CLI handle |
+| `cron` `tz?` | 5-field cron · IANA name, or `null` for UTC |
+| `input` | first user message of every run (≤ 32 KiB) |
+| `overlap` | `skip` (default) · `allow` |
+| `state` | `active · paused · auto_paused` |
+| `next_fire_at` `last_fired_at?` | next occurrence, UTC (derived) · last fire |
+| `consecutive_failures` `last_error?` | in-a-row enactment failures (`≥ 5` → `auto_paused`) · last error, cleared on success |
+| `created_at` `updated_at` | timestamps |
+
+### States
+
+| State | Meaning |
+| --- | --- |
+| `active` | Firing on schedule. |
+| `paused` | You paused it; the cron is ignored until resume. |
+| `auto_paused` | Five straight enactment failures paused it; `last_error` says why. |
+
+## Runs
+
+Each firing decision appends a `srn_…` run, so the history shows why a slot did or didn't produce a session.
+
+| `outcome` | When |
+| --- | --- |
+| `enacted` | A session was created — `session_id` is set. |
+| `skipped` | The previous run was still going and `overlap` is `skip`. |
+| `failed` | Enactment errored; `error` is set and it counts toward auto-pause. |
+
+Fields: `id` (`srn_…`), `scheduled_for?` (the slot; `null` for a manual fire), `fired_at`, `outcome`, `session_id?`, `error?`.
+
+## Limits
+
+- **≤ 20** schedules per agent.
+- `input` **≤ 32 KiB**.
+- Cron floor **1 minute**.
+
+<Warning>
+Scheduled sessions run unattended — cap them. Set agent [`limits`](/agent-sessions/sessions#limits) `turns` and `turn_seconds` (every run inherits them). `limits.tokens` is not enforced yet, so don't rely on it to bound spend.
+</Warning>
+
+## Dashboard
+
+The agent's **Schedules** card lists each schedule with its next fire and state, a create dialog that previews upcoming fire times as you type the cron, and per-schedule run history linked to the sessions. Repo-linked schedules are read-only except pause/resume; `auto_paused` shows the last error.
+
+## Example
+
+1. `agent.toml` declares `[[schedules]] name = "morning-docs-sweep", cron = "0 9 * * 1-5"`. `git push` deploys the agent and the schedule goes `active`.
+2. Weekday 09:00 → a session starts on the active revision, first message = `input`, `actor.kind = "schedule"`.
+3. The agent reconciles `docs/` and opens a draft PR — an ordinary session on the dashboard and your destinations.
+4. Next 09:00, if the prior run is still `running` (`overlap: "skip"`) → the firing records `skipped` and the schedule advances.

--- a/docs/agent-sessions/triggers.mdx
+++ b/docs/agent-sessions/triggers.mdx
@@ -18,6 +18,8 @@ on   = "issue.labeled:agent"
 - **Routing:** a routing key groups events into sessions — by default one session per issue; a comment on a PR the agent opened resumes the session that opened it.
 - **Who can trigger:** restricted to members of your organization by default, configurable per agent.
 
+To fire an agent on a **cron** rather than an external event, use [Schedules](/agent-sessions/schedules) — a time-based trigger with its own stable API.
+
 ## Integrations
 
 Triggers and outbound deliveries run through platform integrations, so the agent holds no

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -86,6 +86,7 @@
           "agent-sessions/runtimes",
           "agent-sessions/runtime-tools",
           "agent-sessions/watches",
+          "agent-sessions/schedules",
           "agent-sessions/api-reference",
           {
             "group": "Frameworks",


### PR DESCRIPTION
Aspirational, **doc-first** user-facing docs for **Schedules** (design 015 in oc-bg-agents) — cron-triggered agent sessions. These describe intended behavior **ahead of implementation**; reviewing the docs *is* the design review. No code in this PR.

## What a schedule is
A schedule fires an agent on a cron; each firing starts one ordinary session with a fixed `input`. An agent can carry several (different cadences/inputs). Rides existing machinery — the per-minute product-async tick, `startSession`, create-idempotency, the free-form event actor.

## Changes
- **`agent-sessions/schedules.mdx`** (new) — feature guide: mechanics table, `agent.toml` `[[schedules]]` + deploy-sync, SDK/CLI/REST management, the `Schedule`/`Run` objects, states, limits, dashboard, example.
- **`agent-sessions/api-reference.mdx`** — a `## Schedules` section (SDK/REST/CLI tabs + object shapes).
- **`agent-sessions/triggers.mdx`** — one additive pointer (Labs page, not rewritten).
- **`docs.json`** — nav entry after Watches, in the stable Durable Agent Sessions group.

## Calls worth confirming in review
- **SDK shape** — documented as `oc.agents.schedules("agt_…").create(…)` (factory accessor, per the design). The page documents deployments as `oc.agents.deployments.create(id, …)` (namespace form) — pick one for consistency.
- **CLI** — schedule subcommands take `--agent <id>`; assumed it resolves from the cwd `agent.toml` when omitted.
- **Limits** — 20 schedules/agent, `input` ≤ 32 KiB, 1-minute cron floor. The 20 is an arbitrary-but-safe cap; easy to change now.
- **Honest caveat surfaced** — the guide tells users to bound unattended runs with `limits.turns`/`turn_seconds` and *not* rely on `limits.tokens` (design §9's known no-op). Confirm that's OK to state publicly in a Preview doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)