### PR TITLE
Schedules (design 015) — docs + SDK + CLI + dashboard

### DIFF
--- a/cmd/oc/internal/client/client.go
+++ b/cmd/oc/internal/client/client.go
@@ -181,6 +181,34 @@ func (c *Client) Post(ctx context.Context, path string, body, result interface{}
 	return nil
 }
 
+// Patch performs a PATCH request with a JSON body and decodes the response.
+func (c *Client) Patch(ctx context.Context, path string, body, result interface{}) error {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, "PATCH", c.baseURL+path, bodyReader)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if result != nil {
+		return json.NewDecoder(resp.Body).Decode(result)
+	}
+	return nil
+}
+
 // GetStream performs a GET request and returns the raw response so the
 // caller can stream chunks (e.g. SSE log feeds). Caller closes resp.Body.
 func (c *Client) GetStream(ctx context.Context, path string) (*http.Response, error) {

--- a/cmd/oc/internal/commands/agent.go
+++ b/cmd/oc/internal/commands/agent.go
@@ -173,5 +173,6 @@ var agentCmd = &cobra.Command{
 func init() {
 	registerAgentCrud()
 	registerAgentDeploy()
+	registerAgentSchedules()
 	rootCmd.AddCommand(sessionCmd)
 }

--- a/cmd/oc/internal/commands/agent_deploy.go
+++ b/cmd/oc/internal/commands/agent_deploy.go
@@ -25,7 +25,17 @@ type manifest struct {
 	Agent struct {
 		ID string `toml:"id"`
 	} `toml:"agent"`
-	Limits map[string]interface{} `toml:"limits"`
+	Limits    map[string]interface{} `toml:"limits"`
+	Schedules []scheduleDecl         `toml:"schedules"` // cron for agents (015); synced on deploy-activate
+}
+
+// One agent.toml [[schedules]] entry. Rides the deployment input; the server syncs on activate.
+type scheduleDecl struct {
+	Name    string `toml:"name" json:"name"`
+	Cron    string `toml:"cron" json:"cron"`
+	TZ      string `toml:"tz,omitempty" json:"tz,omitempty"`
+	Input   string `toml:"input" json:"input"`
+	Overlap string `toml:"overlap,omitempty" json:"overlap,omitempty"`
 }
 
 type skillFile struct {
@@ -267,6 +277,11 @@ var agentDeployCmd = &cobra.Command{
 		input := map[string]interface{}{"type": "inline", "prompt": prompt, "model": m.Model, "runtime": map[string]string{"type": rt}}
 		if len(skills) > 0 {
 			input["skills"] = skills
+		}
+		// [[schedules]] present in agent.toml → carry them so the server syncs on activate (015 §3).
+		// Absent → omit the key entirely (no sync; existing schedules untouched).
+		if len(m.Schedules) > 0 {
+			input["schedules"] = m.Schedules
 		}
 		body := map[string]interface{}{"input": input, "activate": !noActivate}
 		if idem, _ := cmd.Flags().GetString("idempotency-key"); idem != "" {

--- a/cmd/oc/internal/commands/agent_schedules.go
+++ b/cmd/oc/internal/commands/agent_schedules.go
@@ -1,0 +1,354 @@
+package commands
+
+// `oc agent schedule[s]` — cron for agents (design 015). A schedule fires an agent on a cron; each
+// firing starts one session on the active revision. Agent addressing follows the house convention:
+// --agent <id|name> on every verb, else the cwd agent.toml. Schedules are referenced by NAME (or a
+// sch_… id); the name is resolved to an id against the agent.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/opensandbox/opensandbox/cmd/oc/internal/client"
+	"github.com/spf13/cobra"
+)
+
+// ── Response types (mirror the sessions-api JSON, snake_case) ──
+
+type Schedule struct {
+	ID                  string  `json:"id"`
+	AgentID             string  `json:"agent_id"`
+	Name                string  `json:"name"`
+	Cron                string  `json:"cron"`
+	TZ                  *string `json:"tz"`
+	Input               string  `json:"input"`
+	Overlap             string  `json:"overlap"`
+	State               string  `json:"state"`
+	NextFireAt          string  `json:"next_fire_at"`
+	LastFiredAt         *string `json:"last_fired_at"`
+	ConsecutiveFailures int     `json:"consecutive_failures"`
+	LastError           *string `json:"last_error"`
+	CreatedAt           string  `json:"created_at"`
+}
+
+type scheduleEnvelope struct {
+	Schedule Schedule `json:"schedule"`
+}
+type scheduleListResp struct {
+	Schedules []Schedule `json:"schedules"`
+}
+
+type ScheduleRun struct {
+	ID           string  `json:"id"`
+	ScheduleID   string  `json:"schedule_id"`
+	ScheduledFor *string `json:"scheduled_for"`
+	FiredAt      string  `json:"fired_at"`
+	Outcome      string  `json:"outcome"`
+	SessionID    *string `json:"session_id"`
+	Error        *string `json:"error"`
+}
+type runEnvelope struct {
+	Run ScheduleRun `json:"run"`
+}
+type runListResp struct {
+	Runs       []ScheduleRun `json:"runs"`
+	NextCursor *string       `json:"next_cursor"`
+}
+
+// schedStr renders a nullable/empty string field as "-".
+func schedStr(p *string) string {
+	if p == nil || *p == "" {
+		return "-"
+	}
+	return *p
+}
+
+// resolveScheduleID maps a "sch_…" id (used as-is) or a schedule NAME (looked up on the agent) to id.
+func resolveScheduleID(cmd *cobra.Command, sc *client.Client, agentID, ref string) (string, error) {
+	if strings.HasPrefix(ref, "sch_") {
+		return ref, nil
+	}
+	var list scheduleListResp
+	if err := sc.Get(cmd.Context(), "/v3/agents/"+agentID+"/schedules", &list); err != nil {
+		return "", err
+	}
+	for _, s := range list.Schedules {
+		if s.Name == ref {
+			return s.ID, nil
+		}
+	}
+	return "", fmt.Errorf("no schedule named %q on this agent", ref)
+}
+
+var agentSchedulesCmd = &cobra.Command{
+	Use:   "schedules",
+	Short: "List an agent's schedules (cron for agents)",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+		agentID, err := targetAgentID(cmd, sc, nil)
+		if err != nil {
+			return err
+		}
+		var resp scheduleListResp
+		if err := sc.Get(cmd.Context(), "/v3/agents/"+agentID+"/schedules", &resp); err != nil {
+			return err
+		}
+		printer.Print(resp.Schedules, func() {
+			if len(resp.Schedules) == 0 {
+				fmt.Println("No schedules.")
+				return
+			}
+			headers := []string{"NAME", "CRON", "TZ", "STATE", "NEXT_FIRE", "FAILS"}
+			var rows [][]string
+			for _, s := range resp.Schedules {
+				rows = append(rows, []string{s.Name, s.Cron, schedStr(s.TZ), s.State, s.NextFireAt, fmt.Sprintf("%d", s.ConsecutiveFailures)})
+			}
+			printer.Table(headers, rows)
+		})
+		return nil
+	},
+}
+
+var agentScheduleCmd = &cobra.Command{
+	Use:   "schedule",
+	Short: "Manage an agent's schedules (create/get/pause/resume/delete/fire/runs)",
+}
+
+var agentScheduleCreateCmd = &cobra.Command{
+	Use:     "create <name>",
+	Short:   "Create a schedule on an agent",
+	Example: "  oc agent schedule create morning-sweep --cron \"0 9 * * 1-5\" --input \"Reconcile docs; open a draft PR if anything drifted.\"",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+		agentID, err := targetAgentID(cmd, sc, nil)
+		if err != nil {
+			return err
+		}
+		cron, _ := cmd.Flags().GetString("cron")
+		input, _ := cmd.Flags().GetString("input")
+		tz, _ := cmd.Flags().GetString("tz")
+		overlap, _ := cmd.Flags().GetString("overlap")
+		if cron == "" {
+			return fmt.Errorf("--cron is required")
+		}
+		if input == "" {
+			return fmt.Errorf("--input is required")
+		}
+		body := map[string]interface{}{"name": args[0], "cron": cron, "input": input}
+		if tz != "" {
+			body["tz"] = tz
+		}
+		if overlap != "" {
+			body["overlap"] = overlap
+		}
+		var env scheduleEnvelope
+		if err := sc.Post(cmd.Context(), "/v3/agents/"+agentID+"/schedules", body, &env); err != nil {
+			return err
+		}
+		printer.Print(env.Schedule, func() {
+			fmt.Printf("Created schedule %s (%s) — next fire %s\n", env.Schedule.Name, env.Schedule.ID, env.Schedule.NextFireAt)
+		})
+		return nil
+	},
+}
+
+var agentScheduleGetCmd = &cobra.Command{
+	Use:   "get <name>",
+	Short: "Show a schedule",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+		agentID, err := targetAgentID(cmd, sc, nil)
+		if err != nil {
+			return err
+		}
+		sid, err := resolveScheduleID(cmd, sc, agentID, args[0])
+		if err != nil {
+			return err
+		}
+		var env scheduleEnvelope
+		if err := sc.Get(cmd.Context(), "/v3/agents/"+agentID+"/schedules/"+sid, &env); err != nil {
+			return err
+		}
+		printer.Print(env.Schedule, func() {
+			s := env.Schedule
+			fmt.Printf("Name:       %s\n", s.Name)
+			fmt.Printf("ID:         %s\n", s.ID)
+			fmt.Printf("Cron:       %s (%s)\n", s.Cron, schedStr(s.TZ))
+			fmt.Printf("State:      %s\n", s.State)
+			fmt.Printf("Next fire:  %s\n", s.NextFireAt)
+			fmt.Printf("Last fired: %s\n", schedStr(s.LastFiredAt))
+			fmt.Printf("Overlap:    %s\n", s.Overlap)
+			if s.LastError != nil && *s.LastError != "" {
+				fmt.Printf("Last error: %s (failures: %d)\n", *s.LastError, s.ConsecutiveFailures)
+			}
+			fmt.Printf("Input:      %s\n", s.Input)
+		})
+		return nil
+	},
+}
+
+// patchPaused PATCHes {paused} and reports the resulting state (pause / resume share this).
+func patchPaused(cmd *cobra.Command, args []string, paused bool, verb string) error {
+	sc, err := sessionsClient(cmd)
+	if err != nil {
+		return err
+	}
+	agentID, err := targetAgentID(cmd, sc, nil)
+	if err != nil {
+		return err
+	}
+	sid, err := resolveScheduleID(cmd, sc, agentID, args[0])
+	if err != nil {
+		return err
+	}
+	var env scheduleEnvelope
+	if err := sc.Patch(cmd.Context(), "/v3/agents/"+agentID+"/schedules/"+sid, map[string]interface{}{"paused": paused}, &env); err != nil {
+		return err
+	}
+	printer.Print(env.Schedule, func() {
+		fmt.Printf("%s %s — state %s, next fire %s\n", verb, env.Schedule.Name, env.Schedule.State, env.Schedule.NextFireAt)
+	})
+	return nil
+}
+
+var agentSchedulePauseCmd = &cobra.Command{
+	Use: "pause <name>", Short: "Pause a schedule", Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error { return patchPaused(cmd, args, true, "Paused") },
+}
+var agentScheduleResumeCmd = &cobra.Command{
+	Use: "resume <name>", Short: "Resume a schedule", Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error { return patchPaused(cmd, args, false, "Resumed") },
+}
+
+var agentScheduleDeleteCmd = &cobra.Command{
+	Use: "delete <name>", Aliases: []string{"rm"}, Short: "Delete a schedule (run history is kept)", Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+		agentID, err := targetAgentID(cmd, sc, nil)
+		if err != nil {
+			return err
+		}
+		sid, err := resolveScheduleID(cmd, sc, agentID, args[0])
+		if err != nil {
+			return err
+		}
+		if err := sc.Delete(cmd.Context(), "/v3/agents/"+agentID+"/schedules/"+sid); err != nil {
+			return err
+		}
+		printer.Print(map[string]interface{}{"deleted": args[0]}, func() { fmt.Printf("Deleted schedule %s\n", args[0]) })
+		return nil
+	},
+}
+
+var agentScheduleFireCmd = &cobra.Command{
+	Use: "fire <name>", Short: "Test-fire a schedule now (prints the created session)", Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+		agentID, err := targetAgentID(cmd, sc, nil)
+		if err != nil {
+			return err
+		}
+		sid, err := resolveScheduleID(cmd, sc, agentID, args[0])
+		if err != nil {
+			return err
+		}
+		var env runEnvelope
+		if err := sc.Post(cmd.Context(), "/v3/agents/"+agentID+"/schedules/"+sid+"/fire", nil, &env); err != nil {
+			return err
+		}
+		printer.Print(env.Run, func() {
+			r := env.Run
+			if r.Outcome == "enacted" && r.SessionID != nil {
+				fmt.Printf("Fired — session %s\n", *r.SessionID)
+				fmt.Printf("  tail it: oc session logs %s\n", *r.SessionID)
+			} else {
+				fmt.Printf("Fired — outcome %s\n", r.Outcome)
+				if r.Error != nil && *r.Error != "" {
+					fmt.Printf("  error: %s\n", *r.Error)
+				}
+			}
+		})
+		return nil
+	},
+}
+
+var agentScheduleRunsCmd = &cobra.Command{
+	Use: "runs <name>", Short: "Show a schedule's run history (newest first)", Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sc, err := sessionsClient(cmd)
+		if err != nil {
+			return err
+		}
+		agentID, err := targetAgentID(cmd, sc, nil)
+		if err != nil {
+			return err
+		}
+		sid, err := resolveScheduleID(cmd, sc, agentID, args[0])
+		if err != nil {
+			return err
+		}
+		limit, _ := cmd.Flags().GetInt("limit")
+		path := fmt.Sprintf("/v3/agents/%s/schedules/%s/runs", agentID, sid)
+		if limit > 0 {
+			path += fmt.Sprintf("?limit=%d", limit)
+		}
+		var resp runListResp
+		if err := sc.Get(cmd.Context(), path, &resp); err != nil {
+			return err
+		}
+		printer.Print(resp.Runs, func() {
+			if len(resp.Runs) == 0 {
+				fmt.Println("No runs yet.")
+				return
+			}
+			headers := []string{"OUTCOME", "SCHEDULED_FOR", "FIRED", "SESSION", "ERROR"}
+			var rows [][]string
+			for _, r := range resp.Runs {
+				rows = append(rows, []string{r.Outcome, schedStr(r.ScheduledFor), r.FiredAt, schedStr(r.SessionID), schedStr(r.Error)})
+			}
+			printer.Table(headers, rows)
+		})
+		return nil
+	},
+}
+
+func registerAgentSchedules() {
+	// Agent addressing: --agent on every verb, else the cwd agent.toml.
+	for _, c := range []*cobra.Command{
+		agentSchedulesCmd, agentScheduleCreateCmd, agentScheduleGetCmd,
+		agentSchedulePauseCmd, agentScheduleResumeCmd, agentScheduleDeleteCmd,
+		agentScheduleFireCmd, agentScheduleRunsCmd,
+	} {
+		c.Flags().String("agent", "", "Agent id or name (else the cwd agent.toml)")
+	}
+	agentScheduleCreateCmd.Flags().String("cron", "", "5-field cron, e.g. \"0 9 * * 1-5\" (required)")
+	agentScheduleCreateCmd.Flags().String("tz", "", "IANA time zone, e.g. Europe/London (optional; UTC if omitted)")
+	agentScheduleCreateCmd.Flags().String("input", "", "First user message of every run (required)")
+	agentScheduleCreateCmd.Flags().String("overlap", "", "skip (default) | allow")
+	agentScheduleRunsCmd.Flags().Int("limit", 0, "Max runs to show")
+
+	agentScheduleCmd.AddCommand(
+		agentScheduleCreateCmd, agentScheduleGetCmd, agentSchedulePauseCmd, agentScheduleResumeCmd,
+		agentScheduleDeleteCmd, agentScheduleFireCmd, agentScheduleRunsCmd,
+	)
+	agentCmd.AddCommand(agentSchedulesCmd)
+	agentCmd.AddCommand(agentScheduleCmd)
+}

--- a/cmd/oc/internal/commands/agent_schedules.go
+++ b/cmd/oc/internal/commands/agent_schedules.go
@@ -64,6 +64,8 @@ func schedStr(p *string) string {
 }
 
 // resolveScheduleID maps a "sch_…" id (used as-is) or a schedule NAME (looked up on the agent) to id.
+// The prefix check is unambiguous: schedule names are strict slugs (^[a-z0-9][a-z0-9-]{0,63}$, no
+// underscores), so a name can never begin with "sch_".
 func resolveScheduleID(cmd *cobra.Command, sc *client.Client, agentID, ref string) (string, error) {
 	if strings.HasPrefix(ref, "sch_") {
 		return ref, nil

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -471,6 +471,68 @@ Linking deploys the current production HEAD immediately (unless `deploy_now: fal
 | `status` | `active`, or a problem: `path_missing`, `ref_missing` (production branch deleted), `auth_required`, `repo_not_selected`, `app_suspended`, `error` |
 | `latest_seen_sha?` `active_deployed_sha?` | newest sha observed · sha behind the active revision |
 
+## Schedules
+
+*Run an agent on a cron — each firing starts a session. Managed with the SDK, the `oc` CLI, or REST (org key). Full guide: [Schedules](/agent-sessions/schedules).*
+
+<Tabs>
+
+<Tab title="TypeScript SDK">
+
+| Call | Purpose |
+| --- | --- |
+| `oc.agents.schedules(id).create(params)` | Create a schedule (`{ name, cron, tz?, input, overlap? }`). |
+| `oc.agents.schedules(id).list()` · `.get(sid)` | List / fetch. |
+| `oc.agents.schedules(id).update(sid, params)` | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`. |
+| `oc.agents.schedules(id).del(sid)` | Delete (run history kept). |
+| `oc.agents.schedules(id).fire(sid)` | Fire now → a run; doesn't advance the cron. |
+| `oc.agents.schedules(id).runs(sid, { cursor?, limit? })` | Run history (each carries `sessionId`). |
+
+</Tab>
+
+<Tab title="REST API">
+
+| Method · Path | Purpose |
+| --- | --- |
+| `POST /agents/:id/schedules` | Create → `201 { schedule }`. Body `{ name, cron, tz?, input, overlap? }`. |
+| `GET /agents/:id/schedules` · `…/:sid` | List / fetch. |
+| `PATCH /agents/:id/schedules/:sid` | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`. |
+| `DELETE /agents/:id/schedules/:sid` | Delete → `204` (runs kept). |
+| `POST /agents/:id/schedules/:sid/fire` | Fire now → `202 { run }`; doesn't advance the cron. |
+| `GET /agents/:id/schedules/:sid/runs?cursor=&limit=` | Run history → `{ runs, next_cursor }`. |
+
+</Tab>
+
+<Tab title="oc CLI">
+
+| Command | Purpose |
+| --- | --- |
+| `oc agent schedule create <name> --agent <id> --cron <c> [--tz <z>] --input <s>` | Create a schedule. |
+| `oc agent schedules [--agent <id>]` · `oc agent schedule get <name>` | List / fetch. |
+| `oc agent schedule pause\|resume <name>` | Pause / resume. |
+| `oc agent schedule delete <name>` | Delete. |
+| `oc agent schedule fire <name>` | Fire now (prints the `ses_…`). |
+| `oc agent schedule runs <name>` | Run history. |
+
+</Tab>
+
+</Tabs>
+
+`cron` is a 5-field expression (**1-minute** floor); `tz` is an IANA name (UTC if omitted); `input` (**≤ 32 KiB**) is the first message of every run; `overlap` is `skip` (default) or `allow`. Schedules are also **synced from [`agent.toml`](/agent-sessions/schedules#agent-toml)** on deploy — a repo-driven agent rejects edits other than pause/resume (`409`). Max **20** per agent.
+
+**`Schedule`**
+
+| Field | Notes |
+|---|---|
+| `id` `agent_id` | `sch_…` · the owning agent |
+| `name` `cron` `tz?` `input` | handle (unique per agent) · 5-field cron · IANA tz · first message |
+| `overlap` | `skip` (default) · `allow` |
+| `state` | `active · paused · auto_paused` (five straight enactment failures auto-pause) |
+| `next_fire_at` `last_fired_at?` | next occurrence · last fire |
+| `consecutive_failures` `last_error?` | in-a-row enactment failures · last error (cleared on success) |
+
+**`Run`** — one per firing decision, newest-first: `srn_…` with `outcome` (`enacted` · `skipped` · `failed`), `scheduled_for?` (`null` for a manual fire), `fired_at`, `session_id?` (when enacted), `error?`. Chain `session_id` into `GET /sessions/:id`.
+
 ## Destinations
 
 *Webhooks are configured via SDK/REST (no `oc` command).*

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -481,12 +481,12 @@ Linking deploys the current production HEAD immediately (unless `deploy_now: fal
 
 | Call | Purpose |
 | --- | --- |
-| `oc.agents.schedules(id).create(params)` | Create a schedule (`{ name, cron, tz?, input, overlap? }`). |
-| `oc.agents.schedules(id).list()` · `.get(sid)` | List / fetch. |
-| `oc.agents.schedules(id).update(sid, params)` | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`. |
-| `oc.agents.schedules(id).del(sid)` | Delete (run history kept). |
-| `oc.agents.schedules(id).fire(sid)` | Fire now → a run; doesn't advance the cron. |
-| `oc.agents.schedules(id).runs(sid, { cursor?, limit? })` | Run history (each carries `sessionId`). |
+| `oc.agents.schedules.create(id, params)` | Create a schedule (`{ name, cron, tz?, input, overlap? }`). |
+| `oc.agents.schedules.list(id)` · `.get(id, sid)` | List / fetch. |
+| `oc.agents.schedules.update(id, sid, params)` | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`. |
+| `oc.agents.schedules.delete(id, sid)` | Delete (run history kept). |
+| `oc.agents.schedules.fire(id, sid)` | Fire now → a run; doesn't advance the cron. |
+| `oc.agents.schedules.runs(id, sid, { cursor?, limit? })` | Run history (each carries `sessionId`). |
 
 </Tab>
 
@@ -498,7 +498,7 @@ Linking deploys the current production HEAD immediately (unless `deploy_now: fal
 | `GET /agents/:id/schedules` · `…/:sid` | List / fetch. |
 | `PATCH /agents/:id/schedules/:sid` | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`. |
 | `DELETE /agents/:id/schedules/:sid` | Delete → `204` (runs kept). |
-| `POST /agents/:id/schedules/:sid/fire` | Fire now → `202 { run }`; doesn't advance the cron. |
+| `POST /agents/:id/schedules/:sid/fire` | Fire now → `201 { run }`; doesn't advance the cron. |
 | `GET /agents/:id/schedules/:sid/runs?cursor=&limit=` | Run history → `{ runs, next_cursor }`. |
 
 </Tab>
@@ -527,7 +527,7 @@ Linking deploys the current production HEAD immediately (unless `deploy_now: fal
 | `id` `agent_id` | `sch_…` · the owning agent |
 | `name` `cron` `tz?` `input` | handle (unique per agent) · 5-field cron · IANA tz · first message |
 | `overlap` | `skip` (default) · `allow` |
-| `state` | `active · paused · auto_paused` (five straight enactment failures auto-pause) |
+| `state` | `active · paused · auto_paused` (five straight scheduled-firing failures auto-pause) |
 | `next_fire_at` `last_fired_at?` | next occurrence · last fire |
 | `consecutive_failures` `last_error?` | in-a-row enactment failures · last error (cleared on success) |
 

--- a/docs/agent-sessions/schedules.mdx
+++ b/docs/agent-sessions/schedules.mdx
@@ -20,7 +20,7 @@ A platform tick runs every minute: it claims schedules whose `next_fire_at` has 
 | **Attribution** | The first `user.message` carries `actor { kind: "schedule", id, display }`; the session carries `metadata.schedule = { id, run_id, scheduled_for }`. |
 | **Idempotency** | One session per slot, keyed `sch_<id>:<slot>`. A tick that crashes and retries converges on the same session. |
 | **Overlap** | `skip` (default): if the previous run's session is still `queued`/`running`, record `skipped` and advance. `allow`: fire regardless. |
-| **Catch-up** | After downtime, fire **once** for the most recent missed slot, then advance past now — never replays a backlog. |
+| **Catch-up** | After downtime, a schedule fires **once** — the run's `scheduled_for` is the slot that was due — then advances past now. It never replays a backlog. |
 | **Failure** | Five consecutive scheduled-firing *enactment* failures (missing credential, no credit) → `auto_paused` with `last_error`. Session outcomes never change schedule state; neither do manual fires. |
 
 **Common crons** (`minute hour day-of-month month day-of-week`):
@@ -249,7 +249,7 @@ Scheduled sessions run unattended — cap them. Set agent [`limits`](/agent-sess
 
 ## Dashboard
 
-The agent's **Schedules** card lists each schedule with its next fire and state, a create dialog that previews upcoming fire times as you type the cron, and per-schedule run history linked to the sessions. Repo-linked schedules are read-only except pause/resume; `auto_paused` shows the last error.
+The agent's **Schedules** tab lists each schedule with its next fire and state, plus controls (pause/resume, test-fire, edit, delete) and per-schedule run history. The create form takes a cron — with quick presets and a plain-English gloss for common expressions — and a message; schedules created here run in **UTC** (a zone set via the API/CLI still displays). Repo-linked schedules are read-only except pause/resume; `auto_paused` shows the last error.
 
 ## Example
 

--- a/docs/agent-sessions/schedules.mdx
+++ b/docs/agent-sessions/schedules.mdx
@@ -16,12 +16,12 @@ A platform tick runs every minute: it claims schedules whose `next_fire_at` has 
 
 | Mechanic | Behavior |
 | --- | --- |
-| **Cron** | 5 fields, 1-minute resolution (a seconds field is rejected). `tz` is an IANA name; omit for UTC. DST follows the cron library — a skipped or repeated wall-clock hour resolves to the next real occurrence. |
+| **Cron** | 5 fields, 1-minute resolution (a seconds field is rejected). `tz` is an IANA name; omit for UTC. DST follows the cron library — a match in a skipped hour fires at the next real occurrence; a repeated hour fires once. |
 | **Attribution** | The first `user.message` carries `actor { kind: "schedule", id, display }`; the session carries `metadata.schedule = { id, run_id, scheduled_for }`. |
 | **Idempotency** | One session per slot, keyed `sch_<id>:<slot>`. A tick that crashes and retries converges on the same session. |
 | **Overlap** | `skip` (default): if the previous run's session is still `queued`/`running`, record `skipped` and advance. `allow`: fire regardless. |
 | **Catch-up** | After downtime, fire **once** for the most recent missed slot, then advance past now — never replays a backlog. |
-| **Failure** | Five consecutive *enactment* failures (missing credential, no credit) → `auto_paused` with `last_error`. Session outcomes never change schedule state. |
+| **Failure** | Five consecutive scheduled-firing *enactment* failures (missing credential, no credit) → `auto_paused` with `last_error`. Session outcomes never change schedule state; neither do manual fires. |
 
 **Common crons** (`minute hour day-of-month month day-of-week`):
 
@@ -66,7 +66,7 @@ Org-key authenticated, server-side. Schedules are addressed under the agent.
 <CodeGroup>
 
 ```ts TypeScript SDK
-const schedule = await oc.agents.schedules("agt_...").create({
+const schedule = await oc.agents.schedules.create("agt_...", {
   name: "morning-docs-sweep",
   cron: "0 9 * * 1-5",
   tz: "Europe/London",       // optional — UTC if omitted
@@ -99,8 +99,8 @@ Content-Type: application/json
 <CodeGroup>
 
 ```ts TypeScript SDK
-const schedules = await oc.agents.schedules("agt_...").list();
-const schedule = await oc.agents.schedules("agt_...").get("sch_...");
+const schedules = await oc.agents.schedules.list("agt_...");
+const schedule = await oc.agents.schedules.get("agt_...", "sch_...");
 ```
 
 ```bash oc CLI
@@ -121,9 +121,9 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 <CodeGroup>
 
 ```ts TypeScript SDK
-await oc.agents.schedules("agt_...").update("sch_...", { cron: "0 7 * * *" });
-await oc.agents.schedules("agt_...").update("sch_...", { paused: true });   // pause
-await oc.agents.schedules("agt_...").update("sch_...", { paused: false });  // resume
+await oc.agents.schedules.update("agt_...", "sch_...", { cron: "0 7 * * *" });
+await oc.agents.schedules.update("agt_...", "sch_...", { paused: true });   // pause
+await oc.agents.schedules.update("agt_...", "sch_...", { paused: false });  // resume
 ```
 
 ```bash oc CLI
@@ -146,7 +146,7 @@ Content-Type: application/json
 <CodeGroup>
 
 ```ts TypeScript SDK
-await oc.agents.schedules("agt_...").del("sch_...");
+await oc.agents.schedules.delete("agt_...", "sch_...");
 ```
 
 ```bash oc CLI
@@ -161,12 +161,12 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 
 </CodeGroup>
 
-**Fire now** — enacts immediately in any state (paused included) and doesn't advance the cron. The test loop is `create` then `fire`.
+**Fire now** — enacts immediately in any state (paused included) and doesn't advance the cron. The test loop is `create` then `fire`. A failed manual fire returns the run with `outcome: "failed"` and updates `last_error`, but never changes the schedule's state or failure counter.
 
 <CodeGroup>
 
 ```ts TypeScript SDK
-const run = await oc.agents.schedules("agt_...").fire("sch_...");
+const run = await oc.agents.schedules.fire("agt_...", "sch_...");
 // → { id: "srn_...", outcome: "enacted", sessionId: "ses_..." }
 ```
 
@@ -178,7 +178,7 @@ oc agent schedule fire morning-docs-sweep --agent agt_...
 ```http REST
 POST https://api.opencomputer.dev/v3/agents/agt_.../schedules/sch_.../fire
 Authorization: Bearer $OPENCOMPUTER_API_KEY
-// → 202 { "run": { … } }
+// → 201 { "run": { … } }
 ```
 
 </CodeGroup>
@@ -188,7 +188,7 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 <CodeGroup>
 
 ```ts TypeScript SDK
-const { runs, nextCursor } = await oc.agents.schedules("agt_...").runs("sch_...", { limit: 50 });
+const { runs, nextCursor } = await oc.agents.schedules.runs("agt_...", "sch_...", { limit: 50 });
 ```
 
 ```bash oc CLI
@@ -233,7 +233,7 @@ Each firing decision appends a `srn_…` run, so the history shows why a slot di
 | --- | --- |
 | `enacted` | A session was created — `session_id` is set. |
 | `skipped` | The previous run was still going and `overlap` is `skip`. |
-| `failed` | Enactment errored; `error` is set and it counts toward auto-pause. |
+| `failed` | Enactment errored; `error` is set. Scheduled firings count toward auto-pause; manual fires don't. |
 
 Fields: `id` (`srn_…`), `scheduled_for?` (the slot; `null` for a manual fire), `fired_at`, `outcome`, `session_id?`, `error?`.
 

--- a/docs/agent-sessions/schedules.mdx
+++ b/docs/agent-sessions/schedules.mdx
@@ -1,0 +1,259 @@
+---
+mode: "wide"
+title: "Schedules"
+description: "Run an agent on a cron — each firing starts a new session"
+---
+
+A **schedule** fires an agent on a cron: each firing starts one [session](/agent-sessions/sessions) with a fixed first message, so a recurring job needs no scheduler of your own. The session is ordinary — same runtime, streaming, and [destinations](/agent-sessions/webhooks) as any other.
+
+<Note>**Preview** — APIs may change before general availability.</Note>
+
+Declare schedules in the agent's [`agent.toml`](#agent-toml), or manage them over the [SDK, CLI, or REST](#management-api). They live on the **agent**, not a session.
+
+## How it works
+
+A platform tick runs every minute: it claims schedules whose `next_fire_at` has passed, enacts each, and advances `next_fire_at` to the next occurrence. Enacting starts a session on the agent's **active [revision](/agent-sessions/revisions) at fire time** with `input` as the first message; everything downstream — boot, events, SSE, destinations — is the normal session path.
+
+| Mechanic | Behavior |
+| --- | --- |
+| **Cron** | 5 fields, 1-minute resolution (a seconds field is rejected). `tz` is an IANA name; omit for UTC. DST follows the cron library — a skipped or repeated wall-clock hour resolves to the next real occurrence. |
+| **Attribution** | The first `user.message` carries `actor { kind: "schedule", id, display }`; the session carries `metadata.schedule = { id, run_id, scheduled_for }`. |
+| **Idempotency** | One session per slot, keyed `sch_<id>:<slot>`. A tick that crashes and retries converges on the same session. |
+| **Overlap** | `skip` (default): if the previous run's session is still `queued`/`running`, record `skipped` and advance. `allow`: fire regardless. |
+| **Catch-up** | After downtime, fire **once** for the most recent missed slot, then advance past now — never replays a backlog. |
+| **Failure** | Five consecutive *enactment* failures (missing credential, no credit) → `auto_paused` with `last_error`. Session outcomes never change schedule state. |
+
+**Common crons** (`minute hour day-of-month month day-of-week`):
+
+| Cron | Fires |
+| --- | --- |
+| `*/15 * * * *` | every 15 minutes |
+| `0 9 * * 1-5` | 09:00 on weekdays |
+| `0 0 * * 0` | Sundays at midnight |
+| `0 0 1 * *` | first of the month |
+
+## agent.toml
+
+An agent can carry several schedules — the same behavior on different cadences and inputs — each a `[[schedules]]` entry keyed by a `name` unique to the agent.
+
+```toml
+[[schedules]]
+name  = "docs-sweep"
+cron  = "0 9 * * 1-5"        # weekdays 09:00
+tz    = "Europe/London"      # optional; UTC if omitted
+input = "Reconcile docs/ against changes since yesterday; open a draft PR if anything drifted."
+
+[[schedules]]
+name  = "dep-audit"
+cron  = "0 0 * * 0"          # Sundays 00:00 UTC
+input = "Audit dependencies for CVEs; file an issue per finding."
+```
+
+`input` is the entire first message and no human is in the loop, so write it as a self-contained instruction.
+
+Each deploy (`git push` or `oc agent deploy`) syncs the table: upsert by `name`, drop schedules no longer declared, preserve `paused`. Omitting the `[[schedules]]` table syncs nothing — existing schedules are left alone.
+
+A schedule is a binding, not behavior: it sits outside the [revision](/agent-sessions/revisions) digest, so editing one doesn't cut a revision and a rollback doesn't touch it.
+
+<Note>For a [repo-linked](/agent-sessions/revisions#deploy-from-a-repo) agent the `agent.toml` owns the schedules — the API and dashboard can pause/resume but reject other edits (`409`), same as `prompt`/`model`.</Note>
+
+## Management API
+
+Org-key authenticated, server-side. Schedules are addressed under the agent.
+
+**Create:**
+
+<CodeGroup>
+
+```ts TypeScript SDK
+const schedule = await oc.agents.schedules("agt_...").create({
+  name: "morning-docs-sweep",
+  cron: "0 9 * * 1-5",
+  tz: "Europe/London",       // optional — UTC if omitted
+  input: "Reconcile docs/ against changes since yesterday; open a draft PR if anything drifted.",
+  overlap: "skip",           // skip (default) · allow
+});
+// → { id: "sch_...", state: "active", nextFireAt: "2026-07-07T08:00:00Z", ... }
+```
+
+```bash oc CLI
+oc agent schedule create morning-docs-sweep --agent agt_... \
+  --cron "0 9 * * 1-5" --tz Europe/London \
+  --input "Reconcile docs/ against changes since yesterday; open a draft PR if anything drifted."
+```
+
+```http REST
+POST https://api.opencomputer.dev/v3/agents/agt_.../schedules
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+Content-Type: application/json
+
+{ "name": "morning-docs-sweep", "cron": "0 9 * * 1-5", "tz": "Europe/London",
+  "input": "Reconcile docs/ against changes since yesterday; open a draft PR if anything drifted." }
+// → 201 { "schedule": { … } }
+```
+
+</CodeGroup>
+
+**List and fetch:**
+
+<CodeGroup>
+
+```ts TypeScript SDK
+const schedules = await oc.agents.schedules("agt_...").list();
+const schedule = await oc.agents.schedules("agt_...").get("sch_...");
+```
+
+```bash oc CLI
+oc agent schedules --agent agt_...
+oc agent schedule get morning-docs-sweep --agent agt_...
+```
+
+```http REST
+GET https://api.opencomputer.dev/v3/agents/agt_.../schedules
+GET https://api.opencomputer.dev/v3/agents/agt_.../schedules/sch_...
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+```
+
+</CodeGroup>
+
+**Update, pause, resume.** `PATCH` accepts `cron`, `tz`, `input`, `overlap`, and `paused`. A `cron`/`tz` change recomputes `next_fire_at` from now; resume recomputes from now and resets the failure counter — the paused window never back-fires.
+
+<CodeGroup>
+
+```ts TypeScript SDK
+await oc.agents.schedules("agt_...").update("sch_...", { cron: "0 7 * * *" });
+await oc.agents.schedules("agt_...").update("sch_...", { paused: true });   // pause
+await oc.agents.schedules("agt_...").update("sch_...", { paused: false });  // resume
+```
+
+```bash oc CLI
+oc agent schedule pause  morning-docs-sweep --agent agt_...
+oc agent schedule resume morning-docs-sweep --agent agt_...
+```
+
+```http REST
+PATCH https://api.opencomputer.dev/v3/agents/agt_.../schedules/sch_...
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+Content-Type: application/json
+
+{ "cron": "0 7 * * *" }          // or { "paused": true } / { "paused": false }
+```
+
+</CodeGroup>
+
+**Delete** — removes the schedule; run history is retained.
+
+<CodeGroup>
+
+```ts TypeScript SDK
+await oc.agents.schedules("agt_...").del("sch_...");
+```
+
+```bash oc CLI
+oc agent schedule delete morning-docs-sweep --agent agt_...
+```
+
+```http REST
+DELETE https://api.opencomputer.dev/v3/agents/agt_.../schedules/sch_...
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+// → 204
+```
+
+</CodeGroup>
+
+**Fire now** — enacts immediately in any state (paused included) and doesn't advance the cron. The test loop is `create` then `fire`.
+
+<CodeGroup>
+
+```ts TypeScript SDK
+const run = await oc.agents.schedules("agt_...").fire("sch_...");
+// → { id: "srn_...", outcome: "enacted", sessionId: "ses_..." }
+```
+
+```bash oc CLI
+oc agent schedule fire morning-docs-sweep --agent agt_...
+# prints the ses_… → oc session logs ses_…
+```
+
+```http REST
+POST https://api.opencomputer.dev/v3/agents/agt_.../schedules/sch_.../fire
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+// → 202 { "run": { … } }
+```
+
+</CodeGroup>
+
+**Runs** — newest-first; each row carries `session_id` to chain into [`GET /sessions/:id`](/agent-sessions/api-reference#sessions).
+
+<CodeGroup>
+
+```ts TypeScript SDK
+const { runs, nextCursor } = await oc.agents.schedules("agt_...").runs("sch_...", { limit: 50 });
+```
+
+```bash oc CLI
+oc agent schedule runs morning-docs-sweep --agent agt_...
+```
+
+```http REST
+GET https://api.opencomputer.dev/v3/agents/agt_.../schedules/sch_.../runs?limit=50&cursor=…
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+// → { "runs": [ … ], "next_cursor": … }
+```
+
+</CodeGroup>
+
+## The schedule object
+
+| Field | Notes |
+| --- | --- |
+| `id` `agent_id` | `sch_…` · the agent whose active revision each run uses |
+| `name` | `^[a-z0-9][a-z0-9-]{0,63}$`, unique per agent — the `agent.toml` / CLI handle |
+| `cron` `tz?` | 5-field cron · IANA name, or `null` for UTC |
+| `input` | first user message of every run (≤ 32 KiB) |
+| `overlap` | `skip` (default) · `allow` |
+| `state` | `active · paused · auto_paused` |
+| `next_fire_at` `last_fired_at?` | next occurrence, UTC (derived) · last fire |
+| `consecutive_failures` `last_error?` | in-a-row enactment failures (`≥ 5` → `auto_paused`) · last error, cleared on success |
+| `created_at` `updated_at` | timestamps |
+
+### States
+
+| State | Meaning |
+| --- | --- |
+| `active` | Firing on schedule. |
+| `paused` | You paused it; the cron is ignored until resume. |
+| `auto_paused` | Five straight enactment failures paused it; `last_error` says why. |
+
+## Runs
+
+Each firing decision appends a `srn_…` run, so the history shows why a slot did or didn't produce a session.
+
+| `outcome` | When |
+| --- | --- |
+| `enacted` | A session was created — `session_id` is set. |
+| `skipped` | The previous run was still going and `overlap` is `skip`. |
+| `failed` | Enactment errored; `error` is set and it counts toward auto-pause. |
+
+Fields: `id` (`srn_…`), `scheduled_for?` (the slot; `null` for a manual fire), `fired_at`, `outcome`, `session_id?`, `error?`.
+
+## Limits
+
+- **≤ 20** schedules per agent.
+- `input` **≤ 32 KiB**.
+- Cron floor **1 minute**.
+
+<Warning>
+Scheduled sessions run unattended — cap them. Set agent [`limits`](/agent-sessions/sessions#limits) `turns` and `turn_seconds` (every run inherits them). `limits.tokens` is not enforced yet, so don't rely on it to bound spend.
+</Warning>
+
+## Dashboard
+
+The agent's **Schedules** card lists each schedule with its next fire and state, a create dialog that previews upcoming fire times as you type the cron, and per-schedule run history linked to the sessions. Repo-linked schedules are read-only except pause/resume; `auto_paused` shows the last error.
+
+## Example
+
+1. `agent.toml` declares `[[schedules]] name = "morning-docs-sweep", cron = "0 9 * * 1-5"`. `git push` deploys the agent and the schedule goes `active`.
+2. Weekday 09:00 → a session starts on the active revision, first message = `input`, `actor.kind = "schedule"`.
+3. The agent reconciles `docs/` and opens a draft PR — an ordinary session on the dashboard and your destinations.
+4. Next 09:00, if the prior run is still `running` (`overlap: "skip"`) → the firing records `skipped` and the schedule advances.

--- a/docs/agent-sessions/triggers.mdx
+++ b/docs/agent-sessions/triggers.mdx
@@ -18,6 +18,8 @@ on   = "issue.labeled:agent"
 - **Routing:** a routing key groups events into sessions — by default one session per issue; a comment on a PR the agent opened resumes the session that opened it.
 - **Who can trigger:** restricted to members of your organization by default, configurable per agent.
 
+To fire an agent on a **cron** rather than an external event, use [Schedules](/agent-sessions/schedules) — a time-based trigger with its own stable API.
+
 ## Integrations
 
 Triggers and outbound deliveries run through platform integrations, so the agent holds no

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -86,6 +86,7 @@
           "agent-sessions/runtimes",
           "agent-sessions/runtime-tools",
           "agent-sessions/watches",
+          "agent-sessions/schedules",
           "agent-sessions/api-reference",
           {
             "group": "Frameworks",

--- a/sdks/typescript/src/agents/agents.ts
+++ b/sdks/typescript/src/agents/agents.ts
@@ -4,6 +4,7 @@ import {
   Deployments, Revisions, Activations, Skills, DeploymentSourceResource,
   type Deployment, type InlineSkillFile,
 } from "./deployments.js";
+import { Schedules } from "./schedules.js";
 
 export interface CreateAgentParams {
   name: string;
@@ -68,6 +69,8 @@ export class Agents {
   readonly skills: Skills;
   /** Repo linkage for push-to-deploy. */
   readonly deploymentSource: DeploymentSourceResource;
+  /** Cron for agents — schedules that fire a session per slot (015). */
+  readonly schedules: Schedules;
 
   constructor(private readonly http: Http) {
     this.deployments = new Deployments(http);
@@ -75,6 +78,7 @@ export class Agents {
     this.activations = new Activations(http);
     this.skills = new Skills(http);
     this.deploymentSource = new DeploymentSourceResource(http);
+    this.schedules = new Schedules(http);
   }
 
   create(params: CreateAgentParams): Promise<Agent> {

--- a/sdks/typescript/src/agents/index.ts
+++ b/sdks/typescript/src/agents/index.ts
@@ -32,6 +32,11 @@ export { Destinations, Deliveries } from "./destinations.js";
 export type { CreateDestinationParams, UpdateDestinationParams } from "./destinations.js";
 export { Watches } from "./watches.js";
 export type { Watch, WatchStatus, WakeOn, CreateWatchParams } from "./watches.js";
+export { Schedules } from "./schedules.js";
+export type {
+  Schedule, ScheduleRun, ScheduleState, RunOutcome, Overlap,
+  CreateScheduleParams, UpdateScheduleParams, RunsPage,
+} from "./schedules.js";
 export { verifyWebhook, WebhookVerificationError } from "./webhooks.js";
 export type { WebhookDelivery, VerifyWebhookOptions } from "./webhooks.js";
 

--- a/sdks/typescript/src/agents/schedules.ts
+++ b/sdks/typescript/src/agents/schedules.ts
@@ -1,0 +1,87 @@
+// Schedules sub-resource of `oc.agents` (design 015) — cron for agents. A schedule fires an agent on
+// a cron; each firing starts one session on the active revision with a fixed input. The HTTP layer
+// converts camelCase ⟷ snake_case on the wire, so params/results here are camelCase.
+
+import type { Http, Query } from "./http.js";
+
+export type Overlap = "skip" | "allow";
+export type ScheduleState = "active" | "paused" | "auto_paused";
+export type RunOutcome = "enacted" | "skipped" | "failed";
+
+export interface CreateScheduleParams {
+  name: string;             // ^[a-z0-9][a-z0-9-]{0,63}$, unique per agent
+  cron: string;             // 5-field cron (1-minute resolution)
+  tz?: string | null;       // IANA name; omit for UTC
+  input: string;            // first user message of every run (≤ 32 KiB)
+  overlap?: Overlap;        // default "skip"
+}
+
+export interface UpdateScheduleParams {
+  cron?: string;
+  tz?: string | null;
+  input?: string;
+  overlap?: Overlap;
+  paused?: boolean;         // true = pause, false = resume (recomputes next fire, resets failures)
+}
+
+export interface Schedule {
+  id: string;               // sch_…
+  agentId: string;
+  name: string;
+  cron: string;
+  tz: string | null;
+  input: string;
+  overlap: Overlap;
+  state: ScheduleState;
+  nextFireAt: string;       // UTC ISO
+  lastFiredAt: string | null;
+  consecutiveFailures: number;
+  lastError: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ScheduleRun {
+  id: string;               // srn_…
+  scheduleId: string;
+  scheduledFor: string | null;   // the cron slot; null for a manual fire
+  firedAt: string;
+  outcome: RunOutcome;
+  sessionId: string | null;      // chain into oc.sessions.get(sessionId)
+  error: string | null;
+}
+
+export interface RunsPage { runs: ScheduleRun[]; nextCursor?: string | null; }
+
+/** Cron for agents. Schedules live on the agent — every method takes the agent id first.
+ *  `oc.agents.schedules.create(agentId, { name, cron, input })`. */
+export class Schedules {
+  constructor(private readonly http: Http) {}
+
+  create(agentId: string, params: CreateScheduleParams): Promise<{ schedule: Schedule }> {
+    return this.http.request("POST", `/agents/${agentId}/schedules`, { body: params });
+  }
+  list(agentId: string): Promise<{ schedules: Schedule[] }> {
+    return this.http.request("GET", `/agents/${agentId}/schedules`);
+  }
+  get(agentId: string, scheduleId: string): Promise<{ schedule: Schedule }> {
+    return this.http.request("GET", `/agents/${agentId}/schedules/${scheduleId}`);
+  }
+  update(agentId: string, scheduleId: string, params: UpdateScheduleParams): Promise<{ schedule: Schedule }> {
+    return this.http.request("PATCH", `/agents/${agentId}/schedules/${scheduleId}`, { body: params });
+  }
+  delete(agentId: string, scheduleId: string): Promise<void> {
+    return this.http.request("DELETE", `/agents/${agentId}/schedules/${scheduleId}`);
+  }
+  /** Test-fire now — enacts synchronously in any state (paused included), does not advance the cron.
+   *  Returns the run; branch on `run.outcome` (a failed fire is still a 201 with `outcome:"failed"`). */
+  fire(agentId: string, scheduleId: string): Promise<{ run: ScheduleRun }> {
+    return this.http.request("POST", `/agents/${agentId}/schedules/${scheduleId}/fire`);
+  }
+  /** Run history, newest-first. Each run carries `sessionId` to chain into `oc.sessions.get`. */
+  runs(agentId: string, scheduleId: string, opts: { cursor?: string; limit?: number } = {}): Promise<RunsPage> {
+    return this.http.request("GET", `/agents/${agentId}/schedules/${scheduleId}/runs`, { query: opts as Query });
+  }
+}
+
+

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -479,6 +479,77 @@ export const activateRevision = (agentId: string, rev: string | number) =>
     S.ActivateRevisionSchema,
   )
 
+// Schedules sub-resource (design 015) — cron for agents. A schedule fires an agent on a cron;
+// each firing starts one session on the active revision. Reached via the /v3 passthrough.
+export type ScheduleOverlap = 'skip' | 'allow'
+export type ScheduleState = 'active' | 'paused' | 'auto_paused'
+export type ScheduleRunOutcome = 'enacted' | 'skipped' | 'failed'
+
+export interface Schedule {
+  id: string
+  agent_id: string
+  name: string
+  cron: string
+  tz: string | null
+  input: string
+  overlap: ScheduleOverlap
+  state: ScheduleState
+  next_fire_at: string
+  last_fired_at: string | null
+  consecutive_failures: number
+  last_error: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface ScheduleRun {
+  id: string
+  schedule_id: string
+  scheduled_for: string | null
+  fired_at: string
+  outcome: ScheduleRunOutcome
+  session_id: string | null
+  error: string | null
+}
+
+export const getSchedules = (agentId: string) =>
+  apiFetch<{ schedules: Schedule[] }>(`/v3/agents/${agentId}/schedules`).then((r) => r.schedules)
+
+export const createSchedule = (
+  agentId: string,
+  body: { name: string; cron: string; tz?: string | null; input: string; overlap?: ScheduleOverlap },
+) =>
+  apiFetch<{ schedule: Schedule }>(
+    `/v3/agents/${agentId}/schedules`,
+    { method: 'POST', body: JSON.stringify(body) },
+  ).then((r) => r.schedule)
+
+// PATCH accepts any of { cron, tz, input, overlap, paused }. `paused` toggles pause/resume.
+export const updateSchedule = (
+  agentId: string,
+  scheduleId: string,
+  body: Partial<{ cron: string; tz: string | null; input: string; overlap: ScheduleOverlap; paused: boolean }>,
+) =>
+  apiFetch<{ schedule: Schedule }>(
+    `/v3/agents/${agentId}/schedules/${scheduleId}`,
+    { method: 'PATCH', body: JSON.stringify(body) },
+  ).then((r) => r.schedule)
+
+export const deleteSchedule = (agentId: string, scheduleId: string) =>
+  apiFetch<void>(`/v3/agents/${agentId}/schedules/${scheduleId}`, { method: 'DELETE' })
+
+// Test-fire now — enacts synchronously (a failed fire still returns a run with outcome:"failed").
+export const fireSchedule = (agentId: string, scheduleId: string) =>
+  apiFetch<{ run: ScheduleRun }>(
+    `/v3/agents/${agentId}/schedules/${scheduleId}/fire`,
+    { method: 'POST', body: JSON.stringify({}) },
+  ).then((r) => r.run)
+
+export const getScheduleRuns = (agentId: string, scheduleId: string, limit = 10) =>
+  apiFetch<{ runs: ScheduleRun[]; next_cursor: string | null }>(
+    `/v3/agents/${agentId}/schedules/${scheduleId}/runs?limit=${limit}`,
+  ).then((r) => r.runs)
+
 // Skills sub-resource (design 009 §8) — the API owns zip → validate → bundle, so the
 // dashboard is a thin consumer: read the file list, upload a .zip, or clear.
 export const getAgentSkills = (agentId: string) =>

--- a/web/src/components/agent-schedules.tsx
+++ b/web/src/components/agent-schedules.tsx
@@ -74,17 +74,34 @@ const COMMON_TZS = [
   'Asia/Dubai', 'Asia/Kolkata', 'Asia/Singapore', 'Asia/Shanghai', 'Asia/Tokyo', 'Australia/Sydney',
 ]
 const prettyTz = (z: string) => z.replace(/_/g, ' ')
+// Current UTC offset for a zone — e.g. "UTC-5", "UTC+5:30", "UTC+0" (DST-dependent: the offset in effect now).
+function tzOffset(z: string): string {
+  try {
+    const name =
+      new Intl.DateTimeFormat('en-US', { timeZone: z, timeZoneName: 'shortOffset' })
+        .formatToParts(new Date())
+        .find((p) => p.type === 'timeZoneName')?.value ?? ''
+    return name.replace('GMT', 'UTC').replace(/^UTC$/, 'UTC+0')
+  } catch {
+    return ''
+  }
+}
+function tzLabel(z: string): string {
+  if (z === 'UTC') return 'UTC'
+  const off = tzOffset(z)
+  return off ? `${prettyTz(z)} (${off})` : prettyTz(z)
+}
 function tzOptions(current: string): ({ value: string; label: string } | { separator: true })[] {
   const items: ({ value: string; label: string } | { separator: true })[] = []
   const seen = new Set<string>()
   const push = (z: string, label?: string) => {
     if (z && !seen.has(z)) {
       seen.add(z)
-      items.push({ value: z, label: label ?? prettyTz(z) })
+      items.push({ value: z, label: label ?? tzLabel(z) })
     }
   }
-  push('UTC', 'UTC')
-  if (LOCAL_TZ && LOCAL_TZ !== 'UTC') push(LOCAL_TZ, `${prettyTz(LOCAL_TZ)} (your timezone)`)
+  push('UTC')
+  if (LOCAL_TZ && LOCAL_TZ !== 'UTC') push(LOCAL_TZ, `${tzLabel(LOCAL_TZ)} · your timezone`)
   if (current && current !== 'UTC') push(current) // keep an already-set uncommon zone selectable
   items.push({ separator: true })
   for (const z of COMMON_TZS) push(z)

--- a/web/src/components/agent-schedules.tsx
+++ b/web/src/components/agent-schedules.tsx
@@ -59,49 +59,62 @@ const CRON_PRESETS: { label: string; cron: string }[] = [
   { label: 'Every 15m', cron: '*/15 * * * *' },
 ]
 
-// The user's own zone (auto-detected) + UTC + common zones. The Radix Select isn't searchable, so a
-// curated list beats the ~400-entry IANA set — and the local zone covers most users anyway.
-const LOCAL_TZ = (() => {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone
-  } catch {
-    return ''
-  }
-})()
-const COMMON_TZS = [
-  'America/Los_Angeles', 'America/Denver', 'America/Chicago', 'America/New_York', 'America/Sao_Paulo',
-  'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Europe/Madrid', 'Africa/Johannesburg',
-  'Asia/Dubai', 'Asia/Kolkata', 'Asia/Singapore', 'Asia/Shanghai', 'Asia/Tokyo', 'Australia/Sydney',
-]
 const prettyTz = (z: string) => z.replace(/_/g, ' ')
-// Current offset as a bare "+5:30" / "-4" / "+0" (DST-dependent: the offset in effect now).
-function tzOffset(z: string): string {
-  try {
-    const name =
-      new Intl.DateTimeFormat('en-US', { timeZone: z, timeZoneName: 'shortOffset' })
-        .formatToParts(new Date())
-        .find((p) => p.type === 'timeZoneName')?.value ?? ''
-    return name.replace(/^(?:GMT|UTC)/, '') || '+0'
-  } catch {
-    return ''
-  }
-}
+// Fixed UTC offsets - exactly one entry per offset, so the list is stable (no DST shifting the
+// offsets around). Values are fixed-offset IANA zones the API + cron accept: Etc/GMT has an INVERTED
+// sign (Etc/GMT+5 = UTC-5), and the fractional offsets use the region's non-DST zone. The city is
+// just a recognizable example of that offset.
+const TZ_OFFSETS: { value: string; city: string; hint: string }[] = [
+  { value: 'Etc/GMT+11', city: 'Midway', hint: '-11' },
+  { value: 'Etc/GMT+10', city: 'Honolulu', hint: '-10' },
+  { value: 'Etc/GMT+9', city: 'Anchorage', hint: '-9' },
+  { value: 'Etc/GMT+8', city: 'Los Angeles', hint: '-8' },
+  { value: 'Etc/GMT+7', city: 'Denver', hint: '-7' },
+  { value: 'Etc/GMT+6', city: 'Mexico City', hint: '-6' },
+  { value: 'Etc/GMT+5', city: 'New York', hint: '-5' },
+  { value: 'Etc/GMT+4', city: 'Halifax', hint: '-4' },
+  { value: 'Etc/GMT+3', city: 'Sao Paulo', hint: '-3' },
+  { value: 'Etc/GMT+2', city: 'South Georgia', hint: '-2' },
+  { value: 'Etc/GMT+1', city: 'Azores', hint: '-1' },
+  { value: 'Etc/GMT-1', city: 'Berlin', hint: '+1' },
+  { value: 'Etc/GMT-2', city: 'Cairo', hint: '+2' },
+  { value: 'Etc/GMT-3', city: 'Moscow', hint: '+3' },
+  { value: 'Asia/Tehran', city: 'Tehran', hint: '+3:30' },
+  { value: 'Etc/GMT-4', city: 'Dubai', hint: '+4' },
+  { value: 'Asia/Kabul', city: 'Kabul', hint: '+4:30' },
+  { value: 'Etc/GMT-5', city: 'Karachi', hint: '+5' },
+  { value: 'Asia/Kolkata', city: 'Mumbai', hint: '+5:30' },
+  { value: 'Asia/Kathmandu', city: 'Kathmandu', hint: '+5:45' },
+  { value: 'Etc/GMT-6', city: 'Dhaka', hint: '+6' },
+  { value: 'Asia/Yangon', city: 'Yangon', hint: '+6:30' },
+  { value: 'Etc/GMT-7', city: 'Bangkok', hint: '+7' },
+  { value: 'Etc/GMT-8', city: 'Singapore', hint: '+8' },
+  { value: 'Etc/GMT-9', city: 'Tokyo', hint: '+9' },
+  { value: 'Australia/Darwin', city: 'Darwin', hint: '+9:30' },
+  { value: 'Etc/GMT-10', city: 'Sydney', hint: '+10' },
+  { value: 'Etc/GMT-11', city: 'Noumea', hint: '+11' },
+  { value: 'Etc/GMT-12', city: 'Auckland', hint: '+12' },
+  { value: 'Etc/GMT-13', city: "Nuku'alofa", hint: '+13' },
+  { value: 'Etc/GMT-14', city: 'Kiritimati', hint: '+14' },
+]
 function tzOptions(current: string): ({ value: string; label: string; hint?: string } | { separator: true })[] {
-  const items: ({ value: string; label: string; hint?: string } | { separator: true })[] = []
-  const seen = new Set<string>()
-  const push = (z: string, label?: string) => {
-    if (z && !seen.has(z)) {
-      seen.add(z)
-      // The offset rides in `hint` (muted, right-aligned); UTC needs none.
-      items.push({ value: z, label: label ?? prettyTz(z), hint: z === 'UTC' ? undefined : tzOffset(z) })
-    }
+  const items: ({ value: string; label: string; hint?: string } | { separator: true })[] = [
+    { value: 'UTC', label: 'UTC' },
+    { separator: true },
+    ...TZ_OFFSETS.map((o) => ({ value: o.value, label: o.city, hint: o.hint })),
+  ]
+  // Preserve a zone set elsewhere (CLI/toml) that isn't one of our fixed offsets.
+  if (current && current !== 'UTC' && !items.some((i) => 'value' in i && i.value === current)) {
+    items.push({ separator: true }, { value: current, label: prettyTz(current) })
   }
-  push('UTC')
-  if (LOCAL_TZ && LOCAL_TZ !== 'UTC') push(LOCAL_TZ, `${prettyTz(LOCAL_TZ)} · your timezone`)
-  if (current && current !== 'UTC') push(current) // keep an already-set uncommon zone selectable
-  items.push({ separator: true })
-  for (const z of COMMON_TZS) push(z)
   return items
+}
+const TZ_BY_VALUE = new Map(TZ_OFFSETS.map((o) => [o.value, o]))
+// Friendly display of a stored tz on a schedule card (the raw Etc/GMT+5 has a confusing inverted sign).
+function tzDisplay(tz: string | null): string {
+  if (!tz || tz === 'UTC') return 'UTC'
+  const o = TZ_BY_VALUE.get(tz)
+  return o ? `UTC${o.hint}` : prettyTz(tz)
 }
 
 function StateBadge({ s }: { s: Schedule }) {
@@ -421,7 +434,7 @@ export function AgentSchedulesTab({ agentId }: { agentId: string }) {
                       <code className="text-foreground font-mono">{s.cron}</code>
                       {gloss ? <span>{gloss}</span> : null}
                       <span className="text-border">·</span>
-                      <span>{s.tz ?? 'UTC'}</span>
+                      <span>{tzDisplay(s.tz)}</span>
                       <span className="text-border">·</span>
                       <span className="inline-flex items-center gap-1">
                         <CalendarClock className="size-3" />

--- a/web/src/components/agent-schedules.tsx
+++ b/web/src/components/agent-schedules.tsx
@@ -59,6 +59,38 @@ const CRON_PRESETS: { label: string; cron: string }[] = [
   { label: 'Every 15m', cron: '*/15 * * * *' },
 ]
 
+// The user's own zone (auto-detected) + UTC + common zones. The Radix Select isn't searchable, so a
+// curated list beats the ~400-entry IANA set — and the local zone covers most users anyway.
+const LOCAL_TZ = (() => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone
+  } catch {
+    return ''
+  }
+})()
+const COMMON_TZS = [
+  'America/Los_Angeles', 'America/Denver', 'America/Chicago', 'America/New_York', 'America/Sao_Paulo',
+  'Europe/London', 'Europe/Paris', 'Europe/Berlin', 'Europe/Madrid', 'Africa/Johannesburg',
+  'Asia/Dubai', 'Asia/Kolkata', 'Asia/Singapore', 'Asia/Shanghai', 'Asia/Tokyo', 'Australia/Sydney',
+]
+const prettyTz = (z: string) => z.replace(/_/g, ' ')
+function tzOptions(current: string): ({ value: string; label: string } | { separator: true })[] {
+  const items: ({ value: string; label: string } | { separator: true })[] = []
+  const seen = new Set<string>()
+  const push = (z: string, label?: string) => {
+    if (z && !seen.has(z)) {
+      seen.add(z)
+      items.push({ value: z, label: label ?? prettyTz(z) })
+    }
+  }
+  push('UTC', 'UTC')
+  if (LOCAL_TZ && LOCAL_TZ !== 'UTC') push(LOCAL_TZ, `${prettyTz(LOCAL_TZ)} (your timezone)`)
+  if (current && current !== 'UTC') push(current) // keep an already-set uncommon zone selectable
+  items.push({ separator: true })
+  for (const z of COMMON_TZS) push(z)
+  return items
+}
+
 function StateBadge({ s }: { s: Schedule }) {
   const cls =
     s.state === 'active'
@@ -142,14 +174,15 @@ export function AgentSchedulesTab({ agentId }: { agentId: string }) {
 
   const invalidate = () => void queryClient.invalidateQueries({ queryKey: ['agent-schedules', agentId] })
 
-  const openCreate = () => setForm({ name: '', cron: '0 9 * * 1-5', tz: '', input: '', overlap: 'skip' })
+  const openCreate = () => setForm({ name: '', cron: '0 9 * * 1-5', tz: 'UTC', input: '', overlap: 'skip' })
   const openEdit = (s: Schedule) =>
-    setForm({ id: s.id, name: s.name, cron: s.cron, tz: s.tz ?? '', input: s.input, overlap: s.overlap })
+    setForm({ id: s.id, name: s.name, cron: s.cron, tz: s.tz ?? 'UTC', input: s.input, overlap: s.overlap })
 
   const save = useMutation({
     mutationFn: () => {
       const f = form!
-      const patch = { cron: f.cron.trim(), tz: f.tz.trim() || null, input: f.input.trim(), overlap: f.overlap }
+      // 'UTC' (the default) maps to null on the wire — the API treats null as UTC.
+      const patch = { cron: f.cron.trim(), tz: f.tz && f.tz !== 'UTC' ? f.tz : null, input: f.input.trim(), overlap: f.overlap }
       return f.id
         ? updateSchedule(agentId, f.id, patch)
         : createSchedule(agentId, { name: f.name.trim(), ...patch })
@@ -242,12 +275,11 @@ export function AgentSchedulesTab({ agentId }: { agentId: string }) {
                   placeholder="0 9 * * 1-5"
                   className="font-mono"
                 />
-                <Input
-                  value={form.tz}
-                  onChange={(e) => setForm({ ...form, tz: e.target.value })}
-                  placeholder="UTC"
-                  className="max-w-40"
-                  aria-label="Time zone"
+                <Select
+                  value={form.tz || 'UTC'}
+                  onValueChange={(v) => setForm({ ...form, tz: v })}
+                  options={tzOptions(form.tz)}
+                  className="max-w-48"
                 />
               </div>
               <div className="mt-2 flex flex-wrap items-center gap-1.5">
@@ -267,7 +299,7 @@ export function AgentSchedulesTab({ agentId }: { agentId: string }) {
                   </button>
                 ))}
                 <span className="text-muted-foreground ml-auto text-xs">
-                  {cronGloss ? cronGloss : '5-field cron · IANA time zone (UTC if blank)'}
+                  {cronGloss ? cronGloss : '5-field cron'}
                 </span>
               </div>
             </Field>

--- a/web/src/components/agent-schedules.tsx
+++ b/web/src/components/agent-schedules.tsx
@@ -1,0 +1,267 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Pause, Play, PlayCircle, Plus, Trash2 } from 'lucide-react'
+import { notifyError, notifySuccess } from '@/lib/errors'
+import {
+  ApiError,
+  createSchedule,
+  deleteSchedule,
+  fireSchedule,
+  getDeploymentSource,
+  getSchedules,
+  updateSchedule,
+  type Schedule,
+} from '@/api/client'
+import { Panel, PanelContent } from '@/components/panel'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/form'
+
+// Relative time ("in 3h" / "5m ago") — no dependency; schedules are minute-resolution.
+function rel(iso: string | null): string {
+  if (!iso) return '—'
+  const delta = new Date(iso).getTime() - Date.now()
+  const m = Math.max(1, Math.round(Math.abs(delta) / 60000))
+  const unit = m < 60 ? `${m}m` : m < 1440 ? `${Math.round(m / 60)}h` : `${Math.round(m / 1440)}d`
+  return delta >= 0 ? `in ${unit}` : `${unit} ago`
+}
+
+function StatePill({ s }: { s: Schedule }) {
+  const cls =
+    s.state === 'active'
+      ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+      : s.state === 'auto_paused'
+        ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+        : 'bg-muted text-muted-foreground'
+  return (
+    <span
+      className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${cls}`}
+      title={s.state === 'auto_paused' && s.last_error ? s.last_error : undefined}
+    >
+      {s.state.replace('_', ' ')}
+    </span>
+  )
+}
+
+/**
+ * Schedules card (Overview right rail) — cron for agents (design 015). Lists the agent's schedules
+ * with their next fire + state, a pause/resume toggle, a test-fire, and delete; a compact create
+ * form for name/cron/tz/input. Read-only (except pause/resume) when the agent is repo-driven — the
+ * agent.toml owns the schedules then, matching the deploy-source convention.
+ */
+export function AgentSchedules({ agentId }: { agentId: string }) {
+  const queryClient = useQueryClient()
+  const [showForm, setShowForm] = useState(false)
+  const [name, setName] = useState('')
+  const [cron, setCron] = useState('0 9 * * 1-5')
+  const [tz, setTz] = useState('')
+  const [input, setInput] = useState('')
+
+  // Repo-driven agents manage schedules via agent.toml → the API rejects edits other than
+  // pause/resume (409). Share the deploy-source card's query cache so the two stay consistent.
+  const { data: repoManaged } = useQuery({
+    queryKey: ['agent-deploy-source', agentId],
+    queryFn: async () => {
+      try {
+        return (await getDeploymentSource(agentId)).source
+      } catch (e) {
+        if (e instanceof ApiError && e.status === 404) return null
+        throw e
+      }
+    },
+    select: (src) => !!src,
+  })
+
+  const {
+    data: schedules,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: ['agent-schedules', agentId],
+    queryFn: () => getSchedules(agentId),
+  })
+
+  const invalidate = () => void queryClient.invalidateQueries({ queryKey: ['agent-schedules', agentId] })
+
+  const create = useMutation({
+    mutationFn: () =>
+      createSchedule(agentId, {
+        name: name.trim(),
+        cron: cron.trim(),
+        tz: tz.trim() || null,
+        input: input.trim(),
+      }),
+    onSuccess: () => {
+      invalidate()
+      setShowForm(false)
+      setName('')
+      setInput('')
+      notifySuccess('Schedule created.')
+    },
+    onError: (e) => notifyError("Couldn't create the schedule.", e),
+  })
+
+  const toggle = useMutation({
+    mutationFn: (s: Schedule) => updateSchedule(agentId, s.id, { paused: s.state === 'active' }),
+    onSuccess: () => invalidate(),
+    onError: (e) => notifyError("Couldn't update the schedule.", e),
+  })
+
+  const fire = useMutation({
+    mutationFn: (s: Schedule) => fireSchedule(agentId, s.id),
+    onSuccess: (run) => {
+      invalidate()
+      if (run.outcome === 'enacted' && run.session_id) {
+        notifySuccess(`Fired — session ${run.session_id}`)
+      } else {
+        notifyError(`Fire ${run.outcome}`, new Error(run.error ?? run.outcome))
+      }
+    },
+    onError: (e) => notifyError("Couldn't fire the schedule.", e),
+  })
+
+  const remove = useMutation({
+    mutationFn: (s: Schedule) => deleteSchedule(agentId, s.id),
+    onSuccess: () => {
+      invalidate()
+      notifySuccess('Schedule deleted.')
+    },
+    onError: (e) => notifyError("Couldn't delete the schedule.", e),
+  })
+
+  const canCreate = name.trim() && cron.trim() && input.trim()
+
+  return (
+    <Panel className="overflow-hidden">
+      <PanelContent className="space-y-3">
+        <div>
+          <h3 className="text-sm font-medium">Schedules</h3>
+          <p className="text-muted-foreground text-xs">Run this agent on a cron — each firing starts a session.</p>
+        </div>
+
+        {isLoading ? (
+          <p className="text-muted-foreground text-xs">Loading…</p>
+        ) : isError ? (
+          <div className="space-y-2">
+            <p className="text-xs text-red-600 dark:text-red-500">Couldn’t load schedules.</p>
+            <Button size="sm" variant="outline" onClick={() => void refetch()}>
+              Retry
+            </Button>
+          </div>
+        ) : (
+          <>
+            {repoManaged ? (
+              <p className="text-muted-foreground text-xs">
+                Managed by the linked repository — edit <code className="font-mono">agent.toml</code> to change. You can
+                still pause/resume here.
+              </p>
+            ) : null}
+
+            {schedules && schedules.length > 0 ? (
+              <ul className="space-y-2">
+                {schedules.map((s) => (
+                  <li key={s.id} className="bg-muted/40 space-y-1 rounded-md p-2 text-xs">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="truncate font-medium">{s.name}</span>
+                      <StatePill s={s} />
+                    </div>
+                    <div className="text-muted-foreground flex flex-wrap items-center gap-x-2">
+                      <code className="font-mono">{s.cron}</code>
+                      {s.tz ? <span>{s.tz}</span> : null}
+                      <span>· next {s.state === 'active' ? rel(s.next_fire_at) : '—'}</span>
+                      {s.last_fired_at ? <span>· last {rel(s.last_fired_at)}</span> : null}
+                    </div>
+                    <div className="flex items-center gap-1 pt-0.5">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        title={s.state === 'active' ? 'Pause' : 'Resume'}
+                        disabled={toggle.isPending}
+                        onClick={() => toggle.mutate(s)}
+                      >
+                        {s.state === 'active' ? <Pause className="size-3.5" /> : <PlayCircle className="size-3.5" />}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        title="Test-fire now"
+                        disabled={fire.isPending}
+                        onClick={() => fire.mutate(s)}
+                      >
+                        <Play className="size-3.5" />
+                      </Button>
+                      {!repoManaged ? (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="text-muted-foreground hover:text-red-600"
+                          title="Delete"
+                          disabled={remove.isPending}
+                          onClick={() => remove.mutate(s)}
+                        >
+                          <Trash2 className="size-3.5" />
+                        </Button>
+                      ) : null}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-muted-foreground text-xs">No schedules yet.</p>
+            )}
+
+            {!repoManaged ? (
+              showForm ? (
+                <div className="bg-muted/40 space-y-2 rounded-md p-2">
+                  <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="name (e.g. morning-sweep)" />
+                  <div className="flex gap-2">
+                    <Input
+                      value={cron}
+                      onChange={(e) => setCron(e.target.value)}
+                      placeholder="0 9 * * 1-5"
+                      className="font-mono"
+                    />
+                    <Input
+                      value={tz}
+                      onChange={(e) => setTz(e.target.value)}
+                      placeholder="UTC"
+                      className="max-w-32"
+                    />
+                  </div>
+                  <Input
+                    value={input}
+                    onChange={(e) => setInput(e.target.value)}
+                    placeholder="first message of every run"
+                  />
+                  <div className="flex items-center gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={create.isPending || !canCreate}
+                      onClick={() => create.mutate()}
+                    >
+                      {create.isPending ? 'Creating…' : 'Create'}
+                    </Button>
+                    <Button size="sm" variant="ghost" onClick={() => setShowForm(false)}>
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <Button size="sm" variant="outline" onClick={() => setShowForm(true)}>
+                  <Plus className="size-4" />
+                  New schedule
+                </Button>
+              )
+            ) : null}
+
+            <p className="text-muted-foreground text-xs">
+              Or use the CLI: <code className="font-mono">oc agent schedule create</code>
+            </p>
+          </>
+        )}
+      </PanelContent>
+    </Panel>
+  )
+}
+

--- a/web/src/components/agent-schedules.tsx
+++ b/web/src/components/agent-schedules.tsx
@@ -1,6 +1,18 @@
 import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Pause, Play, PlayCircle, Plus, Trash2 } from 'lucide-react'
+import {
+  AlertTriangle,
+  CalendarClock,
+  ChevronDown,
+  ChevronRight,
+  GitBranch,
+  Pause,
+  Pencil,
+  Play,
+  PlayCircle,
+  Plus,
+  Trash2,
+} from 'lucide-react'
 import { notifyError, notifySuccess } from '@/lib/errors'
 import {
   ApiError,
@@ -8,15 +20,19 @@ import {
   deleteSchedule,
   fireSchedule,
   getDeploymentSource,
+  getScheduleRuns,
   getSchedules,
   updateSchedule,
   type Schedule,
+  type ScheduleOverlap,
 } from '@/api/client'
 import { Panel, PanelContent } from '@/components/panel'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/form'
+import { Field, Input, Select, Textarea } from '@/components/form'
 
-// Relative time ("in 3h" / "5m ago") — no dependency; schedules are minute-resolution.
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+// Relative time ("in 3h" / "5m ago") — schedules are minute-resolution, so no dependency needed.
 function rel(iso: string | null): string {
   if (!iso) return '—'
   const delta = new Date(iso).getTime() - Date.now()
@@ -25,39 +41,82 @@ function rel(iso: string | null): string {
   return delta >= 0 ? `in ${unit}` : `${unit} ago`
 }
 
-function StatePill({ s }: { s: Schedule }) {
+// A friendly gloss for the common crons; unknown expressions just show the raw fields.
+const CRON_HINTS: Record<string, string> = {
+  '0 9 * * 1-5': 'weekdays at 09:00',
+  '0 9 * * *': 'every day at 09:00',
+  '0 * * * *': 'every hour',
+  '*/15 * * * *': 'every 15 minutes',
+  '*/30 * * * *': 'every 30 minutes',
+  '0 0 * * 0': 'Sundays at midnight',
+  '0 0 1 * *': 'first of the month',
+  '0 0 * * *': 'every day at midnight',
+}
+const CRON_PRESETS: { label: string; cron: string }[] = [
+  { label: 'Weekdays 9am', cron: '0 9 * * 1-5' },
+  { label: 'Daily 9am', cron: '0 9 * * *' },
+  { label: 'Hourly', cron: '0 * * * *' },
+  { label: 'Every 15m', cron: '*/15 * * * *' },
+]
+
+function StateBadge({ s }: { s: Schedule }) {
   const cls =
     s.state === 'active'
       ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
       : s.state === 'auto_paused'
         ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
         : 'bg-muted text-muted-foreground'
+  return <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${cls}`}>{s.state.replace('_', ' ')}</span>
+}
+
+function OutcomeBadge({ outcome }: { outcome: string }) {
+  const cls =
+    outcome === 'enacted'
+      ? 'text-green-700 dark:text-green-400'
+      : outcome === 'failed'
+        ? 'text-red-600 dark:text-red-500'
+        : 'text-muted-foreground'
+  return <span className={`font-medium ${cls}`}>{outcome}</span>
+}
+
+// Recent runs for a schedule — lazily fetched when a row is expanded.
+function ScheduleRuns({ agentId, scheduleId }: { agentId: string; scheduleId: string }) {
+  const { data: runs, isLoading } = useQuery({
+    queryKey: ['schedule-runs', agentId, scheduleId],
+    queryFn: () => getScheduleRuns(agentId, scheduleId, 5),
+  })
+  if (isLoading) return <p className="text-muted-foreground px-3 py-2 text-xs">Loading runs…</p>
+  if (!runs || runs.length === 0) return <p className="text-muted-foreground px-3 py-2 text-xs">No runs yet.</p>
   return (
-    <span
-      className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${cls}`}
-      title={s.state === 'auto_paused' && s.last_error ? s.last_error : undefined}
-    >
-      {s.state.replace('_', ' ')}
-    </span>
+    <ul className="divide-border/60 divide-y text-xs">
+      {runs.map((r) => (
+        <li key={r.id} className="flex items-center gap-2 px-3 py-1.5">
+          <OutcomeBadge outcome={r.outcome} />
+          <span className="text-muted-foreground">{rel(r.fired_at)}</span>
+          {r.session_id ? (
+            <code className="text-muted-foreground ml-auto font-mono text-[11px]" title={r.session_id}>
+              {r.session_id.slice(0, 12)}…
+            </code>
+          ) : r.error ? (
+            <span className="ml-auto max-w-[16rem] truncate text-red-600 dark:text-red-500" title={r.error}>
+              {r.error}
+            </span>
+          ) : null}
+        </li>
+      ))}
+    </ul>
   )
 }
 
-/**
- * Schedules card (Overview right rail) — cron for agents (design 015). Lists the agent's schedules
- * with their next fire + state, a pause/resume toggle, a test-fire, and delete; a compact create
- * form for name/cron/tz/input. Read-only (except pause/resume) when the agent is repo-driven — the
- * agent.toml owns the schedules then, matching the deploy-source convention.
- */
-export function AgentSchedules({ agentId }: { agentId: string }) {
-  const queryClient = useQueryClient()
-  const [showForm, setShowForm] = useState(false)
-  const [name, setName] = useState('')
-  const [cron, setCron] = useState('0 9 * * 1-5')
-  const [tz, setTz] = useState('')
-  const [input, setInput] = useState('')
+type FormState = { id?: string; name: string; cron: string; tz: string; input: string; overlap: ScheduleOverlap }
 
-  // Repo-driven agents manage schedules via agent.toml → the API rejects edits other than
-  // pause/resume (409). Share the deploy-source card's query cache so the two stay consistent.
+// ── the tab ─────────────────────────────────────────────────────────────────────
+
+export function AgentSchedulesTab({ agentId }: { agentId: string }) {
+  const queryClient = useQueryClient()
+  const [form, setForm] = useState<FormState | null>(null)
+  const [expanded, setExpanded] = useState<string | null>(null)
+
   const { data: repoManaged } = useQuery({
     queryKey: ['agent-deploy-source', agentId],
     queryFn: async () => {
@@ -83,22 +142,25 @@ export function AgentSchedules({ agentId }: { agentId: string }) {
 
   const invalidate = () => void queryClient.invalidateQueries({ queryKey: ['agent-schedules', agentId] })
 
-  const create = useMutation({
-    mutationFn: () =>
-      createSchedule(agentId, {
-        name: name.trim(),
-        cron: cron.trim(),
-        tz: tz.trim() || null,
-        input: input.trim(),
-      }),
-    onSuccess: () => {
-      invalidate()
-      setShowForm(false)
-      setName('')
-      setInput('')
-      notifySuccess('Schedule created.')
+  const openCreate = () => setForm({ name: '', cron: '0 9 * * 1-5', tz: '', input: '', overlap: 'skip' })
+  const openEdit = (s: Schedule) =>
+    setForm({ id: s.id, name: s.name, cron: s.cron, tz: s.tz ?? '', input: s.input, overlap: s.overlap })
+
+  const save = useMutation({
+    mutationFn: () => {
+      const f = form!
+      const patch = { cron: f.cron.trim(), tz: f.tz.trim() || null, input: f.input.trim(), overlap: f.overlap }
+      return f.id
+        ? updateSchedule(agentId, f.id, patch)
+        : createSchedule(agentId, { name: f.name.trim(), ...patch })
     },
-    onError: (e) => notifyError("Couldn't create the schedule.", e),
+    onSuccess: () => {
+      const editing = !!form?.id
+      invalidate()
+      setForm(null)
+      notifySuccess(editing ? 'Schedule updated.' : 'Schedule created.')
+    },
+    onError: (e) => notifyError("Couldn't save the schedule.", e),
   })
 
   const toggle = useMutation({
@@ -106,20 +168,16 @@ export function AgentSchedules({ agentId }: { agentId: string }) {
     onSuccess: () => invalidate(),
     onError: (e) => notifyError("Couldn't update the schedule.", e),
   })
-
   const fire = useMutation({
     mutationFn: (s: Schedule) => fireSchedule(agentId, s.id),
-    onSuccess: (run) => {
+    onSuccess: (run, s) => {
+      void queryClient.invalidateQueries({ queryKey: ['schedule-runs', agentId, s.id] })
       invalidate()
-      if (run.outcome === 'enacted' && run.session_id) {
-        notifySuccess(`Fired — session ${run.session_id}`)
-      } else {
-        notifyError(`Fire ${run.outcome}`, new Error(run.error ?? run.outcome))
-      }
+      if (run.outcome === 'enacted' && run.session_id) notifySuccess(`Fired — session ${run.session_id}`)
+      else notifyError(`Fire ${run.outcome}`, new Error(run.error ?? run.outcome))
     },
     onError: (e) => notifyError("Couldn't fire the schedule.", e),
   })
-
   const remove = useMutation({
     mutationFn: (s: Schedule) => deleteSchedule(agentId, s.id),
     onSuccess: () => {
@@ -129,139 +187,252 @@ export function AgentSchedules({ agentId }: { agentId: string }) {
     onError: (e) => notifyError("Couldn't delete the schedule.", e),
   })
 
-  const canCreate = name.trim() && cron.trim() && input.trim()
+  const f = form
+  const canSave = f && (f.id || f.name.trim()) && f.cron.trim() && f.input.trim()
+  const cronGloss = f ? CRON_HINTS[f.cron.trim()] : undefined
 
   return (
-    <Panel className="overflow-hidden">
-      <PanelContent className="space-y-3">
+    <div className="max-w-3xl space-y-5">
+      <div className="flex items-start justify-between gap-4">
         <div>
-          <h3 className="text-sm font-medium">Schedules</h3>
-          <p className="text-muted-foreground text-xs">Run this agent on a cron — each firing starts a session.</p>
+          <h2 className="text-base font-medium">Schedules</h2>
+          <p className="text-muted-foreground mt-0.5 text-sm">
+            Run this agent on a cron — each firing starts a new session with a fixed message.
+          </p>
         </div>
+        {!repoManaged && !form ? (
+          <Button size="sm" onClick={openCreate}>
+            <Plus className="size-4" />
+            New schedule
+          </Button>
+        ) : null}
+      </div>
 
-        {isLoading ? (
-          <p className="text-muted-foreground text-xs">Loading…</p>
-        ) : isError ? (
-          <div className="space-y-2">
-            <p className="text-xs text-red-600 dark:text-red-500">Couldn’t load schedules.</p>
-            <Button size="sm" variant="outline" onClick={() => void refetch()}>
-              Retry
-            </Button>
-          </div>
-        ) : (
-          <>
-            {repoManaged ? (
-              <p className="text-muted-foreground text-xs">
-                Managed by the linked repository — edit <code className="font-mono">agent.toml</code> to change. You can
-                still pause/resume here.
+      {repoManaged ? (
+        <div className="border-border bg-panel-2 flex items-start gap-2 rounded-md border px-3 py-2.5 text-xs">
+          <GitBranch className="text-muted-foreground mt-0.5 size-3.5 shrink-0" />
+          <p className="text-muted-foreground">
+            Managed from the connected repo — edit the <span className="font-mono">[[schedules]]</span> table in{' '}
+            <span className="font-mono">agent.toml</span> and push. You can still pause, resume, and test-fire here.
+          </p>
+        </div>
+      ) : null}
+
+      {/* Create / edit form */}
+      {form ? (
+        <Panel>
+          <PanelContent className="space-y-4">
+            <Field label="Name" htmlFor="sch-name">
+              <Input
+                id="sch-name"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                placeholder="Morning docs sweep"
+                disabled={!!form.id}
+              />
+              {form.id ? <p className="text-muted-foreground mt-1 text-xs">Name can’t be changed after creation.</p> : null}
+            </Field>
+
+            <Field label="Schedule" htmlFor="sch-cron">
+              <div className="flex gap-2">
+                <Input
+                  id="sch-cron"
+                  value={form.cron}
+                  onChange={(e) => setForm({ ...form, cron: e.target.value })}
+                  placeholder="0 9 * * 1-5"
+                  className="font-mono"
+                />
+                <Input
+                  value={form.tz}
+                  onChange={(e) => setForm({ ...form, tz: e.target.value })}
+                  placeholder="UTC"
+                  className="max-w-40"
+                  aria-label="Time zone"
+                />
+              </div>
+              <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                {CRON_PRESETS.map((p) => (
+                  <button
+                    key={p.cron}
+                    type="button"
+                    onClick={() => setForm({ ...form, cron: p.cron })}
+                    className={
+                      'rounded-full border px-2 py-0.5 text-xs transition-colors ' +
+                      (form.cron.trim() === p.cron
+                        ? 'border-foreground text-foreground'
+                        : 'border-border text-muted-foreground hover:text-foreground')
+                    }
+                  >
+                    {p.label}
+                  </button>
+                ))}
+                <span className="text-muted-foreground ml-auto text-xs">
+                  {cronGloss ? cronGloss : '5-field cron · IANA time zone (UTC if blank)'}
+                </span>
+              </div>
+            </Field>
+
+            <Field label="Message" htmlFor="sch-input">
+              <Textarea
+                id="sch-input"
+                value={form.input}
+                onChange={(e) => setForm({ ...form, input: e.target.value })}
+                placeholder="Reconcile docs/ against changes since the last run; open a draft PR if anything drifted."
+                className="min-h-32"
+              />
+              <p className="text-muted-foreground mt-1 text-xs">
+                Sent as the first message on every run. Write it as a complete instruction — no human is in the loop to
+                clarify.
               </p>
-            ) : null}
+            </Field>
 
-            {schedules && schedules.length > 0 ? (
-              <ul className="space-y-2">
-                {schedules.map((s) => (
-                  <li key={s.id} className="bg-muted/40 space-y-1 rounded-md p-2 text-xs">
-                    <div className="flex items-center justify-between gap-2">
+            <Field label="If the previous run is still going" htmlFor="sch-overlap">
+              <Select
+                id="sch-overlap"
+                value={form.overlap}
+                onValueChange={(v) => setForm({ ...form, overlap: v as ScheduleOverlap })}
+                className="max-w-xs"
+                options={[
+                  { value: 'skip', label: 'Skip this firing (default)' },
+                  { value: 'allow', label: 'Run them concurrently' },
+                ]}
+              />
+            </Field>
+
+            <div className="flex items-center gap-2">
+              <Button size="sm" variant="outline" disabled={save.isPending || !canSave} onClick={() => save.mutate()}>
+                {save.isPending ? 'Saving…' : form.id ? 'Save changes' : 'Create schedule'}
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setForm(null)}>
+                Cancel
+              </Button>
+            </div>
+          </PanelContent>
+        </Panel>
+      ) : null}
+
+      {/* List */}
+      {isLoading ? (
+        <p className="text-muted-foreground text-sm">Loading…</p>
+      ) : isError ? (
+        <div className="space-y-2">
+          <p className="text-sm text-red-600 dark:text-red-500">Couldn’t load schedules.</p>
+          <Button size="sm" variant="outline" onClick={() => void refetch()}>
+            Retry
+          </Button>
+        </div>
+      ) : schedules && schedules.length > 0 ? (
+        <ul className="space-y-3">
+          {schedules.map((s) => {
+            const gloss = CRON_HINTS[s.cron]
+            const open = expanded === s.id
+            return (
+              <li key={s.id}>
+                <Panel>
+                  <PanelContent className="space-y-2.5">
+                    <div className="flex items-center gap-2">
                       <span className="truncate font-medium">{s.name}</span>
-                      <StatePill s={s} />
-                    </div>
-                    <div className="text-muted-foreground flex flex-wrap items-center gap-x-2">
-                      <code className="font-mono">{s.cron}</code>
-                      {s.tz ? <span>{s.tz}</span> : null}
-                      <span>· next {s.state === 'active' ? rel(s.next_fire_at) : '—'}</span>
-                      {s.last_fired_at ? <span>· last {rel(s.last_fired_at)}</span> : null}
-                    </div>
-                    <div className="flex items-center gap-1 pt-0.5">
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        title={s.state === 'active' ? 'Pause' : 'Resume'}
-                        disabled={toggle.isPending}
-                        onClick={() => toggle.mutate(s)}
-                      >
-                        {s.state === 'active' ? <Pause className="size-3.5" /> : <PlayCircle className="size-3.5" />}
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        title="Test-fire now"
-                        disabled={fire.isPending}
-                        onClick={() => fire.mutate(s)}
-                      >
-                        <Play className="size-3.5" />
-                      </Button>
-                      {!repoManaged ? (
+                      <StateBadge s={s} />
+                      <div className="ml-auto flex items-center gap-0.5">
                         <Button
                           size="sm"
                           variant="ghost"
-                          className="text-muted-foreground hover:text-red-600"
-                          title="Delete"
-                          disabled={remove.isPending}
-                          onClick={() => remove.mutate(s)}
+                          title={s.state === 'active' ? 'Pause' : 'Resume'}
+                          disabled={toggle.isPending}
+                          onClick={() => toggle.mutate(s)}
                         >
-                          <Trash2 className="size-3.5" />
+                          {s.state === 'active' ? <Pause className="size-4" /> : <PlayCircle className="size-4" />}
                         </Button>
-                      ) : null}
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          title="Test-fire now"
+                          disabled={fire.isPending}
+                          onClick={() => fire.mutate(s)}
+                        >
+                          <Play className="size-4" />
+                        </Button>
+                        {!repoManaged ? (
+                          <>
+                            <Button size="sm" variant="ghost" title="Edit" onClick={() => openEdit(s)}>
+                              <Pencil className="size-4" />
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="text-muted-foreground hover:text-red-600"
+                              title="Delete"
+                              disabled={remove.isPending}
+                              onClick={() => remove.mutate(s)}
+                            >
+                              <Trash2 className="size-4" />
+                            </Button>
+                          </>
+                        ) : null}
+                      </div>
                     </div>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="text-muted-foreground text-xs">No schedules yet.</p>
-            )}
 
-            {!repoManaged ? (
-              showForm ? (
-                <div className="bg-muted/40 space-y-2 rounded-md p-2">
-                  <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="name (e.g. morning-sweep)" />
-                  <div className="flex gap-2">
-                    <Input
-                      value={cron}
-                      onChange={(e) => setCron(e.target.value)}
-                      placeholder="0 9 * * 1-5"
-                      className="font-mono"
-                    />
-                    <Input
-                      value={tz}
-                      onChange={(e) => setTz(e.target.value)}
-                      placeholder="UTC"
-                      className="max-w-32"
-                    />
-                  </div>
-                  <Input
-                    value={input}
-                    onChange={(e) => setInput(e.target.value)}
-                    placeholder="first message of every run"
-                  />
-                  <div className="flex items-center gap-2">
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={create.isPending || !canCreate}
-                      onClick={() => create.mutate()}
+                    <div className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+                      <code className="text-foreground font-mono">{s.cron}</code>
+                      {gloss ? <span>{gloss}</span> : null}
+                      <span className="text-border">·</span>
+                      <span>{s.tz ?? 'UTC'}</span>
+                      <span className="text-border">·</span>
+                      <span className="inline-flex items-center gap-1">
+                        <CalendarClock className="size-3" />
+                        next {s.state === 'active' ? rel(s.next_fire_at) : '—'}
+                      </span>
+                      {s.last_fired_at ? <span>· last ran {rel(s.last_fired_at)}</span> : null}
+                    </div>
+
+                    {s.state === 'auto_paused' && s.last_error ? (
+                      <div className="flex items-start gap-1.5 text-xs text-red-600 dark:text-red-500">
+                        <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                        <span className="min-w-0">
+                          Auto-paused after repeated failures — {s.last_error}. Resume once fixed.
+                        </span>
+                      </div>
+                    ) : null}
+
+                    <button
+                      type="button"
+                      onClick={() => setExpanded(open ? null : s.id)}
+                      className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs transition-colors"
                     >
-                      {create.isPending ? 'Creating…' : 'Create'}
-                    </Button>
-                    <Button size="sm" variant="ghost" onClick={() => setShowForm(false)}>
-                      Cancel
-                    </Button>
-                  </div>
-                </div>
-              ) : (
-                <Button size="sm" variant="outline" onClick={() => setShowForm(true)}>
-                  <Plus className="size-4" />
-                  New schedule
-                </Button>
-              )
-            ) : null}
+                      {open ? <ChevronDown className="size-3.5" /> : <ChevronRight className="size-3.5" />}
+                      Recent runs
+                    </button>
+                    {open ? (
+                      <div className="bg-muted/40 -mx-1 rounded-md">
+                        <ScheduleRuns agentId={agentId} scheduleId={s.id} />
+                      </div>
+                    ) : null}
+                  </PanelContent>
+                </Panel>
+              </li>
+            )
+          })}
+        </ul>
+      ) : !form ? (
+        <div className="border-border rounded-lg border border-dashed py-12 text-center">
+          <CalendarClock className="text-muted-foreground mx-auto size-6" />
+          <p className="mt-3 text-sm font-medium">No schedules yet</p>
+          <p className="text-muted-foreground mx-auto mt-1 max-w-sm text-sm">
+            Run this agent automatically — a draft PR every morning, a nightly audit, a periodic sweep.
+          </p>
+          {!repoManaged ? (
+            <Button size="sm" className="mt-4" onClick={openCreate}>
+              <Plus className="size-4" />
+              Create a schedule
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
 
-            <p className="text-muted-foreground text-xs">
-              Or use the CLI: <code className="font-mono">oc agent schedule create</code>
-            </p>
-          </>
-        )}
-      </PanelContent>
-    </Panel>
+      <p className="text-muted-foreground text-xs">
+        Or from the CLI: <code className="font-mono">oc agent schedule create &lt;name&gt; --cron "0 9 * * 1-5" --input …</code>
+      </p>
+    </div>
   )
 }
 

--- a/web/src/components/agent-schedules.tsx
+++ b/web/src/components/agent-schedules.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/api/client'
 import { Panel, PanelContent } from '@/components/panel'
 import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from '@/components/confirm-dialog'
 import { Field, Input, Select, Textarea } from '@/components/form'
 
 // ── helpers ────────────────────────────────────────────────────────────────────
@@ -123,6 +124,7 @@ export function AgentSchedulesTab({ agentId }: { agentId: string }) {
   const queryClient = useQueryClient()
   const [form, setForm] = useState<FormState | null>(null)
   const [expanded, setExpanded] = useState<string | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<Schedule | null>(null)
 
   const { data: repoManaged } = useQuery({
     queryKey: ['agent-deploy-source', agentId],
@@ -190,6 +192,7 @@ export function AgentSchedulesTab({ agentId }: { agentId: string }) {
     mutationFn: (s: Schedule) => deleteSchedule(agentId, s.id),
     onSuccess: () => {
       invalidate()
+      setPendingDelete(null)
       notifySuccess('Schedule deleted.')
     },
     onError: (e) => notifyError("Couldn't delete the schedule.", e),
@@ -235,7 +238,7 @@ export function AgentSchedulesTab({ agentId }: { agentId: string }) {
                 id="sch-name"
                 value={form.name}
                 onChange={(e) => setForm({ ...form, name: e.target.value })}
-                placeholder="Morning docs sweep"
+                placeholder="morning-docs-sweep"
                 disabled={!!form.id}
               />
               {form.id ? <p className="text-muted-foreground mt-1 text-xs">Name can’t be changed after creation.</p> : null}
@@ -369,8 +372,7 @@ export function AgentSchedulesTab({ agentId }: { agentId: string }) {
                               variant="ghost"
                               className="text-muted-foreground hover:text-red-600"
                               title="Delete"
-                              disabled={remove.isPending}
-                              onClick={() => remove.mutate(s)}
+                              onClick={() => setPendingDelete(s)}
                             >
                               <Trash2 className="size-4" />
                             </Button>
@@ -439,6 +441,17 @@ export function AgentSchedulesTab({ agentId }: { agentId: string }) {
       <p className="text-muted-foreground text-xs">
         Or from the CLI: <code className="font-mono">oc agent schedule create &lt;name&gt; --cron "0 9 * * 1-5" --input …</code>
       </p>
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => !open && setPendingDelete(null)}
+        title={`Delete "${pendingDelete?.name ?? ''}"?`}
+        description="This schedule stops firing immediately. Run history is kept."
+        confirmLabel="Delete"
+        destructive
+        pending={remove.isPending}
+        onConfirm={() => pendingDelete && remove.mutate(pendingDelete)}
+      />
     </div>
   )
 }

--- a/web/src/components/agent-schedules.tsx
+++ b/web/src/components/agent-schedules.tsx
@@ -74,34 +74,30 @@ const COMMON_TZS = [
   'Asia/Dubai', 'Asia/Kolkata', 'Asia/Singapore', 'Asia/Shanghai', 'Asia/Tokyo', 'Australia/Sydney',
 ]
 const prettyTz = (z: string) => z.replace(/_/g, ' ')
-// Current UTC offset for a zone — e.g. "UTC-5", "UTC+5:30", "UTC+0" (DST-dependent: the offset in effect now).
+// Current offset as a bare "+5:30" / "-4" / "+0" (DST-dependent: the offset in effect now).
 function tzOffset(z: string): string {
   try {
     const name =
       new Intl.DateTimeFormat('en-US', { timeZone: z, timeZoneName: 'shortOffset' })
         .formatToParts(new Date())
         .find((p) => p.type === 'timeZoneName')?.value ?? ''
-    return name.replace('GMT', 'UTC').replace(/^UTC$/, 'UTC+0')
+    return name.replace(/^(?:GMT|UTC)/, '') || '+0'
   } catch {
     return ''
   }
 }
-function tzLabel(z: string): string {
-  if (z === 'UTC') return 'UTC'
-  const off = tzOffset(z)
-  return off ? `${prettyTz(z)} (${off})` : prettyTz(z)
-}
-function tzOptions(current: string): ({ value: string; label: string } | { separator: true })[] {
-  const items: ({ value: string; label: string } | { separator: true })[] = []
+function tzOptions(current: string): ({ value: string; label: string; hint?: string } | { separator: true })[] {
+  const items: ({ value: string; label: string; hint?: string } | { separator: true })[] = []
   const seen = new Set<string>()
   const push = (z: string, label?: string) => {
     if (z && !seen.has(z)) {
       seen.add(z)
-      items.push({ value: z, label: label ?? tzLabel(z) })
+      // The offset rides in `hint` (muted, right-aligned); UTC needs none.
+      items.push({ value: z, label: label ?? prettyTz(z), hint: z === 'UTC' ? undefined : tzOffset(z) })
     }
   }
   push('UTC')
-  if (LOCAL_TZ && LOCAL_TZ !== 'UTC') push(LOCAL_TZ, `${tzLabel(LOCAL_TZ)} · your timezone`)
+  if (LOCAL_TZ && LOCAL_TZ !== 'UTC') push(LOCAL_TZ, `${prettyTz(LOCAL_TZ)} · your timezone`)
   if (current && current !== 'UTC') push(current) // keep an already-set uncommon zone selectable
   items.push({ separator: true })
   for (const z of COMMON_TZS) push(z)

--- a/web/src/components/agent-schedules.tsx
+++ b/web/src/components/agent-schedules.tsx
@@ -60,61 +60,10 @@ const CRON_PRESETS: { label: string; cron: string }[] = [
 ]
 
 const prettyTz = (z: string) => z.replace(/_/g, ' ')
-// Fixed UTC offsets - exactly one entry per offset, so the list is stable (no DST shifting the
-// offsets around). Values are fixed-offset IANA zones the API + cron accept: Etc/GMT has an INVERTED
-// sign (Etc/GMT+5 = UTC-5), and the fractional offsets use the region's non-DST zone. The city is
-// just a recognizable example of that offset.
-const TZ_OFFSETS: { value: string; city: string; hint: string }[] = [
-  { value: 'Etc/GMT+11', city: 'Midway', hint: '-11' },
-  { value: 'Etc/GMT+10', city: 'Honolulu', hint: '-10' },
-  { value: 'Etc/GMT+9', city: 'Anchorage', hint: '-9' },
-  { value: 'Etc/GMT+8', city: 'Los Angeles', hint: '-8' },
-  { value: 'Etc/GMT+7', city: 'Denver', hint: '-7' },
-  { value: 'Etc/GMT+6', city: 'Mexico City', hint: '-6' },
-  { value: 'Etc/GMT+5', city: 'New York', hint: '-5' },
-  { value: 'Etc/GMT+4', city: 'Halifax', hint: '-4' },
-  { value: 'Etc/GMT+3', city: 'Sao Paulo', hint: '-3' },
-  { value: 'Etc/GMT+2', city: 'South Georgia', hint: '-2' },
-  { value: 'Etc/GMT+1', city: 'Azores', hint: '-1' },
-  { value: 'Etc/GMT-1', city: 'Berlin', hint: '+1' },
-  { value: 'Etc/GMT-2', city: 'Cairo', hint: '+2' },
-  { value: 'Etc/GMT-3', city: 'Moscow', hint: '+3' },
-  { value: 'Asia/Tehran', city: 'Tehran', hint: '+3:30' },
-  { value: 'Etc/GMT-4', city: 'Dubai', hint: '+4' },
-  { value: 'Asia/Kabul', city: 'Kabul', hint: '+4:30' },
-  { value: 'Etc/GMT-5', city: 'Karachi', hint: '+5' },
-  { value: 'Asia/Kolkata', city: 'Mumbai', hint: '+5:30' },
-  { value: 'Asia/Kathmandu', city: 'Kathmandu', hint: '+5:45' },
-  { value: 'Etc/GMT-6', city: 'Dhaka', hint: '+6' },
-  { value: 'Asia/Yangon', city: 'Yangon', hint: '+6:30' },
-  { value: 'Etc/GMT-7', city: 'Bangkok', hint: '+7' },
-  { value: 'Etc/GMT-8', city: 'Singapore', hint: '+8' },
-  { value: 'Etc/GMT-9', city: 'Tokyo', hint: '+9' },
-  { value: 'Australia/Darwin', city: 'Darwin', hint: '+9:30' },
-  { value: 'Etc/GMT-10', city: 'Sydney', hint: '+10' },
-  { value: 'Etc/GMT-11', city: 'Noumea', hint: '+11' },
-  { value: 'Etc/GMT-12', city: 'Auckland', hint: '+12' },
-  { value: 'Etc/GMT-13', city: "Nuku'alofa", hint: '+13' },
-  { value: 'Etc/GMT-14', city: 'Kiritimati', hint: '+14' },
-]
-function tzOptions(current: string): ({ value: string; label: string; hint?: string } | { separator: true })[] {
-  const items: ({ value: string; label: string; hint?: string } | { separator: true })[] = [
-    { value: 'UTC', label: 'UTC' },
-    { separator: true },
-    ...TZ_OFFSETS.map((o) => ({ value: o.value, label: o.city, hint: o.hint })),
-  ]
-  // Preserve a zone set elsewhere (CLI/toml) that isn't one of our fixed offsets.
-  if (current && current !== 'UTC' && !items.some((i) => 'value' in i && i.value === current)) {
-    items.push({ separator: true }, { value: current, label: prettyTz(current) })
-  }
-  return items
-}
-const TZ_BY_VALUE = new Map(TZ_OFFSETS.map((o) => [o.value, o]))
-// Friendly display of a stored tz on a schedule card (the raw Etc/GMT+5 has a confusing inverted sign).
+// UTC-only in the UI for now (shown as a fixed label, no picker). A schedule pointed at another zone
+// via the API/CLI still renders correctly — the server's validateTz accepts any IANA zone.
 function tzDisplay(tz: string | null): string {
-  if (!tz || tz === 'UTC') return 'UTC'
-  const o = TZ_BY_VALUE.get(tz)
-  return o ? `UTC${o.hint}` : prettyTz(tz)
+  return !tz || tz === 'UTC' ? 'UTC' : prettyTz(tz)
 }
 
 function StateBadge({ s }: { s: Schedule }) {
@@ -166,7 +115,7 @@ function ScheduleRuns({ agentId, scheduleId }: { agentId: string; scheduleId: st
   )
 }
 
-type FormState = { id?: string; name: string; cron: string; tz: string; input: string; overlap: ScheduleOverlap }
+type FormState = { id?: string; name: string; cron: string; input: string; overlap: ScheduleOverlap }
 
 // ── the tab ─────────────────────────────────────────────────────────────────────
 
@@ -200,18 +149,18 @@ export function AgentSchedulesTab({ agentId }: { agentId: string }) {
 
   const invalidate = () => void queryClient.invalidateQueries({ queryKey: ['agent-schedules', agentId] })
 
-  const openCreate = () => setForm({ name: '', cron: '0 9 * * 1-5', tz: 'UTC', input: '', overlap: 'skip' })
+  const openCreate = () => setForm({ name: '', cron: '0 9 * * 1-5', input: '', overlap: 'skip' })
   const openEdit = (s: Schedule) =>
-    setForm({ id: s.id, name: s.name, cron: s.cron, tz: s.tz ?? 'UTC', input: s.input, overlap: s.overlap })
+    setForm({ id: s.id, name: s.name, cron: s.cron, input: s.input, overlap: s.overlap })
 
   const save = useMutation({
     mutationFn: () => {
       const f = form!
-      // 'UTC' (the default) maps to null on the wire — the API treats null as UTC.
-      const patch = { cron: f.cron.trim(), tz: f.tz && f.tz !== 'UTC' ? f.tz : null, input: f.input.trim(), overlap: f.overlap }
+      const common = { cron: f.cron.trim(), input: f.input.trim(), overlap: f.overlap }
+      // Create is UTC-only (tz: null). Edit omits tz entirely so it never clobbers a zone set via the API/CLI.
       return f.id
-        ? updateSchedule(agentId, f.id, patch)
-        : createSchedule(agentId, { name: f.name.trim(), ...patch })
+        ? updateSchedule(agentId, f.id, common)
+        : createSchedule(agentId, { name: f.name.trim(), tz: null, ...common })
     },
     onSuccess: () => {
       const editing = !!form?.id
@@ -293,7 +242,7 @@ export function AgentSchedulesTab({ agentId }: { agentId: string }) {
             </Field>
 
             <Field label="Schedule" htmlFor="sch-cron">
-              <div className="flex gap-2">
+              <div className="flex items-center gap-2">
                 <Input
                   id="sch-cron"
                   value={form.cron}
@@ -301,12 +250,12 @@ export function AgentSchedulesTab({ agentId }: { agentId: string }) {
                   placeholder="0 9 * * 1-5"
                   className="font-mono"
                 />
-                <Select
-                  value={form.tz || 'UTC'}
-                  onValueChange={(v) => setForm({ ...form, tz: v })}
-                  options={tzOptions(form.tz)}
-                  className="max-w-48"
-                />
+                <span
+                  className="border-border text-muted-foreground shrink-0 rounded-md border px-2.5 py-1 text-sm"
+                  title="Schedules run in UTC"
+                >
+                  UTC
+                </span>
               </div>
               <div className="mt-2 flex flex-wrap items-center gap-1.5">
                 {CRON_PRESETS.map((p) => (

--- a/web/src/components/form.tsx
+++ b/web/src/components/form.tsx
@@ -23,8 +23,9 @@ export function Select({
   value: string
   onValueChange: (value: string) => void
   // A `{ separator: true }` entry renders a divider between groups (e.g. models
-  // grouped by provider) rather than a selectable item.
-  options: ({ value: string; label: string } | { separator: true })[]
+  // grouped by provider) rather than a selectable item. An optional `hint` renders
+  // right-aligned + muted (e.g. a timezone's UTC offset).
+  options: ({ value: string; label: string; hint?: string } | { separator: true })[]
   id?: string
   placeholder?: string
   disabled?: boolean
@@ -71,6 +72,11 @@ export function Select({
                   className="focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center rounded-md py-1 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50"
                 >
                   <SelectPrimitive.ItemText>{o.label}</SelectPrimitive.ItemText>
+                  {o.hint ? (
+                    <span className="text-muted-foreground ml-auto pl-4 text-xs tabular-nums">
+                      {o.hint}
+                    </span>
+                  ) : null}
                   <span className="absolute right-2 flex items-center">
                     <SelectPrimitive.ItemIndicator>
                       <Check className="size-4" />

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -30,7 +30,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { SlackConnect } from '@/components/slack-connect'
 import { AgentSkills } from '@/components/agent-skills'
 import { AgentDeploySource } from '@/components/agent-deploy-source'
-import { AgentSchedules } from '@/components/agent-schedules'
+import { AgentSchedulesTab } from '@/components/agent-schedules'
 import { AgentRevisions } from '@/components/agent-revisions'
 import {
   WorkingRepoField,
@@ -46,7 +46,7 @@ const ORG_DEFAULT = '__default__' // no pinned credential → org default resolv
 const NEW_CRED = '__new__' // create one inline
 const MANAGED = 'managed' // run via OpenComputer, no BYO key (token-billing §6.6)
 
-type Tab = 'overview' | 'revisions' | 'sessions' | 'settings'
+type Tab = 'overview' | 'revisions' | 'sessions' | 'schedules' | 'settings'
 
 export default function AgentDetail() {
   const { agentId = '', tab } = useParams()
@@ -57,9 +57,11 @@ export default function AgentDetail() {
       ? 'revisions'
       : tab === 'sessions'
         ? 'sessions'
-        : tab === 'settings'
-          ? 'settings'
-          : 'overview'
+        : tab === 'schedules'
+          ? 'schedules'
+          : tab === 'settings'
+            ? 'settings'
+            : 'overview'
 
   // Each tab is a thin control panel over one API resource — surface the call it drives
   // (REST + SDK), same as the other pages, so the dashboard reads as programmable.
@@ -67,6 +69,7 @@ export default function AgentDetail() {
     overview: { method: 'GET', path: `/v3/agents/${agentId}`, sdk: 'oc.agents.get(id)', docs: `${DOCS}/agents` },
     revisions: { method: 'GET', path: `/v3/agents/${agentId}/revisions`, sdk: 'oc.agents.revisions.list(id)', docs: `${DOCS}/revisions` },
     sessions: { method: 'POST', path: '/v3/sessions', sdk: 'oc.sessions.create({ agent })', docs: `${DOCS}/sessions` },
+    schedules: { method: 'GET', path: `/v3/agents/${agentId}/schedules`, sdk: 'oc.agents.schedules.list(id)', docs: `${DOCS}/schedules` },
     settings: { method: 'PATCH', path: `/v3/agents/${agentId}`, sdk: 'oc.agents.update(id, …)', docs: `${DOCS}/agents` },
   }
 
@@ -322,6 +325,11 @@ export default function AgentDetail() {
             current={active === 'sessions'}
           />
           <TabLink
+            to={`${base}/schedules`}
+            label="Schedules"
+            current={active === 'schedules'}
+          />
+          <TabLink
             to={`${base}/settings`}
             label="Settings"
             current={active === 'settings'}
@@ -438,16 +446,16 @@ export default function AgentDetail() {
               </Panel>
               <AgentSkills agentId={agent.id} />
             </div>
-            {/* Right rail: connect-or-status for the agent's source + Slack + schedules. */}
+            {/* Right rail: connect-or-status for the agent's source + Slack. */}
             <div className="space-y-4">
               <AgentDeploySource agentId={agent.id} />
-              <AgentSchedules agentId={agent.id} />
               <SlackConnect agentId={agent.id} agentName={agent.name} />
             </div>
           </div>
         )}
 
         {active === 'revisions' && <AgentRevisions agentId={agent.id} />}
+        {active === 'schedules' && <AgentSchedulesTab agentId={agent.id} />}
 
         {active === 'sessions' && (
           <Panel className="overflow-hidden">

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -30,6 +30,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { SlackConnect } from '@/components/slack-connect'
 import { AgentSkills } from '@/components/agent-skills'
 import { AgentDeploySource } from '@/components/agent-deploy-source'
+import { AgentSchedules } from '@/components/agent-schedules'
 import { AgentRevisions } from '@/components/agent-revisions'
 import {
   WorkingRepoField,
@@ -437,9 +438,10 @@ export default function AgentDetail() {
               </Panel>
               <AgentSkills agentId={agent.id} />
             </div>
-            {/* Right rail: connect-or-status for the agent's source + Slack. */}
+            {/* Right rail: connect-or-status for the agent's source + Slack + schedules. */}
             <div className="space-y-4">
               <AgentDeploySource agentId={agent.id} />
+              <AgentSchedules agentId={agent.id} />
               <SlackConnect agentId={agent.id} agentName={agent.name} />
             </div>
           </div>


### PR DESCRIPTION
The full **opencomputer** changeset for Schedules (design 015) — cron for agents. Backend lives in sessions-api#68 (deployed to prod, auto-fire verified end-to-end).

## Docs
- `docs/agent-sessions/schedules.mdx` (new) — the feature guide
- `agent-sessions/api-reference.mdx` — a Schedules section (SDK/REST/CLI)
- Labs `triggers.mdx` pointer + nav entry

## TypeScript SDK
`oc.agents.schedules` — `create/list/get/update/delete/fire/runs`, namespace form, agent-id first.

## oc CLI
`oc agent schedules` + `oc agent schedule {create,get,pause,resume,delete,fire,runs}`; name→id resolution, `--agent`/cwd-`agent.toml` addressing; `[[schedules]]` in the manifest rides `oc agent deploy`.

## Dashboard
A **Schedules tab** on AgentDetail: create/edit form (Textarea for the message, cron quick-picks + gloss, overlap), schedule cards with pause/resume · test-fire · edit · delete, auto-paused warning, expandable recent-runs. Rides the existing `/api/dashboard/v3/*` passthrough — no edge/BFF change. Timezone is UTC-only in the UI for now (the API accepts any IANA zone).

tsc / go build / eslint all clean. (Consolidates the former docs PR #493.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)