### PR TITLE
web (W11): sessions dashboard — runtime + spend, richer viewer, submission-health panel

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -33,8 +33,10 @@ export type {
   SkillItem,
   AgentDeploy,
   Session,
+  AgentSnapshot,
   SessionEvent,
   Turn,
+  SessionResult,
   Destination,
   Delivery,
   SandboxWebhook,
@@ -735,6 +737,19 @@ export const getSessionEvents = (id: string, level?: string) =>
     {},
     S.SessionEventListSchema,
   ).then((r) => r.data)
+
+// Turns — the per-submission execution records behind a session (state, timing,
+// usage, error). Read-only; powers the submission-health panel. Newest first.
+export const getSessionTurns = (id: string) =>
+  apiFetch(
+    `/v3/sessions/${id}/turns`,
+    {},
+    S.SessionTurnListSchema,
+  ).then((r) => r.data)
+
+// The latest turn + its result event (if the turn produced one).
+export const getSessionResult = (id: string) =>
+  apiFetch(`/v3/sessions/${id}/result`, {}, S.SessionResultSchema)
 
 // Steer — post a user message into a session.
 export const sendMessage = (

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -657,10 +657,14 @@ const credentials = [
 
 const sessions = [
   {
+    // A flue (CF-native) session — meters at the gateway, so its `usage` is empty here
+    // (spend renders "—"); the runtime badge is accented to set it apart from brain-box.
     id: 'ses_a1b2c3',
     status: 'running',
     agent_id: 'agt_3kf9xz',
+    agent_snapshot: { runtime: 'flue', model: 'anthropic/claude-haiku-4-5' },
     head: 24,
+    usage: {},
     created_at: at(0, 1),
     last_turn: { state: 'running' },
     sandboxes: { brain: 'sbx_a1b2c3d4e5', hands: 'sbx_f6g7h8i9j0' },
@@ -669,7 +673,9 @@ const sessions = [
     id: 'ses_d4e5f6',
     status: 'awaiting_input',
     agent_id: 'agt_3kf9xz',
+    agent_snapshot: { runtime: 'claude', model: 'anthropic/claude-sonnet-5' },
     head: 12,
+    usage: { cost_usd: 0.0231, input_tokens: 8200, output_tokens: 640 },
     created_at: at(0, 3),
     last_turn: { state: 'ok', yield_reason: 'needs_input' },
   },
@@ -677,7 +683,10 @@ const sessions = [
     id: 'ses_g7h8i9',
     status: 'idle',
     agent_id: 'agt_7mq2aa',
+    agent_snapshot: { runtime: 'pi', model: 'anthropic/claude-sonnet-5' },
     head: 41,
+    // No cost reported → the spend column falls back to a token total.
+    usage: { input_tokens: 15000, output_tokens: 2200 },
     created_at: at(1, 2),
     last_turn: { state: 'ok', yield_reason: 'completed' },
   },
@@ -685,7 +694,9 @@ const sessions = [
     id: 'ses_j1k2l3',
     status: 'failed',
     agent_id: 'agt_3kf9xz',
+    agent_snapshot: { runtime: 'codex', model: 'openai/gpt-5.3-codex' },
     head: 8,
+    usage: { cost_usd: 0.11 },
     created_at: at(2, 5),
     last_turn: { state: 'error', yield_reason: 'error' },
   },
@@ -693,7 +704,9 @@ const sessions = [
     id: 'ses_m4n5o6',
     status: 'archived',
     agent_id: 'agt_7mq2aa',
+    agent_snapshot: { runtime: 'claude', model: 'anthropic/claude-opus-4-8' },
     head: 60,
+    usage: { cost_usd: 1.42, input_tokens: 320000, output_tokens: 18400 },
     created_at: at(4, 1),
     last_turn: { state: 'ok', yield_reason: 'completed' },
   },
@@ -722,6 +735,17 @@ const sessionEvents = [
   {
     id: 'evt_3',
     seq: 3,
+    type: 'agent.thinking',
+    level: 'progress',
+    actor: { type: 'agent', display: 'PR Reviewer' },
+    body: {
+      text: 'Fetch the PR head, then read the auth middleware diff before commenting.',
+    },
+    ts: at(0, 1),
+  },
+  {
+    id: 'evt_4',
+    seq: 4,
     type: 'tool.call',
     level: 'progress',
     actor: { type: 'runtime' },
@@ -729,8 +753,21 @@ const sessionEvents = [
     ts: at(0, 1),
   },
   {
-    id: 'evt_4',
-    seq: 4,
+    id: 'evt_5',
+    seq: 5,
+    type: 'exec.completed',
+    level: 'progress',
+    actor: { type: 'runtime' },
+    body: {
+      tool: 'bash',
+      summary: 'fetched pull/412/head → FETCH_HEAD',
+      duration_ms: 412,
+    },
+    ts: at(0, 1),
+  },
+  {
+    id: 'evt_6',
+    seq: 6,
     type: 'agent.message',
     level: 'user',
     actor: { type: 'agent', display: 'PR Reviewer' },
@@ -740,13 +777,36 @@ const sessionEvents = [
     ts: at(0, 1),
   },
   {
-    id: 'evt_5',
-    seq: 5,
+    id: 'evt_7',
+    seq: 7,
     type: 'turn.completed',
     level: 'user',
     actor: { type: 'runtime' },
     body: { yield_reason: 'needs_input' },
     ts: at(0, 1),
+  },
+]
+
+// Turns power the submission-health panel (GET /v3/sessions/:id/turns), newest first.
+const sessionTurns = [
+  {
+    id: 'trn_2',
+    state: 'ok',
+    yield_reason: 'needs_input',
+    started_at: at(0, 1),
+    completed_at: at(0, 1),
+    active_seconds: 6.4,
+    usage: { cost_usd: 0.0121, input_tokens: 4200, output_tokens: 310 },
+  },
+  {
+    id: 'trn_1',
+    state: 'error',
+    yield_reason: 'error',
+    started_at: at(0, 2),
+    completed_at: at(0, 2),
+    active_seconds: 2.1,
+    usage: {},
+    error: { code: 'provision_infra', message: 'brain sandbox failed to start' },
   },
 ]
 
@@ -767,8 +827,8 @@ const deliveries = [
   {
     id: 'dlv_1',
     destination: 'dst_1',
-    event_id: 'evt_5',
-    event_seq: 5,
+    event_id: 'evt_7',
+    event_seq: 7,
     status: 'delivered',
     attempts: 1,
     last_attempt_at: at(0, 1),
@@ -778,8 +838,8 @@ const deliveries = [
   {
     id: 'dlv_2',
     destination: 'dst_1',
-    event_id: 'evt_4',
-    event_seq: 4,
+    event_id: 'evt_6',
+    event_seq: 6,
     status: 'failed',
     attempts: 3,
     last_attempt_at: at(0, 1),
@@ -876,6 +936,11 @@ const ROUTES: Array<[RegExp, Handler]> = [
   [/^\/v3\/agents$/, () => ({ data: agents })],
   [/^\/v3\/credentials$/, () => ({ data: credentials })],
   [/^\/v3\/sessions\/[^/]+\/events/, () => ({ data: sessionEvents })],
+  [/^\/v3\/sessions\/[^/]+\/turns$/, () => ({ data: sessionTurns })],
+  [
+    /^\/v3\/sessions\/[^/]+\/result$/,
+    () => ({ last_turn: sessionTurns[0], result: sessionEvents[6] }),
+  ],
   [/^\/v3\/sessions\/[^/]+\/destinations$/, () => ({ data: destinations })],
   [/^\/v3\/sessions\/[^/]+\/deliveries$/, () => ({ data: deliveries })],
   [/^\/v3\/sessions\/[^/]+$/, () => sessions[0]],

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -487,10 +487,23 @@ export const SlackManifestResponseSchema = z.object({
   status: z.string(),
 })
 
+// The pinned effective agent tuple (design 009 §3.5) the session ran with. `runtime`
+// is what distinguishes flue from the brain-box runtimes (claude/codex/pi) in read views.
+export const AgentSnapshotSchema = z.object({
+  runtime: z.string().nullish(),
+  model: z.string().nullish(),
+  prompt_hash: z.string().nullish(),
+  revision: z.union([z.string(), z.number()]).nullish(),
+  agent_revision_number: z.number().nullish(),
+  digest: z.string().nullish(),
+  skill_bundle_digest: z.string().nullish(),
+})
+
 export const SessionSchema = z.object({
   id: z.string(),
   status: z.string(),
   agent_id: z.string().nullable().optional(),
+  agent_snapshot: AgentSnapshotSchema.nullish(),
   credential_id: z.string().nullable().optional(),
   head: z.coerce.number().optional(), // current event seq; API returns it as a string ("0")
   last_turn: record.nullish(),
@@ -525,7 +538,11 @@ export const SessionEventSchema = z.object({
   level: z.string(),
   actor: ActorSchema.optional(),
   body: z.unknown().optional(),
-  content_ref: z.string().nullish(), // set when body spilled to blob storage
+  // Set together when the body spilled to blob storage (body > 32KB): the inline
+  // `body` is absent/partial, `content_ref` points at the blob, `body_bytes` is the size.
+  content_ref: z.string().nullish(),
+  body_truncated: z.boolean().nullish(),
+  body_bytes: z.number().nullish(),
   refs: record.nullish(),
   source: z.string().optional(),
   turn_id: z.string().nullable().optional(),
@@ -544,8 +561,19 @@ export const TurnSchema = z.object({
   attempt: z.number().optional(),
   started_at: z.string().nullable().optional(),
   completed_at: z.string().nullable().optional(),
-  usage: record.optional(),
-  error: z.string().nullable().optional(),
+  active_seconds: z.number().nullish(),
+  result_event_id: z.string().nullish(),
+  usage: record.nullish(),
+  error: z.unknown().nullish(), // server serializes the error as an opaque object, not a string
+})
+export const SessionTurnListSchema = z.object({
+  data: z.array(TurnSchema),
+  next_cursor: z.string().nullish(),
+})
+// GET /v3/sessions/:id/result → the latest turn + its result event (if any).
+export const SessionResultSchema = z.object({
+  last_turn: TurnSchema.nullable(),
+  result: SessionEventSchema.nullable(),
 })
 
 export const DestinationSchema = z.object({
@@ -583,8 +611,10 @@ export type Credential = z.infer<typeof CredentialSchema>
 export type SlackConnection = z.infer<typeof SlackConnectionSchema>
 export type SlackManifestResponse = z.infer<typeof SlackManifestResponseSchema>
 export type Session = z.infer<typeof SessionSchema>
+export type AgentSnapshot = z.infer<typeof AgentSnapshotSchema>
 export type SessionEvent = z.infer<typeof SessionEventSchema>
 export type Turn = z.infer<typeof TurnSchema>
+export type SessionResult = z.infer<typeof SessionResultSchema>
 export type Destination = z.infer<typeof DestinationSchema>
 export type Delivery = z.infer<typeof DeliverySchema>
 

--- a/web/src/components/runtime-badge.tsx
+++ b/web/src/components/runtime-badge.tsx
@@ -1,0 +1,36 @@
+import { Bot, Cloud, type LucideIcon } from 'lucide-react'
+import { runtimeLabel } from '@/lib/runtimes'
+import { cn } from '@/lib/utils'
+
+// Runtime is a category, not a health state — so it gets a quiet, neutral pill (not a
+// status tone). `flue` (the CF-native durable path) carries a subtle accent + a distinct
+// icon so it reads apart from the brain-box runtimes (claude/codex/pi) at a glance.
+const ICON: Record<string, LucideIcon> = {
+  flue: Cloud,
+}
+
+export function RuntimeBadge({
+  runtime,
+  className,
+}: {
+  runtime: string | null | undefined
+  className?: string
+}) {
+  if (!runtime) return <span className="text-muted-foreground text-sm">—</span>
+  const Icon = ICON[runtime] ?? Bot
+  const isFlue = runtime === 'flue'
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium',
+        isFlue
+          ? 'bg-status-running-bg text-status-running'
+          : 'bg-secondary text-secondary-foreground',
+        className,
+      )}
+    >
+      <Icon className="size-3.5" aria-hidden />
+      {runtimeLabel(runtime)}
+    </span>
+  )
+}

--- a/web/src/components/session-turns.tsx
+++ b/web/src/components/session-turns.tsx
@@ -1,0 +1,114 @@
+import { useQuery } from '@tanstack/react-query'
+import { getSessionTurns, type Turn } from '@/api/client'
+import { Panel } from '@/components/panel'
+import { StatusBadge } from '@/components/status-badge'
+import { ApiHint } from '@/components/api-hint'
+import { formatSpend } from '@/lib/usage'
+
+// A turn's `error` is an opaque object (or a string); pull a one-line message defensively.
+function errorMessage(error: unknown): string | null {
+  if (error == null) return null
+  if (typeof error === 'string') return error
+  if (typeof error === 'number' || typeof error === 'boolean') {
+    return String(error)
+  }
+  if (typeof error === 'object') {
+    const e = error as Record<string, unknown>
+    const msg = e.message ?? e.error ?? e.detail
+    const code = typeof e.code === 'string' ? e.code : null
+    if (typeof msg === 'string') return code ? `${code}: ${msg}` : msg
+    if (code) return code
+    try {
+      return JSON.stringify(error)
+    } catch {
+      return 'error'
+    }
+  }
+  return 'error'
+}
+
+// Wall-clock duration of a turn: prefer active_seconds (billed compute), else derive
+// from started/completed timestamps. Returns a compact label like "4.2s" / "1m 03s".
+function duration(turn: Turn): string | null {
+  let secs: number | null =
+    typeof turn.active_seconds === 'number' ? turn.active_seconds : null
+  if (secs == null && turn.started_at && turn.completed_at) {
+    const ms = Date.parse(turn.completed_at) - Date.parse(turn.started_at)
+    if (Number.isFinite(ms) && ms >= 0) secs = ms / 1000
+  }
+  if (secs == null) return null
+  if (secs < 60) return `${secs.toFixed(1)}s`
+  const m = Math.floor(secs / 60)
+  const s = Math.round(secs % 60)
+  return `${m}m ${String(s).padStart(2, '0')}s`
+}
+
+export function SessionTurns({
+  sessionId,
+  active,
+}: {
+  sessionId: string
+  active: boolean
+}) {
+  const { data: turns, isLoading } = useQuery({
+    queryKey: ['session-turns', sessionId],
+    queryFn: () => getSessionTurns(sessionId),
+    // Keep the health view current while the session is doing work; idle when settled.
+    refetchInterval: active ? 5000 : false,
+  })
+
+  if (!isLoading && (turns?.length ?? 0) === 0) return null // nothing to show for a session with no turns yet
+
+  return (
+    <Panel className="mt-4 overflow-hidden">
+      <div className="flex items-center justify-between border-b px-4 py-2.5">
+        <h2 className="text-sm font-semibold">Submission health</h2>
+        <ApiHint
+          method="GET"
+          path="/v3/sessions/:id/turns"
+          sdk="oc.sessions.turns()"
+          docs="https://docs.opencomputer.dev/agent-sessions/sessions"
+        />
+      </div>
+
+      {isLoading ? (
+        <div className="text-muted-foreground px-4 py-3 text-xs">Loading…</div>
+      ) : (
+        <ul className="divide-y">
+          {(turns ?? []).map((t) => {
+            const err = t.state === 'error' ? errorMessage(t.error) : null
+            const dur = duration(t)
+            const spend = formatSpend(t.usage)
+            return (
+              <li key={t.id} className="px-4 py-2.5">
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                  <StatusBadge
+                    status={t.state === 'ok' ? 'success' : t.state}
+                    label={t.state === 'ok' ? 'OK' : undefined}
+                  />
+                  <code className="text-muted-foreground/80 font-mono text-[11px]">
+                    {t.id}
+                  </code>
+                  {t.yield_reason ? (
+                    <span className="text-muted-foreground text-xs">
+                      {t.yield_reason.replace(/_/g, ' ')}
+                    </span>
+                  ) : null}
+                  <span className="text-muted-foreground/70 ml-auto flex items-center gap-3 font-mono text-[11px] tabular-nums">
+                    {dur ? <span title="active compute">{dur}</span> : null}
+                    {spend !== '—' ? <span title="turn usage">{spend}</span> : null}
+                  </span>
+                </div>
+                {err ? (
+                  <p className="text-status-error mt-1 font-mono text-[11px] break-words">
+                    {err}
+                  </p>
+                ) : null}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </Panel>
+  )
+}

--- a/web/src/lib/runtimes.ts
+++ b/web/src/lib/runtimes.ts
@@ -86,6 +86,25 @@ export const PROVIDER_KEY_FIELDS: Record<string, { keyLabel: string; keyPlacehol
 
 export const DEFAULT_RUNTIME = RUNTIMES[0].value
 
+// Display labels for EVERY runtime a session can report — a superset of the create
+// picker (RUNTIMES). `flue` is intentionally NOT in RUNTIMES (its behavior ships in a
+// deployed artifact — there's no model/key to pick here), but read-only views must
+// still label it correctly instead of falling back to "Claude". `hands` is the
+// tool-sandbox runtime, shown only if it ever surfaces on a session.
+export const RUNTIME_LABELS: Record<string, string> = {
+  claude: 'Claude',
+  codex: 'Codex',
+  pi: 'Pi',
+  flue: 'Flue',
+  hands: 'Hands',
+}
+
+// A stable label for any runtime string (display-only — does NOT gate the create picker).
+export function runtimeLabel(runtime: string | null | undefined): string {
+  if (!runtime) return '—'
+  return RUNTIME_LABELS[runtime] ?? runtime
+}
+
 export const runtimeOptions = RUNTIMES.map((r) => ({
   value: r.value,
   label: r.label,

--- a/web/src/lib/usage.ts
+++ b/web/src/lib/usage.ts
@@ -1,0 +1,54 @@
+// A session's / turn's `usage` is an opaque, runtime-authored object — its shape
+// varies by runtime (brain-box runtimes report token counts + sometimes a cost;
+// flue currently emits `{}`, with spend metered authoritatively at the gateway).
+// Extract the human-meaningful bits defensively — never assume a field is present.
+
+export type UsageLike = Record<string, unknown> | null | undefined
+
+function num(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null
+}
+
+export function hasUsage(usage: UsageLike): boolean {
+  return !!usage && Object.keys(usage).length > 0
+}
+
+// Cost in USD if the runtime reported one — several field spellings appear across runtimes.
+export function usageCostUsd(usage: UsageLike): number | null {
+  if (!usage) return null
+  const u = usage
+  for (const k of ['cost_usd', 'total_cost_usd', 'cost', 'total_cost', 'usd']) {
+    const n = num(u[k])
+    if (n !== null) return n
+  }
+  return null
+}
+
+// Total tokens, summing input/output when a direct total isn't given.
+export function usageTokens(usage: UsageLike): number | null {
+  if (!usage) return null
+  const u = usage
+  const total = num(u.total_tokens) ?? num(u.tokens)
+  if (total !== null) return total
+  const inp = num(u.input_tokens) ?? num(u.prompt_tokens)
+  const out = num(u.output_tokens) ?? num(u.completion_tokens)
+  if (inp !== null || out !== null) return (inp ?? 0) + (out ?? 0)
+  return null
+}
+
+// Sub-cent per-session spend is common; show enough precision to stay non-zero.
+export function formatUsd(n: number): string {
+  if (n === 0) return '$0'
+  if (n < 0.01) return `$${n.toFixed(4)}`
+  if (n < 1) return `$${n.toFixed(3)}`
+  return `$${n.toFixed(2)}`
+}
+
+// A compact one-line spend label for a table cell / metric: "$0.0230", "1,240 tok", or "—".
+export function formatSpend(usage: UsageLike): string {
+  const cost = usageCostUsd(usage)
+  if (cost !== null) return formatUsd(cost)
+  const tok = usageTokens(usage)
+  if (tok !== null) return `${tok.toLocaleString()} tok`
+  return '—'
+}

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -1,7 +1,16 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft, Send, Wrench, CircleAlert } from 'lucide-react'
+import {
+  ArrowLeft,
+  Send,
+  Wrench,
+  CircleAlert,
+  Brain,
+  CheckCircle2,
+  XCircle,
+  FileWarning,
+} from 'lucide-react'
 import { notifyError } from '@/lib/errors'
 import { useHalted } from '@/hooks/useHalted'
 import {
@@ -19,12 +28,16 @@ import { Button } from '@/components/ui/button'
 import { ChatTextarea } from '@/components/chat-textarea'
 import { Skeleton } from '@/components/ui/skeleton'
 import { StatusBadge } from '@/components/status-badge'
+import { RuntimeBadge } from '@/components/runtime-badge'
+import { MetricCard } from '@/components/metric-card'
+import { SessionTurns } from '@/components/session-turns'
 import { EmptyState } from '@/components/empty-state'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 import { SessionWebhooks } from '@/components/session-webhooks'
 import { ApiHint } from '@/components/api-hint'
 import { MessagesSquare } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { formatSpend, usageTokens } from '@/lib/usage'
 
 // body is unknown (inline JSON ≤32KB); pull the common shapes defensively.
 function bodyText(ev: SessionEvent): string | null {
@@ -43,6 +56,30 @@ function toolSummary(ev: SessionEvent): string {
   const tool = typeof b.tool === 'string' ? b.tool : 'tool'
   const input = typeof b.input === 'string' ? b.input : ''
   return input ? `${tool} · ${input}` : tool
+}
+// A tool RESULT — brain-box emits `exec.completed`, the flue tailer emits `tool.result`;
+// both land here so flue + brain-box render identically.
+function isToolResult(ev: SessionEvent): boolean {
+  return ev.type === 'exec.completed' || ev.type === 'tool.result'
+}
+function toolResult(ev: SessionEvent): { text: string; isError: boolean } {
+  const b = (ev.body ?? {}) as Record<string, unknown>
+  const tool = typeof b.tool === 'string' ? b.tool : 'tool'
+  const isError = b.is_error === true || b.error != null
+  const summary =
+    (typeof b.summary === 'string' && b.summary) ||
+    (typeof b.output === 'string' && b.output) ||
+    (typeof b.text === 'string' && b.text) ||
+    ''
+  const dur = typeof b.duration_ms === 'number' ? ` · ${b.duration_ms}ms` : ''
+  return { text: summary ? `${tool} → ${summary}${dur}` : `${tool} →${dur}`, isError }
+}
+// The body spilled to blob storage (event > 32KB) — surface an affordance instead of
+// rendering an empty bubble.
+function truncationNote(ev: SessionEvent): string | null {
+  if (!ev.body_truncated && !ev.content_ref) return null
+  const kb = ev.body_bytes ? ` (${Math.round(ev.body_bytes / 1024)} KB)` : ''
+  return `Output too large to inline${kb} — stored in blob`
 }
 function humanizeType(t: string): string {
   return t.replace(/[._]/g, ' ').replace(/^\w/, (c) => c.toUpperCase())
@@ -202,11 +239,14 @@ export default function SessionDetail() {
       <Panel className="mb-4 p-5">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="min-w-0 space-y-1.5">
-            <div className="flex items-center gap-2.5">
+            <div className="flex flex-wrap items-center gap-2.5">
               <code className="text-foreground font-mono text-sm">
                 {sessionId}
               </code>
               <StatusBadge status={status} />
+              {session?.agent_snapshot?.runtime ? (
+                <RuntimeBadge runtime={session.agent_snapshot.runtime} />
+              ) : null}
             </div>
             <p className="text-muted-foreground text-xs">
               {session?.head ?? 0} events · created{' '}
@@ -269,6 +309,21 @@ export default function SessionDetail() {
           </div>
         </div>
       </Panel>
+
+      {/* Spend / usage — derived from the session's opaque usage object (no dedicated
+          spend endpoint). Tokens shown only when the runtime reports them (flue meters
+          at the gateway and reports none here). */}
+      <div className="mb-4 grid grid-cols-2 gap-4 sm:grid-cols-3">
+        <MetricCard label="Spend" value={formatSpend(session?.usage)} />
+        <MetricCard
+          label="Tokens"
+          value={usageTokens(session?.usage)?.toLocaleString() ?? '—'}
+        />
+        <MetricCard
+          label="Events"
+          value={(session?.head ?? 0).toLocaleString()}
+        />
+      </div>
 
       {/* Event stream */}
       <Panel className="overflow-hidden">
@@ -367,6 +422,15 @@ export default function SessionDetail() {
         </div>
       </Panel>
 
+      <SessionTurns
+        sessionId={sessionId}
+        active={
+          status === 'running' ||
+          status === 'awaiting_input' ||
+          status === 'queued'
+        }
+      />
+
       <SessionWebhooks sessionId={sessionId} />
 
       <ConfirmDialog
@@ -389,6 +453,18 @@ export default function SessionDetail() {
 
 function EventRow({ ev }: { ev: SessionEvent }) {
   const text = bodyText(ev)
+  const trunc = truncationNote(ev)
+
+  // Reasoning — muted, set apart from the answer. (flue tailer + brain-box both emit this.)
+  if (ev.type === 'agent.thinking') {
+    if (!text && !trunc) return null
+    return (
+      <li className="text-muted-foreground flex gap-2 px-4 py-2 text-xs italic">
+        <Brain className="mt-0.5 size-3.5 shrink-0 opacity-60" />
+        <span className="whitespace-pre-wrap">{text ?? trunc}</span>
+      </li>
+    )
+  }
 
   // Conversation messages — the signal.
   if (ev.type === 'user.message' || ev.type === 'agent.message') {
@@ -408,7 +484,16 @@ function EventRow({ ev }: { ev: SessionEvent }) {
             #{ev.seq}
           </span>
         </div>
-        <p className="text-foreground/90 text-sm whitespace-pre-wrap">{text}</p>
+        {text ? (
+          <p className="text-foreground/90 text-sm whitespace-pre-wrap">
+            {text}
+          </p>
+        ) : trunc ? (
+          <p className="text-muted-foreground flex items-center gap-1.5 text-xs italic">
+            <FileWarning className="size-3.5 shrink-0" />
+            {trunc}
+          </p>
+        ) : null}
         {outOfCredits && (
           <Button asChild size="sm" className="mt-2">
             <Link to="/billing">Top up</Link>
@@ -428,11 +513,35 @@ function EventRow({ ev }: { ev: SessionEvent }) {
     )
   }
 
-  // Errors.
-  if (ev.type.startsWith('error')) {
+  // Tool results — `exec.completed` (brain-box) or `tool.result` (flue). Error results
+  // get the error tone; success stays quiet. Body-spill falls back to the truncation note.
+  if (isToolResult(ev)) {
+    const { text: rtext, isError } = toolResult(ev)
+    const Icon = isError ? XCircle : CheckCircle2
     return (
-      <li className="bg-status-error-bg/40 text-status-error px-4 py-2 text-xs">
-        {text ?? humanizeType(ev.type)}
+      <li
+        className={cn(
+          'flex items-center gap-2 px-4 py-1.5 font-mono text-xs',
+          isError ? 'text-status-error' : 'text-muted-foreground',
+        )}
+      >
+        <Icon className="size-3.5 shrink-0 opacity-70" />
+        <span className="truncate">{trunc ?? rtext}</span>
+      </li>
+    )
+  }
+
+  // Failures — turn.failed + any error* event.
+  if (ev.type === 'turn.failed' || ev.type.startsWith('error')) {
+    const reason =
+      typeof (ev.body as Record<string, unknown> | null | undefined)
+        ?.yield_reason === 'string'
+        ? String((ev.body as Record<string, unknown>).yield_reason)
+        : null
+    return (
+      <li className="bg-status-error-bg/40 text-status-error flex items-center gap-2 px-4 py-2 text-xs">
+        <CircleAlert className="size-3.5 shrink-0" />
+        <span>{text ?? reason ?? humanizeType(ev.type)}</span>
       </li>
     )
   }

--- a/web/src/pages/Sessions.tsx
+++ b/web/src/pages/Sessions.tsx
@@ -24,8 +24,10 @@ import {
 } from '@/components/working-repo-field'
 import { ChatTextarea } from '@/components/chat-textarea'
 import { StatusBadge } from '@/components/status-badge'
+import { RuntimeBadge } from '@/components/runtime-badge'
 import { EmptyState } from '@/components/empty-state'
 import { ResourceTable, type Column } from '@/components/resource-table'
+import { formatSpend } from '@/lib/usage'
 
 export default function Sessions() {
   const navigate = useNavigate()
@@ -111,12 +113,27 @@ export default function Sessions() {
       ),
     },
     {
+      key: 'runtime',
+      header: 'Runtime',
+      cell: (s) => <RuntimeBadge runtime={s.agent_snapshot?.runtime} />,
+    },
+    {
       key: 'events',
       header: 'Events',
       align: 'right',
       cell: (s) => (
         <span className="text-muted-foreground font-mono text-xs">
           {s.head ?? 0}
+        </span>
+      ),
+    },
+    {
+      key: 'spend',
+      header: 'Spend',
+      align: 'right',
+      cell: (s) => (
+        <span className="text-muted-foreground font-mono text-xs tabular-nums">
+          {formatSpend(s.usage)}
         </span>
       ),
     },


### PR DESCRIPTION
**W11 — Dashboard + Tier-2.** Extends the existing Sessions UI (`web/`) rather than building greenfield. Runtime-agnostic: renders **flue** and brain-box (claude/codex/pi) sessions alike.

## What's new
1. **Sessions list** — `Runtime` badge (flue accented + `Cloud` icon, brain-box neutral) and a `Spend` column. Adds `agent_snapshot` to the web `SessionSchema` and a **display-only** flue label to `lib/runtimes` — deliberately kept OUT of the create picker (`RUNTIMES`), since flue's behavior ships in a deployed artifact (no model/key to pick).
2. **Conversation viewer** — distinct rendering for `agent.thinking`, tool **results** (`exec.completed` from brain-box AND flue's `tool.result` — so both render identically), `turn.failed`, and a **body-spill affordance** (`content_ref`/`body_truncated`/`body_bytes` → "output too large, stored in blob" instead of an empty bubble). Keeps the existing Conversation/All level filter and the live SSE tail untouched.
3. **Submission health** — new turns panel (`GET /v3/sessions/:id/turns`): per-turn `state`, `yield_reason`, timing (`active_seconds`), `usage`, and `error` (opaque object → one-line message). Recovery stays the existing **cancel + steer** and webhook **redeliver** — no fake "retry turn" button.
4. **Per-session spend** — Spend / Tokens / Events metric cards on the detail page, derived defensively from the opaque `usage` object.

## Honest scope reconciliation (spec vs. `/v3` reality)
- **"Tier-2 streaming parts/deltas" does not exist in `/v3`.** The runtime emits whole events; tiering is the **`level`** field (`internal|progress|user`). There's no token-delta stream to render — so "Tier-2 fidelity" = a faithful full `internal`-level trace, which this delivers. No `view=`/`parts=`/`tier=` params exist.
- **No public turn re-drive/retry endpoint.** Recovery is cancel + steer + webhook redeliver; the panel labels this honestly.
- **No dedicated spend endpoint.** Spend is derived from `session.usage` / `turn.usage`. **flue** meters at the gateway and reports `{}` here → spend renders `—` (correct, not a bug).

## Live SSE tail
Left the working inline `EventSource` client as-is (resume via `Last-Event-ID`/`?after=<seq>`, `seq` cursor, 5s poll fallback). Did **not** extract a `useSSE` hook — extraction risked regressing the working live tail for no functional gain (per the task's guardrail).

## Verification
- `npm run typecheck` ✅ · `npm run build` ✅ · preview dev server boots clean.
- `npm run lint`: the only 2 errors are **pre-existing on `main`** (`SessionDetail.tsx` synchronous setState-in-effect — the SSE reset I didn't touch; `Browsers.tsx` media-caption — not in this diff). **Zero new lint errors.**
- Preview mocks (`api/mock.ts`) extended (a flue session + brain-box sessions with usage, `agent.thinking`/`exec.completed` events, a turns fixture) so `VITE_PREVIEW=1 npm run dev` renders every new surface with no backend.
- Live prod verification is the reviewer's (localhost is wired to prod) — see run steps below.

## Run against prod locally
- **Fast path:** `OC_V3_KEY=osb_… npm run dev` from `web/` (Vite injects `x-api-key` server-side to prod `/v3`, per `vite.config.ts`), then open `/sessions`.
- **Cookie path:** plain `npm run dev` if your edge/session is already wired.
- Open `/sessions` (runtime + spend columns), a session detail (`/sessions/:id` — spend cards, submission-health panel, richer trace), and a running session to watch the live tail.

## Base branch
Based on `main` — W11 is runtime-agnostic dashboard breadth that ships independently of the flue-native evergreen. If the coordinator wants it inside the `flue-native` unit, it's a cheap rebase (web-only, separate surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)