### PR TITLE
feat(oc): oc agent deploy for the flue Worker-DO model (W7-c)

### DIFF
--- a/cmd/oc/internal/commands/agent_deploy_flue.go
+++ b/cmd/oc/internal/commands/agent_deploy_flue.go
@@ -2,38 +2,51 @@ package commands
 
 // Flue deploy flow (design 013 §6 — the Worker-for-Platforms Durable-Object model).
 // When agent.toml declares `[runtime] family = "flue"`, `oc agent deploy` does NOT
-// read prompt.md/skills/; it runs the app's own `flue build --target cloudflare` and
-// POSTs the built Worker module + the generated wrangler to the control plane. The CP
-// owns compose (synthesize the migration ledger) + per-deploy token mint + WfP upload
-// + canary-verify + activate — because the CF creds and the signing key live
-// server-side and the CLI must not hold them. The existing deployment poll absorbs the
-// verify latency (verifying → ready|failed).
+// read prompt.md/skills/; it runs the app's own `flue build --target cloudflare`, then
+// stages the WHOLE built dir (the entry module + the no_bundle assets/ tree) as one
+// tar.gz in R2 via a presigned PUT, and POSTs the deployment referencing only the R2
+// bundle digest + the (small, strict-JSON) generated wrangler + the entrypoint agent
+// name — NO module bytes in the JSON, so the API host stays byte-free. The CP records
+// a `verifying` deploy; an off-host runner fetches the bundle, composes, mints the
+// per-deploy token, WfP-uploads, and canary-verifies before activating. The existing
+// deployment poll absorbs the verify latency (verifying → ready|failed).
 
 import (
+	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
 
+	"github.com/opensandbox/opensandbox/cmd/oc/internal/bundle"
 	"github.com/opensandbox/opensandbox/cmd/oc/internal/client"
 	"github.com/opensandbox/opensandbox/cmd/oc/internal/credscan"
 	"github.com/spf13/cobra"
 )
 
-// flueBuildOutputDir is `flue build --target cloudflare`'s output root; the tool
-// writes the Cloudflare build under dist/<app>/ (wrangler.json + the entry module +
-// assets/), so we discover the wrangler beneath it rather than assume a flat layout.
-const flueBuildOutputDir = "dist"
+const (
+	// flueBuildOutputDir is `flue build --target cloudflare`'s output root; the tool
+	// writes the Cloudflare build under dist/<app>/ (wrangler.json + the entry module +
+	// assets/), so we discover the wrangler beneath it rather than assume a flat layout.
+	flueBuildOutputDir = "dist"
+	flueBundleMaxBytes = 64 << 20 // server caps the staged bundle at 64 MiB — fail early
+)
 
-// flueModule is the built Worker entry module, forwarded to the CP verbatim (the CP
-// uploads it to WfP as metadata.main_module — its filename must equal wrangler.main).
-type flueModule struct {
-	Filename   string `json:"filename"`
-	ContentB64 string `json:"contentB64"`
+// artifactUploadResponse is the reply from POST /v3/agents/:id/artifacts. AlreadyUploaded
+// is set (and URL omitted) when the content-addressed object already exists: R2 is
+// write-once, so the server refuses to re-issue a PUT for a pinned digest (a re-issuable
+// PUT would let scan-clean bytes be swapped for key-bearing ones post-verify). The CLI
+// then skips the PUT and references the digest directly.
+type artifactUploadResponse struct {
+	URL             string `json:"url"`
+	ExpiresAt       string `json:"expires_at"`
+	AlreadyUploaded bool   `json:"already_uploaded"`
 }
 
 func deployFlue(cmd *cobra.Command, sc *client.Client, dir string, m *manifest, noActivate bool) error {
@@ -53,7 +66,7 @@ func deployFlue(cmd *cobra.Command, sc *client.Client, dir string, m *manifest, 
 
 	// 2. Resolve the target agent (create with runtime=flue + no prompt if new).
 	//    Done before the build so a runtime-family mismatch fails fast — ahead of the
-	//    build, not after it.
+	//    build and the upload, not after.
 	id, err := resolveDeployAgent(cmd, sc, m)
 	if err != nil {
 		return err
@@ -64,26 +77,41 @@ func deployFlue(cmd *cobra.Command, sc *client.Client, dir string, m *manifest, 
 		return err
 	}
 
-	// 4. Read the generated wrangler + the entry module the CP needs.
-	module, wrangler, err := readFlueBuildOutput(filepath.Join(dir, flueBuildOutputDir))
+	// 4. Stage the whole built dir as one content-addressed tar.gz + read the wrangler.
+	//    The digest is sha256 of the blob the server and box will hash byte-for-byte.
+	files, wrangler, err := readFlueBundle(filepath.Join(dir, flueBuildOutputDir))
 	if err != nil {
 		return err
 	}
+	tarGz, err := bundle.Pack(files)
+	if err != nil {
+		return fmt.Errorf("pack bundle: %w", err)
+	}
+	digest := bundle.Digest(tarGz)
+	if len(tarGz) > flueBundleMaxBytes {
+		return fmt.Errorf("bundle is %d bytes, over the %d MiB limit", len(tarGz), flueBundleMaxBytes>>20)
+	}
 
-	// 5. Deployment carrying the module + wrangler (no prompt/skills path). The CP
-	//    keys the flue-DO path off the agent's runtime="flue" + the presence of
-	//    flue_module/flue_wrangler, then composes + mints + WfP-uploads → verifying.
+	// 5. Upload: presigned PUT to R2 (the API host never sees the bytes).
+	if err := uploadArtifact(cmd.Context(), sc, id, digest, tarGz); err != nil {
+		return err
+	}
+
+	// 6. Deployment referencing the R2 bundle digest + the generated wrangler (no
+	//    module bytes in the JSON). The CP keys the flue-DO path off the agent's
+	//    runtime="flue" + the presence of flue_bundle_digest/flue_wrangler, then hands
+	//    off to the off-host runner (fetch → compose → mint → WfP-upload) → verifying.
 	rt := m.Runtime.Type
 	if rt == "" {
 		rt = "default"
 	}
 	input := map[string]interface{}{
-		"type":            "inline",
-		"model":           m.Model,
-		"runtime":         map[string]string{"type": rt},
-		"flue_module":     module,   // { filename, contentB64 }
-		"flue_wrangler":   wrangler, // the generated wrangler.json object, verbatim
-		"flue_agent_name": m.Name,   // entrypoint agent (agent.toml name → DO admit address)
+		"type":               "inline",
+		"model":              m.Model,
+		"runtime":            map[string]string{"type": rt},
+		"flue_bundle_digest": digest,   // sha256: of the tar.gz staged in R2
+		"flue_wrangler":      wrangler, // the generated wrangler.json object, verbatim
+		"flue_agent_name":    m.Name,   // entrypoint agent (agent.toml name → DO admit address)
 	}
 	body := map[string]interface{}{"input": input, "activate": !noActivate}
 	if idem, _ := cmd.Flags().GetString("idempotency-key"); idem != "" {
@@ -95,7 +123,7 @@ func deployFlue(cmd *cobra.Command, sc *client.Client, dir string, m *manifest, 
 	}
 	d := env.Deployment
 
-	// 6. Poll to terminal — the CP canary boots the tenant DO before activating.
+	// 7. Poll to terminal — the CP canary boots the tenant DO before activating.
 	if !terminalState(d.State) && d.State != "" {
 		to, _ := cmd.Flags().GetInt("timeout")
 		d, err = pollDeployment(cmd, sc, id, d.ID, time.Duration(to)*time.Second)
@@ -113,7 +141,7 @@ func deployFlue(cmd *cobra.Command, sc *client.Client, dir string, m *manifest, 
 		if d.Active {
 			status = "active"
 		}
-		fmt.Printf("Deployed revision %d — %s\n", n, status)
+		fmt.Printf("Deployed revision %d — %s (%s)\n", n, status, shortDigest(digest))
 	})
 	return nil
 }
@@ -156,37 +184,49 @@ func runFlueBuild(ctx context.Context, dir string) error {
 	return nil
 }
 
-// readFlueBuildOutput locates the generated wrangler under the `flue build` output and
-// reads the entry module it names. `flue build --target cloudflare` writes
-// dist/<app>/{wrangler.json, <main>, assets/…}; a flat dist/ is also accepted. The
-// wrangler's `main` names the entry module (its filename MUST equal the CP's
-// metadata.main_module), so we read `main` rather than hardcode a name.
-func readFlueBuildOutput(distDir string) (flueModule, map[string]interface{}, error) {
+// readFlueBundle locates the generated wrangler under the `flue build` output, parses
+// it, and reads the whole build dir into a fileset (the entry module + the assets/
+// tree). `flue build --target cloudflare` writes dist/<app>/{wrangler.json, <main>,
+// assets/…}; a flat dist/ is also accepted. The fileset is rooted at the wrangler's dir
+// so wrangler.main resolves at the bundle root. Returns the fileset + the wrangler
+// object (forwarded to the CP verbatim as flue_wrangler).
+func readFlueBundle(distDir string) ([]bundle.File, map[string]interface{}, error) {
 	wranglerPath, err := findGeneratedWrangler(distDir)
 	if err != nil {
-		return flueModule{}, nil, err
+		return nil, nil, err
 	}
 	raw, err := os.ReadFile(wranglerPath)
 	if err != nil {
-		return flueModule{}, nil, fmt.Errorf("read %s: %w", wranglerPath, err)
+		return nil, nil, fmt.Errorf("read %s: %w", wranglerPath, err)
 	}
 	var wrangler map[string]interface{}
 	if err := json.Unmarshal(raw, &wrangler); err != nil {
-		return flueModule{}, nil, fmt.Errorf("parse %s: %w", wranglerPath, err)
+		return nil, nil, fmt.Errorf("parse %s: %w", wranglerPath, err)
 	}
 	main, _ := wrangler["main"].(string)
 	if main == "" {
-		return flueModule{}, nil, fmt.Errorf("%s has no `main` — the flue build did not produce a Worker entry module", wranglerPath)
+		return nil, nil, fmt.Errorf("%s has no `main` — the flue build did not produce a Worker entry module", wranglerPath)
 	}
-	modPath := filepath.Join(filepath.Dir(wranglerPath), filepath.FromSlash(main))
-	modBytes, err := os.ReadFile(modPath)
+
+	bundleRoot := filepath.Dir(wranglerPath)
+	files, err := readBundleFiles(bundleRoot)
 	if err != nil {
-		return flueModule{}, nil, fmt.Errorf("read entry module %s: %w", modPath, err)
+		return nil, nil, err
 	}
-	return flueModule{
-		Filename:   filepath.ToSlash(main),
-		ContentB64: base64.StdEncoding.EncodeToString(modBytes),
-	}, wrangler, nil
+	// The entry module wrangler.main names MUST be in the bundle (the runner uploads it
+	// to WfP as metadata.main_module).
+	mainRel := filepath.ToSlash(main)
+	found := false
+	for _, f := range files {
+		if f.Path == mainRel {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, nil, fmt.Errorf("entry module %q (wrangler.main) is not in the build output %s", mainRel, bundleRoot)
+	}
+	return files, wrangler, nil
 }
 
 // findGeneratedWrangler returns the generated wrangler.json path — dist/wrangler.json
@@ -209,4 +249,80 @@ func findGeneratedWrangler(distDir string) (string, error) {
 	default:
 		return "", fmt.Errorf("multiple wrangler.json under %s (%v) — ambiguous flue build output", distDir, matches)
 	}
+}
+
+// readBundleFiles walks the build output into a fileset with normalized modes and
+// forward-slash, root-relative paths (the tar the CP fetches + unpacks off-host).
+func readBundleFiles(root string) ([]bundle.File, error) {
+	if info, err := os.Stat(root); err != nil || !info.IsDir() {
+		return nil, fmt.Errorf("build output %s not found — did `flue build --target cloudflare` run?", root)
+	}
+	var files []bundle.File
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		content, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		st, err := d.Info()
+		if err != nil {
+			return err
+		}
+		files = append(files, bundle.File{
+			Path:    filepath.ToSlash(rel),
+			Mode:    bundle.NormalizeMode(int(st.Mode().Perm())),
+			Content: content,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", root, err)
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("build output %s is empty", root)
+	}
+	return files, nil
+}
+
+// uploadArtifact requests a presigned PUT URL, then PUTs the bundle to it. The PUT
+// carries no OC auth (the signature is in the URL); Content-Type must match what the
+// server signed for the object (application/gzip).
+func uploadArtifact(ctx context.Context, sc *client.Client, agentID, digest string, tarGz []byte) error {
+	reqBody := map[string]interface{}{"digest": digest, "size_bytes": len(tarGz)}
+	var resp artifactUploadResponse
+	if err := sc.Post(ctx, "/v3/agents/"+agentID+"/artifacts", reqBody, &resp); err != nil {
+		return fmt.Errorf("request bundle upload url: %w", err)
+	}
+	if resp.AlreadyUploaded {
+		// The digest's bytes are already in R2 (write-once); nothing to PUT.
+		return nil
+	}
+	if resp.URL == "" {
+		return fmt.Errorf("bundle upload url response was empty")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, resp.URL, bytes.NewReader(tarGz))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/gzip")
+	req.ContentLength = int64(len(tarGz))
+	put, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("upload bundle: %w", err)
+	}
+	defer put.Body.Close()
+	if put.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(put.Body, 512))
+		return fmt.Errorf("bundle upload failed (HTTP %d): %s", put.StatusCode, string(snippet))
+	}
+	return nil
 }

--- a/cmd/oc/internal/commands/agent_deploy_flue.go
+++ b/cmd/oc/internal/commands/agent_deploy_flue.go
@@ -1,19 +1,19 @@
 package commands
 
-// Flue deploy flow (design 012 §11.7.8, flue-slice.md W4 + contracts 3/4/5/10).
-// When agent.toml declares `[runtime] family = "flue"`, `oc agent deploy` does
-// NOT read prompt.md/skills/; instead it builds the app into a content-addressed
-// artifact, uploads it via a presigned PUT, and references the digest in the
-// deployment. The host boot-verifies the artifact (a ~30–60s scratch-sandbox
-// probe) before activating the revision — the existing poll absorbs that latency.
+// Flue deploy flow (design 013 §6 — the Worker-for-Platforms Durable-Object model).
+// When agent.toml declares `[runtime] family = "flue"`, `oc agent deploy` does NOT
+// read prompt.md/skills/; it runs the app's own `flue build --target cloudflare` and
+// POSTs the built Worker module + the generated wrangler to the control plane. The CP
+// owns compose (synthesize the migration ledger) + per-deploy token mint + WfP upload
+// + canary-verify + activate — because the CF creds and the signing key live
+// server-side and the CLI must not hold them. The existing deployment poll absorbs the
+// verify latency (verifying → ready|failed).
 
 import (
-	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
-	"io"
-	"io/fs"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,29 +21,24 @@ import (
 
 	"github.com/opensandbox/opensandbox/cmd/oc/internal/client"
 	"github.com/opensandbox/opensandbox/cmd/oc/internal/credscan"
-	"github.com/opensandbox/opensandbox/cmd/oc/internal/bundle"
 	"github.com/spf13/cobra"
 )
 
-const (
-	flueBuildOutputDir   = "dist-oc" // oc-flue-build's output (gitignored in the app)
-	flueArtifactMaxBytes = 64 << 20  // contract 3: server caps at 64 MiB — fail early
-)
+// flueBuildOutputDir is `flue build --target cloudflare`'s output root; the tool
+// writes the Cloudflare build under dist/<app>/ (wrangler.json + the entry module +
+// assets/), so we discover the wrangler beneath it rather than assume a flat layout.
+const flueBuildOutputDir = "dist"
 
-// artifactUploadResponse is the reply from POST /v3/agents/:id/artifacts (contract 3).
-// AlreadyUploaded is set (and URL omitted) when the content-addressed object already exists:
-// R2 is write-once, so the server refuses to re-issue a PUT for a pinned digest (a re-issuable
-// PUT would let scan-clean bytes be swapped for key-bearing ones post-verify). The CLI then
-// skips the PUT and references the digest directly.
-type artifactUploadResponse struct {
-	URL             string `json:"url"`
-	ExpiresAt       string `json:"expires_at"`
-	AlreadyUploaded bool   `json:"already_uploaded"`
+// flueModule is the built Worker entry module, forwarded to the CP verbatim (the CP
+// uploads it to WfP as metadata.main_module — its filename must equal wrangler.main).
+type flueModule struct {
+	Filename   string `json:"filename"`
+	ContentB64 string `json:"contentB64"`
 }
 
 func deployFlue(cmd *cobra.Command, sc *client.Client, dir string, m *manifest, noActivate bool) error {
-	// 1. Primary credential scan over the user's pre-bundle sources (§11.2.6):
-	//    model keys come from the OC credential, never from committed code.
+	// 1. Primary credential scan over the user's source (§11.2.6): model keys come
+	//    from the OC credential, never from committed code. Stays client-side.
 	findings, err := credscan.ScanDir(dir)
 	if err != nil {
 		return fmt.Errorf("credential scan: %w", err)
@@ -57,49 +52,38 @@ func deployFlue(cmd *cobra.Command, sc *client.Client, dir string, m *manifest, 
 	}
 
 	// 2. Resolve the target agent (create with runtime=flue + no prompt if new).
-	//    Done before the build so a runtime-family mismatch fails fast — ahead
-	//    of the build and the artifact upload, not after a late server reject.
+	//    Done before the build so a runtime-family mismatch fails fast — ahead of the
+	//    build, not after it.
 	id, err := resolveDeployAgent(cmd, sc, m)
 	if err != nil {
 		return err
 	}
 
-	// 3. Build the artifact with the app's own @opencomputer/flue devDependency.
+	// 3. Build the app with its own `flue` CLI (a devDependency).
 	if err := runFlueBuild(cmd.Context(), dir); err != nil {
 		return err
 	}
 
-	// 4. Pack dist-oc/ into the tar.gz and content-address it: the digest is
-	//    sha256 of the blob the server and box will hash byte-for-byte.
-	outDir := filepath.Join(dir, flueBuildOutputDir)
-	files, err := readArtifactFiles(outDir)
+	// 4. Read the generated wrangler + the entry module the CP needs.
+	module, wrangler, err := readFlueBuildOutput(filepath.Join(dir, flueBuildOutputDir))
 	if err != nil {
 		return err
 	}
-	tarGz, err := bundle.Pack(files)
-	if err != nil {
-		return fmt.Errorf("pack artifact: %w", err)
-	}
-	digest := bundle.Digest(tarGz)
-	if len(tarGz) > flueArtifactMaxBytes {
-		return fmt.Errorf("artifact is %d bytes, over the %d MiB limit", len(tarGz), flueArtifactMaxBytes>>20)
-	}
 
-	// 5. Upload: presigned PUT (contract 3).
-	if err := uploadArtifact(cmd.Context(), sc, id, digest, tarGz); err != nil {
-		return err
-	}
-
-	// 6. Deployment referencing the digest (contract 10 — no prompt/skills path).
+	// 5. Deployment carrying the module + wrangler (no prompt/skills path). The CP
+	//    keys the flue-DO path off the agent's runtime="flue" + the presence of
+	//    flue_module/flue_wrangler, then composes + mints + WfP-uploads → verifying.
 	rt := m.Runtime.Type
 	if rt == "" {
 		rt = "default"
 	}
 	input := map[string]interface{}{
-		"type":                      "inline",
-		"model":                     m.Model,
-		"runtime":                   map[string]string{"type": rt},
-		"framework_artifact_digest": digest,
+		"type":            "inline",
+		"model":           m.Model,
+		"runtime":         map[string]string{"type": rt},
+		"flue_module":     module,   // { filename, contentB64 }
+		"flue_wrangler":   wrangler, // the generated wrangler.json object, verbatim
+		"flue_agent_name": m.Name,   // entrypoint agent (agent.toml name → DO admit address)
 	}
 	body := map[string]interface{}{"input": input, "activate": !noActivate}
 	if idem, _ := cmd.Flags().GetString("idempotency-key"); idem != "" {
@@ -111,7 +95,7 @@ func deployFlue(cmd *cobra.Command, sc *client.Client, dir string, m *manifest, 
 	}
 	d := env.Deployment
 
-	// 7. Poll to terminal — deploy boots a verify sandbox before activating.
+	// 6. Poll to terminal — the CP canary boots the tenant DO before activating.
 	if !terminalState(d.State) && d.State != "" {
 		to, _ := cmd.Flags().GetInt("timeout")
 		d, err = pollDeployment(cmd, sc, id, d.ID, time.Duration(to)*time.Second)
@@ -129,7 +113,7 @@ func deployFlue(cmd *cobra.Command, sc *client.Client, dir string, m *manifest, 
 		if d.Active {
 			status = "active"
 		}
-		fmt.Printf("Deployed revision %d — %s (%s)\n", n, status, shortDigest(digest))
+		fmt.Printf("Deployed revision %d — %s\n", n, status)
 	})
 	return nil
 }
@@ -147,110 +131,82 @@ func resolveDeployAgent(cmd *cobra.Command, sc *client.Client, m *manifest) (str
 	return id, err
 }
 
-// runFlueBuild runs the app's oc-flue-build (its own devDependency). Prefers the
-// locally-installed bin; falls back to `npx --no-install`, which runs the
-// package only if it is already in node_modules and NEVER fetches a same-named
-// package from the registry (a supply-chain hole). Build output goes to stderr
-// so stdout stays clean for --json.
+// runFlueBuild runs the app's own `flue` CLI: `flue build --target cloudflare`.
+// Prefers the locally-installed bin; falls back to `npx --no-install`, which runs the
+// package only if it is already in node_modules and NEVER fetches a same-named package
+// from the registry (a supply-chain hole). Build output goes to stderr so stdout stays
+// clean for --json.
 func runFlueBuild(ctx context.Context, dir string) error {
-	bin := filepath.Join(dir, "node_modules", ".bin", "oc-flue-build")
+	args := []string{"build", "--target", "cloudflare"}
+	bin := filepath.Join(dir, "node_modules", ".bin", "flue")
 	var c *exec.Cmd
 	if _, err := os.Stat(bin); err == nil {
-		c = exec.CommandContext(ctx, bin)
+		c = exec.CommandContext(ctx, bin, args...)
 	} else {
-		c = exec.CommandContext(ctx, "npx", "--no-install", "oc-flue-build")
+		c = exec.CommandContext(ctx, "npx", append([]string{"--no-install", "flue"}, args...)...)
 	}
 	c.Dir = dir
 	c.Stdout = os.Stderr
 	c.Stderr = os.Stderr
-	// No stdin: oc-flue-build is a non-interactive bundler, and wiring the
-	// terminal through let an npx install prompt hijack it.
+	// No stdin: `flue build` is a non-interactive bundler, and wiring the terminal
+	// through would let an npx install prompt hijack it.
 	if err := c.Run(); err != nil {
-		return fmt.Errorf("oc-flue-build failed: %w\n(run `npm install` so @opencomputer/flue is available, node >= 22)", err)
+		return fmt.Errorf("flue build failed: %w\n(run `npm install` so the flue CLI is available, node >= 22.19)", err)
 	}
 	return nil
 }
 
-// readArtifactFiles walks the build output into a fileset with normalized modes,
-// requiring artifact.json (the manifest the host validates + pins).
-func readArtifactFiles(outDir string) ([]bundle.File, error) {
-	if info, err := os.Stat(outDir); err != nil || !info.IsDir() {
-		return nil, fmt.Errorf("build output %s not found — did oc-flue-build run?", outDir)
-	}
-	var files []bundle.File
-	hasManifest := false
-	err := filepath.WalkDir(outDir, func(p string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(outDir, p)
-		if err != nil {
-			return err
-		}
-		rel = filepath.ToSlash(rel)
-		content, err := os.ReadFile(p)
-		if err != nil {
-			return err
-		}
-		st, err := d.Info()
-		if err != nil {
-			return err
-		}
-		if rel == "artifact.json" {
-			hasManifest = true
-		}
-		files = append(files, bundle.File{
-			Path:    rel,
-			Mode:    bundle.NormalizeMode(int(st.Mode().Perm())),
-			Content: content,
-		})
-		return nil
-	})
+// readFlueBuildOutput locates the generated wrangler under the `flue build` output and
+// reads the entry module it names. `flue build --target cloudflare` writes
+// dist/<app>/{wrangler.json, <main>, assets/…}; a flat dist/ is also accepted. The
+// wrangler's `main` names the entry module (its filename MUST equal the CP's
+// metadata.main_module), so we read `main` rather than hardcode a name.
+func readFlueBuildOutput(distDir string) (flueModule, map[string]interface{}, error) {
+	wranglerPath, err := findGeneratedWrangler(distDir)
 	if err != nil {
-		return nil, fmt.Errorf("read %s: %w", outDir, err)
+		return flueModule{}, nil, err
 	}
-	if len(files) == 0 {
-		return nil, fmt.Errorf("build output %s is empty", outDir)
+	raw, err := os.ReadFile(wranglerPath)
+	if err != nil {
+		return flueModule{}, nil, fmt.Errorf("read %s: %w", wranglerPath, err)
 	}
-	if !hasManifest {
-		return nil, fmt.Errorf("%s/artifact.json missing — build did not produce a valid artifact", outDir)
+	var wrangler map[string]interface{}
+	if err := json.Unmarshal(raw, &wrangler); err != nil {
+		return flueModule{}, nil, fmt.Errorf("parse %s: %w", wranglerPath, err)
 	}
-	return files, nil
+	main, _ := wrangler["main"].(string)
+	if main == "" {
+		return flueModule{}, nil, fmt.Errorf("%s has no `main` — the flue build did not produce a Worker entry module", wranglerPath)
+	}
+	modPath := filepath.Join(filepath.Dir(wranglerPath), filepath.FromSlash(main))
+	modBytes, err := os.ReadFile(modPath)
+	if err != nil {
+		return flueModule{}, nil, fmt.Errorf("read entry module %s: %w", modPath, err)
+	}
+	return flueModule{
+		Filename:   filepath.ToSlash(main),
+		ContentB64: base64.StdEncoding.EncodeToString(modBytes),
+	}, wrangler, nil
 }
 
-// uploadArtifact requests a presigned PUT URL, then PUTs the bundle to it. The
-// PUT carries no OC auth (the signature is in the URL); Content-Type must match
-// what the server signed for the object (application/gzip).
-func uploadArtifact(ctx context.Context, sc *client.Client, agentID, digest string, tarGz []byte) error {
-	reqBody := map[string]interface{}{"digest": digest, "size_bytes": len(tarGz)}
-	var resp artifactUploadResponse
-	if err := sc.Post(ctx, "/v3/agents/"+agentID+"/artifacts", reqBody, &resp); err != nil {
-		return fmt.Errorf("request artifact upload url: %w", err)
+// findGeneratedWrangler returns the generated wrangler.json path — dist/wrangler.json
+// (flat) or the single dist/<app>/wrangler.json `flue build` writes. Zero or more than
+// one candidate is an error (nothing built / ambiguous output).
+func findGeneratedWrangler(distDir string) (string, error) {
+	if info, err := os.Stat(distDir); err != nil || !info.IsDir() {
+		return "", fmt.Errorf("build output %s not found — did `flue build --target cloudflare` run?", distDir)
 	}
-	if resp.AlreadyUploaded {
-		// The digest's bytes are already in R2 (write-once); nothing to PUT.
-		return nil
+	flat := filepath.Join(distDir, "wrangler.json")
+	if _, err := os.Stat(flat); err == nil {
+		return flat, nil
 	}
-	if resp.URL == "" {
-		return fmt.Errorf("artifact upload url response was empty")
+	matches, _ := filepath.Glob(filepath.Join(distDir, "*", "wrangler.json"))
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no wrangler.json under %s — `flue build --target cloudflare` produced no Cloudflare build", distDir)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("multiple wrangler.json under %s (%v) — ambiguous flue build output", distDir, matches)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, resp.URL, bytes.NewReader(tarGz))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/gzip")
-	req.ContentLength = int64(len(tarGz))
-	put, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("upload artifact: %w", err)
-	}
-	defer put.Body.Close()
-	if put.StatusCode >= 300 {
-		snippet, _ := io.ReadAll(io.LimitReader(put.Body, 512))
-		return fmt.Errorf("artifact upload failed (HTTP %d): %s", put.StatusCode, string(snippet))
-	}
-	return nil
 }

--- a/cmd/oc/internal/commands/agent_deploy_flue_test.go
+++ b/cmd/oc/internal/commands/agent_deploy_flue_test.go
@@ -1,47 +1,45 @@
 package commands
 
-// Contract-mock end-to-end for the Flue deploy flow. A fake control plane
-// implements contract 3 (POST /v3/agents/:id/artifacts + the presigned PUT) and
-// contract 10 (deployment create + a verifying→ready poll). A throwaway
-// `node_modules/.bin/oc-flue-build` script stands in for @opencomputer/flue, so
-// the real runFlueBuild exec path runs and produces a dist-oc/. deployFlue is
-// driven end to end; we assert the uploaded bytes are byte-exactly the canonical
-// bundle for the digest the CLI advertised — the whole content-address chain.
+// Contract-mock end-to-end for the Flue DO deploy flow (design 013 §6). A fake
+// control plane implements the deployment create + a verifying→ready poll. A throwaway
+// `node_modules/.bin/flue` script stands in for the app's flue CLI, so the real
+// runFlueBuild exec path runs and produces a dist/<app>/ (the entry module + the
+// generated wrangler.json). deployFlue is driven end to end; we assert the POSTed
+// deployment body is the well-formed DO-deploy request: input.type=inline, no prompt,
+// no framework_artifact_digest, flue_module={filename,contentB64} carrying the base64
+// of the built entry module, flue_wrangler=the generated wrangler object, and
+// flue_agent_name=the agent.toml name — then that verifying→ready was actually polled.
 
 import (
-	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 	"testing"
 
 	"github.com/opensandbox/opensandbox/cmd/oc/internal/client"
-	"github.com/opensandbox/opensandbox/cmd/oc/internal/bundle"
 	"github.com/opensandbox/opensandbox/cmd/oc/internal/output"
 	"github.com/spf13/cobra"
 )
 
-// The exact bytes the fake build emits into dist-oc/ (heredoc appends a newline).
+// The exact bytes the fake `flue build` emits into dist/e2e_flue/ (heredoc appends a
+// trailing newline). The wrangler is nested a directory deep to also exercise the
+// dist/<app>/ discovery.
 const (
-	e2eArtifactBody = `{"entry":"oc.js","profile_version":1,"model":"anthropic/claude-sonnet-5"}`
-	e2eOcBody       = `export const agent = "e2e";`
+	e2eModuleBody   = `export default { fetch() { return new Response("ok"); } };`
+	e2eWranglerBody = `{"name":"e2e-flue","main":"index.js","compatibility_date":"2026-04-01","compatibility_flags":["nodejs_compat"],"durable_objects":{"bindings":[{"name":"AGENT","class_name":"FlueE2EAgent"}]},"migrations":[{"tag":"v1","new_sqlite_classes":["FlueE2EAgent"]}]}`
 )
 
 type fakeCP struct {
-	mu             sync.Mutex
-	self           string
-	createBody     map[string]any
-	artifactDigest string
-	artifactSize   float64
-	uploaded       []byte
-	deployBody     map[string]any
-	getCount       int
+	mu         sync.Mutex
+	createBody map[string]any
+	deployBody map[string]any
+	getCount   int
 }
 
 func (f *fakeCP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -57,21 +55,6 @@ func (f *fakeCP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case r.Method == "POST" && r.URL.Path == "/v3/agents":
 		_ = json.NewDecoder(r.Body).Decode(&f.createBody)
 		writeJSON(map[string]any{"id": "agt_e2e", "name": "e2e-flue", "model": "anthropic/claude-sonnet-5", "runtime": "flue"})
-	case r.Method == "POST" && r.URL.Path == "/v3/agents/agt_e2e/artifacts":
-		var body map[string]any
-		_ = json.NewDecoder(r.Body).Decode(&body)
-		f.artifactDigest, _ = body["digest"].(string)
-		f.artifactSize, _ = body["size_bytes"].(float64)
-		writeJSON(map[string]any{"url": f.self + "/upload/" + f.artifactDigest, "expires_at": "2099-01-01T00:00:00Z"})
-	case r.Method == "PUT" && strings.HasPrefix(r.URL.Path, "/upload/"):
-		if ct := r.Header.Get("Content-Type"); ct != "application/gzip" {
-			http.Error(w, "bad content-type: "+ct, http.StatusBadRequest)
-			return
-		}
-		buf := new(bytes.Buffer)
-		_, _ = buf.ReadFrom(r.Body)
-		f.uploaded = buf.Bytes()
-		w.WriteHeader(http.StatusOK)
 	case r.Method == "POST" && r.URL.Path == "/v3/agents/agt_e2e/deployments":
 		_ = json.NewDecoder(r.Body).Decode(&f.deployBody)
 		writeJSON(map[string]any{"deployment": map[string]any{"id": "dep_1", "state": "verifying"}})
@@ -89,39 +72,27 @@ func (f *fakeCP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func TestDeployFlueEndToEnd(t *testing.T) {
+func TestDeployFlueDoEndToEnd(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("fake oc-flue-build is a POSIX shell script")
+		t.Skip("fake flue build is a POSIX shell script")
 	}
 
-	// A Flue app dir: manifest + clean source + a stand-in build bin.
+	// A Flue app dir: manifest + clean source + a stand-in `flue` bin whose
+	// `build --target cloudflare` writes a deterministic dist/e2e_flue/.
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "agent.toml"),
 		"name  = \"e2e-flue\"\nmodel = \"anthropic/claude-sonnet-5\"\n\n[runtime]\nfamily = \"flue\"\n", 0o644)
 	writeFile(t, filepath.Join(dir, "src", "opencomputer.ts"),
 		"import { serveOC } from '@opencomputer/flue';\nexport default serveOC(agent);\n", 0o644)
-	// The build emits a deterministic dist-oc/ (mirrors what oc-flue-build would).
-	buildScript := "#!/bin/sh\nset -e\nmkdir -p dist-oc\n" +
-		"cat > dist-oc/artifact.json <<'JSON'\n" + e2eArtifactBody + "\nJSON\n" +
-		"cat > dist-oc/oc.js <<'JS'\n" + e2eOcBody + "\nJS\n"
-	writeFile(t, filepath.Join(dir, "node_modules", ".bin", "oc-flue-build"), buildScript, 0o755)
-
-	// What the CLI must produce from that dist-oc/ (mode normalized to 0644).
-	expectedFiles := []bundle.File{
-		{Path: "artifact.json", Mode: 0o644, Content: []byte(e2eArtifactBody + "\n")},
-		{Path: "oc.js", Mode: 0o644, Content: []byte(e2eOcBody + "\n")},
-	}
-	expectedTarGz, err := bundle.Pack(expectedFiles)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expectedDigest := bundle.Digest(expectedTarGz)
+	buildScript := "#!/bin/sh\nset -e\nmkdir -p dist/e2e_flue\n" +
+		"cat > dist/e2e_flue/index.js <<'JS'\n" + e2eModuleBody + "\nJS\n" +
+		"cat > dist/e2e_flue/wrangler.json <<'JSON'\n" + e2eWranglerBody + "\nJSON\n"
+	writeFile(t, filepath.Join(dir, "node_modules", ".bin", "flue"), buildScript, 0o755)
 
 	// Fake control plane.
 	f := &fakeCP{}
 	srv := httptest.NewServer(f)
 	defer srv.Close()
-	f.self = srv.URL
 
 	// Drive the real deployFlue.
 	sc := client.NewSessionsAPI(srv.URL, "test-key")
@@ -149,30 +120,53 @@ func TestDeployFlueEndToEnd(t *testing.T) {
 		t.Errorf("create body carried a prompt for a flue agent: %v", f.createBody["prompt"])
 	}
 
-	// Content address the CLI advertised == the digest of the known fileset.
-	if f.artifactDigest != expectedDigest {
-		t.Errorf("advertised digest = %s, want %s", f.artifactDigest, expectedDigest)
-	}
-	// size_bytes is honest, and the PUT body is byte-exactly the canonical bundle
-	// for that digest — the full upload integrity chain.
-	if int(f.artifactSize) != len(f.uploaded) {
-		t.Errorf("size_bytes %d != uploaded len %d", int(f.artifactSize), len(f.uploaded))
-	}
-	if !bytes.Equal(f.uploaded, expectedTarGz) {
-		t.Errorf("uploaded bytes are not the canonical bundle for the digest (len got %d want %d)", len(f.uploaded), len(expectedTarGz))
-	}
-
-	// Deployment referenced the same digest, via input.framework_artifact_digest.
+	// The DO-deploy request body is well-formed.
 	input, _ := f.deployBody["input"].(map[string]any)
 	if input == nil {
 		t.Fatalf("deployment body had no input: %v", f.deployBody)
 	}
-	if input["framework_artifact_digest"] != expectedDigest {
-		t.Errorf("deployment digest = %v, want %s", input["framework_artifact_digest"], expectedDigest)
+	if input["type"] != "inline" {
+		t.Errorf("input.type = %v, want inline", input["type"])
 	}
+	if f.deployBody["activate"] != true {
+		t.Errorf("activate = %v, want true (no --no-activate)", f.deployBody["activate"])
+	}
+	if input["flue_agent_name"] != "e2e-flue" {
+		t.Errorf("flue_agent_name = %v, want e2e-flue", input["flue_agent_name"])
+	}
+	// The DO model must NOT carry the pre-013 fields.
 	if _, ok := input["prompt"]; ok {
-		t.Errorf("deployment input carried a prompt: %v", input["prompt"])
+		t.Errorf("flue DO deploy carried a prompt: %v", input["prompt"])
 	}
+	if _, ok := input["framework_artifact_digest"]; ok {
+		t.Errorf("flue DO deploy carried a framework_artifact_digest: %v", input["framework_artifact_digest"])
+	}
+
+	// flue_module: filename from wrangler.main, contentB64 = base64 of the built entry.
+	mod, _ := input["flue_module"].(map[string]any)
+	if mod == nil {
+		t.Fatalf("input.flue_module missing: %v", input)
+	}
+	if mod["filename"] != "index.js" {
+		t.Errorf("flue_module.filename = %v, want index.js (from wrangler.main)", mod["filename"])
+	}
+	wantB64 := base64.StdEncoding.EncodeToString([]byte(e2eModuleBody + "\n"))
+	if mod["contentB64"] != wantB64 {
+		t.Errorf("flue_module.contentB64 is not the base64 of the built entry module")
+	}
+
+	// flue_wrangler: the generated wrangler forwarded verbatim (DO bindings intact).
+	wr, _ := input["flue_wrangler"].(map[string]any)
+	if wr == nil {
+		t.Fatalf("input.flue_wrangler missing: %v", input)
+	}
+	if wr["main"] != "index.js" {
+		t.Errorf("flue_wrangler.main = %v, want index.js", wr["main"])
+	}
+	if wr["durable_objects"] == nil {
+		t.Errorf("flue_wrangler lost durable_objects: %v", wr)
+	}
+
 	// The verifying→ready sequence was actually polled.
 	if f.getCount < 2 {
 		t.Errorf("expected the poll to observe verifying→ready (got %d GETs)", f.getCount)

--- a/cmd/oc/internal/commands/agent_deploy_flue_test.go
+++ b/cmd/oc/internal/commands/agent_deploy_flue_test.go
@@ -1,45 +1,53 @@
 package commands
 
-// Contract-mock end-to-end for the Flue DO deploy flow (design 013 §6). A fake
-// control plane implements the deployment create + a verifying→ready poll. A throwaway
+// Contract-mock end-to-end for the Flue DO deploy flow (design 013 §6). A fake control
+// plane implements the presigned-PUT bundle upload (POST /v3/agents/:id/artifacts + the
+// signed PUT) and the deployment create + a verifying→ready poll. A throwaway
 // `node_modules/.bin/flue` script stands in for the app's flue CLI, so the real
-// runFlueBuild exec path runs and produces a dist/<app>/ (the entry module + the
-// generated wrangler.json). deployFlue is driven end to end; we assert the POSTed
-// deployment body is the well-formed DO-deploy request: input.type=inline, no prompt,
-// no framework_artifact_digest, flue_module={filename,contentB64} carrying the base64
-// of the built entry module, flue_wrangler=the generated wrangler object, and
-// flue_agent_name=the agent.toml name — then that verifying→ready was actually polled.
+// runFlueBuild exec path runs and produces a dist/<app>/ with the entry module + an
+// assets/ file. deployFlue is driven end to end; we assert the uploaded bytes are
+// byte-exactly the canonical tar.gz of the whole build dir for the digest the CLI
+// advertised (the content-address chain), and that the POSTed deployment body is the
+// byte-free DO request: flue_bundle_digest + flue_wrangler + flue_agent_name, with no
+// module bytes / no framework_artifact_digest.
 
 import (
+	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 
+	"github.com/opensandbox/opensandbox/cmd/oc/internal/bundle"
 	"github.com/opensandbox/opensandbox/cmd/oc/internal/client"
 	"github.com/opensandbox/opensandbox/cmd/oc/internal/output"
 	"github.com/spf13/cobra"
 )
 
 // The exact bytes the fake `flue build` emits into dist/e2e_flue/ (heredoc appends a
-// trailing newline). The wrangler is nested a directory deep to also exercise the
-// dist/<app>/ discovery.
+// trailing newline). The build is nested a directory deep, with an assets/ file, to
+// exercise the dist/<app>/ discovery and prove the WHOLE tree is staged.
 const (
 	e2eModuleBody   = `export default { fetch() { return new Response("ok"); } };`
+	e2eAssetBody    = `export const chunk = 1;`
 	e2eWranglerBody = `{"name":"e2e-flue","main":"index.js","compatibility_date":"2026-04-01","compatibility_flags":["nodejs_compat"],"durable_objects":{"bindings":[{"name":"AGENT","class_name":"FlueE2EAgent"}]},"migrations":[{"tag":"v1","new_sqlite_classes":["FlueE2EAgent"]}]}`
 )
 
 type fakeCP struct {
-	mu         sync.Mutex
-	createBody map[string]any
-	deployBody map[string]any
-	getCount   int
+	mu             sync.Mutex
+	self           string
+	createBody     map[string]any
+	artifactDigest string
+	artifactSize   float64
+	uploaded       []byte
+	deployBody     map[string]any
+	getCount       int
 }
 
 func (f *fakeCP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -55,6 +63,21 @@ func (f *fakeCP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case r.Method == "POST" && r.URL.Path == "/v3/agents":
 		_ = json.NewDecoder(r.Body).Decode(&f.createBody)
 		writeJSON(map[string]any{"id": "agt_e2e", "name": "e2e-flue", "model": "anthropic/claude-sonnet-5", "runtime": "flue"})
+	case r.Method == "POST" && r.URL.Path == "/v3/agents/agt_e2e/artifacts":
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		f.artifactDigest, _ = body["digest"].(string)
+		f.artifactSize, _ = body["size_bytes"].(float64)
+		writeJSON(map[string]any{"url": f.self + "/upload/" + f.artifactDigest, "expires_at": "2099-01-01T00:00:00Z"})
+	case r.Method == "PUT" && strings.HasPrefix(r.URL.Path, "/upload/"):
+		if ct := r.Header.Get("Content-Type"); ct != "application/gzip" {
+			http.Error(w, "bad content-type: "+ct, http.StatusBadRequest)
+			return
+		}
+		buf := new(bytes.Buffer)
+		_, _ = buf.ReadFrom(r.Body)
+		f.uploaded = buf.Bytes()
+		w.WriteHeader(http.StatusOK)
 	case r.Method == "POST" && r.URL.Path == "/v3/agents/agt_e2e/deployments":
 		_ = json.NewDecoder(r.Body).Decode(&f.deployBody)
 		writeJSON(map[string]any{"deployment": map[string]any{"id": "dep_1", "state": "verifying"}})
@@ -78,21 +101,37 @@ func TestDeployFlueDoEndToEnd(t *testing.T) {
 	}
 
 	// A Flue app dir: manifest + clean source + a stand-in `flue` bin whose
-	// `build --target cloudflare` writes a deterministic dist/e2e_flue/.
+	// `build --target cloudflare` writes a deterministic dist/e2e_flue/ (entry + asset
+	// + wrangler), a directory deep.
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "agent.toml"),
 		"name  = \"e2e-flue\"\nmodel = \"anthropic/claude-sonnet-5\"\n\n[runtime]\nfamily = \"flue\"\n", 0o644)
 	writeFile(t, filepath.Join(dir, "src", "opencomputer.ts"),
 		"import { serveOC } from '@opencomputer/flue';\nexport default serveOC(agent);\n", 0o644)
-	buildScript := "#!/bin/sh\nset -e\nmkdir -p dist/e2e_flue\n" +
+	buildScript := "#!/bin/sh\nset -e\nmkdir -p dist/e2e_flue/assets\n" +
 		"cat > dist/e2e_flue/index.js <<'JS'\n" + e2eModuleBody + "\nJS\n" +
+		"cat > dist/e2e_flue/assets/chunk.js <<'JS'\n" + e2eAssetBody + "\nJS\n" +
 		"cat > dist/e2e_flue/wrangler.json <<'JSON'\n" + e2eWranglerBody + "\nJSON\n"
 	writeFile(t, filepath.Join(dir, "node_modules", ".bin", "flue"), buildScript, 0o755)
+
+	// What the CLI must produce from that dist/e2e_flue/ (modes normalized to 0644,
+	// rooted at the wrangler's dir so index.js/assets are at the tar root).
+	expectedFiles := []bundle.File{
+		{Path: "index.js", Mode: 0o644, Content: []byte(e2eModuleBody + "\n")},
+		{Path: "assets/chunk.js", Mode: 0o644, Content: []byte(e2eAssetBody + "\n")},
+		{Path: "wrangler.json", Mode: 0o644, Content: []byte(e2eWranglerBody + "\n")},
+	}
+	expectedTarGz, err := bundle.Pack(expectedFiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedDigest := bundle.Digest(expectedTarGz)
 
 	// Fake control plane.
 	f := &fakeCP{}
 	srv := httptest.NewServer(f)
 	defer srv.Close()
+	f.self = srv.URL
 
 	// Drive the real deployFlue.
 	sc := client.NewSessionsAPI(srv.URL, "test-key")
@@ -120,7 +159,19 @@ func TestDeployFlueDoEndToEnd(t *testing.T) {
 		t.Errorf("create body carried a prompt for a flue agent: %v", f.createBody["prompt"])
 	}
 
-	// The DO-deploy request body is well-formed.
+	// The content address the CLI advertised == the digest of the whole-dir bundle, and
+	// the PUT body is byte-exactly that canonical tar.gz — the full upload integrity chain.
+	if f.artifactDigest != expectedDigest {
+		t.Errorf("advertised digest = %s, want %s", f.artifactDigest, expectedDigest)
+	}
+	if int(f.artifactSize) != len(f.uploaded) {
+		t.Errorf("size_bytes %d != uploaded len %d", int(f.artifactSize), len(f.uploaded))
+	}
+	if !bytes.Equal(f.uploaded, expectedTarGz) {
+		t.Errorf("uploaded bytes are not the canonical bundle for the digest (len got %d want %d)", len(f.uploaded), len(expectedTarGz))
+	}
+
+	// The deployment body is the byte-free DO request.
 	input, _ := f.deployBody["input"].(map[string]any)
 	if input == nil {
 		t.Fatalf("deployment body had no input: %v", f.deployBody)
@@ -131,28 +182,21 @@ func TestDeployFlueDoEndToEnd(t *testing.T) {
 	if f.deployBody["activate"] != true {
 		t.Errorf("activate = %v, want true (no --no-activate)", f.deployBody["activate"])
 	}
+	if input["flue_bundle_digest"] != expectedDigest {
+		t.Errorf("flue_bundle_digest = %v, want %s", input["flue_bundle_digest"], expectedDigest)
+	}
 	if input["flue_agent_name"] != "e2e-flue" {
 		t.Errorf("flue_agent_name = %v, want e2e-flue", input["flue_agent_name"])
 	}
-	// The DO model must NOT carry the pre-013 fields.
+	// No module bytes, no pre-013 digest field.
+	if _, ok := input["flue_module"]; ok {
+		t.Errorf("byte-free contract violated: input carried flue_module: %v", input["flue_module"])
+	}
 	if _, ok := input["prompt"]; ok {
 		t.Errorf("flue DO deploy carried a prompt: %v", input["prompt"])
 	}
 	if _, ok := input["framework_artifact_digest"]; ok {
 		t.Errorf("flue DO deploy carried a framework_artifact_digest: %v", input["framework_artifact_digest"])
-	}
-
-	// flue_module: filename from wrangler.main, contentB64 = base64 of the built entry.
-	mod, _ := input["flue_module"].(map[string]any)
-	if mod == nil {
-		t.Fatalf("input.flue_module missing: %v", input)
-	}
-	if mod["filename"] != "index.js" {
-		t.Errorf("flue_module.filename = %v, want index.js (from wrangler.main)", mod["filename"])
-	}
-	wantB64 := base64.StdEncoding.EncodeToString([]byte(e2eModuleBody + "\n"))
-	if mod["contentB64"] != wantB64 {
-		t.Errorf("flue_module.contentB64 is not the base64 of the built entry module")
 	}
 
 	// flue_wrangler: the generated wrangler forwarded verbatim (DO bindings intact).


### PR DESCRIPTION
## `oc agent deploy` for the flue Worker-DO model (W7-c)

Reworks the flue branch of `oc agent deploy` for the WfP Durable-Object model (design 013 §6). The CLI builds with the app's own `flue` CLI, stages the whole built dir in R2, and hands the control plane only a digest ref + the generated wrangler — **the API host stays byte-free** (no module bytes in the JSON). The CP composes + mints the per-deploy token + WfP-uploads + canary-verifies off-host; the CF creds and signing key never leave the server.

**`deployFlue` flow** (`cmd/oc/internal/commands/agent_deploy_flue.go`)
1. `credscan.ScanDir(dir)` — kept, client-side (model keys come from the OC credential, never code).
2. `resolveDeployAgent` — unchanged (create runtime=flue, no prompt, if new).
3. `flue build --target cloudflare` via `node_modules/.bin/flue` (falls back to `npx --no-install flue`).
4. tar.gz the **whole build dir** (entry module + the `no_bundle` `assets/` tree + wrangler.json), rooted at the wrangler's dir so `wrangler.main` resolves at the bundle root. `digest = sha256:<hex>` of the tar.gz.
5. Presigned R2 PUT: `POST /v3/agents/<id>/artifacts {digest,size_bytes}` → `{url}` (or `{already_uploaded:true}` → skip), then PUT the tar.gz (`application/gzip`).
6. `POST /v3/agents/<id>/deployments`:
   ```json
   { "input": { "type": "inline", "model": "<agent.toml model>",
       "flue_bundle_digest": "sha256:<hex of the tar.gz>",
       "flue_wrangler": <generated wrangler.json object>,
       "flue_agent_name": "<agent.toml name>" },
     "activate": <!--no-activate> }
   ```
7. Reuse `pollDeployment` (verifying → ready|failed).

Rollback / revisions / status verbs unchanged.

**Byte-free contract (updated).** An earlier revision of this PR sent `flue_module:{filename,contentB64}` inline. Per the contract change, the API host is now byte-free: the module bytes never ride the JSON. Staging the whole dir also resolves the multi-module reality of `flue build` (`main: index.js` + `no_bundle` + `assets/*.js`) — the entry and its chunk tree travel together in the one tar.gz; the off-host runner fetches, unpacks, and WfP-uploads. Matches the CP side on `sessions-api flue-w7-deploy` (`core/flue-do-deploy.ts` `enqueueFlueDoDeploy` — byte-free enqueue; digest = sha256 of the tar.gz; requires `wrangler.main` + `flue_agent_name`).

**Robustness (grounded in the real `flue build` output):** the wrangler is at the nested `dist/<app>/wrangler.json` (also accepts flat `dist/`), strict JSON, forwarded verbatim; the entry filename is read from `wrangler.main` (real value `index.js`) and asserted present in the bundle.

**Test — `go test ./cmd/oc/internal/commands/ -run TestDeployFlue` → PASS** (build/vet green, gofmt clean):
- `TestDeployFlueDoEndToEnd` drives the **real** `deployFlue` against a fake `flue` build (a POSIX script emitting `dist/e2e_flue/{index.js, assets/chunk.js, wrangler.json}`) + a fake CP; asserts the uploaded PUT body is **byte-exactly** the canonical tar.gz of the whole dir (so `flue_bundle_digest` == `bundle.Digest`), `size_bytes` == uploaded length, and the deployment body is byte-free — `flue_bundle_digest` + `flue_wrangler` (DO bindings intact) + `flue_agent_name`, with **no** `flue_module`, no `prompt`, no `framework_artifact_digest` — then verifying→ready was actually polled.
- `TestDeployFlueBlocksOnLeakedKey` — the credscan gate still blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
