### PR TITLE
Signup flow

### DIFF
--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -1039,6 +1039,31 @@ export async function handleDashboard(
     if (!cell) return json({ error: "home cell unavailable" }, 503);
     return proxyToCell(req, env, caller, cell, `/internal/dashboard${sub}`);
   }
+
+  // ── sandboxes: one-click create from the dashboard → the org's home cell.
+  // Reuses the cap-token /internal/sandboxes/create path (same token shape the
+  // /api/sandboxes create mints); the cell stamps ownership from the token's org.
+  if (sub === "/sandboxes" && method === "POST") {
+    const cell = await homeCell(env, caller.orgID);
+    if (!cell) return json({ error: "home cell unavailable" }, 503);
+    return proxyToCell(req, env, caller, cell, "/internal/sandboxes/create");
+  }
+
+  // ── sandbox preview URLs: expose/list/unexpose a port on a running sandbox.
+  // Proxies to the public /api/sandboxes/:id/preview, which accepts this same
+  // edge cap-token (PGAPIKeyMiddleware validates it and sets the org), so no
+  // cell-side handler is needed. POST create, GET list, DELETE /:port unexpose.
+  {
+    const pv = sub.match(/^\/sandboxes\/([^/]+)\/preview(?:\/(\d+))?$/);
+    if (pv) {
+      const cell = await homeCell(env, caller.orgID);
+      if (!cell) return json({ error: "home cell unavailable" }, 503);
+      const cellPath = pv[2]
+        ? `/api/sandboxes/${pv[1]}/preview/${pv[2]}`
+        : `/api/sandboxes/${pv[1]}/preview`;
+      return proxyToCell(req, env, caller, cell, cellPath);
+    }
+  }
   if (sub === "/billing/agent-subscriptions" && method === "GET") return handleListAgentSubscriptions(req, env, caller);
 
   // /billing — basic billing read used by the dashboard billing page.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -33,6 +33,7 @@ export default function App() {
         <Route element={<ProtectedRoute />}>
           <Route element={<AppShell />}>
             <Route index element={<Dashboard />} />
+            <Route path="getting-started" element={<Dashboard />} />
             {/* Agent plane */}
             <Route path="agents" element={<Agents />} />
             <Route path="agents/:agentId" element={<AgentDetail />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -180,6 +180,35 @@ export const getSandboxes = (status?: string) =>
     S.SandboxListSchema,
   )
 
+// Create a sandbox from the dashboard. Proxied by the edge to the org's home
+// cell (POST /api/dashboard/sandboxes → cell /internal/sandboxes/create with a
+// cap-token), so the box is owned by + billed to the logged-in org. Returns the
+// new sandbox id so the caller can navigate straight into its live terminal.
+export const createSandbox = (body: {
+  memoryMB?: number
+  cpuCount?: number
+  networkEnabled?: boolean
+  image?: string
+}) =>
+  apiFetch<{ sandboxID: string; status?: string }>('/sandboxes', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+
+// Expose a port on a running sandbox → a public preview URL (proxied edge→cell
+// to the cap-token-authed /api/sandboxes/:id/preview). Returns the registered
+// row incl. hostname; the sandbox detail page renders it in Preview URLs.
+export const createPreviewUrl = (sandboxId: string, port: number) =>
+  apiFetch<{ id: string; sandboxId: string; hostname: string; port: number }>(
+    `/sandboxes/${sandboxId}/preview`,
+    { method: 'POST', body: JSON.stringify({ port }) },
+  )
+
+export const deletePreviewUrl = (sandboxId: string, port: number) =>
+  apiFetch<void>(`/sandboxes/${sandboxId}/preview/${port}`, {
+    method: 'DELETE',
+  })
+
 export const getAPIKeys = () =>
   apiFetch('/api-keys', {}, z.array(S.APIKeySchema))
 

--- a/web/src/components/Terminal.tsx
+++ b/web/src/components/Terminal.tsx
@@ -9,14 +9,30 @@ import { cn } from '@/lib/utils'
 interface TerminalProps {
   sandboxId: string
   onClose?: () => void
+  /** Typed into the shell once connected — used by dashboard example chips. */
+  startupCommand?: string
+  /** Fired once after the startup command is sent (parent clears it so a
+   * later manual reopen of the terminal doesn't re-run it). */
+  onStarted?: () => void
 }
 
-export default function Terminal({ sandboxId, onClose }: TerminalProps) {
+export default function Terminal({
+  sandboxId,
+  onClose,
+  startupCommand,
+  onStarted,
+}: TerminalProps) {
   const termRef = useRef<HTMLDivElement>(null)
   const xtermRef = useRef<XTerm | null>(null)
   const wsRef = useRef<WebSocket | null>(null)
   const fitRef = useRef<FitAddon | null>(null)
   const ptySessionIdRef = useRef<string | null>(null)
+  // Latest-value refs so the PTY effect can stay keyed on [sandboxId] alone
+  // (a changing startupCommand/onStarted must not tear down the connection).
+  const startupRef = useRef(startupCommand)
+  startupRef.current = startupCommand
+  const onStartedRef = useRef(onStarted)
+  onStartedRef.current = onStarted
   const [status, setStatus] = useState<
     'connecting' | 'connected' | 'disconnected' | 'error'
   >('connecting')
@@ -122,6 +138,16 @@ export default function Terminal({ sandboxId, onClose }: TerminalProps) {
           setStatus('connected')
           term.clear()
           term.focus()
+          // Auto-run a starter command (from a dashboard example chip). Small
+          // delay so the shell's first prompt has painted before we type in.
+          const cmd = startupRef.current
+          if (cmd) {
+            setTimeout(() => {
+              if (disposed || ws.readyState !== WebSocket.OPEN) return
+              ws.send(new TextEncoder().encode(cmd + '\n'))
+              onStartedRef.current?.()
+            }, 500)
+          }
         }
 
         ws.onmessage = (event) => {

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -3,6 +3,7 @@ import { Link, NavLink, Outlet, useLocation } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import {
   LayoutGrid,
+  Rocket,
   Bot,
   MessagesSquare,
   Monitor,
@@ -55,7 +56,12 @@ type NavGroup = { label?: string; items: NavItem[] }
 // (sandbox) plane, plus account/org. Groups render with spacing + a small muted
 // label rather than hard dividers.
 const NAV: NavGroup[] = [
-  { items: [{ to: '/', label: 'Dashboard', icon: LayoutGrid, end: true }] },
+  {
+    items: [
+      { to: '/', label: 'Dashboard', icon: LayoutGrid, end: true },
+      { to: '/getting-started', label: 'Getting started', icon: Rocket },
+    ],
+  },
   {
     label: 'Agents',
     items: [

--- a/web/src/components/code-off-ramp.tsx
+++ b/web/src/components/code-off-ramp.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react'
+import { Check, ChevronDown, Code2, Copy, ExternalLink } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useTransientFlag } from '@/lib/use-transient-flag'
+import { notifyError } from '@/lib/errors'
+import { cn } from '@/lib/utils'
+
+export type CodeTab = { label: string; code: string }
+
+/**
+ * A collapsible "dev off-ramp": a muted "</> Show code" toggle that expands to
+ * tabbed, copyable code (SDK / CLI / cURL) for whatever the adjacent one-click
+ * button does under the hood. Collapsed by default so it never touches the
+ * guided happy path — technical users pop it to see that the dashboard is just a
+ * thin client over the public API/SDK, and copy the exact call.
+ */
+export function CodeOffRamp({
+  tabs,
+  docs,
+  label = 'Show code',
+  className,
+}: {
+  tabs: CodeTab[]
+  docs?: string
+  label?: string
+  className?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const [active, setActive] = useState(0)
+  const [copied, markCopied] = useTransientFlag(1500)
+
+  const current = tabs[active] ?? tabs[0]
+
+  const copy = () => {
+    void navigator.clipboard.writeText(current.code).then(
+      () => markCopied(),
+      (e: unknown) => notifyError("Couldn't copy to clipboard.", e),
+    )
+  }
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 text-xs font-medium transition-colors"
+        aria-expanded={open}
+      >
+        <Code2 className="size-3.5" />
+        {label}
+        <ChevronDown
+          className={cn(
+            'size-3.5 transition-transform',
+            open ? '' : '-rotate-90',
+          )}
+        />
+      </button>
+
+      {open ? (
+        <div className="mt-2 overflow-hidden rounded-md border">
+          <div className="bg-panel-2 flex items-center gap-1 border-b px-2 py-1.5">
+            {tabs.map((t, i) => (
+              <button
+                key={t.label}
+                type="button"
+                onClick={() => setActive(i)}
+                className={cn(
+                  'rounded px-2 py-1 text-xs font-medium transition-colors',
+                  i === active
+                    ? 'bg-background text-foreground'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                {t.label}
+              </button>
+            ))}
+            <div className="flex-1" />
+            {docs ? (
+              <a
+                href={docs}
+                target="_blank"
+                rel="noreferrer"
+                className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 px-2 py-1 text-xs underline-offset-4 hover:underline"
+              >
+                Docs
+                <ExternalLink className="size-3" />
+              </a>
+            ) : null}
+            <Button variant="ghost" size="xs" onClick={copy}>
+              {copied ? (
+                <Check className="size-3.5" />
+              ) : (
+                <Copy className="size-3.5" />
+              )}
+              {copied ? 'Copied' : 'Copy'}
+            </Button>
+          </div>
+          <pre className="bg-panel-2 overflow-x-auto px-3 py-3 text-[12.5px] leading-relaxed">
+            <code className="text-foreground font-mono">{current.code}</code>
+          </pre>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/web/src/components/connect-panel.tsx
+++ b/web/src/components/connect-panel.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react'
+import { Check, Copy } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import { Panel } from '@/components/panel'
+import { Button } from '@/components/ui/button'
+import { useTransientFlag } from '@/lib/use-transient-flag'
+import { notifyError } from '@/lib/errors'
+import { cn } from '@/lib/utils'
+
+type Lang = 'shell' | 'ts' | 'python'
+
+const TABS: { key: Lang; label: string }[] = [
+  { key: 'shell', label: 'Shell' },
+  { key: 'ts', label: 'TypeScript' },
+  { key: 'python', label: 'Python' },
+]
+
+// Real, copy-and-go snippets for reaching THIS sandbox by id. The SDK/CLI both
+// read the key from OPENCOMPUTER_API_KEY (or `oc config`), so we never inline a
+// secret — the placeholder + API-keys link is the auth story.
+function snippetFor(lang: Lang, id: string): string {
+  switch (lang) {
+    case 'shell':
+      return [
+        '# one-time: point the CLI at your account',
+        'oc config set api-key <your-key>',
+        '',
+        '# drop into an interactive shell on this sandbox',
+        `oc shell ${id}`,
+      ].join('\n')
+    case 'ts':
+      return [
+        '// npm i @opencomputer/sdk   ·   export OPENCOMPUTER_API_KEY=<your-key>',
+        'import { Sandbox } from "@opencomputer/sdk"',
+        '',
+        `const sandbox = await Sandbox.connect("${id}")`,
+        'const { stdout } = await sandbox.exec.run("echo hello from code")',
+        'console.log(stdout)',
+      ].join('\n')
+    case 'python':
+      return [
+        '# pip install opencomputer-sdk   ·   export OPENCOMPUTER_API_KEY=<your-key>',
+        'import asyncio',
+        'from opencomputer import Sandbox',
+        '',
+        'async def main():',
+        `    sandbox = await Sandbox.connect("${id}")`,
+        '    result = await sandbox.exec.run("echo hello from code")',
+        '    print(result.stdout)',
+        '',
+        'asyncio.run(main())',
+      ].join('\n')
+  }
+}
+
+function CodeBlock({ code }: { code: string }) {
+  const [copied, markCopied] = useTransientFlag(1500)
+  const copy = () => {
+    void navigator.clipboard.writeText(code).then(
+      () => markCopied(),
+      (e: unknown) => notifyError("Couldn't copy to clipboard.", e),
+    )
+  }
+  return (
+    <div className="bg-panel-2 relative overflow-hidden rounded-md border">
+      <Button
+        variant="ghost"
+        size="xs"
+        onClick={copy}
+        className="text-muted-foreground hover:text-foreground absolute top-2 right-2 z-10"
+      >
+        {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+        {copied ? 'Copied' : 'Copy'}
+      </Button>
+      <pre className="text-foreground overflow-x-auto px-3 py-3 pr-20 font-mono text-[12.5px] leading-relaxed">
+        {code}
+      </pre>
+    </div>
+  )
+}
+
+/**
+ * "Connect" reference for a sandbox — shell in via the CLI or drive it from the
+ * TypeScript / Python SDKs, prefilled with this sandbox's id.
+ */
+export function ConnectPanel({ sandboxId }: { sandboxId: string }) {
+  const [lang, setLang] = useState<Lang>('shell')
+  return (
+    <Panel className="p-6">
+      <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-sm font-semibold">Connect</h2>
+          <p className="text-muted-foreground mt-0.5 text-xs">
+            Shell in or drive this sandbox from your code.
+          </p>
+        </div>
+        <div className="bg-secondary inline-flex w-fit rounded-md p-0.5">
+          {TABS.map((t) => (
+            <button
+              key={t.key}
+              type="button"
+              onClick={() => setLang(t.key)}
+              className={cn(
+                'rounded px-3 py-1 text-xs font-medium transition-colors',
+                lang === t.key
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <CodeBlock code={snippetFor(lang, sandboxId)} />
+
+      <p className="text-muted-foreground mt-3 text-xs">
+        Need a key?{' '}
+        <Link
+          to="/api-keys"
+          className="text-foreground font-medium underline underline-offset-4"
+        >
+          Create one on the API Keys page
+        </Link>
+        .
+      </p>
+    </Panel>
+  )
+}

--- a/web/src/components/guided-tour.tsx
+++ b/web/src/components/guided-tour.tsx
@@ -1,0 +1,294 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import {
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  Copy,
+  ExternalLink,
+  X,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { type CodeTab } from '@/components/code-off-ramp'
+import { useTransientFlag } from '@/lib/use-transient-flag'
+import { cn } from '@/lib/utils'
+
+export type GuideStep = {
+  /** The real UI element this step points at (spotlighted). */
+  target: React.RefObject<HTMLElement | null>
+  title: string
+  body: string
+  /** The API call that produced this region, e.g. "POST /v3/sessions". */
+  api?: string
+  /** Tabbed, copyable snippets of the real call (SDK / CLI / API). */
+  code?: CodeTab[]
+  docs?: string
+}
+
+const CALLOUT_W = 520
+const PAD = 8
+const M = 16 // viewport margin
+const GAP = 12 // gap between spotlight and callout
+
+const clamp = (v: number, lo: number, hi: number) =>
+  Math.max(lo, Math.min(v, hi))
+
+/**
+ * A first-run guided overlay: spotlights real UI regions on the destination view
+ * and, beside each, explains what it is + the exact public API call that
+ * produced it, with SDK / CLI / API tabs so people can jump to the path they
+ * care about. Non-blocking (the page behind stays usable); resize/scroll-safe.
+ */
+export function GuidedTour({
+  steps,
+  open,
+  onClose,
+}: {
+  steps: GuideStep[]
+  open: boolean
+  onClose: () => void
+}) {
+  const [i, setI] = useState(0)
+  const [tab, setTab] = useState(0)
+  const [rect, setRect] = useState<DOMRect | null>(null)
+  const [copied, markCopied] = useTransientFlag(1500)
+  const calloutRef = useRef<HTMLDivElement>(null)
+  const [calloutH, setCalloutH] = useState(360)
+
+  useEffect(() => {
+    if (open) {
+      setI(0)
+      setTab(0)
+    }
+  }, [open])
+
+  // Reset the code tab whenever the step changes.
+  useEffect(() => {
+    setTab(0)
+  }, [i])
+
+  // Measure the callout's real height so placement can avoid overlapping the
+  // spotlight (a fixed estimate misplaces short/tall callouts).
+  useLayoutEffect(() => {
+    if (calloutRef.current) setCalloutH(calloutRef.current.offsetHeight)
+  }, [open, i, tab, rect])
+
+  const step = steps[i]
+
+  // Measure the current target, scroll it into view, and keep the spotlight
+  // pinned to it through the smooth-scroll settle + any resize/scroll.
+  useLayoutEffect(() => {
+    if (!open || !step) return
+    const measure = () => {
+      const el = step.target.current
+      if (el) setRect(el.getBoundingClientRect())
+    }
+    step.target.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    measure()
+    const timers = [setTimeout(measure, 150), setTimeout(measure, 450)]
+    window.addEventListener('resize', measure)
+    window.addEventListener('scroll', measure, true)
+    return () => {
+      timers.forEach(clearTimeout)
+      window.removeEventListener('resize', measure)
+      window.removeEventListener('scroll', measure, true)
+    }
+  }, [open, i, step])
+
+  // Esc closes; arrows navigate.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+      else if (e.key === 'ArrowRight' && i < steps.length - 1) setI((n) => n + 1)
+      else if (e.key === 'ArrowLeft' && i > 0) setI((n) => n - 1)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, i, steps.length, onClose])
+
+  if (!open || !step) return null
+
+  const spot = rect
+    ? {
+        top: rect.top - PAD,
+        left: rect.left - PAD,
+        width: rect.width + PAD * 2,
+        height: rect.height + PAD * 2,
+      }
+    : null
+
+  // Place the callout in whichever region around the spotlight has real room —
+  // below → above → right → left — so it never sits on top of the target. If the
+  // target is too big to clear (full-width, tall panels), dock it to the right
+  // edge (guaranteed on-screen).
+  const vw = window.innerWidth
+  const vh = window.innerHeight
+  let calloutTop = M
+  let calloutLeft = M
+  if (spot) {
+    const roomBelow = vh - (spot.top + spot.height)
+    const roomAbove = spot.top
+    const roomRight = vw - (spot.left + spot.width)
+    const roomLeft = spot.left
+    if (roomBelow >= calloutH + GAP + M) {
+      calloutTop = spot.top + spot.height + GAP
+      calloutLeft = clamp(spot.left, M, vw - CALLOUT_W - M)
+    } else if (roomAbove >= calloutH + GAP + M) {
+      calloutTop = spot.top - calloutH - GAP
+      calloutLeft = clamp(spot.left, M, vw - CALLOUT_W - M)
+    } else if (roomRight >= CALLOUT_W + GAP + M) {
+      calloutLeft = spot.left + spot.width + GAP
+      calloutTop = clamp(spot.top, M, vh - calloutH - M)
+    } else if (roomLeft >= CALLOUT_W + GAP + M) {
+      calloutLeft = spot.left - CALLOUT_W - GAP
+      calloutTop = clamp(spot.top, M, vh - calloutH - M)
+    } else {
+      calloutLeft = vw - CALLOUT_W - M
+      calloutTop = clamp(vh / 2 - calloutH / 2, M, vh - calloutH - M)
+    }
+  }
+
+  const tabs = step.code ?? []
+  const current = tabs[tab] ?? tabs[0]
+  const copy = () => {
+    if (current) void navigator.clipboard.writeText(current.code).then(markCopied)
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-[100]" role="dialog" aria-modal="false">
+      {/* Spotlight: a ring around the target with a huge box-shadow scrim so
+          everything else dims. pointer-events-none → the page stays usable. */}
+      {spot ? (
+        <div
+          className="ring-primary pointer-events-none absolute rounded-lg ring-2 transition-all duration-200"
+          style={{
+            top: spot.top,
+            left: spot.left,
+            width: spot.width,
+            height: spot.height,
+            boxShadow: '0 0 0 9999px rgba(0,0,0,0.55)',
+          }}
+        />
+      ) : (
+        <div className="pointer-events-none absolute inset-0 bg-black/55" />
+      )}
+
+      {/* Callout */}
+      <div
+        ref={calloutRef}
+        className="bg-background absolute rounded-lg border p-4 shadow-xl"
+        style={{
+          top: calloutTop,
+          left: calloutLeft,
+          width: CALLOUT_W,
+          maxWidth: 'calc(100vw - 32px)',
+        }}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <span className="text-muted-foreground text-xs">
+            Step {i + 1} of {steps.length}
+          </span>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-muted-foreground hover:text-foreground -mt-1 -mr-1"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <h3 className="text-foreground mt-1 text-sm font-semibold">
+          {step.title}
+        </h3>
+        <p className="text-muted-foreground mt-1 text-sm">{step.body}</p>
+
+        {step.api ? (
+          <div className="text-muted-foreground mt-2 font-mono text-xs">
+            {step.api}
+          </div>
+        ) : null}
+
+        {tabs.length > 0 ? (
+          <div className="bg-panel-2 mt-2 overflow-hidden rounded-md border">
+            <div className="flex items-center gap-1 border-b px-2 py-1.5">
+              {tabs.map((t, n) => (
+                <button
+                  key={t.label}
+                  type="button"
+                  onClick={() => setTab(n)}
+                  className={cn(
+                    'rounded px-2 py-1 text-xs font-medium transition-colors',
+                    n === tab
+                      ? 'bg-background text-foreground'
+                      : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  {t.label}
+                </button>
+              ))}
+              <div className="flex-1" />
+              <Button variant="ghost" size="xs" onClick={copy}>
+                {copied ? (
+                  <Check className="size-3.5" />
+                ) : (
+                  <Copy className="size-3.5" />
+                )}
+                {copied ? 'Copied' : 'Copy'}
+              </Button>
+            </div>
+            <pre className="max-h-[220px] overflow-auto px-3 py-3 text-[12.5px] leading-relaxed">
+              <code className="text-foreground font-mono whitespace-pre">
+                {current?.code}
+              </code>
+            </pre>
+          </div>
+        ) : null}
+
+        <div className="mt-3 flex items-center justify-between">
+          <div className="flex items-center gap-1.5">
+            {steps.map((_, n) => (
+              <span
+                key={n}
+                className={cn(
+                  'size-1.5 rounded-full',
+                  n === i ? 'bg-primary' : 'bg-border',
+                )}
+              />
+            ))}
+          </div>
+          <div className="flex items-center gap-2">
+            {step.docs ? (
+              <a
+                href={step.docs}
+                target="_blank"
+                rel="noreferrer"
+                className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs underline-offset-4 hover:underline"
+              >
+                Docs
+                <ExternalLink className="size-3" />
+              </a>
+            ) : null}
+            {i > 0 ? (
+              <Button variant="ghost" size="sm" onClick={() => setI((n) => n - 1)}>
+                <ArrowLeft className="size-3.5" />
+                Back
+              </Button>
+            ) : null}
+            {i < steps.length - 1 ? (
+              <Button size="sm" onClick={() => setI((n) => n + 1)}>
+                Next
+                <ArrowRight className="size-3.5" />
+              </Button>
+            ) : (
+              <Button size="sm" onClick={onClose}>
+                Done
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -31,6 +31,7 @@ import { PageHeader } from '@/components/page-header'
 import { Panel, PanelHeader, PanelTitle } from '@/components/panel'
 import { MetricCard } from '@/components/metric-card'
 import { CopyRow } from '@/components/copy-row'
+import { CodeOffRamp, type CodeTab } from '@/components/code-off-ramp'
 import { StatusBadge } from '@/components/status-badge'
 import { EmptyState } from '@/components/empty-state'
 import { ResourceTable, type Column } from '@/components/resource-table'
@@ -108,6 +109,80 @@ const SANDBOX_EXAMPLES: {
     intent: { startupCommand: SANDBOX_TRY_TOOL_CMD },
   },
   { icon: Code2, label: 'Use from code', intent: { focus: 'connect' } },
+]
+
+// Dev off-ramps: the exact public API/SDK/CLI calls each one-click card runs
+// under the hood. Surfaced (collapsed) so technical users see the dashboard is a
+// thin client over the API and can copy the real call. Kept in sync with the
+// launchMutation / createSandboxMutation bodies below.
+const AGENT_CODE: CodeTab[] = [
+  {
+    label: 'SDK',
+    code: `import { OpenComputer } from "@opencomputer/sdk";
+
+const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY });
+
+// Create a managed agent — billed to your OpenComputer credits, no model key
+const agent = await oc.agents.create({
+  name: "my-agent",
+  runtime: "claude",
+  model: "anthropic/claude-opus-4-8",
+  prompt: "You are a helpful AI assistant working in a sandboxed computer.",
+  credential: "managed",
+});
+
+// Start a session — returns a browser-safe client token you can stream from
+const session = await oc.sessions.create({
+  agent: agent.id,
+  input: "Give me a quick tour of this sandbox.",
+});
+console.log(session.id, session.clientToken);`,
+  },
+  {
+    label: 'cURL',
+    code: `# 1. Create a managed agent
+curl -X POST https://api.opencomputer.dev/v3/agents \\
+  -H "Authorization: Bearer $OPENCOMPUTER_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"name":"my-agent","runtime":"claude","model":"anthropic/claude-opus-4-8","prompt":"You are a helpful AI assistant.","credential":"managed"}'
+
+# 2. Start a session on that agent
+curl -X POST https://api.opencomputer.dev/v3/sessions \\
+  -H "Authorization: Bearer $OPENCOMPUTER_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"agent":"agt_...","input":"Give me a quick tour of this sandbox."}'`,
+  },
+]
+
+const SANDBOX_CODE: CodeTab[] = [
+  {
+    label: 'SDK',
+    code: `import { Sandbox } from "@opencomputer/sdk";
+
+const sandbox = await Sandbox.create();
+
+const result = await sandbox.commands.run("python3 --version");
+console.log(result.stdout);
+
+// It stays alive until you kill it or it idles out
+await sandbox.kill();`,
+  },
+  {
+    label: 'CLI',
+    code: `# Create a sandbox
+oc create
+
+# Run a command in it — or drop into an interactive shell
+oc exec <sandbox-id> "python3 --version"
+oc shell <sandbox-id>`,
+  },
+  {
+    label: 'cURL',
+    code: `curl -X POST https://app.opencomputer.dev/api/sandboxes \\
+  -H "X-API-Key: $OPENCOMPUTER_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"memoryMB":1024,"cpuCount":1,"networkEnabled":true}'`,
+  },
 ]
 
 // Derive a friendly first name from an email local part (brian+test81@… → "Brian").
@@ -424,7 +499,9 @@ function GettingStarted({ onBack }: { onBack?: () => void }) {
     },
     onSuccess: (session) => {
       void queryClient.invalidateQueries({ queryKey: ['agents'] })
-      void navigate(`/sessions/${session.id}`)
+      // Land on the session with the first-run guided overlay (maps this UI to
+      // the API calls that produced it). SessionDetail reads this nav state.
+      void navigate(`/sessions/${session.id}`, { state: { guide: 'agent' } })
     },
   })
   const launching = launchMutation.isPending
@@ -437,14 +514,10 @@ function GettingStarted({ onBack }: { onBack?: () => void }) {
       createSandbox({ memoryMB: 1024, cpuCount: 1, networkEnabled: true }),
     onSuccess: (sb, intent) => {
       void queryClient.invalidateQueries({ queryKey: ['sandboxes'] })
+      // Always land with the first-run guided overlay (SandboxDetail reads
+      // `guide`); the chip's intent fields order the tour to lead with its step.
       void navigate(`/sandboxes/${sb.sandboxID}`, {
-        state:
-          intent.startupCommand ||
-          intent.focus ||
-          intent.exposePort ||
-          intent.webApp
-            ? intent
-            : undefined,
+        state: { ...intent, guide: true },
       })
     },
   })
@@ -540,6 +613,11 @@ function GettingStarted({ onBack }: { onBack?: () => void }) {
               </button>
             ))}
           </div>
+          <CodeOffRamp
+            className="mt-3"
+            tabs={AGENT_CODE}
+            docs="https://docs.opencomputer.dev/agent-sessions/quickstart"
+          />
         </div>
 
         {launchMutation.isError ? (
@@ -599,11 +677,16 @@ function GettingStarted({ onBack }: { onBack?: () => void }) {
               </button>
             ))}
           </div>
+          <CodeOffRamp
+            className="mt-3"
+            tabs={SANDBOX_CODE}
+            docs="https://docs.opencomputer.dev/quickstart"
+          />
         </div>
 
         <p className="text-muted-foreground mt-3 text-xs">
           {creatingSandbox
-            ? 'Booting a fresh cloud VM — this can take 10–20s…'
+            ? 'Booting a fresh cloud VM…'
             : 'Ubuntu · Python and Node.js preinstalled · Interactive terminal'}
         </p>
         {createSandboxMutation.isError ? (

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -104,10 +104,10 @@ const SANDBOX_EXAMPLES: {
   },
   {
     icon: Terminal,
-    label: 'Try a tool instantly',
+    label: 'Try a tool',
     intent: { startupCommand: SANDBOX_TRY_TOOL_CMD },
   },
-  { icon: Code2, label: 'Drive it from code', intent: { focus: 'connect' } },
+  { icon: Code2, label: 'Use from code', intent: { focus: 'connect' } },
 ]
 
 // Derive a friendly first name from an email local part (brian+test81@… → "Brian").
@@ -487,15 +487,15 @@ function GettingStarted({ onBack }: { onBack?: () => void }) {
         </h2>
         <p className="text-muted-foreground text-sm">
           {freeCents != null && freeCents > 0
-            ? `You've got $${(freeCents / 100).toFixed(2)} in free credits — enough to run a real agent right now. No card, no setup.`
-            : 'Run a real Claude agent in a fresh sandbox — no setup, no API key required.'}
+            ? `$${(freeCents / 100).toFixed(2)} in free credits. Give your agent a real computer.`
+            : 'Run a managed Claude agent in an isolated cloud sandbox, ready in seconds.'}
         </p>
         <div className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 pt-0.5 text-xs">
-          <span>Real Claude Opus</span>
+          <span>Claude Opus</span>
           <span aria-hidden>·</span>
           <span>Isolated cloud VM</span>
           <span aria-hidden>·</span>
-          <span>Watch it work live</span>
+          <span>Real-time execution</span>
         </div>
       </div>
 
@@ -504,11 +504,11 @@ function GettingStarted({ onBack }: { onBack?: () => void }) {
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1">
             <h3 className="text-foreground text-base font-semibold">
-              Launch an agent
+              Run an agent
             </h3>
             <p className="text-muted-foreground text-sm">
-              Spin up a Claude agent in a fresh sandbox and watch it work —
-              billed to your credits, no API key.
+              Run a Claude agent in an isolated sandbox and monitor its work in
+              real time. Billed to your account credits.
             </p>
           </div>
           <Button
@@ -524,7 +524,7 @@ function GettingStarted({ onBack }: { onBack?: () => void }) {
 
         <div className="border-border/60 mt-4 border-t pt-4">
           <p className="text-muted-foreground mb-2 text-xs">
-            Or start with an example:
+            Start from a template:
           </p>
           <div className="flex flex-wrap gap-2">
             {QUICKLAUNCH_TASKS.map((t) => (
@@ -564,11 +564,11 @@ function GettingStarted({ onBack }: { onBack?: () => void }) {
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1">
             <h3 className="text-foreground text-base font-semibold">
-              Build with a sandbox
+              Work in a sandbox
             </h3>
             <p className="text-muted-foreground text-sm">
-              Spin up a real cloud computer — a full Linux shell, files, and
-              ports — and drive it from the browser or your code.
+              Provision an isolated Linux environment with full shell, file, and
+              network access. Control it from the browser or programmatically.
             </p>
           </div>
           <Button
@@ -584,7 +584,7 @@ function GettingStarted({ onBack }: { onBack?: () => void }) {
         </div>
 
         <div className="border-border/60 mt-4 border-t pt-4">
-          <p className="text-muted-foreground mb-2 text-xs">Or jump straight in:</p>
+          <p className="text-muted-foreground mb-2 text-xs">Get started:</p>
           <div className="flex flex-wrap gap-2">
             {SANDBOX_EXAMPLES.map((ex) => (
               <button
@@ -604,7 +604,7 @@ function GettingStarted({ onBack }: { onBack?: () => void }) {
         <p className="text-muted-foreground mt-3 text-xs">
           {creatingSandbox
             ? 'Booting a fresh cloud VM — this can take 10–20s…'
-            : 'Ubuntu · Python & Node preinstalled · opens a live terminal'}
+            : 'Ubuntu · Python and Node.js preinstalled · Interactive terminal'}
         </p>
         {createSandboxMutation.isError ? (
           <div className="mt-3 flex items-center gap-3">
@@ -631,7 +631,7 @@ function GettingStarted({ onBack }: { onBack?: () => void }) {
           <ChevronDown
             className={`size-3.5 transition-transform ${showTerminal ? '' : '-rotate-90'}`}
           />
-          Prefer your terminal? Drive OpenComputer from Claude Code or the CLI
+          Prefer the command line? Use OpenComputer with Claude Code or the CLI
         </button>
 
         {showTerminal ? (

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,7 +1,17 @@
-import { useEffect, useRef, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link, useNavigate } from 'react-router-dom'
-import { Boxes, MessagesSquare, Sparkles } from 'lucide-react'
+import {
+  ArrowLeft,
+  BarChart3,
+  Boxes,
+  ChevronDown,
+  Code2,
+  Globe,
+  MessagesSquare,
+  Sparkles,
+  Terminal,
+} from 'lucide-react'
 import {
   createAPIKey,
   getAPIKeys,
@@ -10,6 +20,9 @@ import {
   getAgents,
   createAgent,
   createSession,
+  createSandbox,
+  getMe,
+  getBilling,
   type Sandbox,
 } from '@/api/client'
 import type { Session } from '@/api/schemas'
@@ -40,6 +53,69 @@ const QL_NOUN = ['otter', 'harbor', 'falcon', 'cedar', 'comet', 'ember', 'grove'
 function quicklaunchName(): string {
   const pick = (a: readonly string[]) => a[Math.floor(Math.random() * a.length)]
   return `${pick(QL_ADJ)}-${pick(QL_NOUN)}`
+}
+
+// Example tasks shown as chips on the launch card — concrete starting points so a
+// new user sees what the product actually does, instead of a blank button.
+const QUICKLAUNCH_TASKS: { icon: typeof BarChart3; label: string; task: string }[] = [
+  {
+    icon: BarChart3,
+    label: 'Analyze a CSV',
+    task: 'Create a small sample sales CSV, analyze it with Python, and produce a chart summarizing the key trends.',
+  },
+  {
+    icon: Globe,
+    label: 'Build a web app',
+    task: 'Build a small working single-page web app, start a dev server, and give me the preview URL so I can see it.',
+  },
+  {
+    icon: Terminal,
+    label: 'Write & run a script',
+    task: 'Write a short Python script that prints the current date/time and basic system info, then run it and show me the output.',
+  },
+]
+
+// Sandbox example chips. Unlike the agent chips (which are tasks for Claude), a
+// sandbox has no "task" — so each chip creates the box and lands you somewhere
+// useful: two auto-run a starter command in the terminal; "Drive it from code"
+// jumps to the Connect panel (SDK snippets). Commands lean on python3 (always
+// present on the base image) so the demo is self-contained — no external routing.
+// "Host a web app" is a webApp intent (not a static command): the sandbox page
+// exposes :8000, then builds the terminal command with the real preview hostname
+// so it can echo the live URL. See buildWebAppCommand in SandboxDetail.
+const SANDBOX_TRY_TOOL_CMD =
+  `echo "Python $(python3 --version 2>&1 | cut -d' ' -f2)  ·  Node $(node --version)  ·  $(uname -sr)" && echo "It's a real machine — try: pip install <pkg>  or  npm i <pkg>"`
+
+type SandboxIntent = {
+  startupCommand?: string
+  focus?: 'connect'
+  exposePort?: number
+  webApp?: boolean
+}
+const SANDBOX_EXAMPLES: {
+  icon: typeof Globe
+  label: string
+  intent: SandboxIntent
+}[] = [
+  {
+    icon: Globe,
+    label: 'Host a web app',
+    intent: { exposePort: 8000, webApp: true },
+  },
+  {
+    icon: Terminal,
+    label: 'Try a tool instantly',
+    intent: { startupCommand: SANDBOX_TRY_TOOL_CMD },
+  },
+  { icon: Code2, label: 'Drive it from code', intent: { focus: 'connect' } },
+]
+
+// Derive a friendly first name from an email local part (brian+test81@… → "Brian").
+function firstNameFromEmail(email: string | undefined): string {
+  if (!email) return ''
+  const local = email.split('@')[0]?.split('+')[0] ?? ''
+  const first = local.replace(/[._-]+/g, ' ').trim().split(' ')[0] ?? ''
+  return first ? first.charAt(0).toUpperCase() + first.slice(1) : ''
 }
 
 function formatDuration(sandbox: Sandbox): string {
@@ -73,6 +149,8 @@ const isLiveSession = (s: Session) =>
 
 export default function Dashboard() {
   const prefetch = usePrefetchSandbox()
+  // Returning users can re-open the getting-started screen from the header.
+  const [showGettingStarted, setShowGettingStarted] = useState(false)
 
   const { data: runningSandboxesData, isLoading: loadingRunningSandboxes } =
     useQuery({
@@ -115,6 +193,9 @@ export default function Dashboard() {
     !loadingSessions &&
     allSandboxes.length === 0 &&
     sessions.length === 0
+
+  // Genuine first-run auto-shows onboarding; returning users opt in via the link.
+  const showOnboarding = isFirstRun || showGettingStarted
 
   const sessionColumns: Column<Session>[] = [
     {
@@ -201,17 +282,27 @@ export default function Dashboard() {
 
   return (
     <div>
-      <PageHeader
-        title={isFirstRun ? 'Welcome to OpenComputer' : 'Dashboard'}
-        description={
-          isFirstRun
-            ? 'Get started in two steps'
-            : 'Overview of your agent sessions and sandboxes'
-        }
-      />
+      {!showOnboarding && (
+        <PageHeader
+          title="Dashboard"
+          description="Overview of your agent sessions and sandboxes"
+          actions={
+            <button
+              type="button"
+              onClick={() => setShowGettingStarted(true)}
+              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 text-sm underline-offset-4 hover:underline"
+            >
+              <Sparkles className="size-3.5" />
+              Getting started
+            </button>
+          }
+        />
+      )}
 
-      {isFirstRun ? (
-        <GettingStarted />
+      {showOnboarding ? (
+        <GettingStarted
+          onBack={!isFirstRun ? () => setShowGettingStarted(false) : undefined}
+        />
       ) : (
         <div className="space-y-6">
           <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
@@ -295,7 +386,7 @@ export default function Dashboard() {
 }
 
 /* ── First-run onboarding ─────────────────────────────────────────────────── */
-function GettingStarted() {
+function GettingStarted({ onBack }: { onBack?: () => void }) {
   const queryClient = useQueryClient()
   const {
     data: keys,
@@ -305,7 +396,10 @@ function GettingStarted() {
     queryKey: ['api-keys'],
     queryFn: getAPIKeys,
   })
+  const { data: me } = useQuery({ queryKey: ['me'], queryFn: getMe })
+  const { data: billing } = useQuery({ queryKey: ['billing'], queryFn: getBilling })
   const autoCreateRef = useRef(false)
+  const [showTerminal, setShowTerminal] = useState(false)
 
   const navigate = useNavigate()
 
@@ -314,10 +408,11 @@ function GettingStarted() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['api-keys'] }),
   })
 
-  // One click: create a managed agent + start a session on it, then drop the
-  // user straight onto the live session screen. No skill, no key, no terminal.
+  // One click: create a managed agent + start a session on it (with the given
+  // task), then drop the user straight onto the live session screen. No skill,
+  // no key, no terminal. The task varies by which chip/button the user picked.
   const launchMutation = useMutation({
-    mutationFn: async () => {
+    mutationFn: async (task: string) => {
       const agent = await createAgent({
         name: quicklaunchName(),
         prompt: QUICKLAUNCH_PROMPT,
@@ -325,16 +420,40 @@ function GettingStarted() {
         runtime: DEFAULT_RUNTIME,
         credential: 'managed', // run via OpenComputer, billed to credits, no BYO key
       })
-      return createSession({ agent: agent.id, input: QUICKLAUNCH_TASK })
+      return createSession({ agent: agent.id, input: task })
     },
     onSuccess: (session) => {
       void queryClient.invalidateQueries({ queryKey: ['agents'] })
       void navigate(`/sessions/${session.id}`)
     },
   })
+  const launching = launchMutation.isPending
+
+  // Second door: create a real sandbox and drop into its live terminal. Goes
+  // through the CP (edge → home cell → /internal/sandboxes/create), so unlike
+  // the managed-agent path this works end to end today.
+  const createSandboxMutation = useMutation({
+    mutationFn: (_intent: SandboxIntent) =>
+      createSandbox({ memoryMB: 1024, cpuCount: 1, networkEnabled: true }),
+    onSuccess: (sb, intent) => {
+      void queryClient.invalidateQueries({ queryKey: ['sandboxes'] })
+      void navigate(`/sandboxes/${sb.sandboxID}`, {
+        state:
+          intent.startupCommand ||
+          intent.focus ||
+          intent.exposePort ||
+          intent.webApp
+            ? intent
+            : undefined,
+      })
+    },
+  })
+  const creatingSandbox = createSandboxMutation.isPending
 
   const hasKeys = (keys?.length ?? 0) > 0
   const createdKey = createMutation.data?.key ?? null
+  const firstName = firstNameFromEmail(me?.email)
+  const freeCents = billing?.freeCreditsRemainingCents ?? null
 
   // On first signup (no keys), auto-create a Default key so the user sees it
   // immediately without clicking anything.
@@ -349,7 +468,38 @@ function GettingStarted() {
   }, [keysLoaded, hasKeys, createdKey, createMutation])
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-5">
+      {onBack ? (
+        <button
+          type="button"
+          onClick={onBack}
+          className="text-muted-foreground hover:text-foreground -mb-1 inline-flex items-center gap-1.5 text-sm underline-offset-4 hover:underline"
+        >
+          <ArrowLeft className="size-3.5" />
+          Back to dashboard
+        </button>
+      ) : null}
+
+      {/* Personalized welcome + reassurance in the first paint */}
+      <div className="space-y-2">
+        <h2 className="text-foreground text-2xl font-semibold tracking-tight">
+          Welcome{firstName ? `, ${firstName}` : ''}.
+        </h2>
+        <p className="text-muted-foreground text-sm">
+          {freeCents != null && freeCents > 0
+            ? `You've got $${(freeCents / 100).toFixed(2)} in free credits — enough to run a real agent right now. No card, no setup.`
+            : 'Run a real Claude agent in a fresh sandbox — no setup, no API key required.'}
+        </p>
+        <div className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1 pt-0.5 text-xs">
+          <span>Real Claude Opus</span>
+          <span aria-hidden>·</span>
+          <span>Isolated cloud VM</span>
+          <span aria-hidden>·</span>
+          <span>Watch it work live</span>
+        </div>
+      </div>
+
+      {/* Agent card — primary door, with concrete example tasks */}
       <Panel className="p-5">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1">
@@ -357,20 +507,41 @@ function GettingStarted() {
               Launch an agent
             </h3>
             <p className="text-muted-foreground text-sm">
-              Spin up a Claude agent in a fresh sandbox and watch it work — no
-              setup, no API key. Runs on OpenComputer, billed to your credits.
+              Spin up a Claude agent in a fresh sandbox and watch it work —
+              billed to your credits, no API key.
             </p>
           </div>
           <Button
             size="lg"
             className="shrink-0"
-            onClick={() => launchMutation.mutate()}
-            disabled={launchMutation.isPending}
+            onClick={() => launchMutation.mutate(QUICKLAUNCH_TASK)}
+            disabled={launching}
           >
             <Sparkles className="size-4" />
-            {launchMutation.isPending ? 'Launching…' : 'Launch agent'}
+            {launching ? 'Launching…' : 'Launch agent'}
           </Button>
         </div>
+
+        <div className="border-border/60 mt-4 border-t pt-4">
+          <p className="text-muted-foreground mb-2 text-xs">
+            Or start with an example:
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {QUICKLAUNCH_TASKS.map((t) => (
+              <button
+                key={t.label}
+                type="button"
+                onClick={() => launchMutation.mutate(t.task)}
+                disabled={launching}
+                className="border-border bg-background hover:bg-secondary text-foreground inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50"
+              >
+                <t.icon className="size-3.5" />
+                {t.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
         {launchMutation.isError ? (
           <div className="mt-3 flex items-center gap-3">
             <span className="text-status-error text-sm">
@@ -378,7 +549,9 @@ function GettingStarted() {
             </span>
             <button
               className="text-foreground text-sm font-medium underline underline-offset-4"
-              onClick={() => launchMutation.mutate()}
+              onClick={() =>
+                launchMutation.mutate(launchMutation.variables ?? QUICKLAUNCH_TASK)
+              }
             >
               Retry
             </button>
@@ -386,72 +559,148 @@ function GettingStarted() {
         ) : null}
       </Panel>
 
-      <p className="text-muted-foreground px-1 text-xs">
-        Or drive OpenComputer from your terminal:
-      </p>
-
-      <StepCard
-        index={1}
-        title="Install the OpenComputer skill"
-        description="Adds OpenComputer controls to Claude Code so you can create and manage agents, sessions, and sandboxes from your terminal."
-      >
-        <CopyRow value={SKILL_INSTALL_CMD} />
-      </StepCard>
-
-      <StepCard
-        index={2}
-        title="Your API key"
-        description="The skill uses this key to authenticate with OpenComputer. We've created a Default key for you — copy it now, you won't be able to see it again."
-      >
-        {loadingKeys || createMutation.isPending ? (
-          <p className="text-muted-foreground text-sm">
-            Preparing your API key…
-          </p>
-        ) : null}
-
-        {createdKey ? (
-          <div className="space-y-2.5">
-            <CopyRow value={createdKey} maskable />
-            <p className="text-muted-foreground text-xs">
-              Then run this in your terminal to configure the CLI:
+      {/* Second door: a real sandbox — a full VM you drive yourself */}
+      <Panel className="p-5">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <h3 className="text-foreground text-base font-semibold">
+              Build with a sandbox
+            </h3>
+            <p className="text-muted-foreground text-sm">
+              Spin up a real cloud computer — a full Linux shell, files, and
+              ports — and drive it from the browser or your code.
             </p>
-            <CopyRow
-              value={createdKey}
-              maskable
-              transform={(s) => `oc config set api-key ${s}`}
-            />
           </div>
-        ) : null}
+          <Button
+            size="lg"
+            variant="outline"
+            className="shrink-0"
+            onClick={() => createSandboxMutation.mutate({})}
+            disabled={creatingSandbox}
+          >
+            <Boxes className="size-4" />
+            {creatingSandbox ? 'Creating…' : 'Create a sandbox'}
+          </Button>
+        </div>
 
-        {!createdKey && !createMutation.isPending && hasKeys ? (
-          <p className="text-muted-foreground text-sm">
-            You already have {keys!.length} API key
-            {keys!.length === 1 ? '' : 's'} from a previous session. For
-            security, existing key values can&apos;t be re-displayed.{' '}
-            <Link
-              to="/api-keys"
-              className="text-foreground font-medium underline underline-offset-4"
-            >
-              Manage keys
-            </Link>{' '}
-            to rotate.
-          </p>
-        ) : null}
+        <div className="border-border/60 mt-4 border-t pt-4">
+          <p className="text-muted-foreground mb-2 text-xs">Or jump straight in:</p>
+          <div className="flex flex-wrap gap-2">
+            {SANDBOX_EXAMPLES.map((ex) => (
+              <button
+                key={ex.label}
+                type="button"
+                onClick={() => createSandboxMutation.mutate(ex.intent)}
+                disabled={creatingSandbox}
+                className="border-border bg-background hover:bg-secondary text-foreground inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50"
+              >
+                <ex.icon className="size-3.5" />
+                {ex.label}
+              </button>
+            ))}
+          </div>
+        </div>
 
-        {createMutation.isError ? (
-          <div className="flex items-center gap-3">
+        <p className="text-muted-foreground mt-3 text-xs">
+          {creatingSandbox
+            ? 'Booting a fresh cloud VM — this can take 10–20s…'
+            : 'Ubuntu · Python & Node preinstalled · opens a live terminal'}
+        </p>
+        {createSandboxMutation.isError ? (
+          <div className="mt-3 flex items-center gap-3">
             <span className="text-status-error text-sm">
-              Failed to create your API key.
+              Couldn&apos;t create the sandbox.
             </span>
             <button
               className="text-foreground text-sm font-medium underline underline-offset-4"
-              onClick={() => createMutation.mutate()}
+              onClick={() => createSandboxMutation.mutate({})}
             >
               Retry
             </button>
           </div>
         ) : null}
-      </StepCard>
+      </Panel>
+
+      {/* Terminal / power-user path — available, not the required first step */}
+      <div>
+        <button
+          type="button"
+          onClick={() => setShowTerminal((v) => !v)}
+          className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 px-1 text-xs font-medium"
+        >
+          <ChevronDown
+            className={`size-3.5 transition-transform ${showTerminal ? '' : '-rotate-90'}`}
+          />
+          Prefer your terminal? Drive OpenComputer from Claude Code or the CLI
+        </button>
+
+        {showTerminal ? (
+          <div className="mt-3 space-y-4">
+            <StepCard
+              index={1}
+              title="Install the OpenComputer skill"
+              description="Adds OpenComputer controls to Claude Code so you can create and manage agents, sessions, and sandboxes from your terminal."
+            >
+              <CopyRow value={SKILL_INSTALL_CMD} />
+            </StepCard>
+
+            <StepCard
+              index={2}
+              title="Your API key"
+              description="The skill uses this key to authenticate with OpenComputer. We've created a Default key for you — copy it now, you won't be able to see it again."
+            >
+              {loadingKeys || createMutation.isPending ? (
+                <p className="text-muted-foreground text-sm">
+                  Preparing your API key…
+                </p>
+              ) : null}
+
+              {createdKey ? (
+                <div className="space-y-2.5">
+                  <CopyRow value={createdKey} maskable />
+                  <p className="text-muted-foreground text-xs">
+                    Then run this in your terminal to configure the CLI:
+                  </p>
+                  <CopyRow
+                    value={createdKey}
+                    maskable
+                    transform={(s) => `oc config set api-key ${s}`}
+                  />
+                </div>
+              ) : null}
+
+              {!createdKey && !createMutation.isPending && hasKeys ? (
+                <p className="text-muted-foreground text-sm">
+                  You already have {keys!.length} API key
+                  {keys!.length === 1 ? '' : 's'} from a previous session. For
+                  security, existing key values can&apos;t be re-displayed.{' '}
+                  <Link
+                    to="/api-keys"
+                    className="text-foreground font-medium underline underline-offset-4"
+                  >
+                    Manage keys
+                  </Link>{' '}
+                  to rotate.
+                </p>
+              ) : null}
+
+              {createMutation.isError ? (
+                <div className="flex items-center gap-3">
+                  <span className="text-status-error text-sm">
+                    Failed to create your API key.
+                  </span>
+                  <button
+                    className="text-foreground text-sm font-medium underline underline-offset-4"
+                    onClick={() => createMutation.mutate()}
+                  >
+                    Retry
+                  </button>
+                </div>
+              ) : null}
+            </StepCard>
+          </div>
+        ) : null}
+      </div>
     </div>
   )
 }

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useRef, type ReactNode } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Link } from 'react-router-dom'
-import { Boxes, MessagesSquare } from 'lucide-react'
+import { Link, useNavigate } from 'react-router-dom'
+import { Boxes, MessagesSquare, Sparkles } from 'lucide-react'
 import {
   createAPIKey,
   getAPIKeys,
   getSandboxes,
   getSessions,
   getAgents,
+  createAgent,
+  createSession,
   type Sandbox,
 } from '@/api/client'
 import type { Session } from '@/api/schemas'
@@ -19,8 +21,26 @@ import { CopyRow } from '@/components/copy-row'
 import { StatusBadge } from '@/components/status-badge'
 import { EmptyState } from '@/components/empty-state'
 import { ResourceTable, type Column } from '@/components/resource-table'
+import { Button } from '@/components/ui/button'
+import { DEFAULT_RUNTIME, defaultModelFor } from '@/lib/runtimes'
 
 const SKILL_INSTALL_CMD = 'npx skills add diggerhq/opencomputer'
+
+// One-click launch defaults. Mirrors the Create-agent dialog's defaults so the
+// dashboard button produces the same agent the modal would — but with the
+// "managed" credential (run via OpenComputer, billed to credits, no BYO key) so
+// a brand-new user with no key can go straight to a live session.
+const QUICKLAUNCH_PROMPT =
+  'You are a helpful AI assistant working in a sandboxed computer. Complete tasks end to end, use the tools available to you, and keep your answers clear and concise. When something is ambiguous, make a sensible assumption and say so.'
+// Starter task so the agent does something visible the moment the session opens.
+const QUICKLAUNCH_TASK =
+  'Give me a quick tour of this sandbox: check the OS and what tools/languages are installed, then suggest three things we could build together.'
+const QL_ADJ = ['swift', 'calm', 'bright', 'clever', 'bold', 'quiet', 'keen', 'brave', 'nimble', 'lucid', 'deft', 'vivid']
+const QL_NOUN = ['otter', 'harbor', 'falcon', 'cedar', 'comet', 'ember', 'grove', 'heron', 'lynx', 'nova', 'quartz', 'willow']
+function quicklaunchName(): string {
+  const pick = (a: readonly string[]) => a[Math.floor(Math.random() * a.length)]
+  return `${pick(QL_ADJ)}-${pick(QL_NOUN)}`
+}
 
 function formatDuration(sandbox: Sandbox): string {
   const start = new Date(sandbox.startedAt).getTime()
@@ -287,9 +307,30 @@ function GettingStarted() {
   })
   const autoCreateRef = useRef(false)
 
+  const navigate = useNavigate()
+
   const createMutation = useMutation({
     mutationFn: () => createAPIKey('Default'),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['api-keys'] }),
+  })
+
+  // One click: create a managed agent + start a session on it, then drop the
+  // user straight onto the live session screen. No skill, no key, no terminal.
+  const launchMutation = useMutation({
+    mutationFn: async () => {
+      const agent = await createAgent({
+        name: quicklaunchName(),
+        prompt: QUICKLAUNCH_PROMPT,
+        model: defaultModelFor(DEFAULT_RUNTIME),
+        runtime: DEFAULT_RUNTIME,
+        credential: 'managed', // run via OpenComputer, billed to credits, no BYO key
+      })
+      return createSession({ agent: agent.id, input: QUICKLAUNCH_TASK })
+    },
+    onSuccess: (session) => {
+      void queryClient.invalidateQueries({ queryKey: ['agents'] })
+      void navigate(`/sessions/${session.id}`)
+    },
   })
 
   const hasKeys = (keys?.length ?? 0) > 0
@@ -309,6 +350,46 @@ function GettingStarted() {
 
   return (
     <div className="space-y-4">
+      <Panel className="p-5">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <h3 className="text-foreground text-base font-semibold">
+              Launch an agent
+            </h3>
+            <p className="text-muted-foreground text-sm">
+              Spin up a Claude agent in a fresh sandbox and watch it work — no
+              setup, no API key. Runs on OpenComputer, billed to your credits.
+            </p>
+          </div>
+          <Button
+            size="lg"
+            className="shrink-0"
+            onClick={() => launchMutation.mutate()}
+            disabled={launchMutation.isPending}
+          >
+            <Sparkles className="size-4" />
+            {launchMutation.isPending ? 'Launching…' : 'Launch agent'}
+          </Button>
+        </div>
+        {launchMutation.isError ? (
+          <div className="mt-3 flex items-center gap-3">
+            <span className="text-status-error text-sm">
+              Couldn&apos;t launch the agent.
+            </span>
+            <button
+              className="text-foreground text-sm font-medium underline underline-offset-4"
+              onClick={() => launchMutation.mutate()}
+            >
+              Retry
+            </button>
+          </div>
+        ) : null}
+      </Panel>
+
+      <p className="text-muted-foreground px-1 text-xs">
+        Or drive OpenComputer from your terminal:
+      </p>
+
       <StepCard
         index={1}
         title="Install the OpenComputer skill"

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useLocation } from 'react-router-dom'
 import {
   ArrowLeft,
   BarChart3,
@@ -139,6 +139,14 @@ const session = await oc.sessions.create({
 console.log(session.id, session.clientToken);`,
   },
   {
+    label: 'CLI',
+    code: `oc agent create my-agent \\
+  --runtime claude --model anthropic/claude-opus-4-8 --credential managed
+
+oc session create --agent my-agent \\
+  --input "Give me a quick tour of this sandbox."`,
+  },
+  {
     label: 'cURL',
     code: `# 1. Create a managed agent
 curl -X POST https://api.opencomputer.dev/v3/agents \\
@@ -224,8 +232,11 @@ const isLiveSession = (s: Session) =>
 
 export default function Dashboard() {
   const prefetch = usePrefetchSandbox()
-  // Returning users can re-open the getting-started screen from the header.
-  const [showGettingStarted, setShowGettingStarted] = useState(false)
+  const location = useLocation()
+  const navigate = useNavigate()
+  // Getting started is its own left-nav item (/getting-started). Brand-new orgs
+  // also see it inline on first run (at /).
+  const onGettingStartedRoute = location.pathname === '/getting-started'
 
   const { data: runningSandboxesData, isLoading: loadingRunningSandboxes } =
     useQuery({
@@ -269,8 +280,9 @@ export default function Dashboard() {
     allSandboxes.length === 0 &&
     sessions.length === 0
 
-  // Genuine first-run auto-shows onboarding; returning users opt in via the link.
-  const showOnboarding = isFirstRun || showGettingStarted
+  // Genuine first-run auto-shows onboarding; returning users reach it via the
+  // left-nav "Getting started" item (/getting-started).
+  const showOnboarding = isFirstRun || onGettingStartedRoute
 
   const sessionColumns: Column<Session>[] = [
     {
@@ -361,22 +373,12 @@ export default function Dashboard() {
         <PageHeader
           title="Dashboard"
           description="Overview of your agent sessions and sandboxes"
-          actions={
-            <button
-              type="button"
-              onClick={() => setShowGettingStarted(true)}
-              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 text-sm underline-offset-4 hover:underline"
-            >
-              <Sparkles className="size-3.5" />
-              Getting started
-            </button>
-          }
         />
       )}
 
       {showOnboarding ? (
         <GettingStarted
-          onBack={!isFirstRun ? () => setShowGettingStarted(false) : undefined}
+          onBack={onGettingStartedRoute ? () => navigate('/') : undefined}
         />
       ) : (
         <div className="space-y-6">

--- a/web/src/pages/SandboxDetail.tsx
+++ b/web/src/pages/SandboxDetail.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { notifyError } from '@/lib/errors'
 import {
@@ -13,6 +13,9 @@ import {
   Loader2,
 } from 'lucide-react'
 import {
+  ApiError,
+  createPreviewUrl,
+  deletePreviewUrl,
   deleteSandbox,
   getSandboxDetail,
   getSandboxStats,
@@ -26,12 +29,29 @@ const Terminal = lazy(() => import('@/components/Terminal'))
 const LogsPanel = lazy(() => import('@/components/LogsPanel'))
 import { Panel } from '@/components/panel'
 import { Button } from '@/components/ui/button'
-import { Skeleton } from '@/components/ui/skeleton'
+import { Input } from '@/components/ui/input'
 import { MetricCard } from '@/components/metric-card'
-import { CopyRow } from '@/components/copy-row'
+import { ConnectPanel } from '@/components/connect-panel'
 import { StatusBadge } from '@/components/status-badge'
 import { EmptyState } from '@/components/empty-state'
 import { ConfirmDialog } from '@/components/confirm-dialog'
+
+// "Host a web app" demo, built once the preview hostname is known: a styled
+// index.html (with a charset so the emoji renders instead of mojibake), a
+// background server, then the live URL echoed into the terminal — which is the
+// front-and-center element on the sandbox page.
+const WEB_APP_HTML =
+  '<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Live from my sandbox</title><style>body{font-family:system-ui,-apple-system,sans-serif;margin:0;min-height:100vh;display:grid;place-items:center;background:radial-gradient(circle at 50% 30%,#1a1a24,#0b0b0f);color:#e6e1d8}main{text-align:center;padding:2rem}h1{font-size:2.25rem;margin:0 0 .5rem}p{color:#9a948a;margin:0}.tag{display:inline-block;margin-top:1.25rem;font-family:ui-monospace,monospace;font-size:.8rem;color:#818cf8;border:1px solid #2a2a35;border-radius:999px;padding:.4rem .8rem}</style></head><body><main><h1>Hello from your sandbox 👋</h1><p>This page is served live from a real cloud VM.</p><span class="tag">OpenComputer</span></main></body></html>'
+
+function buildWebAppCommand(hostname: string): string {
+  return (
+    `printf '%s' '${WEB_APP_HTML}' > index.html` +
+    ` && (python3 -m http.server 8000 >/dev/null 2>&1 &)` +
+    ` && sleep 1` +
+    ` && echo "" && echo "🌐  Your site is LIVE — open it in a new tab:"` +
+    ` && echo "    https://${hostname}" && echo ""`
+  )
+}
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B'
@@ -55,6 +75,7 @@ type ConfirmKind = 'delete' | 'reboot' | 'power-cycle' | null
 export default function SandboxDetail() {
   const { sandboxId } = useParams<{ sandboxId: string }>()
   const navigate = useNavigate()
+  const location = useLocation()
   const queryClient = useQueryClient()
 
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null)
@@ -63,10 +84,46 @@ export default function SandboxDetail() {
   const [showInternal, setShowInternal] = useState(false)
   const [confirm, setConfirm] = useState<ConfirmKind>(null)
 
+  // Consumed once from navigation state (dashboard example chips): a command to
+  // auto-run in the terminal, and whether to jump to the Connect panel.
+  const [startupCommand, setStartupCommand] = useState<string | undefined>(
+    () => (location.state as { startupCommand?: string } | null)?.startupCommand,
+  )
+  const [focusConnect] = useState(
+    () => (location.state as { focus?: string } | null)?.focus === 'connect',
+  )
+  // "Host a web app" carries a port to auto-expose once the box is running; the
+  // webApp flag then runs the styled-page demo (with the real preview hostname).
+  const [exposePort] = useState(
+    () => (location.state as { exposePort?: number } | null)?.exposePort,
+  )
+  const [webApp] = useState(
+    () => (location.state as { webApp?: boolean } | null)?.webApp === true,
+  )
+  const exposedRef = useRef(false)
+  const [portInput, setPortInput] = useState('')
+  const connectRef = useRef<HTMLDivElement>(null)
+  const scrolledRef = useRef(false)
+
+  // On arrival from an example chip: open the terminal (so the startup command
+  // has somewhere to run) and wipe history state so a refresh doesn't re-fire.
+  useEffect(() => {
+    if (startupCommand) setShowTerminal(true)
+    if (location.state) window.history.replaceState({}, '')
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const { data: session, isLoading } = useQuery({
     queryKey: ['sandbox-detail', sandboxId],
     queryFn: () => getSandboxDetail(sandboxId!),
     enabled: !!sandboxId,
+    // A just-created sandbox is briefly not-yet-queryable on the cell (create
+    // returns before the read path is consistent, so the detail GET 404s for a
+    // few seconds). Retry a 404 through the boot window — the skeleton stays up
+    // instead of flashing "Sandbox not found" — then give up for a real 404.
+    retry: (failureCount, error) =>
+      failureCount < 10 && error instanceof ApiError && error.status === 404,
+    retryDelay: 1000,
   })
 
   const { data: stats } = useQuery({
@@ -125,6 +182,24 @@ export default function SandboxDetail() {
     onSettled: invalidate,
   })
 
+  const createPreviewMutation = useMutation({
+    mutationFn: (port: number) => createPreviewUrl(sandboxId!, port),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ['sandbox-detail', sandboxId],
+      }),
+    onError: (e) => notifyError("Couldn't expose the port.", e),
+  })
+
+  const deletePreviewMutation = useMutation({
+    mutationFn: (port: number) => deletePreviewUrl(sandboxId!, port),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ['sandbox-detail', sandboxId],
+      }),
+    onError: (e) => notifyError("Couldn't remove the preview URL.", e),
+  })
+
   const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(
     () => () => {
@@ -132,6 +207,41 @@ export default function SandboxDetail() {
     },
     [],
   )
+
+  // "Drive it from code" chip: once the sandbox has loaded, bring the Connect
+  // panel into view so the SDK snippets are the first thing you see.
+  useEffect(() => {
+    if (focusConnect && !scrolledRef.current && session && connectRef.current) {
+      scrolledRef.current = true
+      connectRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }, [focusConnect, session])
+
+  // "Host a web app" chip: once the box is running, auto-expose the port so the
+  // Preview URLs section fills in with a real clickable link (skip if one for
+  // that port already exists).
+  useEffect(() => {
+    if (exposedRef.current || !exposePort || session?.status !== 'running')
+      return
+    exposedRef.current = true
+    const existing = session.previewUrls?.find((u) => u.port === exposePort)
+    if (existing) {
+      if (webApp) {
+        setStartupCommand(buildWebAppCommand(existing.hostname))
+        setShowTerminal(true)
+      }
+      return
+    }
+    createPreviewMutation.mutate(exposePort, {
+      onSuccess: (pv) => {
+        if (webApp && pv?.hostname) {
+          setStartupCommand(buildWebAppCommand(pv.hostname))
+          setShowTerminal(true)
+        }
+      },
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [exposePort, session])
 
   const copyUrl = (hostname: string, key: string) => {
     void navigator.clipboard.writeText(`https://${hostname}`).then(
@@ -146,9 +256,28 @@ export default function SandboxDetail() {
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
-        <Skeleton className="h-28 w-full" />
-        <Skeleton className="h-40 w-full" />
+      <div>
+        <Link
+          to="/sandboxes"
+          className="text-muted-foreground hover:text-foreground mb-5 inline-flex items-center gap-1.5 text-sm transition-colors"
+        >
+          <ArrowLeft className="size-4" />
+          Back to Sandboxes
+        </Link>
+        <Panel className="p-8">
+          <div className="flex flex-col items-center justify-center gap-3 py-6 text-center">
+            <Loader2 className="text-muted-foreground size-6 animate-spin" />
+            <div className="space-y-1">
+              <p className="text-foreground text-sm font-medium">
+                Provisioning your sandbox…
+              </p>
+              <p className="text-muted-foreground text-xs">
+                Booting a fresh cloud VM
+                {sandboxId ? ` · ${sandboxId}` : ''}. This takes a few seconds.
+              </p>
+            </div>
+          </div>
+        </Panel>
       </div>
     )
   }
@@ -266,6 +395,8 @@ export default function SandboxDetail() {
           <Suspense fallback={<PanelLoading />}>
             <Terminal
               sandboxId={sandboxId!}
+              startupCommand={startupCommand}
+              onStarted={() => setStartupCommand(undefined)}
               onClose={() => setShowTerminal(false)}
             />
           </Suspense>
@@ -307,26 +438,76 @@ export default function SandboxDetail() {
         </div>
       ) : null}
 
-      {/* Preview URLs */}
-      {session.previewUrls && session.previewUrls.length > 0 ? (
+      {/* Preview URLs — expose a port to get a public https URL */}
+      {isRunning || (session.previewUrls?.length ?? 0) > 0 ? (
         <Panel className="mb-4 p-6">
           <h2 className="mb-3 text-sm font-semibold">Preview URLs</h2>
-          <div className="space-y-2">
-            {session.previewUrls.map((url) => {
-              const host = url.customHostname || url.hostname
-              return (
-                <PreviewUrlRow
-                  key={url.id}
-                  port={url.port}
-                  host={host}
-                  copied={copiedUrl === `${url.port}`}
-                  onCopy={() => copyUrl(host, `${url.port}`)}
-                />
-              )
-            })}
-          </div>
+          {session.previewUrls && session.previewUrls.length > 0 ? (
+            <div className="space-y-2">
+              {session.previewUrls.map((url) => {
+                const host = url.customHostname || url.hostname
+                return (
+                  <PreviewUrlRow
+                    key={url.id}
+                    port={url.port}
+                    host={host}
+                    copied={copiedUrl === `${url.port}`}
+                    onCopy={() => copyUrl(host, `${url.port}`)}
+                    onRemove={
+                      isRunning
+                        ? () => deletePreviewMutation.mutate(url.port)
+                        : undefined
+                    }
+                    removing={
+                      deletePreviewMutation.isPending &&
+                      deletePreviewMutation.variables === url.port
+                    }
+                  />
+                )
+              })}
+            </div>
+          ) : (
+            <p className="text-muted-foreground text-sm">
+              No ports exposed yet — start a server in the sandbox, then expose
+              its port to get a public URL.
+            </p>
+          )}
 
-          {session.previewUrls.some((u) => u.customHostname) ? (
+          {isRunning ? (
+            <form
+              className="mt-3 flex items-center gap-2"
+              onSubmit={(e) => {
+                e.preventDefault()
+                const port = Number(portInput)
+                if (Number.isInteger(port) && port >= 1 && port <= 65535) {
+                  createPreviewMutation.mutate(port, {
+                    onSuccess: () => setPortInput(''),
+                  })
+                }
+              }}
+            >
+              <Input
+                type="number"
+                min={1}
+                max={65535}
+                placeholder="Port (e.g. 8000)"
+                value={portInput}
+                onChange={(e) => setPortInput(e.target.value)}
+                className="w-44"
+              />
+              <Button
+                type="submit"
+                variant="outline"
+                size="sm"
+                disabled={createPreviewMutation.isPending || !portInput}
+              >
+                {createPreviewMutation.isPending ? 'Exposing…' : 'Expose port'}
+              </Button>
+            </form>
+          ) : null}
+
+          {session.previewUrls &&
+          session.previewUrls.some((u) => u.customHostname) ? (
             <div className="mt-3">
               <button
                 onClick={() => setShowInternal((v) => !v)}
@@ -354,6 +535,11 @@ export default function SandboxDetail() {
           ) : null}
         </Panel>
       ) : null}
+
+      {/* Connect — shell in / drive from code */}
+      <div ref={connectRef} className="mb-4 scroll-mt-6">
+        <ConnectPanel sandboxId={session.sandboxId} />
+      </div>
 
       {/* Details */}
       <Panel className="mb-4 p-6">
@@ -383,12 +569,6 @@ export default function SandboxDetail() {
             <Detail label="Error" value={session.errorMsg} error />
           ) : null}
         </dl>
-        {isRunning ? (
-          <div className="mt-4 space-y-1.5">
-            <div className="text-muted-foreground text-xs">CLI shell</div>
-            <CopyRow value={`oc shell ${session.sandboxId}`} />
-          </div>
-        ) : null}
       </Panel>
 
       {/* Checkpoint */}
@@ -466,11 +646,15 @@ function PreviewUrlRow({
   host,
   copied,
   onCopy,
+  onRemove,
+  removing,
 }: {
   port: number
   host: string
   copied: boolean
   onCopy: () => void
+  onRemove?: () => void
+  removing?: boolean
 }) {
   return (
     <div className="flex items-center gap-3">
@@ -488,6 +672,17 @@ function PreviewUrlRow({
       <Button variant="ghost" size="sm" onClick={onCopy}>
         {copied ? 'Copied' : 'Copy'}
       </Button>
+      {onRemove ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onRemove}
+          disabled={removing}
+          className="text-muted-foreground"
+        >
+          {removing ? '…' : 'Remove'}
+        </Button>
+      ) : null}
     </div>
   )
 }

--- a/web/src/pages/SandboxDetail.tsx
+++ b/web/src/pages/SandboxDetail.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useRef, useState } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { notifyError } from '@/lib/errors'
@@ -11,7 +11,9 @@ import {
   Trash2,
   ChevronRight,
   Loader2,
+  Sparkles,
 } from 'lucide-react'
+import { GuidedTour, type GuideStep } from '@/components/guided-tour'
 import {
   ApiError,
   createPreviewUrl,
@@ -104,6 +106,109 @@ export default function SandboxDetail() {
   const [portInput, setPortInput] = useState('')
   const connectRef = useRef<HTMLDivElement>(null)
   const scrolledRef = useRef(false)
+
+  // Guided first-run overlay: maps this sandbox's UI to the API/SDK/CLI that
+  // achieves each thing. Ordered so the chip you launched from leads (after the
+  // create step). Anchors: header, Terminal button, Preview panel, Connect panel.
+  const headerRef = useRef<HTMLDivElement>(null)
+  const terminalBtnRef = useRef<HTMLButtonElement>(null)
+  const previewRef = useRef<HTMLDivElement>(null)
+  const [guideOpen, setGuideOpen] = useState(
+    () => (location.state as { guide?: boolean } | null)?.guide === true,
+  )
+  const guideSteps: GuideStep[] = useMemo(() => {
+    const id = sandboxId || '<id>'
+    const stepCreate: GuideStep = {
+      target: headerRef,
+      title: 'You created a real cloud sandbox',
+      body: 'One call spun up a persistent Linux VM. It stays alive until you kill it or it idles out.',
+      api: 'POST /api/sandboxes',
+      code: [
+        {
+          label: 'SDK',
+          code: `import { Sandbox } from "@opencomputer/sdk";
+
+const sandbox = await Sandbox.create();`,
+        },
+        { label: 'CLI', code: `oc create` },
+        {
+          label: 'API',
+          code: `curl -X POST https://app.opencomputer.dev/api/sandboxes \\
+  -H "X-API-Key: $OPENCOMPUTER_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"memoryMB":1024,"cpuCount":1,"networkEnabled":true}'`,
+        },
+      ],
+      docs: 'https://docs.opencomputer.dev/quickstart',
+    }
+    const stepExec: GuideStep = {
+      target: terminalBtnRef,
+      title: 'Run commands in it',
+      body: 'This terminal runs against the live VM. In code it is exec — install packages, run scripts, anything.',
+      api: 'sandbox.exec.run(…)',
+      code: [
+        {
+          label: 'SDK',
+          code: `const { stdout } = await sandbox.exec.run("python3 --version");
+console.log(stdout);`,
+        },
+        { label: 'CLI', code: `oc exec ${id} -- python3 --version` },
+        {
+          label: 'API',
+          code: `curl -X POST https://app.opencomputer.dev/api/sandboxes/${id}/exec/run \\
+  -H "X-API-Key: $OPENCOMPUTER_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"cmd":"python3 --version"}'`,
+        },
+      ],
+      docs: 'https://docs.opencomputer.dev/sandboxes/overview',
+    }
+    const stepExpose: GuideStep = {
+      target: previewRef,
+      title: 'Expose a port → public URL',
+      body: 'Start a server in the box, then expose its port to get a public https URL — great for web apps and webhooks.',
+      api: 'sandbox.createPreviewURL({ port })',
+      code: [
+        {
+          label: 'SDK',
+          code: `await sandbox.exec.run("python3 -m http.server 8000 &");
+const preview = await sandbox.createPreviewURL({ port: 8000 });
+console.log(preview.url);`,
+        },
+        { label: 'CLI', code: `oc preview create ${id} 8000` },
+        {
+          label: 'API',
+          code: `curl -X POST https://app.opencomputer.dev/api/sandboxes/${id}/preview \\
+  -H "X-API-Key: $OPENCOMPUTER_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"port":8000}'`,
+        },
+      ],
+      docs: 'https://docs.opencomputer.dev/sandboxes/preview-urls',
+    }
+    const stepConnect: GuideStep = {
+      target: connectRef,
+      title: 'Drive it from your code',
+      body: 'Reconnect to this exact box by id from your own app and keep working — same VM, same state.',
+      api: `Sandbox.connect("${id}")`,
+      code: [
+        {
+          label: 'SDK',
+          code: `import { Sandbox } from "@opencomputer/sdk";
+
+const sandbox = await Sandbox.connect("${id}");
+const { stdout } = await sandbox.exec.run("echo hello from code");`,
+        },
+        { label: 'CLI', code: `oc shell ${id}` },
+      ],
+      docs: 'https://docs.opencomputer.dev/sandboxes/overview',
+    }
+    // Lead with the step matching the chip that launched this box.
+    if (webApp || exposePort) return [stepCreate, stepExpose, stepExec, stepConnect]
+    if (focusConnect) return [stepCreate, stepConnect, stepExec, stepExpose]
+    if (startupCommand) return [stepCreate, stepExec, stepExpose, stepConnect]
+    return [stepCreate, stepExec, stepExpose, stepConnect]
+  }, [sandboxId, webApp, exposePort, focusConnect, startupCommand])
 
   // On arrival from an example chip: open the terminal (so the startup command
   // has somewhere to run) and wipe history state so a refresh doesn't re-fire.
@@ -273,7 +378,7 @@ export default function SandboxDetail() {
               </p>
               <p className="text-muted-foreground text-xs">
                 Booting a fresh cloud VM
-                {sandboxId ? ` · ${sandboxId}` : ''}. This takes a few seconds.
+                {sandboxId ? ` · ${sandboxId}` : ''}…
               </p>
             </div>
           </div>
@@ -318,8 +423,14 @@ export default function SandboxDetail() {
         Back to Sandboxes
       </Link>
 
+      <GuidedTour
+        steps={guideSteps}
+        open={guideOpen}
+        onClose={() => setGuideOpen(false)}
+      />
+
       {/* Header */}
-      <Panel className="mb-4 p-6">
+      <Panel ref={headerRef} className="mb-4 p-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-3">
@@ -336,6 +447,15 @@ export default function SandboxDetail() {
 
           <div className="flex flex-wrap gap-2">
             <Button
+              variant="ghost"
+              size="sm"
+              className="text-muted-foreground"
+              onClick={() => setGuideOpen(true)}
+            >
+              <Sparkles className="size-4" />
+              How it works
+            </Button>
+            <Button
               variant={showLogs ? 'default' : 'outline'}
               size="sm"
               onClick={() => setShowLogs((v) => !v)}
@@ -346,6 +466,7 @@ export default function SandboxDetail() {
             {isRunning ? (
               <>
                 <Button
+                  ref={terminalBtnRef}
                   variant={showTerminal ? 'default' : 'outline'}
                   size="sm"
                   onClick={() => setShowTerminal((v) => !v)}
@@ -440,7 +561,7 @@ export default function SandboxDetail() {
 
       {/* Preview URLs — expose a port to get a public https URL */}
       {isRunning || (session.previewUrls?.length ?? 0) > 0 ? (
-        <Panel className="mb-4 p-6">
+        <Panel ref={previewRef} className="mb-4 p-6">
           <h2 className="mb-3 text-sm font-semibold">Preview URLs</h2>
           {session.previewUrls && session.previewUrls.length > 0 ? (
             <div className="space-y-2">

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useParams, useLocation } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft, Send, Wrench, CircleAlert } from 'lucide-react'
+import { ArrowLeft, Send, Wrench, CircleAlert, Sparkles } from 'lucide-react'
+import { GuidedTour, type GuideStep } from '@/components/guided-tour'
 import { notifyError } from '@/lib/errors'
 import { useHalted } from '@/hooks/useHalted'
 import {
@@ -63,6 +64,103 @@ export default function SessionDetail() {
   const [confirmCancel, setConfirmCancel] = useState(false)
   const [liveEvents, setLiveEvents] = useState<SessionEvent[]>([])
   const [streamOk, setStreamOk] = useState(false)
+
+  // Guided first-run overlay: the chip launch passes { guide: 'agent' } via nav
+  // state; the "How it works" button reopens it any time. Anchors point at the
+  // real regions below (header / event stream / composer).
+  const location = useLocation()
+  const headerRef = useRef<HTMLDivElement>(null)
+  const eventsRef = useRef<HTMLDivElement>(null)
+  const composerRef = useRef<HTMLFormElement>(null)
+  const [guideOpen, setGuideOpen] = useState(
+    () => (location.state as { guide?: string } | null)?.guide === 'agent',
+  )
+  const guideSteps: GuideStep[] = useMemo(
+    () => [
+      {
+        target: headerRef,
+        title: 'This session came from two API calls',
+        body: 'Clicking the example created a managed agent, then started a session on it — the dashboard just called the public API on your behalf.',
+        api: 'POST /v3/agents · POST /v3/sessions',
+        code: [
+          {
+            label: 'SDK',
+            code: `import { OpenComputer } from "@opencomputer/sdk";
+const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY });
+
+const agent = await oc.agents.create({
+  runtime: "claude",
+  model: "anthropic/claude-opus-4-8",
+  credential: "managed",
+});
+
+const session = await oc.sessions.create({
+  agent: agent.id,
+  input: "Give me a quick tour of this sandbox.",
+});`,
+          },
+          {
+            label: 'API',
+            code: `# 1. Create a managed agent
+curl -X POST https://api.opencomputer.dev/v3/agents \\
+  -H "Authorization: Bearer $OPENCOMPUTER_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"runtime":"claude","model":"anthropic/claude-opus-4-8","credential":"managed"}'
+
+# 2. Start a session on that agent
+curl -X POST https://api.opencomputer.dev/v3/sessions \\
+  -H "Authorization: Bearer $OPENCOMPUTER_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"agent":"agt_...","input":"Give me a quick tour of this sandbox."}'`,
+          },
+        ],
+        docs: 'https://docs.opencomputer.dev/agent-sessions/quickstart',
+      },
+      {
+        target: eventsRef,
+        title: "This is the session's live event log",
+        body: 'Every turn the agent takes streams here over SSE — the same feed you consume in code, no polling.',
+        api: 'GET /v3/sessions/:id/events',
+        code: [
+          {
+            label: 'SDK',
+            code: `// session is the handle returned by oc.sessions.create()
+for await (const event of session.events()) {
+  console.log(event.type, event.body);
+}`,
+          },
+          {
+            label: 'API',
+            code: `curl -N https://api.opencomputer.dev/v3/sessions/$SESSION_ID/events?stream=sse \\
+  -H "Authorization: Bearer $OPENCOMPUTER_API_KEY"
+# server-sent events stream: one event per line`,
+          },
+        ],
+        docs: 'https://docs.opencomputer.dev/agent-sessions/sessions',
+      },
+      {
+        target: composerRef,
+        title: 'Steer it from here',
+        body: 'Sending a message posts more input to the same session — the agent picks it up on its next turn.',
+        api: 'POST /v3/sessions/:id/messages',
+        code: [
+          {
+            label: 'SDK',
+            code: `await session.steer("Also add a dark mode toggle.");`,
+          },
+          {
+            label: 'API',
+            code: `curl -X POST https://api.opencomputer.dev/v3/sessions/$SESSION_ID/messages \\
+  -H "Authorization: Bearer $OPENCOMPUTER_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"text":"Also add a dark mode toggle."}'`,
+          },
+        ],
+        docs: 'https://docs.opencomputer.dev/agent-sessions/messaging',
+      },
+    ],
+    [],
+  )
 
   const { data: session, isLoading } = useQuery({
     queryKey: ['session', sessionId],
@@ -190,6 +288,11 @@ export default function SessionDetail() {
 
   return (
     <div className="max-w-4xl">
+      <GuidedTour
+        steps={guideSteps}
+        open={guideOpen}
+        onClose={() => setGuideOpen(false)}
+      />
       <Link
         to="/sessions"
         className="text-muted-foreground hover:text-foreground mb-4 inline-flex items-center gap-1.5 text-sm"
@@ -199,7 +302,7 @@ export default function SessionDetail() {
       </Link>
 
       {/* Header */}
-      <Panel className="mb-4 p-5">
+      <Panel ref={headerRef} className="mb-4 p-5">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="min-w-0 space-y-1.5">
             <div className="flex items-center gap-2.5">
@@ -246,6 +349,15 @@ export default function SessionDetail() {
             />
           </div>
           <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-muted-foreground"
+              onClick={() => setGuideOpen(true)}
+            >
+              <Sparkles className="size-3.5" />
+              How it works
+            </Button>
             {canCancel ? (
               <Button
                 variant="outline"
@@ -271,7 +383,7 @@ export default function SessionDetail() {
       </Panel>
 
       {/* Event stream */}
-      <Panel className="overflow-hidden">
+      <Panel ref={eventsRef} className="overflow-hidden">
         <div className="flex items-center justify-between border-b px-4 py-2.5">
           <div className="flex items-center gap-2">
             <h2 className="text-sm font-semibold">Events</h2>
@@ -331,6 +443,7 @@ export default function SessionDetail() {
             </div>
           )}
           <form
+            ref={composerRef}
             className="flex items-end gap-2"
             onSubmit={(e) => {
               e.preventDefault()

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -100,6 +100,14 @@ const session = await oc.sessions.create({
 });`,
           },
           {
+            label: 'CLI',
+            code: `oc agent create my-agent \\
+  --runtime claude --model anthropic/claude-opus-4-8 --credential managed
+
+oc session create --agent my-agent \\
+  --input "Give me a quick tour of this sandbox."`,
+          },
+          {
             label: 'API',
             code: `# 1. Create a managed agent
 curl -X POST https://api.opencomputer.dev/v3/agents \\
@@ -129,6 +137,7 @@ for await (const event of session.events()) {
   console.log(event.type, event.body);
 }`,
           },
+          { label: 'CLI', code: `oc session logs $SESSION_ID` },
           {
             label: 'API',
             code: `curl -N https://api.opencomputer.dev/v3/sessions/$SESSION_ID/events?stream=sse \\
@@ -147,6 +156,10 @@ for await (const event of session.events()) {
           {
             label: 'SDK',
             code: `await session.steer("Also add a dark mode toggle.");`,
+          },
+          {
+            label: 'CLI',
+            code: `oc session steer $SESSION_ID "Also add a dark mode toggle."`,
           },
           {
             label: 'API',


### PR DESCRIPTION
Make a landing page after sign up that is more featured

Basically added tour and code snippets at each step for each chip, so that we have a "hand you the controller" and "here's how to do it" at the same time. I

<img width="1604" height="787" alt="Screenshot 2026-07-10 at 3 13 15 PM" src="https://github.com/user-attachments/assets/756e6737-8b40-48a5-bd09-2cafb4511e74" />



<img width="1591" height="788" alt="Screenshot 2026-07-10 at 3 25 41 PM" src="https://github.com/user-attachments/assets/ede53d72-31c0-4014-81b2-ff2fcb30b897" />

<img width="1610" height="923" alt="Screenshot 2026-07-10 at 3 25 51 PM" src="https://github.com/user-attachments/assets/bd89123c-a58e-482a-935d-41a785b52355" />
<img width="1616" height="915" alt="Screenshot 2026-07-10 at 3 26 01 PM" src="https://github.com/user-attachments/assets/d0e34fec-6372-4f31-9393-87b0c198c72b" />
