### PR TITLE
Expose browser recording option

### DIFF
--- a/docs/browser-sessions/overview.mdx
+++ b/docs/browser-sessions/overview.mdx
@@ -30,6 +30,7 @@ import { Browser } from "@opencomputer/sdk";
 const browser = await Browser.create({
   headless: false,
   stealth: true,
+  recording: false,
   startUrl: "https://example.com",
   timeoutSeconds: 120,
 });
@@ -47,6 +48,7 @@ from opencomputer import Browser
 browser = await Browser.create(
     headless=False,
     stealth=True,
+    recording=False,
     start_url="https://example.com",
     timeout_seconds=120,
 )
@@ -61,7 +63,8 @@ await browser.delete()
 </CodeGroup>
 
 Headful browsers return a live-view URL. Headless browsers are lighter, but do
-not provide a live view.
+not provide a live view. Set `recording: false` / `recording=False` to disable
+replay recording for a headful browser session.
 
 ## Playwright
 
@@ -131,6 +134,7 @@ import { startBrowserAgent } from "magnitude-core";
 const ocBrowser = await Browser.create({
   headless: false,
   stealth: true,
+  recording: false,
   startUrl: "https://example.com",
 });
 

--- a/sdks/python/opencomputer/__init__.py
+++ b/sdks/python/opencomputer/__init__.py
@@ -68,4 +68,4 @@ __all__ = [
     "TagKeyInfo",
 ]
 
-__version__ = "0.6.7"
+__version__ = "0.6.8"

--- a/sdks/python/opencomputer/browser.py
+++ b/sdks/python/opencomputer/browser.py
@@ -59,6 +59,7 @@ class Browser:
         start_url: str | None = None,
         chrome_policy: dict[str, Any] | None = None,
         telemetry: dict[str, Any] | None = None,
+        recording: bool | None = None,
     ) -> Browser:
         """Create a browser session and return direct connection URLs."""
         url = _resolve_browser_api_url(api_url)
@@ -80,6 +81,7 @@ class Browser:
             start_url=start_url,
             chrome_policy=chrome_policy,
             telemetry=telemetry,
+            recording=recording,
         )
         resp = await client.post("/v1/browsers", json=body)
         resp.raise_for_status()

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opencomputer-sdk"
-version = "0.6.7"
+version = "0.6.8"
 description = "Python SDK for OpenComputer - cloud sandbox platform"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/browser.test.ts
+++ b/sdks/typescript/src/browser.test.ts
@@ -32,6 +32,8 @@ describe("Browser", () => {
       stealth: true,
       timeoutSeconds: 120,
       startUrl: "https://example.com",
+      telemetry: { enabled: true },
+      recording: false,
       viewport: { width: 1280, height: 800, refreshRate: 60 },
       profile: { name: "default", saveChanges: true },
     });
@@ -50,6 +52,8 @@ describe("Browser", () => {
           profile: { name: "default", save_changes: true },
           viewport: { width: 1280, height: 800, refresh_rate: 60 },
           start_url: "https://example.com",
+          telemetry: { enabled: true },
+          recording: false,
         }),
       }),
     );

--- a/sdks/typescript/src/browser.ts
+++ b/sdks/typescript/src/browser.ts
@@ -21,6 +21,7 @@ export interface BrowserCreateOpts {
   startUrl?: string;
   chromePolicy?: Record<string, unknown>;
   telemetry?: Record<string, unknown> | null;
+  recording?: boolean;
 }
 
 export interface BrowserData {
@@ -253,6 +254,7 @@ function toCreateBody(opts: BrowserCreateOpts): Record<string, unknown> {
   if (opts.startUrl !== undefined) body.start_url = opts.startUrl;
   if (opts.chromePolicy !== undefined) body.chrome_policy = opts.chromePolicy;
   if (opts.telemetry !== undefined) body.telemetry = opts.telemetry;
+  if (opts.recording !== undefined) body.recording = opts.recording;
   return body;
 }
 


### PR DESCRIPTION
Summary:\n- add recording to TypeScript Browser.create options\n- add recording to Python Browser.create options\n- document recording:false for browser sessions\n- bump TypeScript SDK to 0.12.1 and Python SDK to 0.6.8\n\nValidation:\n- npm test -- browser\n- npm run lint