### PR TITLE
Add browser usage billing UI

### DIFF
--- a/cloudflare-workers/api-edge/src/autumn_webhook.ts
+++ b/cloudflare-workers/api-edge/src/autumn_webhook.ts
@@ -34,6 +34,7 @@ export interface AutumnEnv extends AutumnSyncEnv {
   CF_ADMIN_SECRET: string;
   EVENT_SECRET: string;
   AUTUMN_WEBHOOK_SECRET: string;
+  BROWSER_USAGE_HMAC_SECRET?: string;
 }
 
 const DEFAULT_BASE_URL = "https://api.useautumn.com/v1";
@@ -155,6 +156,66 @@ export async function autumnProjectInternal(req: Request, env: AutumnEnv): Promi
     return json({ error: "projection failed" }, 502);
   }
   return json({ ok: true, org_id: payload.org_id });
+}
+
+
+// browserUsageInternal records Browser Session runtime into Autumn. Browser API
+// sends micro-USD usage at the flat OpenComputer rate and owns the idempotency
+// key, so this endpoint only authenticates, validates, tracks, and projects.
+export async function browserUsageInternal(req: Request, env: AutumnEnv): Promise<Response> {
+  const rawBody = await req.text();
+  const ts = req.headers.get("X-Timestamp") ?? "";
+  const sig = req.headers.get("X-Signature") ?? "";
+  if (!ts || !sig) return json({ error: "missing signature headers" }, 400);
+  const tsNum = parseInt(ts, 10);
+  if (!Number.isFinite(tsNum) || Math.abs(Date.now() / 1000 - tsNum) > SVIX_TOLERANCE_SEC) {
+    return json({ error: "timestamp out of window" }, 401);
+  }
+  const secret = env.BROWSER_USAGE_HMAC_SECRET || env.EVENT_SECRET;
+  const url = new URL(req.url);
+  const expected = await hmacHex(secret, `${ts}.${url.pathname}.${rawBody}`);
+  if (!timingSafeEqual(expected, sig)) return json({ error: "signature mismatch" }, 401);
+
+  let p: {
+    org_id?: string;
+    browser_id?: string;
+    provider_session_id?: string;
+    seconds?: number;
+    value?: number;
+    usage_micro?: number;
+    idempotency_key?: string;
+    feature_id?: string;
+    metadata?: unknown;
+  };
+  try {
+    p = JSON.parse(rawBody);
+  } catch {
+    return json({ error: "bad json" }, 400);
+  }
+
+  const featureID = p.feature_id || "browser_runtime";
+  if (!p.org_id || !p.browser_id || !p.idempotency_key) {
+    return json({ error: "org_id, browser_id, and idempotency_key required" }, 400);
+  }
+  if (featureID !== "browser_runtime") return json({ error: "unsupported feature_id" }, 400);
+  const value = p.value ?? p.seconds;
+  if (!Number.isFinite(value) || Number(value) < 0) {
+    return json({ error: "value must be a non-negative number of browser seconds" }, 400);
+  }
+
+  try {
+    const remaining = await trackAutumnUsage(env, {
+      customerID: p.org_id,
+      featureID,
+      value: Math.ceil(Number(value)),
+      idempotencyKey: p.idempotency_key,
+    });
+    if (remaining !== null && remaining <= 0) await projectOrg(env, p.org_id);
+    return json({ ok: true, billed: true, org_id: p.org_id, browser_id: p.browser_id, remaining });
+  } catch (err) {
+    console.error(`browser-usage: track failed org=${p.org_id} browser=${p.browser_id}`, err);
+    return json({ error: "browser usage billing failed" }, 502);
+  }
 }
 
 // ── self-healing gate ──────────────────────────────────────────────────────

--- a/cloudflare-workers/api-edge/src/browser_usage.test.ts
+++ b/cloudflare-workers/api-edge/src/browser_usage.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { browserUsageInternal, type AutumnEnv } from "./autumn_webhook";
+
+async function hmacHex(secret: string, data: string) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(data),
+  );
+  return [...new Uint8Array(sig)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function env(): AutumnEnv {
+  return {
+    AUTUMN_SECRET_KEY: "autumn-secret",
+    AUTUMN_BASE_URL: "https://autumn.test/v1",
+    AUTUMN_WEBHOOK_SECRET: "whsec_test",
+    EVENT_SECRET: "event-secret",
+    BROWSER_USAGE_HMAC_SECRET: "browser-usage-secret",
+    CF_ADMIN_SECRET: "admin-secret",
+    OPENCOMPUTER_DB: {} as D1Database,
+  };
+}
+
+describe("browser usage billing", () => {
+  it("tracks browser runtime into Autumn with the signed usage payload", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json({ balance: { remaining: 10 } }));
+    const body = JSON.stringify({
+      org_id: "org_1",
+      browser_id: "br_1",
+      provider_session_id: "kernel_1",
+      seconds: 60,
+      value: 60,
+      usage_micro: 8000,
+      idempotency_key: "browser_runtime:br_1",
+      feature_id: "browser_runtime",
+    });
+    const ts = String(Math.floor(Date.now() / 1000));
+    const path = "/internal/browser-usage";
+    const sig = await hmacHex("browser-usage-secret", `${ts}.${path}.${body}`);
+
+    const resp = await browserUsageInternal(
+      new Request(`https://api.test${path}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Timestamp": ts,
+          "X-Signature": sig,
+        },
+        body,
+      }),
+      env(),
+    );
+
+    expect(resp.status).toBe(200);
+    expect(await resp.json()).toMatchObject({
+      ok: true,
+      billed: true,
+      org_id: "org_1",
+      browser_id: "br_1",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://autumn.test/v1/track",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Authorization: "Bearer autumn-secret",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          customer_id: "org_1",
+          feature_id: "browser_runtime",
+          value: 60,
+          idempotency_key: "browser_runtime:br_1",
+        }),
+      }),
+    );
+  });
+});

--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -920,6 +920,7 @@ export async function handleDashboard(
 
   // ── Browser Sessions — proxy to the dedicated browser Worker ───────────
   if (sub === "/browsers" && method === "GET") return proxyToBrowserAPI(req, env, caller, "/v1/browsers");
+  if (sub === "/browser-usage" && method === "GET") return proxyToBrowserAPI(req, env, caller, "/v1/browser-usage");
   {
     const m = sub.match(/^\/browsers\/([^/]+)\/replays\/([^/]+)$/);
     if (m && method === "GET") {

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -22,6 +22,7 @@ import {
   autumnWebhook,
   autumnProjectInternal,
   autumnSetProviderInternal,
+  browserUsageInternal,
   selfHealHalt,
   createAutumnCustomer,
 } from "./autumn_webhook";
@@ -44,6 +45,9 @@ export interface Env extends DashboardEnv {
   // secret (whsec_…) for /webhooks/autumn. AUTUMN_SECRET_KEY / AUTUMN_BASE_URL
   // are inherited from DashboardEnv. Unset on deployments not yet on Autumn.
   AUTUMN_WEBHOOK_SECRET: string;
+  // HMAC secret used by Browser API to submit runtime usage. Falls back to
+  // EVENT_SECRET in the handler when unset for compatibility during rollout.
+  BROWSER_USAGE_HMAC_SECRET?: string;
   // Shared with every CP via Infisical /shared/ → per-cell KV/SM. Used for
   // envelope encryption of secret_store_entries.encrypted_value. Matches
   // internal/crypto.Encryptor key format (hex-encoded 32 bytes).
@@ -1829,6 +1833,12 @@ export default {
       if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
       return autumnProjectInternal(req, env);
     }
+    // Browser API runtime usage → Autumn browser_runtime (BROWSER_USAGE_HMAC_SECRET HMAC).
+    if (path === "/internal/browser-usage") {
+      if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+      return browserUsageInternal(req, env);
+    }
+
     // Migrate tool: flip D1 billing_provider for one org (EVENT_SECRET HMAC).
     if (path === "/internal/autumn-set-provider") {
       if (req.method !== "POST") return json({ error: "method not allowed" }, 405);

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -435,6 +435,9 @@ export const getBrowsers = (
 export const getBrowser = (id: string) =>
   apiFetch(`/browsers/${encodeURIComponent(id)}`, {}, S.BrowserSessionSchema)
 
+export const getBrowserUsage = () =>
+  apiFetch('/browser-usage', {}, S.BrowserUsageSchema)
+
 export const deleteBrowser = (id: string) =>
   apiFetch<void>(`/browsers/${encodeURIComponent(id)}`, { method: 'DELETE' })
 

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -122,6 +122,8 @@ const browserSessions = [
     created_at: at(0, 1),
     updated_at: at(0, 1),
     deleted_at: null,
+    billable_seconds: 3600,
+    estimated_cost_usd: 0.48,
   },
   {
     id: 'br_inbox_headless',
@@ -140,6 +142,8 @@ const browserSessions = [
     created_at: at(0, 4),
     updated_at: at(0, 4),
     deleted_at: null,
+    billable_seconds: 14400,
+    estimated_cost_usd: 1.92,
   },
   {
     id: 'br_old_replay',
@@ -160,6 +164,11 @@ const browserSessions = [
     created_at: at(2, 2),
     updated_at: at(2, 1),
     deleted_at: at(2, 1),
+    metered_at: at(2, 1),
+    metered_seconds: 3600,
+    metered_usage_micro: 480000,
+    billable_seconds: 3600,
+    estimated_cost_usd: 0.48,
   },
 ]
 

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -267,9 +267,24 @@ export const BrowserSessionSchema = z.object({
   created_at: z.string(),
   updated_at: z.string(),
   deleted_at: z.string().nullable().optional(),
+  provider_deleted_at: z.string().nullable().optional(),
+  metered_at: z.string().nullable().optional(),
+  metered_seconds: z.number().nullable().optional(),
+  metered_usage_micro: z.number().nullable().optional(),
+  metering_error: z.string().nullable().optional(),
+  billable_seconds: z.number().optional(),
+  estimated_cost_usd: z.number().optional(),
 })
 export const BrowserSessionListSchema = z.object({
   browsers: z.array(BrowserSessionSchema),
+})
+
+export const BrowserUsageSchema = z.object({
+  total_sessions: z.number(),
+  active_sessions: z.number(),
+  total_billable_seconds: z.number(),
+  total_usage_micro: z.number(),
+  total_cost_usd: z.number(),
 })
 
 export const BrowserProfileSchema = z.object({

--- a/web/src/pages/Browsers.tsx
+++ b/web/src/pages/Browsers.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useState } from 'react'
+import { type ReactNode, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { ExternalLink, Monitor, Trash2, X } from 'lucide-react'
 import { notifyError } from '@/lib/errors'
 import {
   deleteBrowser,
   getBrowserProfiles,
+  getBrowserUsage,
   getBrowsers,
   type BrowserProfile,
   type BrowserSession,
@@ -41,6 +42,34 @@ function browserMode(browser: BrowserSession) {
   return browser.headless ? 'Headless' : 'Headful'
 }
 
+function browserCost(browser: BrowserSession) {
+  return browser.estimated_cost_usd ?? 0
+}
+
+function browserSeconds(browser: BrowserSession) {
+  return browser.billable_seconds ?? browser.metered_seconds ?? 0
+}
+
+function formatCurrency(value: number) {
+  return value.toLocaleString(undefined, {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: value < 1 ? 4 : 2,
+    maximumFractionDigits: value < 1 ? 4 : 2,
+  })
+}
+
+function formatDuration(seconds: number) {
+  if (!Number.isFinite(seconds) || seconds <= 0) return '—'
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.round(seconds % 60)
+  if (mins < 1) return String(secs) + 's'
+  const hours = Math.floor(mins / 60)
+  const remMins = mins % 60
+  if (hours < 1) return String(mins) + 'm ' + String(secs) + 's'
+  return String(hours) + 'h ' + String(remMins) + 'm'
+}
+
 export default function Browsers() {
   const queryClient = useQueryClient()
   const [status, setStatus] = useState('')
@@ -59,6 +88,11 @@ export default function Browsers() {
   const { data: profiles = [], isLoading: loadingProfiles } = useQuery({
     queryKey: ['browser-profiles'],
     queryFn: getBrowserProfiles,
+  })
+  const { data: browserUsage } = useQuery({
+    queryKey: ['browser-usage'],
+    queryFn: getBrowserUsage,
+    retry: false,
   })
 
   const deleteMutation = useMutation({
@@ -89,6 +123,10 @@ export default function Browsers() {
 
   const activeCount = useMemo(
     () => browsers.filter((browser) => canDeleteBrowser(browser)).length,
+    [browsers],
+  )
+  const visibleBrowserCost = useMemo(
+    () => browsers.reduce((sum, browser) => sum + browserCost(browser), 0),
     [browsers],
   )
   const accessPlaceholder = browserAccessPlaceholder(browsersError)
@@ -145,6 +183,28 @@ export default function Browsers() {
           {browser.replay_id ? 'On' : browser.headless ? 'Unavailable' : '—'}
         </span>
       ),
+    },
+    {
+      key: 'duration',
+      header: 'Duration',
+      cell: (browser) => (
+        <span className="text-muted-foreground font-mono text-xs">
+          {formatDuration(browserSeconds(browser))}
+        </span>
+      ),
+    },
+    {
+      key: 'cost',
+      header: 'Cost',
+      cell: (browser) => (
+        <div className="text-right font-mono text-xs">
+          <div className="text-foreground">{formatCurrency(browserCost(browser))}</div>
+          {browser.metering_error ? (
+            <div className="text-status-warning">pending</div>
+          ) : null}
+        </div>
+      ),
+      align: 'right',
     },
     {
       key: 'created',
@@ -238,10 +298,14 @@ export default function Browsers() {
         />
       ) : (
         <>
-          <div className="mb-4 grid gap-3 sm:grid-cols-3">
+          <div className="mb-4 grid gap-3 sm:grid-cols-4">
             <Metric label="Visible sessions" value={browsers.length} />
             <Metric label="Active" value={activeCount} />
             <Metric label="Profiles" value={profiles.length} />
+            <Metric
+              label="Browser session cost"
+              value={formatCurrency(browserUsage?.total_cost_usd ?? visibleBrowserCost)}
+            />
           </div>
 
           <div className="mb-4 flex flex-wrap gap-1.5">
@@ -354,7 +418,7 @@ function InlineBrowserViewer({
   )
 }
 
-function Metric({ label, value }: { label: string; value: number }) {
+function Metric({ label, value }: { label: string; value: ReactNode }) {
   return (
     <Panel className="px-4 py-3">
       <div className="text-muted-foreground text-xs">{label}</div>


### PR DESCRIPTION
## Summary
- add signed api-edge /internal/browser-usage endpoint for browser_runtime usage
- track browser_runtime in Autumn using seconds as the usage value
- proxy /browser-usage to Browser API for dashboard totals
- show Browser Sessions total cost and per-session duration/cost in the dashboard

## Deploy notes
- deploy after or with the Browser API metering PR
- set BROWSER_USAGE_HMAC_SECRET on Browser API and api-edge to the same value
- Autumn credits credit system should include browser_runtime with credit cost 0.000133333333 per unit; one unit is one browser second

## Validation
- npm test -- --run in cloudflare-workers/api-edge
- npm run typecheck in web