### PR TITLE
Make agent runtime errors durably observable

### DIFF
--- a/cloudflare-workers/log-tail/src/index.test.ts
+++ b/cloudflare-workers/log-tail/src/index.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import worker from "./index.ts";
+
+const env = {
+  AXIOM_HOST: "https://axiom.test",
+  AXIOM_DATASET: "edge",
+  AXIOM_TOKEN: "test-token",
+};
+
+test("records a silent HTTP 5xx even when the invocation outcome is ok", async () => {
+  const originalFetch = globalThis.fetch;
+  let records: Array<Record<string, unknown>> = [];
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    records = JSON.parse(String(init?.body));
+    return new Response(null, { status: 200 });
+  }) as typeof fetch;
+
+  try {
+    await worker.tail([{
+      scriptName: "agt_test",
+      outcome: "ok",
+      eventTimestamp: Date.parse("2026-07-13T20:00:00Z"),
+      event: {
+        request: { method: "POST", url: "https://dispatch.test/agents/example/session" },
+        response: { status: 500 },
+      },
+      logs: [],
+      exceptions: [],
+    }], env, {} as ExecutionContext);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0]?.level, "ERROR");
+  assert.equal(records[0]?.msg, "worker request returned HTTP 500");
+  assert.equal(records[0]?.service, "agt_test");
+  assert.equal(records[0]?.response_status, 500);
+});
+
+test("fails the collector invocation when the durable sink rejects a batch", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalConsoleError = console.error;
+  globalThis.fetch = (async () => new Response(
+    JSON.stringify({ code: 403, message: "not allowed to ingest into dataset" }),
+    { status: 403 },
+  )) as typeof fetch;
+  console.error = () => {};
+
+  try {
+    await assert.rejects(
+      worker.tail([{
+        scriptName: "agt_test",
+        outcome: "exception",
+        eventTimestamp: Date.parse("2026-07-13T20:00:00Z"),
+        logs: [],
+        exceptions: [],
+      }], env, {} as ExecutionContext),
+      /axiom ingest failed status=403/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.error = originalConsoleError;
+  }
+});

--- a/cloudflare-workers/log-tail/src/index.ts
+++ b/cloudflare-workers/log-tail/src/index.ts
@@ -104,15 +104,20 @@ export default {
         });
       }
 
-      // Synthetic record when a request ended in exception/exceededCpu/etc
-      // but had no console output — gives us a row to count "failed
-      // requests by script" in Axiom without joining streams.
-      if (item.outcome !== "ok" && item.logs.length === 0 && item.exceptions.length === 0) {
+      // Synthetic record when a request failed without logging. A Worker can
+      // catch an exception and return 5xx while Cloudflare still reports the
+      // invocation outcome as "ok", so response status is part of the failure
+      // contract too. This keeps silent server errors searchable in Axiom.
+      const responseStatus = item.event?.response?.status;
+      const serverError = typeof responseStatus === "number" && responseStatus >= 500;
+      if ((item.outcome !== "ok" || serverError) && item.logs.length === 0 && item.exceptions.length === 0) {
         records.push({
           _time: new Date(item.eventTimestamp ?? Date.now()).toISOString(),
           time: new Date(item.eventTimestamp ?? Date.now()).toISOString(),
           level: "ERROR",
-          msg: `worker request ended with outcome=${item.outcome}`,
+          msg: serverError
+            ? `worker request returned HTTP ${responseStatus}`
+            : `worker request ended with outcome=${item.outcome}`,
           ...baseEnvelope,
         });
       }
@@ -131,7 +136,12 @@ export default {
     });
     if (!resp.ok) {
       const body = await resp.text().catch(() => "");
-      console.error(`axiom ingest failed status=${resp.status} body=${body.slice(0, 200)}`);
+      const message = `axiom ingest failed status=${resp.status} body=${body.slice(0, 200)}`;
+      console.error(message);
+      // The collector has Cloudflare Workers Logs enabled as an independent
+      // fallback. Throwing makes a broken durable sink an observable failed
+      // invocation instead of an apparently healthy, lossy success.
+      throw new Error(message);
     }
   },
 };

--- a/cloudflare-workers/log-tail/wrangler.prod.toml
+++ b/cloudflare-workers/log-tail/wrangler.prod.toml
@@ -1,6 +1,6 @@
 # log-tail Worker — PROD on Mo's CF account.
 # Tail consumer for opencomputer-edge-prod + opencomputer-events-ingest-prod.
-# Forwards console output + exceptions to Axiom dataset cf-prod.
+# Forwards console output + exceptions to Axiom dataset oc-platform-edge.
 # Deploy: `wrangler deploy -c wrangler.prod.toml`
 
 name = "opencomputer-log-tail-prod"
@@ -9,8 +9,18 @@ compatibility_date = "2024-12-01"
 account_id = "b8f23cb87a7a6c64040d3134643da448"
 workers_dev = false
 
+# Independent fallback for failures in the Axiom sink itself. Tenant/dispatch
+# logs go to Axiom; collector invocation failures remain searchable in the
+# Cloudflare Observability dashboard even when Axiom is unavailable.
+[observability]
+enabled = true
+
+  [observability.logs]
+  invocation_logs = true
+  head_sampling_rate = 1
+
 # Secrets (set via `wrangler secret put --config wrangler.prod.toml`):
-#   AXIOM_TOKEN — xaat-... ingest token for the cf-prod dataset
+#   AXIOM_TOKEN — ingest-capable token scoped to the oc-platform-edge dataset
 [vars]
 AXIOM_HOST = "https://api.axiom.co"
 AXIOM_DATASET = "oc-platform-edge"


### PR DESCRIPTION
## Why

Tenant Workers and dispatch now send trace events directly to `opencomputer-log-tail-prod`, but the live cutover exposed two observability gaps:

- a caught error can return HTTP 5xx while Cloudflare reports the invocation outcome as `ok`, leaving no record when the Worker logs nothing;
- the collector logged and swallowed a rejected Axiom batch, so a broken sink looked healthy and the only evidence required an attached live tail.

The live collector was receiving the tenant events correctly, but its deployed Axiom credential returned `403 not allowed to ingest into dataset`. That secret has been rotated in production to an ingest-capable credential; a subsequent tenant failure was durably queryable with the full sandbox error and stack.

## What changes

- synthesize an `ERROR` record for otherwise-silent HTTP 5xx responses;
- throw when Axiom rejects a batch, making loss visible as a failed collector invocation;
- persist 100% of collector invocations and logs in Cloudflare Workers Observability as an independent fallback when Axiom itself is unavailable;
- correct the production dataset documentation and state the least-privilege token requirement;
- add dependency-free regression tests for silent 5xx capture and sink rejection.

Clients continue receiving sanitized errors. Full details remain only in operator telemetry.

## Verification

- `node --experimental-strip-types --test cloudflare-workers/log-tail/src/index.test.ts` — 2 passed
- `wrangler deploy --dry-run --config cloudflare-workers/log-tail/wrangler.prod.toml` — passed
- live: `opencomputer-log-tail-prod` consumed `agt_67b4873b6ffe46cdb2d6f549` events
- live: Axiom `oc-platform-edge` stored the full `oc sandbox exec failed: 524` stack after the credential rotation
