### PR TITLE
fix(cli): quiet non-actionable Flue deploy noise

### DIFF
--- a/cmd/oc/internal/commands/agent_deploy_flue.go
+++ b/cmd/oc/internal/commands/agent_deploy_flue.go
@@ -213,6 +213,7 @@ func runFlueBuild(ctx context.Context, dir string) error {
 		c = exec.CommandContext(ctx, "npx", append([]string{"--no-install", "flue"}, args...)...)
 	}
 	c.Dir = dir
+	c.Env = flueBuildEnv()
 	c.Stdout = os.Stderr
 	c.Stderr = os.Stderr
 	// No stdin: `flue build` is a non-interactive bundler, and wiring the terminal
@@ -221,6 +222,29 @@ func runFlueBuild(ctx context.Context, dir string) error {
 		return fmt.Errorf("flue build failed: %w\n(run `npm install` so the flue CLI is available, node >= 22.19)", err)
 	}
 	return nil
+}
+
+// flueBuildEnv keeps Wrangler's platform-deployment warnings out of `oc agent
+// deploy`. OpenComputer consumes a strict subset of the generated descriptor and
+// owns the eventual Worker-for-Platforms composition, so warnings about directly
+// deploying that scratch Wrangler config (notably declarative Durable Object
+// exports) are not actionable here. Errors still print. An explicit
+// WRANGLER_LOG setting wins, which leaves a debugging escape hatch.
+func flueBuildEnv() []string {
+	const key = "WRANGLER_LOG"
+	const fallback = key + "=error"
+	env := os.Environ()
+	prefix := key + "="
+	for i, value := range env {
+		if !strings.HasPrefix(value, prefix) {
+			continue
+		}
+		if value == prefix {
+			env[i] = fallback
+		}
+		return env
+	}
+	return append(env, fallback)
 }
 
 // readFlueBundle locates the generated wrangler, extracts the exact Flue descriptor,

--- a/cmd/oc/internal/commands/agent_deploy_flue_test.go
+++ b/cmd/oc/internal/commands/agent_deploy_flue_test.go
@@ -107,6 +107,7 @@ func TestDeployFlueDoEndToEnd(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake flue build is a POSIX shell script")
 	}
+	t.Setenv("WRANGLER_LOG", "")
 
 	// A Flue app dir: manifest + clean source + a stand-in `flue` bin whose
 	// `build --target cloudflare` writes a deterministic but noisy dist/e2e_flue/.
@@ -115,7 +116,7 @@ func TestDeployFlueDoEndToEnd(t *testing.T) {
 		"name  = \"e2e-flue\"\nmodel = \"anthropic/claude-sonnet-5\"\n\n[runtime]\nfamily = \"flue\"\n", 0o644)
 	writeFile(t, filepath.Join(dir, "src", "opencomputer.ts"),
 		"import { serveOC } from '@opencomputer/flue';\nexport default serveOC(agent);\n", 0o644)
-	buildScript := "#!/bin/sh\nset -e\nmkdir -p dist/e2e_flue/assets dist/e2e_flue/.vite dist/e2e_flue/.flue-vite\n" +
+	buildScript := "#!/bin/sh\nset -e\ntest \"${WRANGLER_LOG:-}\" = error\nmkdir -p dist/e2e_flue/assets dist/e2e_flue/.vite dist/e2e_flue/.flue-vite\n" +
 		"cat > dist/e2e_flue/index.js <<'JS'\n" + e2eModuleBody + "\nJS\n" +
 		"cat > dist/e2e_flue/assets/chunk.js <<'JS'\n" + e2eAssetBody + "\nJS\n" +
 		"cat > dist/e2e_flue/.flue-vite/runtime.mjs <<'JS'\n" + e2eRuntimeBody + "\nJS\n" +
@@ -249,6 +250,16 @@ func TestDeployFlueDoEndToEnd(t *testing.T) {
 	if vars, ok := f.configPutBody["vars"].(map[string]any); !ok || len(vars) != 0 {
 		t.Errorf("manifest without [vars] should clear desired vars, got %#v", f.configPutBody)
 	}
+}
+
+func TestFlueBuildEnvPreservesExplicitWranglerLog(t *testing.T) {
+	t.Setenv("WRANGLER_LOG", "debug")
+	for _, value := range flueBuildEnv() {
+		if value == "WRANGLER_LOG=debug" {
+			return
+		}
+	}
+	t.Fatal("flueBuildEnv did not preserve explicit WRANGLER_LOG=debug")
 }
 
 func TestExtractFlueWranglerDescriptorRejectsCapabilityVariation(t *testing.T) {

--- a/cmd/oc/internal/commands/update_check.go
+++ b/cmd/oc/internal/commands/update_check.go
@@ -29,7 +29,7 @@ type updateCheckCache struct {
 // per 24h. Any error bails silently — the CLI must never block or warn
 // on a failed version check.
 func maybePromptUpdate() {
-	if Version == "dev" {
+	if !isReleaseVersion(Version) {
 		return
 	}
 	if os.Getenv("OC_NO_UPDATE_CHECK") != "" {
@@ -73,6 +73,27 @@ func maybePromptUpdate() {
 			"\nA new oc release is available: v%s (current: v%s). Run `oc update` to install. Disable this check with OC_NO_UPDATE_CHECK=1.\n",
 			latest, Version)
 	}
+}
+
+// isReleaseVersion distinguishes published dotted-numeric versions from local
+// builds labelled with a branch, commit, or the default "dev". Comparing a label
+// such as "flue-native-67bf0ee" as numeric zero produces a bogus update nag.
+func isReleaseVersion(version string) bool {
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for _, r := range part {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func updateCheckCachePath() (string, error) {

--- a/cmd/oc/internal/commands/update_check_test.go
+++ b/cmd/oc/internal/commands/update_check_test.go
@@ -1,0 +1,26 @@
+package commands
+
+import "testing"
+
+func TestIsReleaseVersion(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"0.6.0.8":             true,
+		"1.0":                 true,
+		"dev":                 false,
+		"flue-native-67bf0ee": false,
+		"0.6.0.8-dirty":       false,
+		"v0.6.0.8":            false,
+		"0":                   false,
+		"0..8":                false,
+	}
+	for version, want := range cases {
+		version, want := version, want
+		t.Run(version, func(t *testing.T) {
+			t.Parallel()
+			if got := isReleaseVersion(version); got != want {
+				t.Fatalf("isReleaseVersion(%q) = %v, want %v", version, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- Default the Flue build subprocess to `WRANGLER_LOG=error`, removing Wrangler warnings about directly deploying the generated scratch config. OpenComputer composes and deploys the Worker itself; actual errors remain visible.
- Preserve an explicit `WRANGLER_LOG` so operators can opt back into warning/debug output.
- Skip background release nags for branch-, commit-, dirty-, and `dev`-labelled local CLI builds; only published dotted-numeric versions participate.

## Why

`oc agent deploy` printed the same inapplicable Durable Object `exports` warning three times, followed by a bogus update prompt for a locally-built `flue-native-*` binary. Both obscured the deployment state without offering an actionable user fix.

## Verification

- `go test ./cmd/oc/internal/commands`
- Real Flue beta.9 Cloudflare build with `WRANGLER_LOG=error`: build succeeds with the repeated warnings absent
- Rebuilt `/tmp/oc-latest-bin/oc` from this branch as `flue-native-10ec3f5-noise`