### PR TITLE
fix(flue): make hands lazy and dashboard turns truthful

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,33 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Developers and operators who deploy OpenComputer agents, start and steer durable sessions, and diagnose their lifecycle from the dashboard. They need to understand current state, queued work, output, and failures without learning framework-specific internals.
+
+## Product Purpose
+
+OpenComputer provides a direct operational surface for creating, controlling, and observing agents and their sessions. Success means an operator can act quickly, trust that the UI reflects durable platform state, and identify a failure without changing or redeploying production code.
+
+## Brand Personality
+
+Calm, direct, and technical. The product should feel dependable and precise while staying approachable to a developer using it for the first time.
+
+## Anti-references
+
+Avoid decorative AI imagery, conversational gimmicks, theatrical loading states, ornamental motion, and framework-specific terminology in shared product concepts. Do not invent novel controls where a familiar operator affordance is clearer.
+
+## Design Principles
+
+1. Show durable truth. Status, ordering, errors, and completion must follow the platform record rather than optimistic animation.
+2. Keep the operator in flow. Common actions and state changes should be immediate, compact, and easy to scan.
+3. Explain failures where they occur. Use actionable language and preserve enough context to diagnose the problem.
+4. Keep framework details behind neutral product concepts unless the framework itself is the subject.
+5. Preserve the existing interface vocabulary. Consistency and earned familiarity matter more than novelty.
+
+## Accessibility & Inclusion
+
+Meet WCAG AA for contrast and interaction. Preserve keyboard and screen-reader semantics, never rely on color alone for state, and provide reduced-motion behavior for every animation.

--- a/sdks/flue/README.md
+++ b/sdks/flue/README.md
@@ -9,8 +9,8 @@ tenant script); this package supplies the OC-specific wiring the app opts into.
 - **`useOcGateway(ctx)` + `DEFAULT_MODEL`** — point the managed `anthropic` provider at the OC model
   gateway (org key injected + per-session metering). Call it **inside** your `defineAgent` initializer.
 - **`route`** — the HTTP-transport opt-in every OC-hosted agent must export (`export { route }`).
-- **`ocSandbox(env)`** — a durable OpenComputer-fleet sandbox as the agent's `SandboxApi` (workspace
-  survives across turns; also serves the repo plane).
+- **`ocSandbox(env)`** — optional, demand-driven Linux shell/files. Declaring it makes no network
+  request; the first actual sandbox operation resolves the persistent session sandbox.
 - **`ocRepoTools(env)`** — `publish_pull_request` and friends (open PRs as the OpenComputer GitHub App).
 - **`@opencomputer/flue/app`** — a default hosting app (`flue()` routes + `/health` + telemetry). Or
   `import '@opencomputer/flue/wire'` from your own `app.ts` for telemetry only.
@@ -18,17 +18,16 @@ tenant script); this package supplies the OC-specific wiring the app opts into.
 ## Minimal agent
 
 ```ts
-import { defineAgent, defineAgentProfile } from '@flue/runtime';
-import { useOcGateway, route, ocSandbox, DEFAULT_MODEL, type OcSandboxEnv } from '@opencomputer/flue';
+import { defineAgent, defineAgentProfile } from "@flue/runtime";
+import { useOcGateway, route, DEFAULT_MODEL } from "@opencomputer/flue";
 
 export { route };
 
-export default defineAgent<OcSandboxEnv>((ctx) => {
+export default defineAgent((ctx) => {
   useOcGateway(ctx);
   return {
-    profile: defineAgentProfile({ instructions: 'You help customers.' }),
-    model: DEFAULT_MODEL,          // prompt-caching-safe
-    sandbox: ocSandbox(ctx.env),
+    profile: defineAgentProfile({ instructions: "You help customers." }),
+    model: DEFAULT_MODEL, // prompt-caching-safe
   };
 });
 ```
@@ -36,12 +35,13 @@ export default defineAgent<OcSandboxEnv>((ctx) => {
 `src/app.ts`:
 
 ```ts
-export { default } from '@opencomputer/flue/app';
+export { default } from "@opencomputer/flue/app";
 ```
 
 Then `flue build --target cloudflare` and `oc agent deploy`. See `oc-flue-starter` for a full example.
 
 ## Environment (set on the tenant script by the OC deploy)
 
-`OC_GATEWAY`, `OC_SESSION_TOKEN`, `OC_INGEST`, `OC_SANDBOX_API` (+ `OC_SANDBOX_ID` or a resolve seam),
-`OC_REPO_API`. Reserved `OC_`/`FLUE_` prefixes are OC-managed.
+`OC_GATEWAY` and `OC_SESSION_TOKEN` are always managed by OC. Agents that explicitly use
+`ocSandbox` use the managed `OC_SANDBOX_API`; `OC_SANDBOX_ID` may be pre-resolved. Reserved
+`OC_`/`FLUE_` prefixes are platform-managed.

--- a/sdks/flue/src/index.ts
+++ b/sdks/flue/src/index.ts
@@ -1,6 +1,6 @@
 // @opencomputer/flue — make a stock Flue agent OpenComputer-native (design 013 §4/§5).
 // - useOcGateway + route + DEFAULT_MODEL: point managed anthropic at the OC gateway; HTTP-transport opt-in.
-// - ocSandbox: a durable OC-fleet sandbox as the agent's SandboxApi.
+// - ocSandbox: optional, demand-driven durable shell/files as the agent's SandboxApi.
 // - ocRepoTools: publish/repo tools (repo plane).
 // - installOcObserver: forward lifecycle/usage to OC_INGEST.
 // Default hosting app is at `@opencomputer/flue/app`; `@opencomputer/flue/wire` is the telemetry-only

--- a/sdks/flue/src/sandbox.test.ts
+++ b/sdks/flue/src/sandbox.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ocSandbox } from "./sandbox.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+async function initialize(id = "ses_1") {
+  const factory = ocSandbox({
+    OC_SANDBOX_API: "https://api.opencomputer.test",
+    OC_SESSION_TOKEN: "deploy-token",
+  });
+  const env = await factory.createSessionEnv({ id });
+  // Flue beta.9's fixed harness bootstrap sequence.
+  expect(await env.exists("/workspace/AGENTS.md")).toBe(false);
+  expect(await env.exists("/workspace/CLAUDE.md")).toBe(false);
+  expect(await env.exists("/workspace/.agents/skills")).toBe(false);
+  expect(await env.readdir("/workspace")).toEqual([]);
+  return { factory, env };
+}
+
+describe("ocSandbox lazy allocation", () => {
+  it("makes zero requests for initialization and model/custom-tool-only work", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    await initialize();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("shares one resolution across concurrent first operations and reuses it", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        calls.push(url);
+        if (url.includes("/flue/session-sandbox")) {
+          return new Response(JSON.stringify({ sandbox_id: "sbx_1" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (url.includes("/exec/run")) {
+          return new Response(
+            JSON.stringify({ exitCode: 0, stdout: "ok", stderr: "" }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+        return new Response("hello", { status: 200 });
+      }),
+    );
+    const { factory, env } = await initialize();
+    await Promise.all([env.exec("echo one"), env.readFile("note.txt")]);
+    const laterTurn = await factory.createSessionEnv({ id: "ses_1" });
+    expect(await laterTurn.exists("/workspace/AGENTS.md")).toBe(false);
+    expect(await laterTurn.exists("/workspace/CLAUDE.md")).toBe(false);
+    expect(await laterTurn.exists("/workspace/.agents/skills")).toBe(false);
+    expect(await laterTurn.readdir("/workspace")).toEqual([]);
+    await laterTurn.exec("echo later turn");
+
+    expect(
+      calls.filter((url) => url.includes("/flue/session-sandbox")),
+    ).toHaveLength(1);
+    expect(
+      calls.filter((url) => url.includes("/sandboxes/sbx_1/")),
+    ).toHaveLength(3);
+  });
+
+  it("surfaces resolution failure to the invoking operation and permits a later retry", async () => {
+    let resolves = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes("/flue/session-sandbox")) {
+          resolves++;
+          if (resolves === 1)
+            return new Response("unavailable", { status: 503 });
+          return new Response(JSON.stringify({ sandbox_id: "sbx_retry" }), {
+            status: 200,
+          });
+        }
+        return new Response(
+          JSON.stringify({ exitCode: 0, stdout: "ok", stderr: "" }),
+          { status: 200 },
+        );
+      }),
+    );
+    const { env } = await initialize();
+    await expect(env.exec("first")).rejects.toThrow(
+      "oc sandbox resolve failed",
+    );
+    await expect(env.exec("second")).resolves.toMatchObject({ exitCode: 0 });
+    expect(resolves).toBe(2);
+  });
+});

--- a/sdks/flue/src/sandbox.ts
+++ b/sdks/flue/src/sandbox.ts
@@ -1,10 +1,10 @@
-// ocSandbox — a Flue `SandboxApi`/`SandboxFactory` (design 013 §5) driving an OpenComputer fleet sandbox
-// over its public HTTP API, so the workspace is DURABLE across turns (git checkout + build cache survive)
-// and also serves the repo plane (§5.2). Public-seam impl, no trick.
+// ocSandbox — an optional Flue `SandboxApi`/`SandboxFactory` driving an OpenComputer fleet sandbox
+// over its public HTTP API. Merely declaring the adapter does not allocate a machine: the first real
+// shell/file operation resolves the session sandbox and all concurrent callers share that promise.
 //
-// The session's sandbox is provisioned by the control plane at Flue-session create (§5.2); this client
-// resolves it per instance and proxies exec/fs. Endpoints (from @opencomputer/sdk, all fetch-based so
-// they run in a CF DO):
+// The first real shell/file operation resolves (and, when needed, provisions) the persistent session
+// sandbox through the control plane; this client then proxies exec/fs. Endpoints (from
+// @opencomputer/sdk, all fetch-based so they run in a CF DO):
 //   exec  POST {base}/sandboxes/{id}/exec/run   {args:["-c",cmd],cwd,envs,timeout}  -> {exitCode,stdout,stderr}
 //   read  GET  {base}/sandboxes/{id}/files?path=
 //   write PUT  {base}/sandboxes/{id}/files?path=   (body = content)
@@ -12,7 +12,13 @@
 // stat/exists/mkdir/rm compose over exec (shell), mirroring cloudflareSandbox.
 
 import { createSandboxSessionEnv } from "@flue/runtime";
-import type { SandboxApi, SandboxFactory, FileStat, ShellResult, SessionEnv } from "@flue/runtime";
+import type {
+  SandboxApi,
+  SandboxFactory,
+  FileStat,
+  ShellResult,
+  SessionEnv,
+} from "@flue/runtime";
 import type { OcEnv } from "./gateway.js";
 import { ocResolveEnv } from "./cf-env.js";
 
@@ -20,14 +26,18 @@ import { ocResolveEnv } from "./cf-env.js";
 export const WORKSPACE_CWD = "/workspace";
 
 export interface OcSandboxEnv extends OcEnv {
-  /** OC sandbox API base, e.g. `https://app.opencomputer.dev/api`. */
+  /** OC sandbox API base, e.g. `https://api.opencomputer.dev`. */
   OC_SANDBOX_API?: string;
   /** Pre-resolved sandbox id, when the control plane injects it; else resolved lazily (see below). */
   OC_SANDBOX_ID?: string;
 }
 
 class OcSandboxApi implements SandboxApi {
-  constructor(private readonly base: string, private readonly token: string, private sandboxId: string) {}
+  constructor(
+    private readonly base: string,
+    private readonly token: string,
+    private sandboxId: string,
+  ) {}
 
   private headers(extra?: Record<string, string>): Record<string, string> {
     return { authorization: `Bearer ${this.token}`, ...extra };
@@ -36,55 +46,186 @@ class OcSandboxApi implements SandboxApi {
     return `${this.base.replace(/\/+$/, "")}/sandboxes/${this.sandboxId}${suffix}`;
   }
 
-  async exec(command: string, options?: { cwd?: string; env?: Record<string, string>; timeoutMs?: number; signal?: AbortSignal }): Promise<ShellResult> {
-    const body: Record<string, unknown> = { args: ["-c", command], timeout: Math.ceil((options?.timeoutMs ?? 60_000) / 1000) };
+  async exec(
+    command: string,
+    options?: {
+      cwd?: string;
+      env?: Record<string, string>;
+      timeoutMs?: number;
+      signal?: AbortSignal;
+    },
+  ): Promise<ShellResult> {
+    const body: Record<string, unknown> = {
+      args: ["-c", command],
+      timeout: Math.ceil((options?.timeoutMs ?? 60_000) / 1000),
+    };
     if (options?.cwd) body.cwd = options.cwd;
     if (options?.env) body.envs = options.env;
-    const resp = await fetch(this.url("/exec/run"), { method: "POST", headers: this.headers({ "content-type": "application/json" }), body: JSON.stringify(body), signal: options?.signal });
-    if (!resp.ok) throw new Error(`oc sandbox exec failed: ${resp.status} ${(await resp.text()).slice(0, 200)}`);
-    const r = (await resp.json()) as { exitCode?: number; stdout?: string; stderr?: string };
-    return { stdout: r.stdout ?? "", stderr: r.stderr ?? "", exitCode: r.exitCode ?? 0 };
+    const resp = await fetch(this.url("/exec/run"), {
+      method: "POST",
+      headers: this.headers({ "content-type": "application/json" }),
+      body: JSON.stringify(body),
+      signal: options?.signal,
+    });
+    if (!resp.ok)
+      throw new Error(
+        `oc sandbox exec failed: ${resp.status} ${(await resp.text()).slice(0, 200)}`,
+      );
+    const r = (await resp.json()) as {
+      exitCode?: number;
+      stdout?: string;
+      stderr?: string;
+    };
+    return {
+      stdout: r.stdout ?? "",
+      stderr: r.stderr ?? "",
+      exitCode: r.exitCode ?? 0,
+    };
   }
 
   async readFile(path: string): Promise<string> {
-    const resp = await fetch(this.url(`/files?path=${encodeURIComponent(path)}`), { headers: this.headers() });
+    const resp = await fetch(
+      this.url(`/files?path=${encodeURIComponent(path)}`),
+      { headers: this.headers() },
+    );
     if (!resp.ok) throw new Error(`oc sandbox read ${path}: ${resp.status}`);
     return resp.text();
   }
   async readFileBuffer(path: string): Promise<Uint8Array> {
-    const resp = await fetch(this.url(`/files?path=${encodeURIComponent(path)}`), { headers: this.headers() });
+    const resp = await fetch(
+      this.url(`/files?path=${encodeURIComponent(path)}`),
+      { headers: this.headers() },
+    );
     if (!resp.ok) throw new Error(`oc sandbox read ${path}: ${resp.status}`);
     return new Uint8Array(await resp.arrayBuffer());
   }
   async writeFile(path: string, content: string | Uint8Array): Promise<void> {
-    const resp = await fetch(this.url(`/files?path=${encodeURIComponent(path)}`), { method: "PUT", headers: this.headers({ "content-type": "application/octet-stream" }), body: content });
+    const resp = await fetch(
+      this.url(`/files?path=${encodeURIComponent(path)}`),
+      {
+        method: "PUT",
+        headers: this.headers({ "content-type": "application/octet-stream" }),
+        body: content,
+      },
+    );
     if (!resp.ok) throw new Error(`oc sandbox write ${path}: ${resp.status}`);
   }
   async readdir(path: string): Promise<string[]> {
-    const resp = await fetch(this.url(`/files/list?path=${encodeURIComponent(path)}`), { headers: this.headers() });
+    const resp = await fetch(
+      this.url(`/files/list?path=${encodeURIComponent(path)}`),
+      { headers: this.headers() },
+    );
     if (!resp.ok) throw new Error(`oc sandbox list ${path}: ${resp.status}`);
-    const entries = (await resp.json()) as Array<{ name?: string; path?: string }>;
-    return entries.map((e) => e.name ?? (e.path ?? "").split("/").pop() ?? "").filter(Boolean);
+    const entries = (await resp.json()) as Array<{
+      name?: string;
+      path?: string;
+    }>;
+    return entries
+      .map((e) => e.name ?? (e.path ?? "").split("/").pop() ?? "")
+      .filter(Boolean);
   }
 
   // stat/exists/mkdir/rm over the shell (mirrors cloudflareSandbox — the files API has no stat/mkdir/rm).
   async stat(path: string): Promise<FileStat> {
     const r = await this.exec(`stat -L -c '%s/%F' ${shq(path)}`);
-    if (r.exitCode !== 0) throw new Error(`oc sandbox stat ${path}: ${r.stderr.slice(0, 120)}`);
+    if (r.exitCode !== 0)
+      throw new Error(`oc sandbox stat ${path}: ${r.stderr.slice(0, 120)}`);
     const [sizeStr, kind = ""] = r.stdout.trim().split("/");
-    return { isFile: /regular file/.test(kind), isDirectory: /directory/.test(kind), size: Number(sizeStr) || undefined };
+    return {
+      isFile: /regular file/.test(kind),
+      isDirectory: /directory/.test(kind),
+      size: Number(sizeStr) || undefined,
+    };
   }
   async exists(path: string): Promise<boolean> {
     return (await this.exec(`test -e ${shq(path)}`)).exitCode === 0;
   }
   async mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {
-    const r = await this.exec(`mkdir ${options?.recursive ? "-p " : ""}${shq(path)}`);
-    if (r.exitCode !== 0) throw new Error(`oc sandbox mkdir ${path}: ${r.stderr.slice(0, 120)}`);
+    const r = await this.exec(
+      `mkdir ${options?.recursive ? "-p " : ""}${shq(path)}`,
+    );
+    if (r.exitCode !== 0)
+      throw new Error(`oc sandbox mkdir ${path}: ${r.stderr.slice(0, 120)}`);
   }
-  async rm(path: string, options?: { recursive?: boolean; force?: boolean }): Promise<void> {
+  async rm(
+    path: string,
+    options?: { recursive?: boolean; force?: boolean },
+  ): Promise<void> {
     const flags = `${options?.recursive ? "r" : ""}${options?.force ? "f" : ""}`;
     const r = await this.exec(`rm ${flags ? `-${flags} ` : ""}${shq(path)}`);
-    if (r.exitCode !== 0 && !options?.force) throw new Error(`oc sandbox rm ${path}: ${r.stderr.slice(0, 120)}`);
+    if (r.exitCode !== 0 && !options?.force)
+      throw new Error(`oc sandbox rm ${path}: ${r.stderr.slice(0, 120)}`);
+  }
+}
+
+/**
+ * Flue discovers workspace context while initializing every harness. OC does not materialize repo
+ * sources for Flue sessions yet, and a newly allocated sandbox is empty, so those fixed bootstrap
+ * probes must not turn a model-only turn into a machine allocation. Any operation outside the exact
+ * discovery sequence falls through to the real remote environment.
+ */
+class LazyOcSandboxApi implements SandboxApi {
+  private bootstrapping = true;
+  private readonly bootstrapAbsent: Set<string>;
+
+  constructor(
+    private readonly cwd: string,
+    private readonly load: () => Promise<SandboxApi>,
+  ) {
+    this.bootstrapAbsent = new Set([
+      `${cwd}/AGENTS.md`,
+      `${cwd}/CLAUDE.md`,
+      `${cwd}/.agents/skills`,
+    ]);
+  }
+
+  private remote(): Promise<SandboxApi> {
+    this.bootstrapping = false;
+    return this.load();
+  }
+
+  async exec(
+    command: string,
+    options?: {
+      cwd?: string;
+      env?: Record<string, string>;
+      timeoutMs?: number;
+      signal?: AbortSignal;
+    },
+  ): Promise<ShellResult> {
+    return (await this.remote()).exec(command, options);
+  }
+  async readFile(path: string): Promise<string> {
+    return (await this.remote()).readFile(path);
+  }
+  async readFileBuffer(path: string): Promise<Uint8Array> {
+    return (await this.remote()).readFileBuffer(path);
+  }
+  async writeFile(path: string, content: string | Uint8Array): Promise<void> {
+    return (await this.remote()).writeFile(path, content);
+  }
+  async stat(path: string): Promise<FileStat> {
+    return (await this.remote()).stat(path);
+  }
+  async readdir(path: string): Promise<string[]> {
+    if (this.bootstrapping && path === this.cwd) {
+      this.bootstrapping = false;
+      return [];
+    }
+    return (await this.remote()).readdir(path);
+  }
+  async exists(path: string): Promise<boolean> {
+    if (this.bootstrapping && this.bootstrapAbsent.has(path)) return false;
+    return (await this.remote()).exists(path);
+  }
+  async mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {
+    return (await this.remote()).mkdir(path, options);
+  }
+  async rm(
+    path: string,
+    options?: { recursive?: boolean; force?: boolean },
+  ): Promise<void> {
+    return (await this.remote()).rm(path, options);
   }
 }
 
@@ -94,38 +235,74 @@ function shq(s: string): string {
 
 /** Resolve the session's OC sandbox id (control-plane seam). Uses the injected id when present, else a
  *  documented resolve endpoint keyed by the session id. Kept a single point so W1/W5 can pin the contract. */
-async function resolveSandboxId(env: OcSandboxEnv, sessionId: string): Promise<string> {
+async function resolveSandboxId(
+  env: OcSandboxEnv,
+  sessionId: string,
+): Promise<string> {
   if (env.OC_SANDBOX_ID) return env.OC_SANDBOX_ID;
   const base = (env.OC_SANDBOX_API ?? "").replace(/\/+$/, "");
-  const resp = await fetch(`${base}/flue/session-sandbox?session=${encodeURIComponent(sessionId)}`, {
-    method: "POST",
-    headers: { authorization: `Bearer ${env.OC_SESSION_TOKEN ?? ""}` },
-  });
-  if (!resp.ok) throw new Error(`oc sandbox resolve failed for ${sessionId}: ${resp.status}`);
-  return ((await resp.json()) as { sandbox_id: string }).sandbox_id;
+  const resp = await fetch(
+    `${base}/flue/session-sandbox?session=${encodeURIComponent(sessionId)}`,
+    {
+      method: "POST",
+      headers: { authorization: `Bearer ${env.OC_SESSION_TOKEN ?? ""}` },
+    },
+  );
+  if (!resp.ok)
+    throw new Error(
+      `oc sandbox resolve failed for ${sessionId}: ${resp.status}`,
+    );
+  const sandboxId = ((await resp.json()) as { sandbox_id?: unknown })
+    .sandbox_id;
+  if (typeof sandboxId !== "string" || !sandboxId) {
+    throw new Error(
+      `oc sandbox resolve failed for ${sessionId}: response has no sandbox_id`,
+    );
+  }
+  return sandboxId;
 }
 
 /**
- * The OC-fleet sandbox factory. Set `sandbox: ocSandbox(env)` in your `defineAgent` initializer; the OC
- * template scaffolds exactly this. Lazily resolves the session's sandbox (keyed by the DO instance id =
- * `ses_`) on first tool use, so no sandbox is provisioned for tool-free turns (§5).
+ * The optional OC-fleet sandbox factory. Add `sandbox: ocSandbox(env)` only when an agent needs a
+ * Linux shell or durable files. The default starter intentionally omits it.
  *
  * Reads the CF ambient env (`cloudflare:workers`), not the passed `ctx.env`: on the `--target
  * cloudflare` build the real `OC_SANDBOX_*`/`OC_SESSION_TOKEN` bindings live on the ambient env and
- * `ctx.env` is empty for them (same reason as `useOcGateway`). The resolution happens lazily inside
- * `createSessionEnv`, so a tool-free turn never touches the sandbox config.
+ * `ctx.env` is empty for them (same reason as `useOcGateway`). `createSessionEnv` validates local
+ * configuration and returns a lazy environment without fetching or provisioning anything.
  */
-export function ocSandbox(env: OcSandboxEnv, opts?: { cwd?: string }): SandboxFactory {
+export function ocSandbox(
+  env: OcSandboxEnv,
+  opts?: { cwd?: string },
+): SandboxFactory {
   const cwd = opts?.cwd ?? WORKSPACE_CWD;
+  const remoteBySession = new Map<string, Promise<SandboxApi>>();
   return {
     async createSessionEnv({ id }: { id: string }): Promise<SessionEnv> {
       const resolved = ocResolveEnv<OcSandboxEnv>(env);
-      if (!resolved.OC_SANDBOX_API && !resolved.OC_SANDBOX_ID) {
-        throw new Error("[oc-flue] ocSandbox: set OC_SANDBOX_API (+ OC_SESSION_TOKEN) or OC_SANDBOX_ID — the OC sandbox binding is not configured.");
+      if (!resolved.OC_SANDBOX_API) {
+        throw new Error(
+          "[oc-flue] ocSandbox: OC_SANDBOX_API is required for sandbox operations.",
+        );
       }
-      const sandboxId = await resolveSandboxId(resolved, id);
-      const api = new OcSandboxApi((resolved.OC_SANDBOX_API ?? "").replace(/\/+$/, ""), resolved.OC_SESSION_TOKEN ?? "", sandboxId);
-      return createSandboxSessionEnv(api, cwd);
+      const load = (): Promise<SandboxApi> => {
+        const existing = remoteBySession.get(id);
+        if (existing) return existing;
+        const pending = (async () => {
+          const sandboxId = await resolveSandboxId(resolved, id);
+          return new OcSandboxApi(
+            (resolved.OC_SANDBOX_API ?? "").replace(/\/+$/, ""),
+            resolved.OC_SESSION_TOKEN ?? "",
+            sandboxId,
+          );
+        })();
+        remoteBySession.set(id, pending);
+        void pending.catch(() => {
+          if (remoteBySession.get(id) === pending) remoteBySession.delete(id);
+        });
+        return pending;
+      };
+      return createSandboxSessionEnv(new LazyOcSandboxApi(cwd, load), cwd);
     },
   };
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -46,7 +46,8 @@
         "tailwindcss": "^4.3.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.0",
-        "vite": "^8.1.0"
+        "vite": "^8.1.0",
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -744,6 +745,474 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3090,6 +3559,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
@@ -3456,10 +3932,28 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3781,6 +4275,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
@@ -4037,6 +4644,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types": {
@@ -4340,6 +4957,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "5.6.2",
@@ -5158,6 +5785,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -5219,6 +5853,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -5683,6 +6361,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5751,6 +6439,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -7999,6 +8697,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -8289,6 +9001,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -9459,6 +10178,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -9509,6 +10235,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -9518,6 +10251,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -9826,6 +10566,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -9841,6 +10598,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -10333,6 +11100,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web-vitals": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
@@ -10442,6 +11299,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "dev": "vite",
     "dev:preview": "VITE_PREVIEW=1 vite",
     "build": "tsc -b && vite build",
+    "test": "vitest run",
     "preview": "vite preview",
     "lint": "eslint .",
     "format": "prettier --write .",
@@ -55,6 +56,7 @@
     "tailwindcss": "^4.3.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.0",
-    "vite": "^8.1.0"
+    "vite": "^8.1.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/web/src/components/session-conversation.tsx
+++ b/web/src/components/session-conversation.tsx
@@ -5,7 +5,10 @@ import { Button } from '@/components/ui/button'
 import {
   bodyText,
   isOutOfCredits,
+  isTerminalSessionStatus,
+  isTurnInput,
   type GroupedTimeline,
+  type TurnState,
 } from '@/lib/session-turns'
 
 // A single chat bubble (You / Agent). Shared between the grouped Conversation
@@ -44,69 +47,84 @@ export function MessageBubble({
   )
 }
 
-// "A reply is coming" — a gentle agent-side typing indicator. Three dots pulse
-// in sequence; no failure is implied. Shown while a turn is running with no
-// answer yet, OR while input sits queued waiting for its follow-up turn to
-// dispatch (the ~gap the user otherwise reads as "stuck").
+function TurnStateChip({
+  state,
+}: {
+  state: Extract<TurnState, 'queued' | 'running'>
+}) {
+  return (
+    <span className="text-muted-foreground bg-muted inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] font-medium">
+      {state === 'queued' ? (
+        <Hourglass className="size-2.5" aria-hidden="true" />
+      ) : (
+        <span
+          className="bg-status-running size-1.5 rounded-full"
+          aria-hidden="true"
+        />
+      )}
+      {state === 'queued' ? 'Queued' : 'Working'}
+    </span>
+  )
+}
+
+// A static operational state, not a theatrical typing animation. It appears
+// only after the durable turn.started boundary and disappears on completion.
 function ReplyIndicator() {
   return (
-    <li className="px-4 py-3">
-      <div className="mb-1 flex items-center gap-2">
-        <span className="text-foreground/70 text-xs font-semibold">Agent</span>
-      </div>
-      <span
-        className="flex items-center gap-1"
-        role="status"
-        aria-label="Agent is responding"
-      >
-        {[0, 1, 2].map((i) => (
-          <span
-            key={i}
-            className="bg-muted-foreground/50 size-1.5 animate-pulse rounded-full"
-            style={{ animationDelay: `${i * 200}ms`, animationDuration: '1s' }}
-          />
-        ))}
-      </span>
-    </li>
+    <div
+      className="flex items-center gap-2 pt-1"
+      role="status"
+      aria-live="polite"
+    >
+      <span className="text-foreground/70 text-xs font-semibold">Agent</span>
+      <TurnStateChip state="running" />
+    </div>
   )
 }
 
 // Grouped chat view: one block per turn (its inputs as "You", its agent.message
-// outputs as "Agent"), an error affordance on failure, and a single trailing
-// "reply coming" indicator while the agent still owes a response. Lifecycle
+// outputs as "Agent"), an error affordance on failure, and one static working
+// state while the agent still owes a response. Lifecycle
 // chrome (turn.started/turn.completed/agent.result/tool.call) is hidden here.
 // Queued input — typed while a turn was running and not yet claimed by a
 // follow-up turn — trails the groups.
 export function TurnConversation({
   grouped,
   halted = false,
+  sessionStatus,
 }: {
   grouped: GroupedTimeline
   halted?: boolean
+  sessionStatus?: string
 }) {
-  const last = grouped.groups[grouped.groups.length - 1]
-  const runningNoAnswer =
-    !!last &&
-    last.state === 'running' &&
-    !last.events.some((e) => e.type === 'agent.message')
-  // A response is expected (no failure) when a turn is mid-flight without an
-  // answer yet, or input is queued for a not-yet-dispatched turn. Suppressed
-  // when halted (out of credits → nothing runs until top-up).
-  const replyPending = !halted && (runningNoAnswer || grouped.pending.length > 0)
+  const sessionTerminal = isTerminalSessionStatus(sessionStatus)
 
   return (
     <ul className="divide-y">
       {grouped.groups.map((group) => {
         const errorEv = group.events.find((e) => e.type.startsWith('error'))
+        const groupInputs = group.events.filter(isTurnInput)
+        const activeInputId = groupInputs[groupInputs.length - 1]?.id
+        const runningNoAnswer =
+          group.state === 'running' &&
+          !group.events.some((event) => event.type === 'agent.message')
+        const showActiveState = !halted && !sessionTerminal
         return (
           <li key={group.turnId} className="space-y-3 px-4 py-3">
             {group.events.map((ev) => {
-              if (ev.turn_id == null) {
+              if (ev.type === 'user.message') {
                 return (
                   <MessageBubble
                     key={ev.id}
                     label={ev.actor?.display ?? 'You'}
                     text={bodyText(ev)}
+                    meta={
+                      showActiveState &&
+                      ev.id === activeInputId &&
+                      group.state === 'queued' ? (
+                        <TurnStateChip state="queued" />
+                      ) : undefined
+                    }
                   />
                 )
               }
@@ -122,9 +140,11 @@ export function TurnConversation({
               }
               return null // hide agent.result / tool.call / error chrome
             })}
+            {showActiveState && runningNoAnswer ? <ReplyIndicator /> : null}
             {group.state === 'error' ? (
               <div className="bg-status-error-bg/40 text-status-error rounded-sm px-3 py-2 text-xs">
-                {(errorEv && bodyText(errorEv)) ??
+                {group.errorMessage ??
+                  (errorEv && bodyText(errorEv)) ??
                   'The agent hit an error on this turn.'}
               </div>
             ) : null}
@@ -137,15 +157,13 @@ export function TurnConversation({
             label={ev.actor?.display ?? 'You'}
             text={bodyText(ev)}
             meta={
-              <span className="text-muted-foreground bg-muted inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] font-medium">
-                <Hourglass className="size-2.5" />
-                Queued · runs next
-              </span>
+              !halted && !sessionTerminal ? (
+                <TurnStateChip state="queued" />
+              ) : undefined
             }
           />
         </li>
       ))}
-      {replyPending ? <ReplyIndicator /> : null}
     </ul>
   )
 }

--- a/web/src/lib/session-turns.test.ts
+++ b/web/src/lib/session-turns.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest'
+import type { SessionEvent } from '@/api/client'
+import { groupIntoTurns } from './session-turns'
+
+function event(
+  seq: number,
+  type: string,
+  overrides: Partial<SessionEvent> = {},
+): SessionEvent {
+  return {
+    id: `evt_${seq}_${type.replace(/\./g, '_')}`,
+    seq,
+    type,
+    level: type.endsWith('message') ? 'user' : 'progress',
+    body: {},
+    ...overrides,
+  }
+}
+
+describe('groupIntoTurns', () => {
+  it('groups a normal brain-box turn by its explicit input bounds', () => {
+    const timeline = groupIntoTurns([
+      event(1, 'user.message', {
+        source: 'client',
+        body: { text: 'hello' },
+        turn_id: null,
+      }),
+      event(2, 'turn.started', {
+        turn_id: 'trn_brain',
+        body: { input_from_seq: 1, input_to_seq: 1 },
+      }),
+      event(3, 'agent.message', {
+        turn_id: 'trn_brain',
+        body: { text: 'hi' },
+      }),
+      event(4, 'turn.completed', {
+        turn_id: 'trn_brain',
+        body: { yield_reason: 'completed' },
+      }),
+    ])
+
+    expect(timeline.pending).toEqual([])
+    expect(timeline.groups).toHaveLength(1)
+    expect(timeline.groups[0]).toMatchObject({
+      turnId: 'trn_brain',
+      fromSeq: 1,
+      toSeq: 1,
+      state: 'completed',
+      yieldReason: 'completed',
+    })
+    expect(timeline.groups[0]?.events.map((item) => item.seq)).toEqual([1, 3])
+  })
+
+  it('uses the platform turn id and neutral outcome for a new Flue turn', () => {
+    const timeline = groupIntoTurns([
+      event(1, 'user.message', {
+        source: 'client',
+        turn_id: 'trn_platform',
+        body: { text: 'triage this' },
+      }),
+      event(2, 'turn.started', {
+        turn_id: 'trn_platform',
+        body: {
+          turn_id: 'trn_platform',
+          input_from_seq: 1,
+          input_to_seq: 1,
+        },
+      }),
+      event(3, 'agent.message', {
+        turn_id: 'trn_platform',
+        body: { text: 'done' },
+      }),
+      event(4, 'turn.completed', {
+        turn_id: 'trn_platform',
+        level: 'user',
+        body: {
+          turn_id: 'trn_platform',
+          outcome: 'quiescent',
+          result_event_id: 'evt_3_agent_message',
+        },
+      }),
+    ])
+
+    expect(timeline.pending).toEqual([])
+    expect(timeline.groups[0]).toMatchObject({
+      turnId: 'trn_platform',
+      state: 'completed',
+      yieldReason: 'quiescent',
+    })
+    expect(timeline.groups[0]).not.toHaveProperty('inferredBounds')
+    expect(timeline.groups[0]?.events.map((item) => item.seq)).toEqual([1, 3])
+  })
+
+  it('repairs the production preview start that omitted input bounds', () => {
+    const timeline = groupIntoTurns([
+      event(1, 'user.message', {
+        source: 'client',
+        turn_id: null,
+        body: { text: 'how are we doing' },
+      }),
+      event(2, 'turn.started', {
+        turn_id: 'trn_flue_preview',
+        body: { submission_id: 'sub_preview' },
+      }),
+      event(3, 'agent.message', {
+        turn_id: 'trn_flue_preview',
+        body: { text: 'all good' },
+      }),
+      event(4, 'turn.completed', {
+        turn_id: 'trn_flue_preview',
+        level: 'user',
+        body: { outcome: 'quiescent' },
+      }),
+    ])
+
+    expect(timeline.pending).toEqual([])
+    expect(timeline.groups[0]).toMatchObject({
+      turnId: 'trn_flue_preview',
+      fromSeq: 1,
+      toSeq: 1,
+      inferredBounds: true,
+      state: 'completed',
+    })
+    expect(timeline.groups[0]?.events.map((item) => item.seq)).toEqual([1, 3])
+  })
+
+  it('keeps a completion-only failure visible with its error', () => {
+    const timeline = groupIntoTurns([
+      event(7, 'turn.completed', {
+        turn_id: 'trn_failed',
+        level: 'user',
+        body: {
+          outcome: 'error',
+          error: { code: 'admission_rejected', message: 'tenant rejected it' },
+        },
+      }),
+    ])
+
+    expect(timeline.groups).toEqual([
+      expect.objectContaining({
+        turnId: 'trn_failed',
+        state: 'error',
+        errorMessage: 'admission_rejected: tenant rejected it',
+        events: [],
+      }),
+    ])
+  })
+
+  it('leaves a follow-up queued until a new turn claims it', () => {
+    const timeline = groupIntoTurns([
+      event(1, 'user.message', {
+        source: 'client',
+        turn_id: null,
+        body: { text: 'first' },
+      }),
+      event(2, 'turn.started', {
+        turn_id: 'trn_first',
+        body: { input_from_seq: 1, input_to_seq: 1 },
+      }),
+      event(3, 'user.message', {
+        source: 'client',
+        turn_id: null,
+        body: { text: 'second' },
+      }),
+    ])
+
+    expect(timeline.groups[0]).toMatchObject({
+      turnId: 'trn_first',
+      state: 'running',
+    })
+    expect(timeline.pending.map((item) => item.seq)).toEqual([3])
+  })
+
+  it('shows a new accepted input as queued before turn.started exists', () => {
+    const timeline = groupIntoTurns([
+      event(1, 'user.message', {
+        source: 'client',
+        turn_id: 'trn_accepted',
+        body: { text: 'start' },
+      }),
+    ])
+
+    expect(timeline.pending).toEqual([])
+    expect(timeline.groups[0]).toMatchObject({
+      turnId: 'trn_accepted',
+      state: 'queued',
+    })
+  })
+
+  it('deduplicates history and SSE copies and cannot regress on arrival order', () => {
+    const input = event(1, 'user.message', {
+      source: 'client',
+      turn_id: 'trn_ordered',
+      body: { text: 'go' },
+    })
+    const started = event(2, 'turn.started', {
+      turn_id: 'trn_ordered',
+      body: { input_from_seq: 1, input_to_seq: 1 },
+    })
+    const answer = event(3, 'agent.message', {
+      turn_id: 'trn_ordered',
+      body: { text: 'done' },
+    })
+    const completed = event(4, 'turn.completed', {
+      turn_id: 'trn_ordered',
+      body: { outcome: 'quiescent' },
+    })
+
+    const timeline = groupIntoTurns([
+      completed,
+      answer,
+      input,
+      started,
+      completed,
+      answer,
+    ])
+
+    expect(timeline.groups).toHaveLength(1)
+    expect(timeline.groups[0]?.state).toBe('completed')
+    expect(timeline.groups[0]?.events.map((item) => item.id)).toEqual([
+      input.id,
+      answer.id,
+    ])
+  })
+
+  it('never steals an input already owned by an explicit range', () => {
+    const timeline = groupIntoTurns([
+      event(1, 'user.message', {
+        source: 'client',
+        turn_id: null,
+        body: { text: 'owned' },
+      }),
+      event(2, 'turn.started', {
+        turn_id: 'trn_explicit',
+        body: { input_from_seq: 1, input_to_seq: 1 },
+      }),
+      event(3, 'turn.started', {
+        turn_id: 'trn_legacy',
+        body: { submission_id: 'sub_later' },
+      }),
+    ])
+
+    expect(
+      timeline.groups.find((group) => group.turnId === 'trn_explicit')?.events,
+    ).toHaveLength(1)
+    expect(
+      timeline.groups.find((group) => group.turnId === 'trn_legacy')?.events,
+    ).toHaveLength(0)
+  })
+})

--- a/web/src/lib/session-turns.ts
+++ b/web/src/lib/session-turns.ts
@@ -1,18 +1,15 @@
 import type { SessionEvent } from '@/api/client'
 
-// Pure, React-free grouping of a session's raw event stream into turns.
-//
-// The backend never interrupts a running turn: input typed mid-turn is queued
-// and gets its own follow-up turn on completion. The only wire linkage between
-// an input event and the turn that consumes it is the inclusive seq range on
-// the turn's `turn.started` body (`input_from_seq`/`input_to_seq`). Input events
-// carry `turn_id == null`, so they cannot be grouped by turn_id — only by range.
-//
-// Rule: an input event with seq S belongs to the turn whose started bounds
-// satisfy `from <= S <= to`. If no started turn covers S, the input is pending
-// (typed but not yet claimed by a turn).
+// Pure, React-free reconstruction of the durable event log into neutral OC turns.
+// New inputs already carry their platform turn id. Older brain-box and preview
+// Flue inputs may need explicit seq bounds or the conservative legacy fallback.
 
-export type TurnState = 'running' | 'completed' | 'error' | 'canceled'
+export type TurnState =
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'error'
+  | 'canceled'
 
 export interface TurnGroup {
   turnId: string
@@ -20,26 +17,49 @@ export interface TurnGroup {
   toSeq: number | null
   state: TurnState
   yieldReason?: string
-  // seq-ordered; the turn's inputs + its outputs; excludes turn.started/turn.completed.
+  errorMessage?: string
+  inferredBounds?: boolean
+  // seq-ordered inputs and outputs; lifecycle markers stay as group metadata.
   events: SessionEvent[]
 }
 
 export interface GroupedTimeline {
-  groups: TurnGroup[] // ordered by turn.started seq
-  pending: SessionEvent[] // input events (turn_id==null) not yet claimed by any turn, seq-ordered
+  groups: TurnGroup[]
+  // Inputs with no authoritative or unambiguous inferred owner.
+  pending: SessionEvent[]
+}
+
+interface MutableTurn extends TurnGroup {
+  firstSeq: number
+  startSeq: number | null
+  completion: SessionEvent | null
+}
+
+const FAILURE_OUTCOMES = new Set([
+  'error',
+  'failed',
+  'deadline_exceeded',
+  'max_turns',
+  'budget_exceeded',
+])
+
+const TERMINAL_SESSION_STATUSES = new Set([
+  'idle',
+  'awaiting_input',
+  'failed',
+  'archived',
+])
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
 }
 
 // body is unknown (inline JSON <=32KB); pull the common { text } shape defensively.
 export function bodyText(ev: SessionEvent): string | null {
-  const b = ev.body
-  if (
-    b &&
-    typeof b === 'object' &&
-    typeof (b as Record<string, unknown>).text === 'string'
-  ) {
-    return (b as Record<string, string>).text
-  }
-  return null
+  const text = record(ev.body).text
+  return typeof text === 'string' ? text : null
 }
 
 // The runtime's failPreExec emits an agent.message tagged with an
@@ -47,93 +67,237 @@ export function bodyText(ev: SessionEvent): string | null {
 export function isOutOfCredits(ev: SessionEvent): boolean {
   return (
     ev.type === 'agent.message' &&
-    (ev.body as Record<string, unknown> | null | undefined)?.code ===
-      'insufficient_credits'
+    record(ev.body).code === 'insufficient_credits'
   )
 }
 
+export function isTurnInput(ev: SessionEvent): boolean {
+  return (
+    ev.type === 'user.message' ||
+    ev.source === 'client' ||
+    ev.source === 'github'
+  )
+}
+
+export function isTerminalSessionStatus(status?: string): boolean {
+  return status != null && TERMINAL_SESSION_STATUSES.has(status)
+}
+
 // Reads input_from_seq/input_to_seq off a turn.started body, coercing legacy
-// string seqs; null when a bound is absent (a turn with null bounds can't claim
-// inputs by range).
+// string seqs. A partial or invalid range is not authoritative.
 export function turnBounds(ev: SessionEvent): {
   from: number | null
   to: number | null
 } {
-  const b = (ev.body ?? {}) as Record<string, unknown>
-  const num = (v: unknown) =>
-    v == null || Number.isNaN(Number(v)) ? null : Number(v)
-  return { from: num(b.input_from_seq), to: num(b.input_to_seq) }
+  const body = record(ev.body)
+  const num = (value: unknown) => {
+    if (value == null) return null
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return { from: num(body.input_from_seq), to: num(body.input_to_seq) }
+}
+
+function turnIdOf(ev: SessionEvent): string | null {
+  if (typeof ev.turn_id === 'string' && ev.turn_id) return ev.turn_id
+  const bodyTurnId = record(ev.body).turn_id
+  return typeof bodyTurnId === 'string' && bodyTurnId ? bodyTurnId : null
+}
+
+function completionOutcome(ev: SessionEvent): string {
+  const body = record(ev.body)
+  const raw =
+    typeof body.outcome === 'string'
+      ? body.outcome
+      : typeof body.yield_reason === 'string'
+        ? body.yield_reason
+        : ''
+  return raw.toLowerCase()
+}
+
+function completionState(ev: SessionEvent): TurnState {
+  const outcome = completionOutcome(ev)
+  if (outcome === 'canceled' || outcome === 'cancelled') return 'canceled'
+  if (FAILURE_OUTCOMES.has(outcome)) return 'error'
+  return 'completed'
+}
+
+function errorText(value: unknown): string | null {
+  if (typeof value === 'string' && value) return value
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const error = value as Record<string, unknown>
+  const code = typeof error.code === 'string' ? error.code : null
+  const message = [error.message, error.error, error.detail].find(
+    (candidate): candidate is string =>
+      typeof candidate === 'string' && candidate.length > 0,
+  )
+  if (code && message) return `${code}: ${message}`
+  if (message) return message
+  if (code) return code
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return null
+  }
+}
+
+function completionError(ev: SessionEvent): string | null {
+  const body = record(ev.body)
+  return (
+    errorText(body.error) ?? errorText(body.message) ?? errorText(body.detail)
+  )
 }
 
 export function groupIntoTurns(input: SessionEvent[]): GroupedTimeline {
-  const sorted = [...input].sort((a, b) => a.seq - b.seq)
-  const byTurn = new Map<string, TurnGroup>()
-  const order: string[] = []
+  // History and SSE intentionally overlap. Event id is the durable identity;
+  // the later copy wins and seq ordering makes arrival order irrelevant.
+  const deduped = new Map<string, SessionEvent>()
+  for (const event of input) deduped.set(event.id, event)
+  const sorted = [...deduped.values()].sort(
+    (a, b) => a.seq - b.seq || a.id.localeCompare(b.id),
+  )
 
-  // Pass 1: skeletons from turn.started (defines the seq ranges + order).
-  for (const ev of sorted) {
-    if (ev.type !== 'turn.started' || !ev.turn_id) continue
-    const { from, to } = turnBounds(ev)
-    byTurn.set(ev.turn_id, {
-      turnId: ev.turn_id,
-      fromSeq: from,
-      toSeq: to,
-      state: 'running',
-      events: [],
-    })
-    order.push(ev.turn_id)
-  }
-
-  // Pass 2: completion -> state.
-  for (const ev of sorted) {
-    if (ev.type !== 'turn.completed' || !ev.turn_id) continue
-    const g = byTurn.get(ev.turn_id)
-    if (!g) continue
-    const rawYr = ((ev.body ?? {}) as Record<string, unknown>).yield_reason
-    const yr = typeof rawYr === 'string' ? rawYr : ''
-    g.yieldReason = yr || undefined
-    g.state =
-      yr === 'error' ? 'error' : yr === 'canceled' ? 'canceled' : 'completed'
-  }
-
-  // Pass 3: assign every event.
-  const pending: SessionEvent[] = []
-  for (const ev of sorted) {
-    // chrome; state already captured above.
-    if (ev.type === 'turn.started' || ev.type === 'turn.completed') continue
-    if (ev.turn_id && byTurn.has(ev.turn_id)) {
-      // agent.message / agent.result / tool.call / error.
-      byTurn.get(ev.turn_id)!.events.push(ev)
-      continue
+  const byTurn = new Map<string, MutableTurn>()
+  const ensureTurn = (turnId: string, seq: number): MutableTurn => {
+    const existing = byTurn.get(turnId)
+    if (existing) {
+      existing.firstSeq = Math.min(existing.firstSeq, seq)
+      return existing
     }
-    if (ev.turn_id == null) {
-      // input event: claim by seq range.
-      const g = [...byTurn.values()].find(
-        (t) =>
-          t.fromSeq != null &&
-          t.toSeq != null &&
-          ev.seq >= t.fromSeq &&
-          ev.seq <= t.toSeq,
-      )
-      if (g) g.events.push(ev)
-      else pending.push(ev) // seq beyond every started turn -> not yet claimed
-      continue
-    }
-    // turn_id set but no matching started skeleton (out-of-order/late): lazily create.
-    const g: TurnGroup = {
-      turnId: ev.turn_id,
+    const created: MutableTurn = {
+      turnId,
       fromSeq: null,
       toSeq: null,
-      state: 'running',
-      events: [ev],
+      state: 'queued',
+      events: [],
+      firstSeq: seq,
+      startSeq: null,
+      completion: null,
     }
-    byTurn.set(ev.turn_id, g)
-    order.push(ev.turn_id)
+    byTurn.set(turnId, created)
+    return created
   }
 
-  for (const g of byTurn.values()) g.events.sort((a, b) => a.seq - b.seq)
+  // Lifecycle pass. Completion is authoritative even if it arrived before
+  // history or its start marker in the browser.
+  for (const event of sorted) {
+    const turnId = turnIdOf(event)
+    if (!turnId) continue
+    const group = ensureTurn(turnId, event.seq)
+    if (event.type === 'turn.started') {
+      const bounds = turnBounds(event)
+      group.startSeq =
+        group.startSeq == null ? event.seq : Math.min(group.startSeq, event.seq)
+      if (bounds.from != null && bounds.to != null) {
+        group.fromSeq = bounds.from
+        group.toSeq = bounds.to
+      }
+    } else if (
+      event.type === 'turn.completed' &&
+      (!group.completion || event.seq >= group.completion.seq)
+    ) {
+      group.completion = event
+    }
+  }
+
+  const claimedInputs = new Set<string>()
+
+  // Direct turn ids are strongest. New OC inputs use this path, as do outputs.
+  for (const event of sorted) {
+    if (event.type === 'turn.started' || event.type === 'turn.completed')
+      continue
+    const turnId = turnIdOf(event)
+    if (!turnId) continue
+    const group = ensureTurn(turnId, event.seq)
+    group.events.push(event)
+    if (isTurnInput(event)) claimedInputs.add(event.id)
+  }
+
+  const inputs = sorted.filter(isTurnInput)
+
+  // Older inputs have no turn id. Explicit inclusive bounds remain authoritative.
+  for (const event of inputs) {
+    if (claimedInputs.has(event.id)) continue
+    const owners = [...byTurn.values()].filter(
+      (group) =>
+        group.fromSeq != null &&
+        group.toSeq != null &&
+        event.seq >= group.fromSeq &&
+        event.seq <= group.toSeq,
+    )
+    const owner = owners.length === 1 ? owners[0] : undefined
+    if (!owner) continue
+    owner.events.push(event)
+    owner.firstSeq = Math.min(owner.firstSeq, event.seq)
+    claimedInputs.add(event.id)
+  }
+
+  // One-release preview fallback. Only a real start with both bounds absent
+  // may claim the nearest earlier input, and never one already owned elsewhere.
+  const legacyStarts = [...byTurn.values()]
+    .filter(
+      (group) =>
+        group.startSeq != null &&
+        group.fromSeq == null &&
+        group.toSeq == null &&
+        !group.events.some(isTurnInput),
+    )
+    .sort(
+      (a, b) =>
+        (a.startSeq ?? 0) - (b.startSeq ?? 0) ||
+        a.turnId.localeCompare(b.turnId),
+    )
+  for (const group of legacyStarts) {
+    const candidates = inputs.filter(
+      (event) =>
+        !claimedInputs.has(event.id) && event.seq < (group.startSeq ?? 0),
+    )
+    const candidate = candidates[candidates.length - 1]
+    if (!candidate) continue
+    group.events.push(candidate)
+    group.fromSeq = candidate.seq
+    group.toSeq = candidate.seq
+    group.inferredBounds = true
+    group.firstSeq = Math.min(group.firstSeq, candidate.seq)
+    claimedInputs.add(candidate.id)
+  }
+
+  const pending = inputs.filter((event) => !claimedInputs.has(event.id))
+
+  for (const group of byTurn.values()) {
+    group.events.sort((a, b) => a.seq - b.seq || a.id.localeCompare(b.id))
+    if (group.completion) {
+      group.state = completionState(group.completion)
+      const outcome = completionOutcome(group.completion)
+      group.yieldReason = outcome || undefined
+      if (group.state === 'error') {
+        group.errorMessage = completionError(group.completion) ?? undefined
+      }
+    } else if (group.startSeq != null) {
+      group.state = 'running'
+    }
+  }
+
   return {
-    groups: order.map((id) => byTurn.get(id)!),
-    pending: pending.sort((a, b) => a.seq - b.seq),
+    groups: [...byTurn.values()]
+      .sort(
+        (a, b) => a.firstSeq - b.firstSeq || a.turnId.localeCompare(b.turnId),
+      )
+      .map(
+        (group): TurnGroup => ({
+          turnId: group.turnId,
+          fromSeq: group.fromSeq,
+          toSeq: group.toSeq,
+          state: group.state,
+          events: group.events,
+          ...(group.yieldReason ? { yieldReason: group.yieldReason } : {}),
+          ...(group.errorMessage ? { errorMessage: group.errorMessage } : {}),
+          ...(group.inferredBounds ? { inferredBounds: true } : {}),
+        }),
+      ),
+    pending,
   }
 }

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -43,7 +43,12 @@ import {
   MessageBubble,
   TurnConversation,
 } from '@/components/session-conversation'
-import { bodyText, groupIntoTurns, isOutOfCredits } from '@/lib/session-turns'
+import {
+  bodyText,
+  groupIntoTurns,
+  isOutOfCredits,
+  isTurnInput,
+} from '@/lib/session-turns'
 
 function toolSummary(ev: SessionEvent): string {
   const b = (ev.body ?? {}) as Record<string, unknown>
@@ -80,6 +85,16 @@ function truncationNote(ev: SessionEvent): string | null {
 }
 function humanizeType(t: string): string {
   return t.replace(/[._]/g, ' ').replace(/^\w/, (c) => c.toUpperCase())
+}
+
+function turnCompletionLabel(ev: SessionEvent): string | null {
+  if (ev.type !== 'turn.completed' || !ev.body) return null
+  const body = ev.body as Record<string, unknown>
+  if (typeof body.outcome === 'string') return humanizeType(body.outcome)
+  if (typeof body.yield_reason === 'string') {
+    return humanizeType(body.yield_reason)
+  }
+  return null
 }
 
 interface TurnStartInfo {
@@ -324,9 +339,17 @@ for await (const event of session.events()) {
   // Group the (unfiltered) stream by turn: turn.started is level:progress, so it
   // must be read from allEvents, never the level==='user' filter.
   const grouped = useMemo(() => groupIntoTurns(allEvents), [allEvents])
-  // Seqs of input events typed but not yet claimed by a turn → tagged "queued".
+  // Inputs whose neutral turn has not crossed the durable start boundary.
   const pendingSeqs = useMemo(
-    () => new Set(grouped.pending.map((e) => e.seq)),
+    () =>
+      new Set([
+        ...grouped.pending.map((event) => event.seq),
+        ...grouped.groups
+          .filter((group) => group.state === 'queued')
+          .flatMap((group) =>
+            group.events.filter(isTurnInput).map((event) => event.seq),
+          ),
+      ]),
     [grouped],
   )
   // Per-turn seq range + input preview, so the All log's turn.started row is
@@ -334,7 +357,7 @@ for await (const event of session.events()) {
   const turnStartInfo = useMemo(() => {
     const m = new Map<string, TurnStartInfo>()
     for (const g of grouped.groups) {
-      const firstInput = g.events.find((e) => e.turn_id == null)
+      const firstInput = g.events.find(isTurnInput)
       const raw = firstInput ? bodyText(firstInput) : null
       const preview =
         raw && raw.length > 40 ? `${raw.slice(0, 40)}…` : (raw ?? null)
@@ -515,7 +538,11 @@ for await (const event of session.events()) {
             description="Events from the agent's turns will stream in here."
           />
         ) : level === 'user' ? (
-          <TurnConversation grouped={grouped} halted={halted} />
+          <TurnConversation
+            grouped={grouped}
+            halted={halted}
+            sessionStatus={status}
+          />
         ) : (
           <ul className="divide-y">
             {allEvents.map((ev) => (
@@ -636,6 +663,7 @@ function EventRow({
 }) {
   const text = bodyText(ev)
   const trunc = truncationNote(ev)
+  const completion = turnCompletionLabel(ev)
 
   // Reasoning — muted, set apart from the answer. (flue tailer + brain-box both emit this.)
   if (ev.type === 'agent.thinking') {
@@ -735,11 +763,7 @@ function EventRow({
     <li className="text-muted-foreground flex items-center gap-2 px-4 py-1.5 text-xs">
       <span className="bg-border h-px w-4 shrink-0" />
       {humanizeType(ev.type)}
-      {ev.type === 'turn.completed' &&
-      ev.body &&
-      typeof (ev.body as Record<string, unknown>).yield_reason === 'string'
-        ? ` · ${humanizeType(String((ev.body as Record<string, unknown>).yield_reason))}`
-        : ''}
+      {completion ? ` · ${completion}` : ''}
     </li>
   )
 }


### PR DESCRIPTION
## Why

The first production run allocated an empty sandbox before a model-only turn and the dashboard continued to render a completed Flue follow-up as queued/working. The UI was reconstructing turns from a brain-box-only assumption (`turn.started` ranges and inputs without `turn_id`) and could regress under history/SSE overlap.

## What changes

### Optional sandbox hands

- `ocSandbox` now resolves the persistent session sandbox only on the first real shell/file operation.
- The exact empty-workspace bootstrap probes used by Flue return locally, so initializer/model/custom-tool-only work performs zero sandbox requests.
- Concurrent first operations share one resolution; failures surface to the invoking operation and a later attempt can retry.
- The package README now presents sandbox hands as an explicit opt-in rather than a default session property.

### Operator dashboard

- Reconstruct neutral turns from platform `turn_id`, explicit input bounds, completion-only records, or a conservative one-release fallback for already-stored malformed preview starts.
- Deduplicate history and SSE by durable event id and make completion authoritative regardless of arrival order.
- Show accepted input as a calm static **Queued** state and started/no-answer work as static **Working**; completion or terminal session state removes it immediately.
- Surface completion-only failure details instead of leaving theatrical blinking activity behind.
- Prefer neutral `outcome` while retaining the old `yield_reason` read path.
- Add the agreed durable product context: calm, direct, technical, and framework-neutral shared UI.

## Scope and rollout

This PR does not publish a new `@opencomputer/flue` package version; publication remains a separate release step. The production branch deploy in this batch affects the dashboard immediately. The fresh starter omits `ocSandbox`, so its fast default path does not depend on that package publication.

Dashboard rollback is a branch deploy of the previous `flue-native`/main edge artifact; there is no data migration.

## Verification

- SDK: 4 tests, typecheck, build
- Dashboard: 8 reducer tests, typecheck, production build
- API edge: 37 tests and TypeScript check
- Scoped Prettier and ESLint checks for the changed UI surface
