### PR TITLE
docs: explain the Flue runtime model

### DIFF
--- a/docs/agent-sessions/agents.mdx
+++ b/docs/agent-sessions/agents.mdx
@@ -4,9 +4,9 @@ title: "Agents"
 description: "Reusable agent configuration"
 ---
 
-An **agent** is reusable configuration: `name`, `prompt`, `model`, [`runtime`](/agent-sessions/runtimes), and optional [**skills**](/agent-sessions/revisions). Every [session](/agent-sessions/sessions) runs on an agent, so create one first, then start as many sessions on it as you like. The behavior (`prompt`/`model`/`skills`) is versioned as [**revisions**](/agent-sessions/revisions): every [deployment](/agent-sessions/revisions) — from the API, the CLI, or a [GitHub push](/agent-sessions/revisions#deploy-from-a-repo) — appends a new one, and you can roll back instantly.
+An **agent** is a reusable identity, runtime, model, and deployed behavior. Every [session](/agent-sessions/sessions) runs on an agent, so create one first, then start as many sessions on it as you like. For the built-in runtimes, behavior is `prompt` plus optional skills and is frozen into independently routable [revisions](/agent-sessions/revisions). A [Flue](/agent-sessions/flue) agent instead carries its instructions, tools, and packaged skills in a compiled Flue app.
 
-<Note>You can create and edit agents in the [dashboard](https://app.opencomputer.dev) too — the create dialog also lets you pick or add a [credential](/agent-sessions/credentials) inline.</Note>
+<Note>You can create and edit built-in runtime agents in the [dashboard](https://app.opencomputer.dev). Flue agents are created and deployed from their app with `oc agent deploy`, then appear in the same agent and session views.</Note>
 
 <CodeGroup>
 
@@ -46,7 +46,7 @@ Pass your model `key` inline and it's stored as a [credential](/agent-sessions/c
 
 ## Start simple, add capability as you go
 
-The only thing an agent needs is a **model** and a **prompt** — create one and it runs on a **default, managed runtime that just works**. Everything beyond that is **additive**: reach for a rung only when you need it, and nothing earlier is undone.
+For a built-in runtime, the only behavior an agent needs is a **model** and a **prompt**. Everything beyond that is additive: reach for a rung only when you need it, and nothing earlier is undone. Flue has a separate [app deployment path](/agent-sessions/flue#add-opencomputer-to-a-flue-app).
 
 | Rung | What you add | What you get |
 |---|---|---|
@@ -55,12 +55,16 @@ The only thing an agent needs is a **model** and a **prompt** — create one and
 | **+ Deploy from a repo / CLI** | keep the agent's `prompt.md` + `skills/` in Git and [push to deploy](/agent-sessions/revisions#deploy-from-a-repo) | versioned, push-to-deploy, staged revisions + rollback — still the default runtime |
 | **+ Custom runtime** *(coming soon)* | bring your own runtime image | full control of the execution environment |
 
-At every rung the agent is just a small directory — at most `agent.toml` + `prompt.md` + `skills/`. You can stop at any rung; most agents never go past skills.
+At every built-in rung the agent is a small directory, at most `agent.toml` + `prompt.md` + `skills/`. You can stop at any rung; most agents never go past skills.
 
 ## Session-pinned config
 
-When a session is created it **freezes** the agent's **active [revision](/agent-sessions/revisions)** — `prompt`, `model`, `runtime`, and `skills` — into the session, and pins the resolved credential too. (A session can start with a one-off [`model`](/agent-sessions/sessions#model) override in place of the agent's, pinned the same way for that session's life.) Editing the named agent afterwards never changes a running or resumed session — its behavior is pinned for its whole life. Update an agent freely: existing sessions keep what they started with, new sessions pick up the change. (Rotating a credential's **key value** is the exception — that flows to running sessions, so a compromised key can be replaced; see [credentials](/agent-sessions/credentials).)
+For a built-in runtime, creating a session **freezes** the agent's active [revision](/agent-sessions/revisions), including its `prompt`, `model`, `runtime`, and `skills`. It also pins the resolved credential. A one-off [`model`](/agent-sessions/sessions#model) override is pinned in the same way. Editing the named agent does not change a running or resumed session: existing sessions keep what they started with, while new sessions pick up the change. Rotating a credential's **key value** is the exception, so a compromised key can be replaced; see [credentials](/agent-sessions/credentials).
+
+That isolation applies to the built-in runtimes. A Flue session records the selected deployment, but all sessions for that agent execute on its one live Worker. Deploying a new Flue Worker can therefore change existing sessions; see [Flue deployment behavior](/agent-sessions/flue#deployment-and-revision-behavior).
 
 ## Model
 
 `model` is a `provider/model` id, and its provider must match the [runtime](/agent-sessions/runtimes): `claude` runs `anthropic/…` (e.g. `anthropic/claude-opus-4-8`), `codex` runs `openai/…` (e.g. `openai/gpt-5-codex`). The model runs either **Managed** (via OpenComputer, billed to your credits — no key) or on [your own key](/agent-sessions/credentials) for that provider, so a key isn't required. The `runtime` / `model` / credential pairing is validated when you **create** the agent. `runtime` is fixed at creation — to switch engines, create a new agent; you can still update `model` later, but keep it within the runtime's provider.
+
+Flue currently uses Managed Anthropic access. Its model is declared in both the compiled app and `agent.toml`; per-session model overrides are not supported.

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -78,15 +78,15 @@ oc agent deploy        # deploy the agent directory in the cwd
 **Create params** — `agent` is **required**; the model resolves to **Managed** (default) or a [credential](#credentials), else `422 no_credential` / `422 managed_unavailable`.
 
 - `input` — the task (string or [envelope](/agent-sessions/messaging#message-input)). Truncate large inputs; let the agent fetch the rest via [sandbox tools](/agent-sessions/runtime-tools).
-- `revision?` — pin a specific revision (number / `rev_…`); default = the agent's active one. Use to test a [staged](/agent-sessions/revisions#staging-vs-activating) revision.
+- `revision?`: pin a specific revision (number / `rev_…`); default = the agent's active one. Use to test a [staged](/agent-sessions/revisions#staging-vs-activating) built-in runtime revision. A Flue agent has one live Worker, so an old revision does not isolate older Worker code.
 - `model?` — run this session on a different model than the agent's (same `provider/model` form; its provider must match the agent's [runtime](/agent-sessions/runtimes), e.g. `anthropic/…` for `claude`). Default = the agent's model. Pinned for the session's life like the rest of the snapshot. Rejected (`400 invalid`) for [flue](/agent-sessions/flue) agents — their model is fixed in the deployed artifact.
 - `key?` — get-or-create (one session per key). Keyless: an `Idempotency-Key` header makes create retry-safe.
 - `metadata?` — opaque routing state (≤ 16 KB); on get/list + **verbatim in webhooks**; never sent to the model, not indexed.
-- `limits?` `{ tokens, turn_seconds, turns }` — non-monetary; tripping one ends the turn (matching `yield_reason`).
-- `sources?` — repos checked out before turn 1 (the token never enters the sandbox; see [GitHub](#github-apps-and-repos)). Each registered `{ repo, ref, sha?, name? }` or inline `{ url, ref, sha, name?, auth }`. `ref` is required; `sha` is required for inline sources but **optional for a registered repo** — omit it and the control plane resolves `ref`→HEAD and pins that commit at create.
+- `limits?` `{ tokens, turn_seconds, turns }`: non-monetary; tripping one ends a built-in runtime turn with the matching `yield_reason`. These limits are stored but not yet enforced for Flue sessions.
+- `sources?`: repos checked out before turn 1 for built-in runtimes (the token never enters the sandbox; see [GitHub](#github-apps-and-repos)). Each registered `{ repo, ref, sha?, name? }` or inline `{ url, ref, sha, name?, auth }`. `ref` is required; `sha` is required for inline sources but **optional for a registered repo**. Flue sessions reject `sources` with `422 sources_not_supported`.
 - Client tokens: `scopes?` (`read`/`steer`), `ttl?` 60–86400 s (SDK `ttlSeconds`).
 
-A session pins the agent's active revision for its whole life — editing the agent later never affects a running one.
+A built-in runtime session pins the agent's active revision for its whole life. A Flue session records its selected deployment but executes on the agent's one live Worker; deploying that Worker can therefore affect an existing session.
 
 **`Session`**
 

--- a/docs/agent-sessions/custom-runtimes.mdx
+++ b/docs/agent-sessions/custom-runtimes.mdx
@@ -1,14 +1,14 @@
 ---
 mode: "wide"
 title: "Custom runtimes"
-description: "Package your own agent harness as a runtime"
+description: "Package your own agent implementation as a runtime"
 ---
 
 <Note>**Labs preview.** Custom runtimes are not part of the stable Durable Sessions API. Production sessions use the built-in [runtimes](/agent-sessions/runtimes): `claude`, `codex`, and `pi`.</Note>
 
-Building on the [Flue framework](https://flueframework.com)? There's a supported path that skips all of this: [Run Flue agents](/agent-sessions/flue) deploys your Flue app onto the platform's brain contract directly. Custom runtimes remain the general escape hatch for any other harness.
+Building on the [Flue framework](https://flueframework.com)? Use the supported [Flue runtime](/agent-sessions/flue) instead. It deploys Flue's Cloudflare target as an agent Worker with one Durable Object per session, so it does not use the custom brain-box contract described here. Custom runtimes remain the general escape hatch for other agent implementations.
 
-A custom runtime lets you run your own agent harness on Durable Agent Sessions. Once registered, select it on an agent with `runtime: "<name>"`; sessions, events, steering, webhooks, recovery, and sandbox tools use the same public API as built-in runtimes.
+A custom runtime lets you run your own agent implementation on Durable Agent Sessions. Once registered, select it on an agent with `runtime: "<name>"`; sessions, events, steering, webhooks, recovery, and sandbox tools use the same public API as built-in runtimes.
 
 The runtime image contains a **brain server**: a resident process around your agent SDK. OpenComputer supplies the platform adapter that reads the session log, owns fencing and idempotency, exposes tools, calls your brain over localhost, and commits the brain's stream as durable events.
 

--- a/docs/agent-sessions/events.mdx
+++ b/docs/agent-sessions/events.mdx
@@ -17,7 +17,7 @@ turn.started
 turn.completed      needs_input
 ```
 
-Everything between `turn.started` and `turn.completed` is that turn's work. **`turn.completed` is the "done" signal — await it** and read its `yield_reason` (here, `needs_input`). The `body` each type carries is in the table below.
+Everything between `turn.started` and `turn.completed` is that turn's work. **`turn.completed` is the done signal, so await it.** New neutral completions report `outcome`; existing built-in runtime events may report the equivalent `yield_reason`. The `body` each type carries is in the table below.
 
 Each event is one envelope:
 
@@ -39,7 +39,7 @@ Treat **`type`** as the stable discriminator. Unknown types should render from t
 | `agent.message` | `{ text }` | agent output (the result is whichever one `turn.completed` points to) |
 | `user.message` | `{ text }` | a steer you sent |
 | `turn.started` | `{ turn_id, input_from_seq, input_to_seq }` | a turn began, consuming input events in `[from,to]` |
-| `turn.completed` | `{ turn_id, yield_reason, result_event_id? }` | **the "done" signal — await this** |
+| `turn.completed` | `{ turn_id, outcome?, yield_reason?, result_event_id?, usage? }` | the done signal; normalize `outcome` and legacy `yield_reason` as the terminal reason |
 | `tool.call` | `{ tool, args_summary }` | the agent invoked a tool |
 | `exec.completed` | `{ command, exit_code, summary, content_ref?, bytes? }` | a finished command |
 | `error.runtime` · `error.model` · `error.task` | `{ code, message, retriable? }` | a failure |
@@ -86,7 +86,7 @@ Read or stream with `after=<seq>` to get everything since that point — this is
 
 <AccordionGroup>
   <Accordion title="Correlate a steer to its turn">
-    Steers coalesce — one turn can pick up several — so [`POST /messages`](/agent-sessions/messaging) returns the *event* `seq`, not a turn. The turn that consumes your steer emits `turn.started` with `input_from_seq ≤ your_seq ≤ input_to_seq`; await its `turn.completed`, then `GET …/events?turn_id=` for everything it produced.
+    [`POST /messages`](/agent-sessions/messaging) returns the input event `seq`, not a turn id. Built-in runtimes may consume several queued inputs in one turn; Flue allocates one ordered turn for each accepted input. In both cases, `turn.started` reports the consumed `input_from_seq` and `input_to_seq`. Await its matching `turn.completed`, then use `GET …/events?turn_id=` for the turn's output.
   </Accordion>
   <Accordion title="Large output and artifacts">
     A large `body` is offloaded to a `content_ref`; fetch the bytes with `GET /sessions/:id/events/:eventId/content` (e.g. full `exec.completed` output). For named files, diffs, screenshots, reports, and previews, see [Artifacts & previews](/agent-sessions/artifacts) in Labs.

--- a/docs/agent-sessions/flue.mdx
+++ b/docs/agent-sessions/flue.mdx
@@ -1,141 +1,170 @@
 ---
 mode: "wide"
 title: "Flue"
-description: "Deploy a Flue app to OpenComputer as a durable session"
+description: "Deploy a Flue app as an OpenComputer agent"
 ---
 
-<Note>**Experimental.** The supported profile below is intentionally
-constrained and will widen. Flue is pre-1.0; each deploy bundles **your exact
-Flue version** into the artifact, so upstream releases never break a deployed
-agent — only new builds pick them up.</Note>
+<Note>
+**Experimental.** The supported profile is intentionally narrow. It currently covers direct text
+sessions on managed Anthropic models, with an optional OpenComputer sandbox. Flue is pre-1.0, and
+each deployment includes the exact Flue version installed in your app.
+</Note>
 
-[Flue](https://flueframework.com) is a TypeScript agent framework by the Astro
-team. OpenComputer runs a Flue app as the resident process of a
-[durable session](/agent-sessions/overview) — same sessions API, events,
-steering, and watches as every other [runtime](/agent-sessions/runtimes).
+[Flue](https://flueframework.com) is a TypeScript framework for durable agents. OpenComputer runs the
+application Flue builds and connects it to OpenComputer agents, sessions, events, steering, model
+billing, and optional sandboxes.
 
-Your app stays plain Flue. You add one file — yours, committed, nothing is
-generated or injected. It plays the role Flue's layout gives `cloudflare.ts`:
-an optional platform-specific entry module.
+Template: [`diggerhq/oc-flue-starter`](https://github.com/diggerhq/oc-flue-starter)
 
-```ts src/opencomputer.ts
-import { serveOC } from '@opencomputer/flue';
-import agent from './agents/support-triage.ts';
+## How Flue differs from the built-in runtimes
 
-serveOC(agent);
+The built-in runtimes run Claude Code, Codex, or pi as a managed coding agent. A Flue agent is
+different: **your application is the runtime**. OpenComputer deploys and operates that app.
+
+| Concern | Built-in runtimes | Flue |
+| --- | --- | --- |
+| Agent loop | OpenComputer runs Claude Code, Codex, or pi | Your compiled Flue app contains the loop |
+| Session compute | Managed per-session brain and workspace sandboxes | One deployed app, with one Durable Object instance per session |
+| Conversation state | Checkpointed runtime files plus the OpenComputer event log | Flue stores its conversation in Durable Object SQLite; OpenComputer projects public milestones into its event log |
+| Tools and skills | Platform tools plus uploaded `prompt.md` and `skills/` | `defineTool` code and packaged skill imports compiled into the Worker |
+| Linux workspace | Part of the normal runtime | Absent by default; `ocSandbox` creates one only when an operation needs it |
+| Deployment | Upload prompt, model, and skill configuration | Build and deploy the compiled app |
+
+Under the hood, OpenComputer runs Flue's Cloudflare target as an agent Worker and gives each session
+its own Durable Object. This architecture lets a Flue session start without provisioning a virtual
+machine. A model-only agent, or one whose custom tools use bundled data, never needs a sandbox.
+
+## How a turn runs
+
+```mermaid
+sequenceDiagram
+    participant Client as Dashboard or API client
+    participant OC as OpenComputer sessions API
+    participant Worker as Deployed agent Worker
+    participant DO as Session Durable Object
+    participant Gateway as OpenComputer model gateway
+    participant Model as Model provider
+    participant Sandbox as Optional sandbox
+
+    Client->>OC: Create session or send message
+    OC->>OC: Store input and allocate turn
+    OC-->>Client: Accepted
+    OC->>Worker: Dispatch accepted input
+    Worker->>DO: Admit the turn
+    DO->>Gateway: Model request
+    Gateway->>Model: Metered provider request
+    Model-->>DO: Response
+    opt First real shell or file operation
+        DO->>Sandbox: Resolve or create session sandbox
+        Sandbox-->>DO: Operation result
+    end
+    DO-->>OC: Durable conversation updates
+    OC->>OC: Append messages, tools, errors, and completion
+    OC-->>Client: Event stream update
 ```
 
-A full Flue app — with `app.ts`, channels, workflows — can add this file
-unchanged and keep self-hosting: only what it imports ends up in the
-OpenComputer artifact.
+OpenComputer returns after it has durably accepted the input. It does not wait for dispatch, the
+Durable Object, a model call, or sandbox creation. Flue executes one turn at a time for each session;
+messages sent while a turn is working remain queued and run in order.
 
-Template: [`diggerhq/oc-flue-starter`](https://github.com/diggerhq/oc-flue-starter).
+Flue's Durable Object is the runtime's conversation store. The OpenComputer event log is the stable
+consumer view used by the dashboard, API, and webhooks. OpenComputer resumes projection from a saved
+cursor after an interruption, so clients do not need to understand Flue submission ids or stream
+offsets.
 
 ## Quickstart
 
+Requirements: Node 22.19 or newer, the `oc` CLI, and an OpenComputer organization with Managed model
+access.
+
 ```sh
-git clone https://github.com/diggerhq/oc-flue-starter && cd oc-flue-starter
+git clone https://github.com/diggerhq/oc-flue-starter
+cd oc-flue-starter
 npm install
 
-# create the agent (optional — `oc agent deploy` creates it from agent.toml if missing)
-oc agent create support-triage --runtime flue --model anthropic/claude-sonnet-5
-
-# build + upload + boot-verify + activate a revision
+# Builds the Cloudflare target, deploys it, verifies the live Worker, and activates a revision.
+# The agent is created from agent.toml when it does not exist yet.
 oc agent deploy
 
-# talk to it
-oc session create --input "Customer says order 1042 hasn't arrived — what do I tell them?"
-oc session logs <session-id>
+oc session create \
+  --agent support-triage \
+  --input "Order 2203 arrived with a torn shoulder strap. What happens next?"
 ```
 
-Answer the agent's questions with `oc session steer <session-id> "..."` or in
-the [dashboard](https://app.opencomputer.dev).
+Continue the session with `oc session steer <session-id> "..."`, inspect it with
+`oc session logs <session-id>`, or open it in the
+[dashboard](https://app.opencomputer.dev).
 
-## Add to an existing Flue app
+## Add OpenComputer to a Flue app
 
-Three files, no changes to your agent code:
+Install the integration alongside Flue:
 
 ```sh
 npm install @opencomputer/flue
 ```
 
-```ts src/opencomputer.ts
-import { serveOC } from '@opencomputer/flue';
-import agent from './agents/your-agent.ts';
+Export the OpenComputer route and register the managed model gateway inside your agent initializer:
 
-serveOC(agent);
+```ts src/agents/support-triage.ts
+import { defineAgent, defineAgentProfile } from '@flue/runtime';
+import { DEFAULT_MODEL, route, useOcGateway } from '@opencomputer/flue';
+
+export { route };
+
+export default defineAgent((ctx) => {
+  useOcGateway(ctx);
+
+  return {
+    profile: defineAgentProfile({
+      instructions: 'Triage customer requests and give the next concrete action.',
+    }),
+    model: DEFAULT_MODEL,
+  };
+});
 ```
 
+Use the default hosting app, which mounts Flue's routes, the deployment health endpoint, and
+OpenComputer telemetry:
+
+```ts src/app.ts
+export { default } from '@opencomputer/flue/app';
+```
+
+Declare the deployment target:
+
 ```toml agent.toml
-name  = "your-agent"                    # the OpenComputer agent name
-model = "anthropic/claude-sonnet-5"     # must equal the model in defineAgent
+name = "support-triage"
+model = "anthropic/claude-haiku-4-5"
 
 [runtime]
 family = "flue"
 ```
 
-Then `oc agent deploy` from the app root — it creates the agent on first
-deploy. If the app sets `sandbox:` or has a `db.ts`, the build tells you
-(both are supplied by the platform — see the table below).
+The manifest name must identify the exported Flue agent, and its model must match the model returned
+by `defineAgent`. `DEFAULT_MODEL` currently resolves to `anthropic/claude-haiku-4-5`.
 
-## What changes vs a stock Flue app
+If your project owns a custom `app.ts`, keep Flue's routes, import `@opencomputer/flue/wire` for
+telemetry, and expose a `GET /health` route that returns success. The default app is the simpler
+choice when you do not need additional routes.
 
-The sandbox, persistence, model, skills, tool-name, and credential rows are
-enforced at build or deploy — violations fail before a session can exist.
-Channels and workflows aren't checked: code not imported by `src/opencomputer.ts`
-isn't in the artifact.
+## What `@opencomputer/flue` supplies
 
-| | Stock Flue | On OpenComputer |
-| --- | --- | --- |
-| Entry | Flue's generated server (`flue build --target node`) | Add `src/opencomputer.ts` calling `serveOC(agent)`. Your agent code is untouched; `flue dev` keeps working locally |
-| Sandbox | You pick one (`local()`, containers, …) | **Leave `sandbox:` unset** — the session's workspace sandbox is supplied (build error) |
-| Persistence | `db.ts` (or volatile in-memory default) | **No `db.ts`** — the conversation is stored durably in the session's state; survives restarts and hibernation (build error) |
-| Model credentials | Env keys or `registerProvider` in code | **No keys anywhere in the app** — the deploy scans the artifact for key-shaped strings and fails on a hit. Managed billing or an [OC credential](/agent-sessions/credentials); routing is injected at run time |
-| Model choice | In code | Still in code — but declared three times total (`defineAgent`, `agent.toml`, the OC agent) and all three **must be equal**; the deploy rejects divergence. Fixed for good at deploy: a [session](/agent-sessions/sessions#model) **can't override** a flue agent's model — passing `model` on a flue session is rejected |
-| Skills | Packaged imports (`with {type:'skill'}`) or workspace files | **`src/skills/<name>/SKILL.md`** — ships with every deploy. Packaged imports are a build error (for now) |
-| Asking the user | No human-in-the-loop primitive | An **`ask` tool** is added: the session yields `needs_input` and hibernates until the user replies |
-| Channels / workflows | Slack/Discord ingress, `defineWorkflow` | Not supported — inbound is session messages + [GitHub watches](/agent-sessions/watches) |
-| Tool names | Anything | `bash`, `read`, `write`, `edit`, `ls`, `grep`, `glob`, `say`, `ask` are **reserved** (build error) |
+| Export | Purpose |
+| --- | --- |
+| `useOcGateway(ctx)` | Registers the managed Anthropic endpoint inside the Flue initializer |
+| `route` | Opts an agent into the HTTP transport used by managed dispatch |
+| `DEFAULT_MODEL` | Selects the supported prompt-caching-safe default model |
+| `@opencomputer/flue/app` | Provides Flue routes, `GET /health`, and telemetry wiring |
+| `@opencomputer/flue/wire` | Adds telemetry when your project owns its hosting app |
+| `ocSandbox(ctx.env)` | Adds an optional, demand-driven Linux shell and filesystem |
 
-## What `@opencomputer/flue` does
+OpenComputer binds a platform-managed credential for its gateway during deployment. Your provider
+key is not compiled into the app or exposed to the Worker.
 
-`serveOC(agent)` runs your agent as the session's resident process and
-connects it to the platform:
+## Custom tools and packaged skills
 
-- **Conversation persistence.** Opens Flue's conversation store on the
-  session's state volume. History survives process restarts, hibernation,
-  and machine moves. A `db.ts` is rejected at build because a second store
-  would fork the conversation history.
-- **Sandbox.** Flue's built-in `read`/`write`/`edit`/`bash`/`grep`/`glob`
-  tools execute on the session's workspace sandbox — a separate machine from
-  your app process, where attached repos are checked out. Custom `defineTool`
-  code runs in-process with your app (see the network-access note below).
-- **Two added tools.** `say` posts a message to the user mid-run. `ask` asks
-  a question: the session yields `needs_input` and hibernates until the user
-  replies, then the run continues with the answer.
-- **Model credentials.** Registers the Anthropic provider with credentials
-  resolved from the platform — managed metering or your key. The bundle and
-  repo contain no credentials.
-- **Turn handling.** Each session turn is admitted into Flue's engine with
-  an idempotent id, so platform-level retries can't double-run it. If the
-  platform side of a turn dies mid-run, the retry **re-attaches to the
-  still-running engine** and streams from where it left off — the model call
-  is not repeated. Every step — model text, custom tool calls, sandbox
-  operations — is written to the session's
-  [event log](/agent-sessions/events).
-- **Retries and timeouts.** Flue's `durability` settings are overridden: one
-  engine attempt per turn, with the timeout set to the platform's turn
-  deadline. Cancel, retry, and deadline behavior is the platform's; there is
-  no second layer to reason about.
-
-`oc-flue-build` (the package's build command, run by `oc agent deploy`)
-bundles `src/opencomputer.ts` with **your** installed Flue version via esbuild, collects
-`src/skills/**` into the artifact, and stamps the metadata (`model`, versions)
-the deploy validates against.
-
-## Custom tools
-
-Plain `defineTool` — typed with valibot, running in-process:
+Custom `defineTool` handlers run inside the Worker. Import any data or templates they need so the
+Cloudflare build includes those files:
 
 ```ts src/tools/lookup-order.ts
 import { defineTool } from '@flue/runtime';
@@ -152,101 +181,157 @@ export const lookupOrder = defineTool({
 });
 ```
 
-Two rules that follow from tools running inside the deployed artifact:
+Package an agent-owned skill through Flue's supported import mechanism, then add it to the agent:
 
-- **Anything a tool needs at run time must be bundled** — `import` fixture
-  data and templates (as above); the repo checkout is not on the app's
-  filesystem.
-- **Outbound network**: custom tools currently have unrestricted outbound
-  access from your app's process — where `defineTool` code runs, a separate
-  machine from the workspace sandbox. An egress policy is planned; until it
-  exists, don't embed secrets in the bundle to call your own APIs — prefer
-  self-contained tools.
+```ts
+import triage from '../skills/triage/SKILL.md' with { type: 'skill' };
 
-## Skills
+// Inside the object returned by defineAgent:
+{
+  tools: [lookupOrder],
+  skills: [triage],
+}
+```
 
-Put the agent's own skills at `src/skills/<name>/SKILL.md`
-([SKILL.md format](/agent-sessions/skills)). The build packages them into the
-artifact; at run time they are written into the agent's workspace, where
-Flue's normal discovery finds them. Changing a skill is a redeploy; a
-rollback also reverts skills. Separately, a repo attached as a session source
-contributes its own `.agents/skills/**` (that convention means "skills for
-agents working on that repo"); on a name clash, the app's skill wins.
+The skill is part of the Worker module graph. It is not copied into a workspace, and loading it does
+not require a sandbox. Changing a tool, imported data file, or packaged skill requires another
+deployment.
 
-Skills take effect **on OpenComputer only**: `flue dev`'s default local
-environment is an empty in-memory filesystem, so it exercises your loop and
-custom tools, not skills.
+Custom tools in the Worker can currently reach only platform-managed outbound hosts. Arbitrary
+external `fetch` destinations are not part of the supported profile. Commands run through an
+optional OpenComputer sandbox follow the sandbox's separate network policy.
 
-## Models
+## Optional sandbox
 
-`anthropic/<id>`, same ids as the other runtimes — `anthropic/claude-sonnet-5`
-(the template default), `anthropic/claude-opus-4-8`,
-`anthropic/claude-haiku-4-5`. Managed billing and BYO keys behave exactly as
-on `claude`/`pi`; see [credentials](/agent-sessions/credentials).
+Add `ocSandbox` only when the agent needs a Linux shell or durable files:
 
-## Limitations vs full Flue
+```ts
+import { defineAgent, defineAgentProfile } from '@flue/runtime';
+import {
+  DEFAULT_MODEL,
+  ocSandbox,
+  route,
+  useOcGateway,
+} from '@opencomputer/flue';
 
-What the current profile does **not** cover, beyond the table above:
+export { route };
 
-- **Channels** (Slack, Discord, web ingress) don't run here — inbound is
-  session messages and [GitHub watches](/agent-sessions/watches). A full app
-  keeps its channels when self-hosting; code not imported by
-  `src/opencomputer.ts` never enters the artifact.
-- **Workflows** (`defineWorkflow`) don't run here; a workflow admission
-  throws at run time.
-- **One agent, one conversation per session.** `serveOC(agent)` hosts one
-  top-level agent, and a session is one conversation instance — Flue's
-  per-instance routing has no equivalent; fan out by creating sessions.
-- **Subagents** (`session.task()`) bundle and execute in-process, but they
-  are outside the tested profile: their model declarations aren't validated
-  the way the top-level agent's is, and subagent steps may appear
-  incompletely in the session event log.
-- **Anthropic models only.** Flue itself supports other providers (OpenAI,
-  Google, …); on OpenComputer there is no credential source for them yet.
-- **`durability` settings are ignored.** The platform pins one engine
-  attempt per turn under the turn deadline; retry and timeout policy is the
-  platform's. Setting `durability:` in `defineAgent` has no effect.
-- **Text in, text out.** Sessions exchange text; there is no way to send
-  the agent an image or a file attachment.
-- **No HTTP endpoints.** A Flue app's own server doesn't run; requests
-  reach the agent only through the
-  [sessions API](/agent-sessions/overview).
+export default defineAgent((ctx) => {
+  useOcGateway(ctx);
 
-Expect this list to shrink. The profile is versioned
-(`profile_version` in the artifact), so a deployed agent never changes
-behavior until you rebuild.
+  return {
+    profile: defineAgentProfile({
+      instructions: 'Work in the sandbox only when a shell or file operation is needed.',
+    }),
+    model: DEFAULT_MODEL,
+    sandbox: ocSandbox(ctx.env),
+  };
+});
+```
 
-## Deploying
+Declaring `ocSandbox` performs no provisioning during Worker startup or Flue runtime initialization.
+The first real shell or file operation resolves one sandbox for the session; later operations and
+turns reuse it.
 
-`oc agent deploy` = build (`oc-flue-build`, which initializes your agent to
-extract and check the profile) → upload the content-addressed artifact →
-**boot-verify** → create and activate an immutable
-[revision](/agent-sessions/revisions). Sessions pin their revision at create;
-rollback is repointing.
+The workspace starts empty. Repository sources and workspace skill discovery are not implemented for
+Flue sessions, so passing `sources` at session creation is rejected.
 
-Boot-verify is the flue-specific step. Your artifact is your brain code, so
-the platform boots it in a throwaway sandbox and waits for a healthy boot
-before pinning a revision. A bundle that throws in `initialize()` — or can't
-otherwise reach a healthy boot — **fails the deploy** with that error; it
-never reaches a session, and the previously active revision keeps serving. So
-a flue deploy isn't instant: it polls through a `verifying` state (tens of
-seconds) while the boot runs, then activates. `--no-activate` still verifies —
-a staged revision is a verified one that isn't live yet. The verify sandbox is
-discarded afterward and never holds your model credential.
+## Variables and secrets
+
+Non-secret Worker variables belong in `agent.toml`:
+
+```toml agent.toml
+[vars]
+SUPPORT_REGION = "eu-west"
+```
+
+Pipe secret values over standard input. Values are write-only and never returned by the API:
+
+```sh
+printf '%s' "$SUPPORT_API_KEY" | oc agent secret set SUPPORT_API_KEY --from-stdin
+oc agent secret list
+
+# A configuration change takes effect on the next deployment.
+oc agent deploy
+```
+
+Deleting a secret also requires a deployment before the Worker changes:
+
+```sh
+oc agent secret delete SUPPORT_API_KEY
+oc agent deploy
+```
+
+Binding names use uppercase letters, digits, and underscores. Names beginning with `OC_` or `FLUE_`
+are reserved for the platform. Never put a secret in `agent.toml` or source code.
+
+## Deployment and revision behavior
+
+`oc agent deploy` performs these operations:
+
+1. Scans the source tree for credential-shaped values.
+2. Runs the app's installed `flue build --target cloudflare`.
+3. Uploads only the generated JavaScript modules and a restricted deployment descriptor.
+4. Applies platform-owned bindings, variables, secrets, and Durable Object migrations, then uploads
+   the agent Worker.
+5. Keeps the deployment in `verifying` until the exact live Worker returns two consecutive healthy
+   responses. Only then does the CLI report the revision as ready.
+
+<Warning>
+Flue currently has one live Worker per agent. Uploading a deployment changes the code used by new and
+existing sessions before revision verification finishes. There is no isolated staged Worker, canary
+route, or automatic Worker rollback. `--no-activate`, an old revision pin, and a pointer-only
+`oc agent rollback` do not restore older Worker code.
+
+To restore a known-good build, check out that source and run `oc agent deploy` again. Flue and Durable
+Object schema changes are forward-only, so do not downgrade across an incompatible Flue storage
+version.
+</Warning>
+
+## Session behavior
+
+Flue uses the same session ids, text input, event stream, steering, cancellation, result endpoint,
+and dashboard as the other runtimes. The important differences are:
+
+- Session creation and steering return after durable acceptance. Model execution continues
+  asynchronously.
+- Each accepted input receives an OpenComputer `trn_...` id. Flue's internal submission identity is
+  not part of the public API.
+- Follow-up messages queue behind the working turn and run in order.
+- The model is compiled into the deployed app. Per-session model overrides are rejected.
+- Generic `tokens`, `turn_seconds`, and `turns` limits are not yet enforced on the Flue execution
+  path. Do not use them as a safety boundary for this runtime.
+- Archiving makes the OpenComputer session read-only but retains the Flue conversation in Durable
+  Object storage. Each session is subject to Cloudflare's
+  [10 GB Durable Object storage limit](https://developers.cloudflare.com/durable-objects/platform/limits/).
+
+## Current limitations
+
+- Direct text session messages are the supported ingress. Flue channels and workflows are not
+  connected to OpenComputer yet.
+- Repository sources, checkout, pull-request publishing, watches, and repo-backed workspaces are not
+  supported for Flue sessions.
+- File and image attachments are not supported.
+- The managed gateway currently supports Anthropic models and requires Managed model access for the
+  organization. Per-session model selection is not supported.
+- Worker code has a platform-managed outbound allowlist. Tenant-configurable egress is not available.
+- Platform turn deadlines, maximum-turn enforcement, automatic conversation compaction, and
+  automatic tenant-Worker rollback are not available yet.
+- Subagents may execute inside Flue, but their event projection and lifecycle are outside the tested
+  profile.
 
 ## Troubleshooting
 
-- **Build fails (`oc-flue-build`)** — a profile violation, named in the
-  error: `sandbox:` set, a `db.ts`, a packaged-skill import, a reserved tool
-  name, or a model that isn't `anthropic/…`. Nothing is uploaded.
-- **Deploy fails at verification** — the bundle built but didn't boot in the
-  scratch sandbox; the deploy output carries the probe error. Usual cause: a
-  top-level crash in your code (something that only happens at import time).
-- **Model rejected at deploy** — the three model declarations diverge
-  (`defineAgent`, `agent.toml`, the OC agent).
-- **`provider 401` on the first turn** — no usable model credential. Managed
-  billing is the default, so this usually means the org's billing isn't set
-  up yet — set up billing, or attach a valid Anthropic credential to the agent.
-- **Skill not loading** — the agent's own skills go in
-  `src/skills/<name>/SKILL.md`; skills from a codebase require that repo
-  attached as a session source (`--source`).
+- **`flue build` is unavailable**: run `npm install` with Node 22.19 or newer. `oc agent deploy` never
+  downloads a missing build tool for you.
+- **Credential scan refuses the deploy**: remove the reported key from source and store application
+  secrets with `oc agent secret set ... --from-stdin`.
+- **Deployment fails while verifying**: the uploaded Worker did not reach a stable healthy response.
+  Inspect the deployment error, correct the import-time or health-route failure, and deploy again.
+- **Provider authentication fails on the first turn**: confirm that Managed model access is active for
+  the organization and that the agent uses an `anthropic/...` model.
+- **A skill is missing**: import its `SKILL.md` with `with { type: 'skill' }` and include it in the
+  agent's `skills` array.
+- **A session shows an error or stops advancing**: inspect the dashboard's **All events** view or run
+  `oc session logs <session-id>`. Runtime failures are recorded without requiring a diagnostic
+  redeployment.

--- a/docs/agent-sessions/overview.mdx
+++ b/docs/agent-sessions/overview.mdx
@@ -11,12 +11,12 @@ Create an agent, start a session, stream its event log, steer it with messages, 
 ## Core behavior
 
 <CardGroup cols={2}>
-  <Card title="Supervised runtime" icon="heart-pulse">
+  <Card title="Built-in runtime supervision" icon="heart-pulse">
     - Runtime crashes restart automatically
     - Idle sessions hibernate and wake on the next message
     - Hung runs stop cleanly instead of staying stuck
   </Card>
-  <Card title="Brain / hands sandboxing" icon="shield-halved">
+  <Card title="Built-in brain / hands sandboxing" icon="shield-halved">
     - **Brain**: agent loop. **Hands**: files and commands.
     - Untrusted work stays contained in the hands sandbox
     - Your model key stays in the [secret store](/sandboxes/secrets), never in a sandbox
@@ -33,11 +33,13 @@ Create an agent, start a session, stream its event log, steer it with messages, 
   </Card>
 </CardGroup>
 
+<Note>[Flue](/agent-sessions/flue) uses the same session, event, steering, and webhook APIs on a different execution substrate. Your compiled Flue app is the runtime, each session gets its own Durable Object, and no Linux sandbox is created unless the app explicitly uses `ocSandbox`.</Note>
+
 ## Get started
 
 <Steps>
   <Step title="Define an agent">
-    Create a reusable `{ name, model, prompt, runtime }` from your backend — `runtime: "claude"` (Anthropic models) or `"codex"` (OpenAI models). Run **Managed** (`credential: "managed"`, billed to your OpenComputer credits — no key) or pass your own model `key` inline / reference a saved [credential](/agent-sessions/credentials). Every [deployment](/agent-sessions/revisions) is versioned as a [revision](/agent-sessions/revisions) (roll back instantly), you can attach [skills](/agent-sessions/revisions#skills), and you can [deploy from a GitHub repo on push](/agent-sessions/revisions#deploy-from-a-repo). ([Agents](/agent-sessions/agents))
+    Create a reusable `{ name, model, prompt, runtime }` from your backend, using `runtime: "claude"` for Anthropic models or `"codex"` for OpenAI models. Run **Managed** (`credential: "managed"`, billed to your OpenComputer credits) or pass your own model key. Built-in runtime deployments support isolated revisions, skills, repo push-to-deploy, and pointer rollback. To deploy your own Flue app instead, use the [Flue guide](/agent-sessions/flue). ([Agents](/agent-sessions/agents))
   </Step>
   <Step title="Start a session">
     Start a session with `{ agent, input }`. The agent starts immediately and returns a browser-safe `client_token`.
@@ -53,7 +55,7 @@ Create an agent, start a session, stream its event log, steer it with messages, 
   <img src="/images/durable-agent-sessions-architecture.svg" alt="Durable Agent Sessions architecture: your app starts, steers, and streams a durable event-log session; a managed runtime adapter commits events while the brain drives the agent loop and acts through the hands sandbox; the model runs on your key from the secret store, which never enters a sandbox; user-level events are delivered out via your webhook." />
 </Frame>
 
-The event log is the durable record. Your app starts sessions, streams events, and steers with messages. The runtime drives the agent loop, acts through the hands sandbox for file and command work, and commits user-level events for webhook delivery. Your model key stays in the secret store.
+The event log is the durable consumer record. Your app starts sessions, streams events, and steers with messages. Built-in runtimes drive the agent loop through brain and hands sandboxes. Flue executes in its Worker and Durable Object, then projects the same public milestone events. Managed model credentials stay outside both execution substrates.
 
 ## When to use sessions
 

--- a/docs/agent-sessions/revisions.mdx
+++ b/docs/agent-sessions/revisions.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Deployments & revisions"
-description: "Deploy agent behavior, version it as immutable revisions, roll back instantly"
+description: "Deploy and version agent behavior"
 ---
 
-What you deploy is a small directory:
+For the built-in runtimes, what you deploy is a small directory:
 
 ```
 my-agent/
@@ -13,15 +13,17 @@ my-agent/
 └─ runtime/        # optional — a custom runtime image (coming soon)
 ```
 
-`agent.toml` + `prompt.md` are all an agent needs; `skills/` and `runtime/` are additive — add them only when you do. A **deployment** packages this directory into an immutable [**revision**](#revisions); the **active revision** is what new [sessions](/agent-sessions/sessions) use, and you roll back by re-activating an earlier one.
+`agent.toml` + `prompt.md` are all a built-in agent needs; `skills/` and `runtime/` are additive. A **deployment** packages this directory into an immutable [**revision**](#revisions), and the **active revision** is what new [sessions](/agent-sessions/sessions) use.
 
-Deploy three ways — all the same underneath: the **API/SDK** (send it inline), the **`oc` CLI** (bundle a local directory), or a [**repo push**](#deploy-from-a-repo).
+<Note>A [Flue](/agent-sessions/flue) deployment packages a compiled Cloudflare app instead. It records revisions in the same API, but currently has one live Worker per agent rather than independently routable revision artifacts. Its staging and rollback behavior is therefore different.</Note>
+
+Built-in runtime behavior can be deployed through the **API/SDK**, the **`oc` CLI**, or a [**repo push**](#deploy-from-a-repo). The current Flue profile uses `oc agent deploy` from a local app checkout because its build must run the app's installed Flue toolchain.
 
 ## Revisions
 
-A **revision** is an immutable snapshot of an agent's behavior — the `prompt`, `model`, and skills from one deployment, frozen and numbered. Every deploy appends a new one (a repo push that changes nothing is skipped); the agent's **active revision** is the one new [sessions](/agent-sessions/sessions) run.
+A **revision** is an immutable, numbered record of one deployment. For a built-in runtime, it freezes the `prompt`, `model`, and skills used by new sessions. For Flue, it records the app deployment and Worker version that passed verification.
 
-Revisions are **linear** (the number only goes up, like a Vercel/Fly deployment) and never rewritten — [rolling back](#roll-back-and-promote) just moves the active pointer to an earlier one. In-flight sessions keep the revision they started on; only new sessions pick up a change.
+Revisions are **linear** (the number only goes up) and never rewritten. Built-in runtime sessions keep the revision they started on; only new sessions pick up a change. Flue sessions share the agent's live Worker, so a Worker deployment also changes the code used by existing sessions.
 
 | Field | |
 |---|---|
@@ -79,9 +81,11 @@ The response is a **deployment**:
 { "deployment": { "id": "dep_…", "state": "ready", "revision_id": "rev_…", "active": true } }
 ```
 
-Inline deployments finish synchronously (`state: "ready"` with a `revision_id`) — except [flue](/agent-sessions/flue) deploys, which return `state: "verifying"` and boot the uploaded artifact in a throwaway sandbox before pinning the revision; poll them like an async deployment (`verifying` → `ready`/`failed`). Asynchronous deployments (GitHub) return `state: "accepted"` — poll `GET /agents/:id/deployments/:deployment_id` until `ready` (or `failed`/`skipped`/`superseded`); a repo deploy also reports progress as a **commit status** on GitHub.
+Inline deployments finish synchronously (`state: "ready"` with a `revision_id`) for the built-in runtimes. A [Flue](/agent-sessions/flue) deploy returns `state: "verifying"` while the managed deploy runner uploads the agent Worker and waits for two consecutive healthy responses from that exact live Worker. Poll it like an asynchronous deployment (`verifying` to `ready` or `failed`). GitHub deployments return `state: "accepted"`; poll `GET /agents/:id/deployments/:deployment_id` until terminal, and use the commit status on GitHub for the same result.
 
 ### Staging vs activating
+
+<Warning>Isolated staging is not available for Flue. A Flue upload changes the one live Worker even when deployment metadata requests `activate: false`. Do not use `--no-activate` or a pinned revision as a Flue canary. See [Flue deployment behavior](/agent-sessions/flue#deployment-and-revision-behavior).</Warning>
 
 By default a ready deployment is **activated** — its revision becomes what new sessions use. Pass **`activate: false`** to **stage** instead: the revision is created but not made active, so you can test it before it goes live.
 
@@ -104,6 +108,8 @@ For [repo deployments](#deploy-from-a-repo) the **branch decides** and `activate
 <Tip>Editing `prompt`/`model` via [`PATCH /agents/:id`](/agent-sessions/agents) also deploys a revision — a shorthand for small edits.</Tip>
 
 ## Deploy from a repo
+
+<Note>Repo-linked push-to-deploy is not available for Flue apps yet. Deploy their compiled Cloudflare target with `oc agent deploy` from a local or CI checkout.</Note>
 
 Keep the agent directory (above) in Git and **push to deploy**. [Install the OpenComputer GitHub App](/agent-sessions/repos#connecting-github) on the repo, then connect it to an agent:
 
@@ -144,21 +150,20 @@ No repo needed — the CLI bundles a local agent directory and deploys it:
 ```bash CLI
 oc agent deploy                       # deploy ./ (the agent named in agent.toml)
 oc agent deploy ./agents/issue-fixer  # a specific directory
-oc agent deploy --no-activate         # stage instead of activate
+oc agent deploy --no-activate         # stage a built-in runtime revision
 ```
 
 Same as a repo push — handy for CI that isn't GitHub, or trying a change before you commit.
 
 ### Flue framework agents
 
-A [Flue](/agent-sessions/flue) agent (`[runtime] family = "flue"` in `agent.toml`) has no `prompt.md` or `skills/` — its behavior lives in code — so `oc agent deploy` builds and ships an artifact instead:
+A [Flue](/agent-sessions/flue) agent (`[runtime] family = "flue"` in `agent.toml`) carries its instructions, tools, and packaged skills in code, so `oc agent deploy` builds and ships the Cloudflare app instead of reading `prompt.md` and the top-level `skills/` directory:
 
 ```bash CLI
-oc agent create support-triage --runtime flue --model anthropic/claude-sonnet-5   # --prompt not needed
-oc agent deploy                                                                   # build → upload → verify → activate
+oc agent deploy   # flue build --target cloudflare, upload, verify live Worker
 ```
 
-Deploy runs the app's own build (`oc-flue-build`), uploads the content-addressed artifact, boot-verifies it in a scratch sandbox, then activates a revision — the same staging and rollback model as any other agent. See [Run Flue agents](/agent-sessions/flue).
+The CLI creates the agent from `agent.toml` when needed, runs the locally installed Flue build, uploads the generated JavaScript modules, and waits for the exact live Worker to become stable. See [Run Flue agents](/agent-sessions/flue) for the required app wiring and current deployment constraints.
 
 ## Roll back and promote
 
@@ -182,6 +187,8 @@ oc agent rollback 3
 </CodeGroup>
 
 Instant — no rebuild. Running sessions are unaffected; new sessions use the newly-active revision.
+
+<Warning>The pointer-only rollback above applies to the built-in runtimes. It does not replace a Flue agent's live Worker bytes. To restore a Flue build, check out the known-good source and run `oc agent deploy` again. Do not downgrade across an incompatible Flue Durable Object schema version.</Warning>
 
 ## Inspect
 

--- a/docs/agent-sessions/runtimes.mdx
+++ b/docs/agent-sessions/runtimes.mdx
@@ -11,16 +11,16 @@ A **runtime** executes the agent loop: provider SDK, model calls, and tool use. 
 | `claude` | `anthropic/…` (e.g. `anthropic/claude-opus-4-8`) | Managed, or an Anthropic key |
 | `codex` | `openai/…` (e.g. `openai/gpt-5-codex`) | Managed, or an OpenAI key |
 | `pi` | `anthropic/…` today — the runtime is provider-agnostic by construction; more providers land next | Managed, or an Anthropic key |
-| `flue` <sup>experimental</sup> | `anthropic/…` today — bring your own [Flue](/agent-sessions/flue) app | Managed, or an Anthropic key |
+| `flue` <sup>experimental</sup> | `anthropic/…` today, declared by your [Flue](/agent-sessions/flue) app | Managed |
 
-`model` is passed straight through to the provider, so any model that provider serves works — only the **`provider/` prefix** is validated against the runtime (a bad prefix is rejected at agent create, a model the provider doesn't recognize fails on the first turn). A [session](/agent-sessions/sessions#model) can override this per run — pass `model` at create to run one session on a different model than its agent, validated the same way (brain-box runtimes `claude`/`codex`/`pi`; not `flue`, which pins its model in the artifact). Common choices:
+For the built-in runtimes, `model` is passed straight through to the provider. The **`provider/` prefix** is validated against the runtime; an unknown provider model fails on the first turn. A [session](/agent-sessions/sessions#model) can override the model for one run. Flue instead declares its model in the app and `agent.toml`, and rejects per-session overrides. Common choices:
 
 - **`claude`:** `anthropic/claude-sonnet-5` (default, balanced), `anthropic/claude-opus-4-8` (most capable), `anthropic/claude-fable-5`, `anthropic/claude-haiku-4-5` (fastest/cheapest).
 - **`codex`:** `openai/gpt-5-codex`.
 - **`pi`:** the `anthropic/…` catalog above. The runtime itself is provider-agnostic; additional providers are next.
-- **`flue`** (experimental): an `anthropic/…` model, declared in your app's code — see [Run Flue agents](/agent-sessions/flue) for the supported ids.
+- **`flue`** (experimental): an `anthropic/…` model declared in your app and routed through Managed access. See [Run Flue agents](/agent-sessions/flue).
 
-Sessions, [events](/agent-sessions/events), [steering](/agent-sessions/messaging), [tools](/agent-sessions/runtime-tools), and [webhooks](/agent-sessions/webhooks) share the same API across runtimes. `runtime` is fixed once the agent exists; to switch engines, create a new agent.
+Sessions, [events](/agent-sessions/events), [steering](/agent-sessions/messaging), and [webhooks](/agent-sessions/webhooks) share the same consumer API across runtimes. Execution, tools, persistence, and recovery depend on the runtime. `runtime` is fixed once the agent exists; to switch engines, create a new agent.
 
 ## `claude`
 
@@ -60,7 +60,7 @@ Content-Type: application/json
 
 ## `pi`
 
-The [pi](https://github.com/earendil-works/pi) coding-agent harness (MIT). `pi` is built provider-agnostic — the harness drives whatever provider the model's `provider/` prefix names. Today it ships with `anthropic/…` models, on Managed billing or your Anthropic key; additional providers land next. Sandbox tools, the event stream, steering, and recovery are the same as the other runtimes.
+The [pi](https://github.com/earendil-works/pi) coding agent (MIT). `pi` is provider-independent by design: it drives whatever provider the model's `provider/` prefix names. Today it ships with `anthropic/…` models, on Managed billing or your Anthropic key; additional providers land next. Sandbox tools, the event stream, steering, and recovery are the same as the other built-in runtimes.
 
 ```http
 POST https://api.opencomputer.dev/v3/agents
@@ -80,19 +80,23 @@ The provider is taken from the model's `provider/` prefix — so as more provide
 
 ## `flue` <sup>experimental</sup>
 
-Unlike the runtimes above, `flue` doesn't run a platform-provided harness —
-it runs **your app**, built with the [Flue framework](https://flueframework.com)
-and deployed with `oc agent deploy`. Your code defines the agent
-(instructions, typed tools, subagents); OpenComputer provides the durable
-session around it: the event log, sandbox tools, steering, hibernation, and
-recovery are the same as every other runtime. `anthropic/…` models today,
-Managed or your Anthropic key. Experimental — see
-[Run Flue agents](/agent-sessions/flue) for the supported profile and
-quickstart.
+Unlike the runtimes above, `flue` does not run a platform-provided coding agent. It
+runs **your compiled Flue app** as an agent Worker, with one Durable Object
+instance holding each session's conversation. OpenComputer durably accepts
+input, dispatches turns, routes managed model calls, and projects Flue's
+durable updates into the shared event log.
+
+A Flue agent has no Linux sandbox by default. Add `ocSandbox` only when the
+agent needs shell or file operations; the first real operation creates it.
+This different hosting and recovery model is explained in
+[How Flue differs from the built-in runtimes](/agent-sessions/flue#how-flue-differs-from-the-built-in-runtimes).
 
 The runtime, model, and credential have to agree. `claude` needs an `anthropic/…` model and an Anthropic key; `codex` needs an `openai/…` model and an OpenAI key; `pi` runs `anthropic/…` models today and needs an Anthropic key (or Managed). A mismatch is rejected when you create the agent, with a clear error — so a session never starts on a broken pairing. See [model credentials](/agent-sessions/credentials).
 
-## Architecture
+## Built-in runtime architecture
+
+The remainder of this page describes `claude`, `codex`, and `pi`. Flue uses the
+Worker and Durable Object architecture described on the [Flue page](/agent-sessions/flue).
 
 The model is configuration, not part of the runtime image. The provider is always taken from the model's `provider/` prefix, never from the runtime — a runtime only declares which providers it can drive: `claude` and `pi` drive Anthropic today (`pi` is built to drive any provider — more land next), `codex` drives OpenAI. You choose the exact `provider/model` and key.
 
@@ -103,7 +107,7 @@ A runtime has two components:
 
 The brain knows the SDK, the model, the prompt, its resumable state directory, and the sandbox tools exposed to it. It does **not** write OpenComputer events directly and does not call the sandbox API itself. The adapter reads new input from the [event log](/agent-sessions/events), sends a bounded turn to the brain, translates the brain's stream into session events, handles fencing/idempotency, and only declares the turn done after committed output is durable.
 
-The built-in runtimes are built this way. See [example runtimes](https://github.com/diggerhq/oc-runtime-examples) for `claude` and `codex` brain servers side by side, and [custom runtimes](/agent-sessions/custom-runtimes) in Labs for the same brain/adapter contract applied to your own harness.
+The built-in runtimes are built this way. See [example runtimes](https://github.com/diggerhq/oc-runtime-examples) for `claude` and `codex` brain servers side by side, and [custom runtimes](/agent-sessions/custom-runtimes) in Labs for the same brain/adapter contract applied to your own runtime implementation.
 
 A runtime also **starts fast**: the engine is prepared ahead of time and baked into the image, so a new or recreated session doesn't wait on a per-session download before its first step.
 
@@ -127,7 +131,7 @@ Across turns the brain keeps provider-specific state under a checkpointed state 
 
 When a session starts it pins the runtime and version it began on (alongside the rest of the [agent snapshot](/agent-sessions/agents#session-pinned-config)). `runtime` is fixed at agent creation — to run a different engine, create a new agent. Other agent edits (`model`, `prompt`, `limits`) never affect a running or resumed session: new sessions pick up the change, in-flight ones keep what they started with.
 
-## Supervision and recovery
+## Built-in supervision and recovery
 
 OpenComputer supervises runtime execution:
 

--- a/docs/agent-sessions/sessions.mdx
+++ b/docs/agent-sessions/sessions.mdx
@@ -4,18 +4,20 @@ title: "Sessions"
 description: "Durable, resumable agent execution"
 ---
 
-A **session** is an [agent](/agent-sessions/agents) run with an append-only [event log](/agent-sessions/events), a pinned agent snapshot, and a lifecycle status. Compute can attach, detach when idle, and reattach on the next message; the log persists.
+A **session** is an [agent](/agent-sessions/agents) run with an append-only [event log](/agent-sessions/events), a pinned configuration snapshot, and a lifecycle status. The execution substrate depends on the [runtime](/agent-sessions/runtimes): built-in runtimes use managed sandboxes, while [Flue](/agent-sessions/flue) uses a deployed Worker and one Durable Object per session.
 
 <Note>The [dashboard](https://app.opencomputer.dev) lists your sessions and opens each with a live event stream you can watch and steer — handy for following or debugging a run without building UI.</Note>
 
 ## Session flow
 
-1. You create a session from an [agent](/agent-sessions/agents). It **pins the agent's active [revision](/agent-sessions/revisions)** (prompt / model / skills) for its whole life — editing the agent later never affects a running session. Pass `revision` to pin a specific one instead (e.g. to test a [staged](/agent-sessions/revisions#staging-vs-activating) revision before promoting). Pass `model` to run this one session on a different model than the agent's — same `provider/model` form, and it must resolve to the agent's runtime's provider ([flue](/agent-sessions/flue) agents don't take an override; their model is fixed in the artifact). The model runs **Managed** (billed to your credits, no key — the default) or on a [model credential](/agent-sessions/credentials) you supply. Pass [`sources`](/agent-sessions/repos) to check repos out into `/workspace/sources/` before turn 1 — the GitHub token never enters the sandbox. The session starts immediately.
-2. The [runtime](/agent-sessions/runtimes) executes the agent in a sandbox, appending [events](/agent-sessions/events) to the log as it works.
-3. With nothing left to do, the session goes **idle** and the sandbox **hibernates**.
-4. A [steer](/agent-sessions/messaging) message wakes it; it resumes with its prior context. Repeat.
+1. You create a session from an [agent](/agent-sessions/agents). Built-in runtimes pin the active [revision](/agent-sessions/revisions), including its prompt, model, and skills. Flue records the selected deployment, but all of an agent's Flue sessions execute on its one live Worker; see [Flue deployment behavior](/agent-sessions/flue#deployment-and-revision-behavior).
+2. OpenComputer stores the input, allocates a turn, and returns. Runtime execution continues asynchronously. Pass `model` to override a built-in runtime's model for this session; Flue rejects model overrides because its model is part of the deployed app.
+3. The runtime appends [events](/agent-sessions/events) as it works. Built-in runtimes execute in managed sandboxes. Flue executes in its Worker and Durable Object, with no sandbox unless the app explicitly uses `ocSandbox`.
+4. With nothing left to do, the session becomes **idle**. A [steer](/agent-sessions/messaging) message starts the next ordered turn with the same conversation context.
 
-<Note>The runtime is supervised: crashes restart from durable state, hangs end at the turn deadline, and idle sessions survive sandbox reclaim. Work since the last logged event may repeat, so make side effects idempotent. Details: [runtime recovery](/agent-sessions/runtimes#failure-behavior).</Note>
+Pass [`sources`](/agent-sessions/repos) to prepare `/workspace/sources/` for a built-in runtime. Flue does not yet support repository sources and rejects that parameter.
+
+<Note>The built-in runtimes restart from checkpointed state, enforce a turn deadline, and survive sandbox reclaim. Flue relies on Durable Object recovery and event projection instead; its current limit and recovery differences are listed on the [Flue page](/agent-sessions/flue#session-behavior).</Note>
 
 ## Lifecycle
 
@@ -24,11 +26,11 @@ A **session** is an [agent](/agent-sessions/agents) run with an append-only [eve
 | `queued` | Scheduled; no turn is running. |
 | `running` | A turn is executing. |
 | `awaiting_input` | A turn ended asking you a question — steerable; reply to continue. |
-| `idle` | No turn running; steerable; the sandbox is hibernated. |
+| `idle` | No turn running; steerable; runtime state is retained. |
 | `failed` | The session errored out. |
 | `archived` | Closed; read-only. |
 
-A session also carries `last_turn = { id, state, yield_reason?, result_event_id? }`; the fuller turn record (`started_at`, `completed_at`, `error`) comes from [`GET …/result`](/agent-sessions/api-reference) and `…/turns`. The **`yield_reason`** tells you *why* the last turn ended — `completed`, `needs_input` (the agent asked a question — the session is now `awaiting_input`; answer by [steering](/agent-sessions/messaging)), `budget_exceeded` / `deadline_exceeded` / `max_turns` (a [limit](#limits) tripped), or `canceled`.
+A session also carries `last_turn = { id, state, yield_reason?, result_event_id? }`; the fuller turn record (`started_at`, `completed_at`, `error`) comes from [`GET …/result`](/agent-sessions/api-reference) and `…/turns`. The **`yield_reason`** tells you why the last turn ended: `completed`, `needs_input` (the agent asked a question and the session is now `awaiting_input`), `budget_exceeded`, `deadline_exceeded`, `max_turns`, or `canceled`. Limit outcomes require runtime enforcement; the current Flue path does not enforce the generic session limits below.
 
 ## Fetch the result
 
@@ -83,11 +85,13 @@ Three independent knobs — don't overload one for another:
 
 Cap a session at create (or default it on the [agent](/agent-sessions/agents)) with `limits: { tokens, turn_seconds, turns }` — a token budget, per-turn wall-clock, and auto-run count. These are runtime limits, not spend controls; model usage is billed to your provider key (BYO) or to your OpenComputer credits (Managed). Hitting one ends the turn with the matching `yield_reason`.
 
+<Warning>These limits are not yet enforced for [Flue](/agent-sessions/flue) sessions. Do not use them as a deadline, turn-count, or token safety boundary for that runtime.</Warning>
+
 ## Model
 
 A session runs the model pinned in its agent snapshot. Pass `model` at create to run **this one session** on a different model — omit it and the session inherits the agent's model (the default). The override is the same `provider/model` form as the agent's model, and its provider must match the agent's [runtime](/agent-sessions/runtimes) (e.g. `anthropic/…` for a `claude` agent — a mismatched prefix is rejected at create, a model the provider doesn't recognize fails on the [first turn](/agent-sessions/runtimes)). Like the rest of the snapshot it's **pinned for the session's life** — there's no mid-session model switch; start another session to run another model.
 
-Not available for [flue](/agent-sessions/flue) agents: their model is fixed in the deployed artifact (the [model triangle](/agent-sessions/flue)), so a `model` on a flue session is rejected.
+Not available for [Flue](/agent-sessions/flue) agents: their model is fixed in the deployed app, so a `model` on a Flue session is rejected.
 
 <CodeGroup>
 
@@ -118,6 +122,9 @@ Content-Type: application/json
 `POST /sessions/:id/cancel` **requests** a cooperative stop: the turn ends at its next checkpoint with a `turn.completed` (`yield_reason: "canceled"`), so an in-flight model call may run to its timeout — billing for that turn stops when it actually exits, not the instant you call. `POST /sessions/:id/archive` cancels any active turn, then closes the session read-only.
 
 **`archive` is not delete** — the session's log is retained, just read-only.
+
+For Flue, archive also retains the conversation in the session's Durable Object storage. See
+[Flue session behavior](/agent-sessions/flue#session-behavior).
 
 <Note>When the agent needs input, the turn ends with `yield_reason: "needs_input"` and the session status becomes `awaiting_input`; reply by [steering](/agent-sessions/messaging).</Note>
 

--- a/sdks/flue/README.md
+++ b/sdks/flue/README.md
@@ -1,17 +1,17 @@
 # @opencomputer/flue
 
-Make a stock [Flue](https://flue.dev) agent OpenComputer-native. A Flue app built with
-`flue build --target cloudflare` runs unchanged as an OpenComputer durable session (a Workers-for-Platforms
-tenant script); this package supplies the OC-specific wiring the app opts into.
+Run a stock [Flue](https://flueframework.com) app as an OpenComputer agent. Your compiled app is the
+runtime; OpenComputer connects it to managed sessions, model access, and optional sandboxes. This
+package supplies the OpenComputer-specific wiring the app opts into. Deployments use Flue's stock
+`flue build --target cloudflare` output, with one Durable Object per session.
 
 ## What it gives you
 
-- **`useOcGateway(ctx)` + `DEFAULT_MODEL`** — point the managed `anthropic` provider at the OC model
-  gateway (org key injected + per-session metering). Call it **inside** your `defineAgent` initializer.
+- **`useOcGateway(ctx)` + `DEFAULT_MODEL`**: point the managed `anthropic` provider at the
+  OpenComputer model gateway. Call it **inside** your `defineAgent` initializer.
 - **`route`** — the HTTP-transport opt-in every OC-hosted agent must export (`export { route }`).
 - **`ocSandbox(env)`** — optional, demand-driven Linux shell/files. Declaring it makes no network
   request; the first actual sandbox operation resolves the persistent session sandbox.
-- **`ocRepoTools(env)`** — `publish_pull_request` and friends (open PRs as the OpenComputer GitHub App).
 - **`@opencomputer/flue/app`** — a default hosting app (`flue()` routes + `/health` + telemetry). Or
   `import '@opencomputer/flue/wire'` from your own `app.ts` for telemetry only.
 
@@ -40,8 +40,13 @@ export { default } from "@opencomputer/flue/app";
 
 Then `flue build --target cloudflare` and `oc agent deploy`. See `oc-flue-starter` for a full example.
 
+The current profile supports direct text sessions and optional demand-driven sandboxes. Channels,
+workflows, repository sources, pull-request publishing, attachments, and arbitrary Worker egress are
+not supported yet.
+
 ## Environment (set on the tenant script by the OC deploy)
 
-`OC_GATEWAY` and `OC_SESSION_TOKEN` are always managed by OC. Agents that explicitly use
-`ocSandbox` use the managed `OC_SANDBOX_API`; `OC_SANDBOX_ID` may be pre-resolved. Reserved
+`OC_GATEWAY` and `OC_SESSION_TOKEN` are always managed by OpenComputer. Agents that explicitly use
+`ocSandbox` use the managed `OC_SANDBOX_API`. User variables come from `agent.toml [vars]`; write-only
+secrets are set with `oc agent secret` and both take effect on the next deployment. Reserved
 `OC_`/`FLUE_` prefixes are platform-managed.

--- a/sdks/flue/package.json
+++ b/sdks/flue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencomputer/flue",
   "version": "0.2.0",
-  "description": "Make a stock Flue agent OpenComputer-native — OC model gateway, OC-fleet sandbox, publish/repo tools, and the default hosting app.",
+  "description": "Run a Flue app as an OpenComputer agent with managed models and optional demand-driven sandboxes.",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- Rewrite the Flue guide around the runtime that is actually shipped: the compiled Flue app is the agent runtime, session input is durably accepted before execution, each session has a Durable Object, and a Linux sandbox is optional and demand-driven.
- Add a current quickstart and integration reference for `useOcGateway`, `route`, the default hosting app, packaged skills, custom tools, variables, secrets, and `ocSandbox`.
- Document the real deployment boundary: one live app per agent, exact live-runtime verification, no isolated Flue canary or automatic byte rollback, and restoration by redeploying known-good source.
- State the current supported profile and gaps directly: Managed Anthropic access, text sessions, static Worker egress, no repo plane/channels/attachments, and no generic turn-limit enforcement yet.
- Correct adjacent agents, sessions, runtimes, revisions, events, API, overview, custom-runtime, and package copy so built-in sandbox/revision behavior is not presented as universal.
- Keep Cloudflare implementation detail in the architecture and deployment sections rather than leading the product description with it; reserve “harness” for its established coding-agent CLI meaning.

## Validation

- `git diff --check`
- Mint local preview: every changed docs route returned HTTP 200.
- Desktop and mobile render checks, including no mobile document overflow.
- Mermaid syntax and rendered-element check for the turn sequence.
- `mint broken-links`: no failures in changed files. The checker still reports 11 pre-existing links in unrelated sandbox/scaling pages.
- Stale Flue terminology and retired-path searches are clean (`serveOC`, `oc-flue-build`, scratch verification, model triangle, unrestricted egress, per-session metering, and `ocRepoTools`).
