### PR TITLE
Billing Index

### DIFF
--- a/cloudflare-workers/api-edge/migrations/0002_usage_samples_org_ts_index.sql
+++ b/cloudflare-workers/api-edge/migrations/0002_usage_samples_org_ts_index.sql
@@ -1,0 +1,20 @@
+-- Fix runaway D1 "Rows Read" billing on the autumn meter cron.
+--
+-- The autumn meter (autumn_meter.ts, runs every 5 min per org) aggregates
+-- usage_samples by (org_id, ts window):
+--   SELECT MIN(ts) ... WHERE org_id = ? AND ts >= ? AND ts < ?
+--   SELECT memory_mb, SUM(interval_s) ... WHERE org_id = ? AND ts >= ? AND ts < ? GROUP BY memory_mb
+-- but the ONLY index on usage_samples is PARTIAL:
+--   idx_usage_samples_unrolled ON usage_samples(org_id, ts) WHERE rolled_up = 0
+-- The autumn queries never filter on rolled_up, so the planner cannot use the
+-- partial index and full-scans the whole table on every bucket. usage_samples
+-- is append-only and never pruned (billing-rollup only flips rolled_up = 1), so
+-- the scan — and the rows-read bill — grows linearly forever.
+--
+-- A non-partial (org_id, ts) index lets the autumn queries do a bounded indexed
+-- range scan (org_id equality prefix + ts range) instead of a full table scan.
+-- Not adding "AND rolled_up = 0" to the autumn queries on purpose: billing-rollup
+-- and the autumn meter are independent consumers with independent progress
+-- tracking (autumn uses orgs.autumn_usage_watermark), so filtering rolled_up
+-- would make autumn silently miss samples that billing-rollup already flipped.
+CREATE INDEX IF NOT EXISTS idx_usage_samples_org_ts ON usage_samples(org_id, ts);

--- a/cloudflare-workers/api-edge/schema-snapshots/current_schema.sql
+++ b/cloudflare-workers/api-edge/schema-snapshots/current_schema.sql
@@ -331,6 +331,7 @@ CREATE INDEX idx_templates_public ON templates(is_public) WHERE is_public = 1;
 CREATE UNIQUE INDEX idx_templates_unique ON templates(org_id, name, tag);
 
 CREATE INDEX idx_usage_samples_unrolled ON usage_samples(org_id, ts) WHERE rolled_up = 0;
+CREATE INDEX idx_usage_samples_org_ts ON usage_samples(org_id, ts);
 
 CREATE INDEX idx_usage_unreported ON usage_snapshots(reported_to_stripe, org_id) WHERE reported_to_stripe = 0;
 


### PR DESCRIPTION
Our Cloudflare D1 bill was climbing every day because the usage-metering job that runs every 5 minutes was scanning our entire usage_samples table on each run. That table only grows (old rows are never deleted), and the one index we had didn't match the metering job's query, so the database fell back to reading every single row — billions of "rows read" per day, growing as the table grew. This adds the missing (org_id, ts) index so the job reads only the small time-slice of rows it actually needs instead of the whole table, which should bring the "D1 - Rows Read" charge back down to normal.