### PR TITLE
feat: add managed Slack onboarding for agents

### DIFF
--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -619,6 +619,53 @@ that deploy auto-activates. Repo/path are server-anchored to the link. Deploymen
 
 **`Run`** — one per firing decision, newest-first: `srn_…` with `outcome` (`enacted` · `skipped` · `failed`), `scheduled_for?` (`null` for a manual fire), `fired_at`, `session_id?` (when enacted), `error?`. Chain `session_id` into `GET /sessions/:id`.
 
+## Slack
+
+Managed Slack uses the OpenComputer-operated app. Starting authorization
+returns a browser-safe Slack OAuth URL; the optional deployment id is validated
+return context, not a redirect URL. Status responses never contain credentials.
+
+<Tabs>
+
+<Tab title="TypeScript SDK">
+
+| Call | Purpose |
+| --- | --- |
+| `oc.agents.authorizeManagedSlack(id, { returnDeploymentId? })` | Start managed-app OAuth. |
+| `oc.agents.getManagedSlack(id)` | Read workspace, app identity, state, and `openUrl`. |
+| `oc.agents.disconnectManagedSlack(id)` | Stop routing this agent without uninstalling the workspace app. |
+
+</Tab>
+
+<Tab title="REST API">
+
+| Method · Path | Purpose |
+| --- | --- |
+| `POST /agents/:id/slack/managed/authorize` | Start managed-app OAuth; accepts `return_deployment_id?`. |
+| `GET /agents/:id/slack/managed` | Read the managed connection. |
+| `DELETE /agents/:id/slack/managed` | Disconnect the agent from the shared app. |
+
+</Tab>
+
+</Tabs>
+
+The managed status is `active`, `disconnected`, `error`, or `revoked`. An active
+response includes `workspace`, `app`, `open_url`, and `connected_at`; error
+states expose only a stable `error_code`.
+
+Builder-owned Slack apps remain a separate resource and can overlap during an
+explicit handoff:
+
+| TypeScript SDK | REST API |
+| --- | --- |
+| `oc.agents.slackManifest(id)` | `POST /agents/:id/slack/manifest` |
+| `oc.agents.connectSlack(id, values)` | `POST /agents/:id/slack` |
+| `oc.agents.getSlack(id)` | `GET /agents/:id/slack` |
+| `oc.agents.disconnectSlack(id)` | `DELETE /agents/:id/slack` |
+
+See [Slack](/agent-sessions/slack) for installation, trust boundaries, and
+conversation behavior.
+
 ## Destinations
 
 *Webhooks are configured via SDK/REST (no `oc` command).*

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -622,8 +622,9 @@ that deploy auto-activates. Repo/path are server-anchored to the link. Deploymen
 ## Slack
 
 Managed Slack uses the OpenComputer-operated app. Starting authorization
-returns a browser-safe Slack OAuth URL; the optional deployment id is validated
-return context, not a redirect URL. Status responses never contain credentials.
+returns a browser-safe Slack OAuth URL, or the current active connection when
+the agent is already connected. The optional deployment id is validated return
+context, not a redirect URL. Status responses never contain credentials.
 
 <Tabs>
 

--- a/docs/agent-sessions/slack.mdx
+++ b/docs/agent-sessions/slack.mdx
@@ -27,6 +27,12 @@ short deploying response and is not queued. Wait for the dashboard to show
   with an agent whose tools and spend are appropriately bounded.
 </Warning>
 
+<Note>
+  A workspace can connect the managed app to one agent at a time. Managed Slack
+  accepts text direct messages and mentions in ordinary workspace channels.
+  Files and mentions in Slack Connect channels are not supported yet.
+</Note>
+
 The same flow is available over the API:
 
 <CodeGroup>

--- a/docs/agent-sessions/slack.mdx
+++ b/docs/agent-sessions/slack.mdx
@@ -23,14 +23,14 @@ short deploying response and is not queued. Wait for the dashboard to show
 
 <Warning>
   Anyone in the connected Slack workspace who can message the app can use this
-  agent, including guests with access to it. Use the shared app for evaluation
-  with an agent whose tools and spend are appropriately bounded.
+  agent. Use the shared app for evaluation with an agent whose tools and spend
+  are appropriately bounded.
 </Warning>
 
 <Note>
   A workspace can connect the managed app to one agent at a time. Managed Slack
   accepts text direct messages and mentions in ordinary workspace channels.
-  Files and mentions in Slack Connect channels are not supported yet.
+  Files and Slack Connect DMs or mentions are not supported yet.
 </Note>
 
 The same flow is available over the API:
@@ -79,9 +79,9 @@ the same session; another root message creates a new one. In a channel, invite
 read unmentioned channel messages.
 
 Slack deliveries are signature-verified and deduplicated before they enter the
-session. A transient **Working…** status may appear for a direct message. The
-final assistant response is posted to the same thread, while diagnostics and
-the full event history remain in OpenComputer.
+session. A transient **Working…** status may appear for a direct message or
+mention. The final assistant response is posted to the same thread, while
+diagnostics and the full event history remain in OpenComputer.
 
 ## Use your own Slack app
 
@@ -127,6 +127,8 @@ the OpenComputer app explicitly.
 - A duplicate Slack event creates at most one agent turn.
 - Direct-message thread replies continue their existing session.
 - Channel replies require another mention.
+- The OpenComputer app replies to a message containing a file with a text-only
+  notice; resend the content as a text message.
 - Responses longer than Slack's message limit include a link to the full
   authenticated session in OpenComputer.
 - Slack delivery can retry independently of agent execution, so a provider

--- a/docs/agent-sessions/slack.mdx
+++ b/docs/agent-sessions/slack.mdx
@@ -36,8 +36,13 @@ const authorization = await oc.agents.authorizeManagedSlack(agentId, {
   returnDeploymentId: deploymentId, // optional validated return context
 });
 
-// Return authorizeUrl from your authenticated server route, then navigate the
-// user's browser to it. Never expose the OpenComputer org key to the browser.
+if ("authorizeUrl" in authorization) {
+  // Return this from your authenticated server route, then navigate the user's
+  // browser to it. Never expose the OpenComputer org key to the browser.
+  return authorization.authorizeUrl;
+}
+// Otherwise the agent was already connected; `authorization` is its current
+// public connection state.
 
 const connection = await oc.agents.getManagedSlack(agentId);
 // { mode: "managed", status: "active", workspace, app, openUrl, ... }

--- a/docs/agent-sessions/slack.mdx
+++ b/docs/agent-sessions/slack.mdx
@@ -1,28 +1,97 @@
 ---
 mode: "wide"
 title: "Slack"
-description: "Give an agent its own Slack handle"
+description: "Message an agent from Slack"
 ---
 
-Connect an [agent](/agent-sessions/agents) to its own Slack app so members `@mention` it in a channel to start and steer [sessions](/agent-sessions/sessions). One app per agent, per workspace.
+Connect an [agent](/agent-sessions/agents) to Slack, then start and continue
+[sessions](/agent-sessions/sessions) from direct messages or channel mentions.
+OpenComputer records the same session and event history you see in the
+dashboard.
 
-Connect from the agent's page in the [dashboard](https://app.opencomputer.dev) (a guided wizard), or over the API: get a manifest, create the Slack app from it, then finalize with the three values Slack shows you.
+## Connect the OpenComputer app
+
+The quickest path uses the OpenComputer-operated Slack app. Open the agent in
+the [dashboard](https://app.opencomputer.dev), choose **Connect OpenComputer
+Slack**, approve the workspace installation, and return to the agent.
+
+You can connect Slack while a repository deployment is still running. The
+connection remains in place if that deployment fails, but the app cannot run a
+message until the agent has a ready deployment. A message sent too early gets a
+short deploying response and is not queued. Wait for the dashboard to show
+**Open Slack**, then send the message again.
+
+<Warning>
+  Anyone in the connected Slack workspace who can message the app can use this
+  agent, including guests with access to it. Use the shared app for evaluation
+  with an agent whose tools and spend are appropriately bounded.
+</Warning>
+
+The same flow is available over the API:
 
 <CodeGroup>
 
 ```ts TypeScript SDK
-// 1. Manifest to create the Slack app from (Create app → From a manifest).
+const authorization = await oc.agents.authorizeManagedSlack(agentId, {
+  returnDeploymentId: deploymentId, // optional validated return context
+});
+
+// Return authorizeUrl from your authenticated server route, then navigate the
+// user's browser to it. Never expose the OpenComputer org key to the browser.
+
+const connection = await oc.agents.getManagedSlack(agentId);
+// { mode: "managed", status: "active", workspace, app, openUrl, ... }
+
+await oc.agents.disconnectManagedSlack(agentId);
+```
+
+```http REST API
+POST   https://api.opencomputer.dev/v3/agents/{agent_id}/slack/managed/authorize
+GET    https://api.opencomputer.dev/v3/agents/{agent_id}/slack/managed
+DELETE https://api.opencomputer.dev/v3/agents/{agent_id}/slack/managed
+Authorization: Bearer $OPENCOMPUTER_API_KEY
+
+// optional authorize body
+{ "return_deployment_id": "dep_..." }
+```
+
+</CodeGroup>
+
+Disconnecting an agent stops its managed Slack routing. It does not uninstall
+the shared app from the workspace or remove existing OpenComputer sessions.
+
+## Conversations and sessions
+
+A new root direct message creates a session. Replies in its Slack thread steer
+the same session; another root message creates a new one. In a channel, invite
+`@OpenComputer` and mention it to start or continue a thread. The app does not
+read unmentioned channel messages.
+
+Slack deliveries are signature-verified and deduplicated before they enter the
+session. A transient **Working…** status may appear for a direct message. The
+final assistant response is posted to the same thread, while diagnostics and
+the full event history remain in OpenComputer.
+
+## Use your own Slack app
+
+For a permanent bot identity, connect an app you operate. On the agent page,
+choose **Use your own Slack app**, copy the generated manifest into Slack, then
+enter the App ID, Signing Secret, and Bot User OAuth Token. Credentials are
+write-only and are never returned by the API.
+
+<CodeGroup>
+
+```ts TypeScript SDK
 const { manifest, createUrl } = await oc.agents.slackManifest(agentId);
 
-// 2. Finalize with the App ID, Signing Secret, and Bot User OAuth Token.
 const slack = await oc.agents.connectSlack(agentId, {
   appId: "A0…",
   signingSecret: "…",
   botToken: "xoxb-…",
 });
 
-await oc.agents.getSlack(agentId); // { status: "active", … } — no secrets
-await oc.agents.disconnectSlack(agentId); // purge + stop routing
+await oc.agents.getSlack(agentId); // public status only
+await oc.agents.disconnectSlack(agentId); // purge credentials and stop routing
 ```
 
 ```http REST API
@@ -38,36 +107,17 @@ Authorization: Bearer $OPENCOMPUTER_API_KEY
 
 </CodeGroup>
 
-Then invite the bot (`/invite @handle`) and `@mention` it.
+The managed and builder-owned apps may overlap while you test the handoff. They
+keep separate conversations and sessions. Once your app is working, disconnect
+the OpenComputer app explicitly.
 
-## Routing
+## Delivery behavior
 
-An `@mention` is signature-verified, de-duplicated, and appended to a session as a [steer](/agent-sessions/messaging). The first mention in a thread starts a session; later mentions in that thread steer the same one. The session's `user`-level [events](/agent-sessions/events#visibility-levels) post back to the thread — the agent never calls Slack itself.
-
-## Reconnect
-
-Replacing the app requires explicit intent, so a stray request can't tear down a live connection:
-
-<CodeGroup>
-
-```ts TypeScript SDK
-await oc.agents.slackManifest(agentId, { reconnect: true });
-```
-
-```http REST API
-POST https://api.opencomputer.dev/v3/agents/{agent_id}/slack/manifest
-
-{ "reconnect": true }
-```
-
-</CodeGroup>
-
-Calling it on an active connection without `reconnect` returns `409`. A reconnect resets the connection to `pending` and retires the prior threads' bindings, so future mentions start fresh.
-
-## Limits
-
-<Warning>
-- Anyone who can `@mention` the bot in a channel it has joined can start and steer the agent — there is no per-user or per-channel allow-list yet. Invite it only where you trust the members.
-- Mention-only: it doesn't passively follow thread replies.
-- Outbound posts `user`-level events; live progress isn't streamed into the thread yet.
-</Warning>
+- A duplicate Slack event creates at most one agent turn.
+- Direct-message thread replies continue their existing session.
+- Channel replies require another mention.
+- Responses longer than Slack's message limit include a link to the full
+  authenticated session in OpenComputer.
+- Slack delivery can retry independently of agent execution, so a provider
+  timeout may rarely produce a duplicate Slack post rather than lose the only
+  answer.

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/agents/agents.test.ts
+++ b/sdks/typescript/src/agents/agents.test.ts
@@ -1,7 +1,32 @@
 import { describe, expect, it, vi } from "vitest";
 import { OpenComputer } from "./client.js";
 
-describe("Agents managed Slack", () => {
+describe("Agents Slack", () => {
+  it("exposes the builder-owned app deep link", async () => {
+    const fetcher = vi.fn(async () =>
+      Response.json({
+        id: "sla_1",
+        agent_id: "agt_1",
+        status: "active",
+        slack_app_id: "A1",
+        team_id: "T1",
+        open_url: "https://slack.com/app_redirect?app=A1&team=T1",
+      }),
+    );
+    const oc = new OpenComputer({
+      apiKey: "test-key",
+      baseUrl: "https://api.example.test/v3",
+      fetch: fetcher as typeof fetch,
+      maxRetries: 0,
+    });
+
+    const result = await oc.agents.getSlack("agt_1");
+
+    expect(result.openUrl).toBe(
+      "https://slack.com/app_redirect?app=A1&team=T1",
+    );
+  });
+
   it("starts OAuth with validated deployment return context", async () => {
     const fetcher = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) =>
       Response.json({

--- a/sdks/typescript/src/agents/agents.test.ts
+++ b/sdks/typescript/src/agents/agents.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { OpenComputer } from "./client.js";
+
+describe("Agents managed Slack", () => {
+  it("starts OAuth with validated deployment return context", async () => {
+    const fetcher = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) =>
+      Response.json({
+        mode: "managed",
+        status: "pending",
+        authorize_url: "https://slack.com/oauth/v2/authorize?state=opaque",
+        expires_at: "2026-07-16T18:00:00Z",
+      }),
+    );
+    const oc = new OpenComputer({
+      apiKey: "test-key",
+      baseUrl: "https://api.example.test/v3",
+      fetch: fetcher as typeof fetch,
+      maxRetries: 0,
+    });
+
+    const result = await oc.agents.authorizeManagedSlack("agt_1", {
+      returnDeploymentId: "dep_1",
+    });
+
+    expect(result.authorizeUrl).toContain("slack.com/oauth/v2/authorize");
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.example.test/v3/agents/agt_1/slack/managed/authorize",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ return_deployment_id: "dep_1" }),
+      }),
+    );
+  });
+
+  it("reads the browser-safe managed connection", async () => {
+    const fetcher = vi.fn(async () =>
+      Response.json({
+        mode: "managed",
+        status: "active",
+        workspace: { id: "T1", name: "Acme" },
+        app: { id: "A1", handle: "OpenComputer" },
+        open_url: "https://slack.com/app_redirect?app=A1&team=T1",
+        connected_at: "2026-07-16T17:00:00Z",
+      }),
+    );
+    const oc = new OpenComputer({
+      apiKey: "test-key",
+      baseUrl: "https://api.example.test/v3",
+      fetch: fetcher as typeof fetch,
+      maxRetries: 0,
+    });
+
+    const result = await oc.agents.getManagedSlack("agt_1");
+
+    expect(result).toMatchObject({
+      mode: "managed",
+      status: "active",
+      openUrl: "https://slack.com/app_redirect?app=A1&team=T1",
+    });
+    expect(JSON.stringify(result)).not.toContain("xoxb-");
+  });
+
+  it("disconnects the managed connection without uninstalling the app", async () => {
+    const fetcher = vi.fn(async () =>
+      Response.json({ ok: true, status: "disconnected" }),
+    );
+    const oc = new OpenComputer({
+      apiKey: "test-key",
+      baseUrl: "https://api.example.test/v3",
+      fetch: fetcher as typeof fetch,
+      maxRetries: 0,
+    });
+
+    await expect(
+      oc.agents.disconnectManagedSlack("agt_1"),
+    ).resolves.toEqual({ ok: true, status: "disconnected" });
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.example.test/v3/agents/agt_1/slack/managed",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+});

--- a/sdks/typescript/src/agents/agents.test.ts
+++ b/sdks/typescript/src/agents/agents.test.ts
@@ -22,7 +22,10 @@ describe("Agents managed Slack", () => {
       returnDeploymentId: "dep_1",
     });
 
-    expect(result.authorizeUrl).toContain("slack.com/oauth/v2/authorize");
+    expect("authorizeUrl" in result).toBe(true);
+    expect("authorizeUrl" in result ? result.authorizeUrl : undefined).toContain(
+      "slack.com/oauth/v2/authorize",
+    );
     expect(fetcher).toHaveBeenCalledWith(
       "https://api.example.test/v3/agents/agt_1/slack/managed/authorize",
       expect.objectContaining({
@@ -58,6 +61,32 @@ describe("Agents managed Slack", () => {
       openUrl: "https://slack.com/app_redirect?app=A1&team=T1",
     });
     expect(JSON.stringify(result)).not.toContain("xoxb-");
+  });
+
+  it("returns an already-active connection from a raced authorize", async () => {
+    const fetcher = vi.fn(async () =>
+      Response.json({
+        mode: "managed",
+        status: "active",
+        workspace: { id: "T1", name: "Acme" },
+        app: { id: "A1", handle: "OpenComputer" },
+        open_url: "https://slack.com/app_redirect?app=A1&team=T1",
+        connected_at: "2026-07-16T17:00:00Z",
+      }),
+    );
+    const oc = new OpenComputer({
+      apiKey: "test-key",
+      baseUrl: "https://api.example.test/v3",
+      fetch: fetcher as typeof fetch,
+      maxRetries: 0,
+    });
+
+    const result = await oc.agents.authorizeManagedSlack("agt_1");
+
+    expect(result).toMatchObject({ status: "active" });
+    expect("openUrl" in result ? result.openUrl : undefined).toContain(
+      "slack.com/app_redirect",
+    );
   });
 
   it("disconnects the managed connection without uninstalling the app", async () => {

--- a/sdks/typescript/src/agents/agents.ts
+++ b/sdks/typescript/src/agents/agents.ts
@@ -142,7 +142,7 @@ export class Agents {
   authorizeManagedSlack(
     id: string,
     opts: { returnDeploymentId?: string } = {},
-  ): Promise<ManagedSlackAuthorization> {
+  ): Promise<ManagedSlackAuthorization | ManagedSlackConnection> {
     return this.http.request("POST", `/agents/${id}/slack/managed/authorize`, {
       body: opts,
     });

--- a/sdks/typescript/src/agents/agents.ts
+++ b/sdks/typescript/src/agents/agents.ts
@@ -57,6 +57,25 @@ export interface ConnectSlackParams {
   signingSecret: string;
 }
 
+/** One browser-safe OAuth start for the OpenComputer-operated Slack app. */
+export interface ManagedSlackAuthorization {
+  mode: "managed";
+  status: "pending";
+  authorizeUrl: string;
+  expiresAt: string;
+}
+
+/** Public state for the OpenComputer-operated Slack app. Never includes credentials. */
+export interface ManagedSlackConnection {
+  mode: "managed";
+  status: "active" | "disconnected" | "error" | "revoked";
+  workspace?: { id: string; name?: string | null } | null;
+  app?: { id: string; handle?: string | null } | null;
+  openUrl?: string | null;
+  connectedAt?: string | null;
+  errorCode?: string | null;
+}
+
 /** Reusable agents — the "what" a session runs. */
 export class Agents {
   /** Deploy behavior (inline or from a linked repo) — each deployment produces a revision. */
@@ -114,6 +133,27 @@ export class Agents {
   /** Disconnect — purges the stored secrets and stops routing. */
   disconnectSlack(id: string): Promise<{ ok: boolean }> {
     return this.http.request("DELETE", `/agents/${id}/slack`);
+  }
+
+  // ── Managed Slack (OpenComputer-operated onboarding app) ──
+
+  /** Start managed Slack OAuth. The optional deployment id is validated return
+   *  context, never a caller-controlled redirect. */
+  authorizeManagedSlack(
+    id: string,
+    opts: { returnDeploymentId?: string } = {},
+  ): Promise<ManagedSlackAuthorization> {
+    return this.http.request("POST", `/agents/${id}/slack/managed/authorize`, {
+      body: opts,
+    });
+  }
+  /** Current managed installation/connection state. */
+  getManagedSlack(id: string): Promise<ManagedSlackConnection> {
+    return this.http.request("GET", `/agents/${id}/slack/managed`);
+  }
+  /** Disconnect this agent without uninstalling the shared app from Slack. */
+  disconnectManagedSlack(id: string): Promise<{ ok: true; status: "disconnected" }> {
+    return this.http.request("DELETE", `/agents/${id}/slack/managed`);
   }
 
   /**

--- a/sdks/typescript/src/agents/agents.ts
+++ b/sdks/typescript/src/agents/agents.ts
@@ -48,6 +48,7 @@ export interface SlackConnection {
   slackAppId?: string | null;
   teamId?: string | null;
   accountLogin?: string | null;
+  openUrl?: string | null;
 }
 
 /** The three values pasted back from Slack to finalize a connection. */

--- a/sdks/typescript/src/agents/index.ts
+++ b/sdks/typescript/src/agents/index.ts
@@ -11,6 +11,7 @@ export { Agents } from "./agents.js";
 export type {
   CreateAgentParams, UpdateAgentParams, Page,
   SlackManifest, SlackConnection, ConnectSlackParams,
+  ManagedSlackAuthorization, ManagedSlackConnection,
 } from "./agents.js";
 export {
   Deployments, Revisions, Activations, Skills, DeploymentSourceResource,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -36,6 +36,9 @@ export type {
   AgentDeploymentLog,
   DeployApp,
   FlueSourceInspection,
+  ManagedSlackAuthorizeResponse,
+  ManagedSlackConnection,
+  ManagedSlackDisconnectResponse,
   Session,
   AgentSnapshot,
   SessionEvent,
@@ -811,6 +814,44 @@ export const completeSlackConnect = (
 
 export const disconnectSlack = (agentId: string) =>
   apiFetch<void>(`/v3/agents/${agentId}/slack`, { method: 'DELETE' })
+
+// Managed Slack is the OpenComputer-operated onboarding app. It is a separate
+// resource from the builder-owned app above so both may coexist during an
+// explicit handoff.
+export const authorizeManagedSlack = (
+  agentId: string,
+  returnDeploymentId?: string,
+) =>
+  apiFetch(
+    `/v3/agents/${encodeURIComponent(agentId)}/slack/managed/authorize`,
+    {
+      method: 'POST',
+      body: JSON.stringify(
+        returnDeploymentId ? { return_deployment_id: returnDeploymentId } : {},
+      ),
+    },
+    S.ManagedSlackAuthorizeResponseSchema,
+  )
+
+export async function getManagedSlackConnection(agentId: string) {
+  try {
+    return await apiFetch(
+      `/v3/agents/${encodeURIComponent(agentId)}/slack/managed`,
+      {},
+      S.ManagedSlackConnectionSchema,
+    )
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) return null
+    throw error
+  }
+}
+
+export const disconnectManagedSlack = (agentId: string) =>
+  apiFetch(
+    `/v3/agents/${encodeURIComponent(agentId)}/slack/managed`,
+    { method: 'DELETE' },
+    S.ManagedSlackDisconnectResponseSchema,
+  )
 
 // Credentials — reusable model-provider keys (the raw key is write-only). An
 // agent pins one (credential_id); sessions resolve the agent's, else the org

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -810,24 +810,6 @@ const slackConnection = {
   updated_at: at(0, 2),
 }
 
-const managedSlackConnection = {
-  mode: 'managed',
-  status: 'active',
-  workspace: { id: 'T0123ABCDEF', name: 'Acme' },
-  app: { id: 'A0OPENCOMPUTER', handle: 'OpenComputer' },
-  open_url:
-    'https://slack.com/app_redirect?app=A0OPENCOMPUTER&team=T0123ABCDEF',
-  connected_at: at(0, 2),
-}
-
-const managedSlackAuthorization = {
-  mode: 'managed',
-  status: 'pending',
-  authorize_url:
-    'https://slack.com/oauth/v2/authorize?client_id=mock&state=opaque',
-  expires_at: at(0, 10),
-}
-
 // START-intent response for the Slack connect wizard (POST …/slack/manifest).
 const slackManifest = {
   manifest: {
@@ -1142,7 +1124,6 @@ const ROUTES: Array<[RegExp, Handler]> = [
   [/^\/org$/, () => org],
   [/^\/agents$/, () => []],
   // Durable Agent Sessions — lists return the { data: [...] } envelope.
-  [/^\/v3\/agents\/[^/]+\/slack\/managed$/, () => managedSlackConnection],
   [/^\/v3\/agents\/[^/]+\/slack$/, () => slackConnection],
   [/^\/v3\/github\/deploy-app$/, () => deployApp],
   [
@@ -1231,14 +1212,6 @@ const POST_ROUTES: [RegExp, () => unknown][] = [
   ],
   [/^\/v3\/agents$/, () => agents[0]],
   [/^\/v3\/agents\/[^/]+\/slack\/manifest$/, () => slackManifest],
-  [
-    /^\/v3\/agents\/[^/]+\/slack\/managed\/authorize$/,
-    () => managedSlackAuthorization,
-  ],
-  [
-    /^\/v3\/agents\/[^/]+\/slack\/managed$/,
-    () => ({ ok: true, status: 'disconnected' }),
-  ],
   [
     /^\/v3\/agents\/[^/]+\/slack$/,
     () => ({ ...slackConnection, status: 'active' }),

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -483,9 +483,7 @@ const agents = [
 //   'installed'     → the repo picker (App installed, this agent not yet linked)
 //   'connected'     → a linked agent showing live status + Disconnect
 const DEPLOY_PREVIEW = 'installed' as
-  | 'not_installed'
-  | 'installed'
-  | 'connected'
+  'not_installed' | 'installed' | 'connected'
 
 const deployAppInstalled = {
   installed: true,
@@ -812,6 +810,24 @@ const slackConnection = {
   updated_at: at(0, 2),
 }
 
+const managedSlackConnection = {
+  mode: 'managed',
+  status: 'active',
+  workspace: { id: 'T0123ABCDEF', name: 'Acme' },
+  app: { id: 'A0OPENCOMPUTER', handle: 'OpenComputer' },
+  open_url:
+    'https://slack.com/app_redirect?app=A0OPENCOMPUTER&team=T0123ABCDEF',
+  connected_at: at(0, 2),
+}
+
+const managedSlackAuthorization = {
+  mode: 'managed',
+  status: 'pending',
+  authorize_url:
+    'https://slack.com/oauth/v2/authorize?client_id=mock&state=opaque',
+  expires_at: at(0, 10),
+}
+
 // START-intent response for the Slack connect wizard (POST …/slack/manifest).
 const slackManifest = {
   manifest: {
@@ -1126,6 +1142,7 @@ const ROUTES: Array<[RegExp, Handler]> = [
   [/^\/org$/, () => org],
   [/^\/agents$/, () => []],
   // Durable Agent Sessions — lists return the { data: [...] } envelope.
+  [/^\/v3\/agents\/[^/]+\/slack\/managed$/, () => managedSlackConnection],
   [/^\/v3\/agents\/[^/]+\/slack$/, () => slackConnection],
   [/^\/v3\/github\/deploy-app$/, () => deployApp],
   [
@@ -1214,6 +1231,14 @@ const POST_ROUTES: [RegExp, () => unknown][] = [
   ],
   [/^\/v3\/agents$/, () => agents[0]],
   [/^\/v3\/agents\/[^/]+\/slack\/manifest$/, () => slackManifest],
+  [
+    /^\/v3\/agents\/[^/]+\/slack\/managed\/authorize$/,
+    () => managedSlackAuthorization,
+  ],
+  [
+    /^\/v3\/agents\/[^/]+\/slack\/managed$/,
+    () => ({ ok: true, status: 'disconnected' }),
+  ],
   [
     /^\/v3\/agents\/[^/]+\/slack$/,
     () => ({ ...slackConnection, status: 'active' }),

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -693,6 +693,7 @@ export const SlackConnectionSchema = z.object({
   slack_app_id: z.string().nullable().optional(),
   team_id: z.string().nullable().optional(),
   account_login: z.string().nullable().optional(),
+  open_url: z.string().nullable().optional(),
   status: z.string(),
   bot_token_verified: z.boolean().optional(),
   signing_verified: z.boolean().optional(),
@@ -706,6 +707,28 @@ export const SlackManifestResponseSchema = z.object({
   create_url: z.string(),
   steps: z.array(z.string()),
   status: z.string(),
+})
+
+export const ManagedSlackAuthorizeResponseSchema = z.object({
+  mode: z.literal('managed'),
+  status: z.literal('pending'),
+  authorize_url: z.string(),
+  expires_at: z.string(),
+})
+
+export const ManagedSlackConnectionSchema = z.object({
+  mode: z.literal('managed'),
+  status: z.enum(['active', 'disconnected', 'error', 'revoked']),
+  workspace: z.object({ id: z.string(), name: z.string().nullish() }).nullish(),
+  app: z.object({ id: z.string(), handle: z.string().nullish() }).nullish(),
+  open_url: z.string().nullish(),
+  connected_at: z.string().nullish(),
+  error_code: z.string().nullish(),
+})
+
+export const ManagedSlackDisconnectResponseSchema = z.object({
+  ok: z.literal(true),
+  status: z.literal('disconnected'),
 })
 
 // The pinned effective agent tuple (design 009 §3.5) the session ran with. `runtime`
@@ -837,6 +860,15 @@ export type FlueSourceInspection = z.infer<typeof FlueSourceInspectionSchema>
 export type Credential = z.infer<typeof CredentialSchema>
 export type SlackConnection = z.infer<typeof SlackConnectionSchema>
 export type SlackManifestResponse = z.infer<typeof SlackManifestResponseSchema>
+export type ManagedSlackAuthorizeResponse = z.infer<
+  typeof ManagedSlackAuthorizeResponseSchema
+>
+export type ManagedSlackConnection = z.infer<
+  typeof ManagedSlackConnectionSchema
+>
+export type ManagedSlackDisconnectResponse = z.infer<
+  typeof ManagedSlackDisconnectResponseSchema
+>
 export type Session = z.infer<typeof SessionSchema>
 export type AgentSnapshot = z.infer<typeof AgentSnapshotSchema>
 export type SessionEvent = z.infer<typeof SessionEventSchema>

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -709,13 +709,6 @@ export const SlackManifestResponseSchema = z.object({
   status: z.string(),
 })
 
-export const ManagedSlackAuthorizeResponseSchema = z.object({
-  mode: z.literal('managed'),
-  status: z.literal('pending'),
-  authorize_url: z.string(),
-  expires_at: z.string(),
-})
-
 export const ManagedSlackConnectionSchema = z.object({
   mode: z.literal('managed'),
   status: z.enum(['active', 'disconnected', 'error', 'revoked']),
@@ -725,6 +718,19 @@ export const ManagedSlackConnectionSchema = z.object({
   connected_at: z.string().nullish(),
   error_code: z.string().nullish(),
 })
+
+// A race-safe authorize is idempotent: if the connection became active after
+// the dashboard status read, the API returns that active connection instead of
+// minting another OAuth intent.
+export const ManagedSlackAuthorizeResponseSchema = z.union([
+  z.object({
+    mode: z.literal('managed'),
+    status: z.literal('pending'),
+    authorize_url: z.string(),
+    expires_at: z.string(),
+  }),
+  ManagedSlackConnectionSchema.refine((value) => value.status === 'active'),
+])
 
 export const ManagedSlackDisconnectResponseSchema = z.object({
   ok: z.literal(true),

--- a/web/src/api/slack-schemas.test.ts
+++ b/web/src/api/slack-schemas.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ManagedSlackAuthorizeResponseSchema,
+  ManagedSlackConnectionSchema,
+} from './schemas'
+
+describe('managed Slack response schemas', () => {
+  it('accepts the browser-safe active connection', () => {
+    const result = ManagedSlackConnectionSchema.parse({
+      mode: 'managed',
+      status: 'active',
+      workspace: { id: 'T1', name: 'Acme' },
+      app: { id: 'A1', handle: 'OpenComputer' },
+      open_url: 'https://slack.com/app_redirect?app=A1&team=T1',
+      connected_at: '2026-07-16T18:00:00Z',
+    })
+
+    expect(result.status).toBe('active')
+    expect(JSON.stringify(result)).not.toContain('xoxb-')
+  })
+
+  it('accepts only the fixed managed OAuth start shape', () => {
+    expect(
+      ManagedSlackAuthorizeResponseSchema.parse({
+        mode: 'managed',
+        status: 'pending',
+        authorize_url: 'https://slack.com/oauth/v2/authorize?state=opaque',
+        expires_at: '2026-07-16T18:10:00Z',
+      }),
+    ).toMatchObject({ mode: 'managed', status: 'pending' })
+
+    expect(() =>
+      ManagedSlackAuthorizeResponseSchema.parse({
+        mode: 'byo',
+        status: 'active',
+        authorize_url: 'https://example.test',
+        expires_at: '2026-07-16T18:10:00Z',
+      }),
+    ).toThrow()
+  })
+})

--- a/web/src/api/slack-schemas.test.ts
+++ b/web/src/api/slack-schemas.test.ts
@@ -38,4 +38,17 @@ describe('managed Slack response schemas', () => {
       }),
     ).toThrow()
   })
+
+  it('accepts an idempotent active response from authorize', () => {
+    expect(
+      ManagedSlackAuthorizeResponseSchema.parse({
+        mode: 'managed',
+        status: 'active',
+        workspace: { id: 'T1', name: 'Acme' },
+        app: { id: 'A1', handle: 'OpenComputer' },
+        open_url: 'https://slack.com/app_redirect?app=A1&team=T1',
+        connected_at: '2026-07-16T18:10:00Z',
+      }),
+    ).toMatchObject({ mode: 'managed', status: 'active' })
+  })
 })

--- a/web/src/components/slack-connect.render.test.tsx
+++ b/web/src/components/slack-connect.render.test.tsx
@@ -1,0 +1,71 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { SlackConnect } from './slack-connect'
+
+const agentId = 'agt_aaaaaaaaaaaaaaaaaaaaaaaa'
+const connectedAgentId = 'agt_bbbbbbbbbbbbbbbbbbbbbbbb'
+
+function renderSlackConnect(
+  managed: Record<string, unknown> | null,
+  url = `/agents/${agentId}`,
+  connectedAgentName?: string,
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  })
+  queryClient.setQueryData(['slack', 'managed', agentId], managed)
+  queryClient.setQueryData(['slack', 'byo', agentId], null)
+  if (connectedAgentName) {
+    queryClient.setQueryData(['agent', connectedAgentId], {
+      id: connectedAgentId,
+      name: connectedAgentName,
+    })
+  }
+
+  return renderToStaticMarkup(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[url]}>
+        <SlackConnect agentId={agentId} agentName="Support triage" />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('SlackConnect managed states', () => {
+  it('preserves disconnected lifecycle truth and offers reconnection', () => {
+    const markup = renderSlackConnect({
+      mode: 'managed',
+      status: 'disconnected',
+      workspace: { id: 'T1', name: 'Acme' },
+      app: { id: 'A1', handle: 'OpenComputer' },
+      connected_at: '2026-07-16T18:00:00Z',
+    })
+
+    expect(markup).toContain('no longer receives messages')
+    expect(markup).toContain('Connect Slack again')
+  })
+
+  it('names and links a same-owner workspace conflict', () => {
+    const markup = renderSlackConnect(
+      null,
+      `/agents/${agentId}?slack=workspace_already_connected&connected_agent=${connectedAgentId}`,
+      'Docs writer',
+    )
+
+    expect(markup).toContain('This workspace sends messages to Docs writer.')
+    expect(markup).toContain(`href="/agents/${connectedAgentId}"`)
+    expect(markup).toContain('Open connected agent')
+  })
+
+  it('keeps a cross-owner workspace conflict anonymous', () => {
+    const markup = renderSlackConnect(
+      null,
+      `/agents/${agentId}?slack=workspace_already_connected`,
+    )
+
+    expect(markup).toContain('Use your own Slack app for this agent.')
+    expect(markup).not.toContain('Open connected agent')
+  })
+})

--- a/web/src/components/slack-connect.render.test.tsx
+++ b/web/src/components/slack-connect.render.test.tsx
@@ -8,14 +8,16 @@ const agentId = 'agt_aaaaaaaaaaaaaaaaaaaaaaaa'
 const connectedAgentId = 'agt_bbbbbbbbbbbbbbbbbbbbbbbb'
 
 function renderSlackConnect(
-  managed: Record<string, unknown> | null,
+  managed: Record<string, unknown> | null | undefined,
   url = `/agents/${agentId}`,
   connectedAgentName?: string,
 ) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Infinity } },
   })
-  queryClient.setQueryData(['slack', 'managed', agentId], managed)
+  if (managed !== undefined) {
+    queryClient.setQueryData(['slack', 'managed', agentId], managed)
+  }
   queryClient.setQueryData(['slack', 'byo', agentId], null)
   if (connectedAgentName) {
     queryClient.setQueryData(['agent', connectedAgentId], {
@@ -34,6 +36,29 @@ function renderSlackConnect(
 }
 
 describe('SlackConnect managed states', () => {
+  it('waits for authoritative connection state before showing OAuth success', () => {
+    const loadingMarkup = renderSlackConnect(
+      undefined,
+      `/agents/${agentId}?slack=connected`,
+    )
+    expect(loadingMarkup).not.toContain('Slack connected')
+
+    const connectedMarkup = renderSlackConnect(
+      {
+        mode: 'managed',
+        status: 'active',
+        workspace: { id: 'T1', name: 'Acme' },
+        app: { id: 'A1', handle: 'OpenComputer' },
+        connected_at: '2026-07-16T18:00:00Z',
+      },
+      `/agents/${agentId}?slack=connected`,
+    )
+    expect(connectedMarkup).toContain('Slack connected')
+    expect(connectedMarkup).toContain(
+      'OpenComputer will send messages in Acme to Support triage.',
+    )
+  })
+
   it('preserves disconnected lifecycle truth and offers reconnection', () => {
     const markup = renderSlackConnect({
       mode: 'managed',

--- a/web/src/components/slack-connect.test.ts
+++ b/web/src/components/slack-connect.test.ts
@@ -24,4 +24,23 @@ describe('managed Slack OAuth notices', () => {
       managedSlackNotice('provider_message_here', null, 'Agent'),
     ).toBeNull()
   })
+
+  it('names a same-owner agent in a workspace conflict', () => {
+    expect(
+      managedSlackNotice(
+        'workspace_already_connected',
+        null,
+        'Support triage',
+        'Docs writer',
+      ),
+    ).toMatchObject({
+      description: 'This workspace sends messages to Docs writer.',
+    })
+  })
+
+  it('does not suggest an inaccessible agent for a cross-owner conflict', () => {
+    expect(
+      managedSlackNotice('workspace_already_connected', null, 'Support triage'),
+    ).toMatchObject({ description: 'Use your own Slack app for this agent.' })
+  })
 })

--- a/web/src/components/slack-connect.test.ts
+++ b/web/src/components/slack-connect.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { managedSlackNotice } from '@/lib/managed-slack-notice'
+
+describe('managed Slack OAuth notices', () => {
+  it('uses the active connection data for a successful return', () => {
+    expect(managedSlackNotice('connected', 'Acme', 'Support triage')).toEqual({
+      title: 'Slack connected',
+      description: 'OpenComputer will send messages in Acme to Support triage.',
+    })
+  })
+
+  it('keeps provider failures actionable without exposing provider detail', () => {
+    expect(
+      managedSlackNotice('slack_upstream_unavailable', null, 'Support triage'),
+    ).toEqual({
+      title: "Slack couldn't complete the connection",
+      description: 'Try again in a moment.',
+      destructive: true,
+    })
+  })
+
+  it('ignores unknown query values', () => {
+    expect(
+      managedSlackNotice('provider_message_here', null, 'Agent'),
+    ).toBeNull()
+  })
+})

--- a/web/src/components/slack-connect.tsx
+++ b/web/src/components/slack-connect.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Check, Copy, ExternalLink } from 'lucide-react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { Check, Copy, ExternalLink, X } from 'lucide-react'
 import { notifyError } from '@/lib/errors'
 import {
+  authorizeManagedSlack,
+  disconnectManagedSlack,
+  getManagedSlackConnection,
   getSlackConnection,
   startSlackConnect,
   completeSlackConnect,
@@ -11,6 +15,13 @@ import {
 import type { SlackManifestResponse } from '@/api/schemas'
 import { Panel, PanelContent } from '@/components/panel'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Alert,
+  AlertAction,
+  AlertDescription,
+  AlertTitle,
+} from '@/components/ui/alert'
 import {
   Dialog,
   DialogContent,
@@ -23,6 +34,7 @@ import { Field, Input } from '@/components/form'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 import { useTransientFlag } from '@/lib/use-transient-flag'
 import { cn } from '@/lib/utils'
+import { managedSlackNotice } from '@/lib/managed-slack-notice'
 
 // An agent connects its OWN Slack app (BYO, 1:1:1). Connect is a two-step,
 // manifest-route wizard (oc-bg-agents/.agents/design/008-slack-presence.md §2):
@@ -87,22 +99,31 @@ export function SlackConnect({
   agentId,
   agentName,
   autoOpen = false,
+  canOpenSlack = true,
 }: {
   agentId: string
   agentName: string
   autoOpen?: boolean
+  canOpenSlack?: boolean
 }) {
   const queryClient = useQueryClient()
-  const invalidate = () =>
-    queryClient.invalidateQueries({ queryKey: ['slack', agentId] })
+  const [searchParams, setSearchParams] = useSearchParams()
+  const invalidateByo = () =>
+    queryClient.invalidateQueries({ queryKey: ['slack', 'byo', agentId] })
+  const invalidateManaged = () =>
+    queryClient.invalidateQueries({ queryKey: ['slack', 'managed', agentId] })
 
   const {
     data: conn,
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ['slack', agentId],
+    queryKey: ['slack', 'byo', agentId],
     queryFn: () => getSlackConnection(agentId),
+  })
+  const managedQuery = useQuery({
+    queryKey: ['slack', 'managed', agentId],
+    queryFn: () => getManagedSlackConnection(agentId),
   })
 
   // Wizard state.
@@ -113,6 +134,8 @@ export function SlackConnect({
   const [botToken, setBotToken] = useState('')
   const [signingSecret, setSigningSecret] = useState('')
   const [confirmDisconnect, setConfirmDisconnect] = useState(false)
+  const [confirmManagedDisconnect, setConfirmManagedDisconnect] =
+    useState(false)
   const [copied, markCopied] = useTransientFlag(1500)
 
   const resetWizard = () => {
@@ -128,7 +151,7 @@ export function SlackConnect({
     onSuccess: (m) => {
       setManifest(m)
       setStep('create')
-      void invalidate() // the row is now pending
+      void invalidateByo() // the row is now pending
     },
     onError: (e) => notifyError("Couldn't start the Slack connection.", e),
   })
@@ -141,7 +164,7 @@ export function SlackConnect({
         signing_secret: signingSecret.trim(),
       }),
     onSuccess: () => {
-      void invalidate()
+      void invalidateByo()
       setStep('done')
       setAppId('')
       setBotToken('')
@@ -154,10 +177,29 @@ export function SlackConnect({
   const disconnectMutation = useMutation({
     mutationFn: () => disconnectSlack(agentId),
     onSuccess: () => {
-      void invalidate()
+      void invalidateByo()
       setConfirmDisconnect(false)
     },
     onError: (e) => notifyError("Couldn't disconnect Slack.", e),
+  })
+
+  const authorizeManagedMutation = useMutation({
+    mutationFn: () => authorizeManagedSlack(agentId),
+    onSuccess: ({ authorize_url }) => {
+      window.location.assign(authorize_url)
+    },
+    onError: (error) =>
+      notifyError("Couldn't start the Slack connection.", error),
+  })
+
+  const disconnectManagedMutation = useMutation({
+    mutationFn: () => disconnectManagedSlack(agentId),
+    onSuccess: () => {
+      void invalidateManaged()
+      setConfirmManagedDisconnect(false)
+    },
+    onError: (error) =>
+      notifyError("Couldn't disconnect OpenComputer Slack.", error),
   })
 
   const beginConnect = (reconnect = false) => {
@@ -181,6 +223,25 @@ export function SlackConnect({
   const isPending = status === 'pending'
   const isErrorStatus = status === 'error'
   const workspace = conn?.account_login || conn?.team_id || null
+  const managed = managedQuery.data
+  const managedActive = managed?.status === 'active'
+  const managedNeedsReconnect =
+    managed?.status === 'error' || managed?.status === 'revoked'
+  const managedWorkspace = managed?.workspace?.name || managed?.workspace?.id
+  const oauthResult = searchParams.get('slack')
+  const connectedAgentId = searchParams.get('connected_agent')
+  const notice = managedSlackNotice(oauthResult, managedWorkspace, agentName)
+  const connectedAgentHref =
+    oauthResult === 'workspace_already_connected' &&
+    connectedAgentId?.startsWith('agt_')
+      ? `/agents/${encodeURIComponent(connectedAgentId)}`
+      : null
+  const dismissNotice = () => {
+    const next = new URLSearchParams(searchParams)
+    next.delete('slack')
+    next.delete('connected_agent')
+    setSearchParams(next, { replace: true })
+  }
   const stepIndex =
     step === 'create' ? 0 : step === 'details' ? 1 : step === 'install' ? 2 : 3
 
@@ -198,53 +259,229 @@ export function SlackConnect({
 
   return (
     <Panel className="overflow-hidden">
-      <PanelContent className="space-y-3">
+      <PanelContent className="space-y-4">
         <div className="text-muted-foreground text-xs font-medium">Slack</div>
-        {isLoading ? (
-          <p className="text-muted-foreground text-xs">Checking…</p>
-        ) : isError ? (
-          <p className="text-muted-foreground text-xs">
-            Slack status unavailable.
-          </p>
-        ) : isActive ? (
-          <div className="flex items-center justify-between gap-2">
-            <span className="truncate text-sm">
-              <span className="text-green-600 dark:text-green-500">●</span>{' '}
-              <span className="text-foreground font-medium">
-                @{conn?.handle}
-              </span>
-              {workspace ? (
-                <span className="text-muted-foreground"> · {workspace}</span>
+
+        {notice ? (
+          <Alert variant={notice.destructive ? 'destructive' : 'default'}>
+            <AlertTitle>{notice.title}</AlertTitle>
+            {notice.description || connectedAgentHref ? (
+              <AlertDescription>
+                {notice.description}{' '}
+                {connectedAgentHref ? (
+                  <Link to={connectedAgentHref}>Open connected agent</Link>
+                ) : null}
+              </AlertDescription>
+            ) : null}
+            <AlertAction>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Dismiss Slack notice"
+                onClick={dismissNotice}
+              >
+                <X aria-hidden />
+              </Button>
+            </AlertAction>
+          </Alert>
+        ) : null}
+
+        <section className="space-y-3" aria-labelledby="managed-slack-title">
+          <div className="space-y-1">
+            <h3 id="managed-slack-title" className="text-sm font-medium">
+              OpenComputer app
+            </h3>
+            {!managedActive ? (
+              <p className="text-muted-foreground text-xs leading-relaxed">
+                Connect the shared app to try this agent in Slack.
+              </p>
+            ) : null}
+          </div>
+
+          {managedQuery.isLoading ? (
+            <div className="space-y-2" aria-label="Checking Slack connection">
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-7 w-32" />
+            </div>
+          ) : managedQuery.isError ? (
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <p className="text-muted-foreground text-xs">
+                Managed Slack status is unavailable.
+              </p>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => void managedQuery.refetch()}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : managedActive ? (
+            <div className="space-y-2">
+              <div className="flex min-w-0 items-center gap-2 text-sm">
+                <span
+                  className="bg-status-running size-2 shrink-0 rounded-full"
+                  aria-hidden
+                />
+                <span className="sr-only">Connected.</span>
+                <span className="truncate">
+                  OpenComputer
+                  {managedWorkspace ? (
+                    <span className="text-muted-foreground">
+                      {' '}
+                      · {managedWorkspace}
+                    </span>
+                  ) : null}
+                </span>
+              </div>
+              {!canOpenSlack ? (
+                <p className="text-muted-foreground text-xs">
+                  Connected. Deploy this agent before opening Slack.
+                </p>
               ) : null}
-            </span>
+              <div className="flex flex-wrap items-center gap-2">
+                {canOpenSlack && managed?.open_url ? (
+                  <Button asChild size="sm">
+                    <a href={managed.open_url} target="_blank" rel="noreferrer">
+                      Open Slack
+                      <ExternalLink aria-hidden />
+                    </a>
+                  </Button>
+                ) : null}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground hover:text-foreground"
+                  onClick={() => setConfirmManagedDisconnect(true)}
+                >
+                  Disconnect
+                </Button>
+              </div>
+            </div>
+          ) : managedNeedsReconnect ? (
+            <div className="space-y-2">
+              <p className="text-status-error text-sm">
+                The OpenComputer app needs authorization.
+              </p>
+              <Button
+                size="sm"
+                onClick={() => authorizeManagedMutation.mutate()}
+                disabled={authorizeManagedMutation.isPending}
+              >
+                {authorizeManagedMutation.isPending
+                  ? 'Connecting…'
+                  : 'Reconnect Slack'}
+              </Button>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <p className="text-muted-foreground text-xs leading-relaxed">
+                Anyone in this Slack workspace who can message the app can use
+                this agent.
+              </p>
+              <Button
+                size="sm"
+                onClick={() => authorizeManagedMutation.mutate()}
+                disabled={authorizeManagedMutation.isPending}
+              >
+                {authorizeManagedMutation.isPending
+                  ? 'Connecting…'
+                  : 'Connect OpenComputer Slack'}
+              </Button>
+            </div>
+          )}
+        </section>
+
+        <section
+          className="space-y-2 border-t pt-3"
+          aria-labelledby="byo-slack-title"
+        >
+          <h3 id="byo-slack-title" className="text-sm font-medium">
+            Your app
+          </h3>
+          {managedActive && isActive ? (
+            <p className="text-muted-foreground text-xs leading-relaxed">
+              Your app is active. Disconnect the OpenComputer app when the
+              handoff is complete.
+            </p>
+          ) : null}
+          {isLoading ? (
+            <Skeleton
+              className="h-7 w-28"
+              aria-label="Checking your Slack app"
+            />
+          ) : isError ? (
+            <p className="text-muted-foreground text-xs">
+              Your Slack app status is unavailable.
+            </p>
+          ) : isActive ? (
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="min-w-0 truncate text-sm">
+                <span className="text-status-running" aria-hidden>
+                  ●
+                </span>{' '}
+                <span className="sr-only">Connected.</span>
+                <span className="text-foreground font-medium">
+                  @{conn?.handle}
+                </span>
+                {workspace ? (
+                  <span className="text-muted-foreground"> · {workspace}</span>
+                ) : null}
+              </span>
+              <div className="flex items-center gap-1">
+                {canOpenSlack && conn?.open_url ? (
+                  <Button asChild variant="outline" size="sm">
+                    <a href={conn.open_url} target="_blank" rel="noreferrer">
+                      Open Slack
+                      <ExternalLink aria-hidden />
+                    </a>
+                  </Button>
+                ) : null}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground hover:text-foreground"
+                  onClick={() => setConfirmDisconnect(true)}
+                >
+                  Disconnect
+                </Button>
+              </div>
+            </div>
+          ) : isErrorStatus ? (
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="text-status-error text-sm">
+                Connection error
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => beginConnect()}
+              >
+                Reconnect your app
+              </Button>
+            </div>
+          ) : isPending ? (
+            <div className="space-y-2">
+              <CompactSteps current={stepIndex} />
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => beginConnect()}
+              >
+                Continue app setup
+              </Button>
+            </div>
+          ) : (
             <Button
-              variant="ghost"
+              variant="link"
               size="sm"
-              className="text-muted-foreground hover:text-foreground shrink-0"
-              onClick={() => setConfirmDisconnect(true)}
+              className="h-auto px-0"
+              onClick={() => beginConnect()}
             >
-              Disconnect
+              Use your own Slack app
             </Button>
-          </div>
-        ) : isErrorStatus ? (
-          <div className="flex items-center justify-between gap-2">
-            <span className="text-status-error text-sm">● Connection error</span>
-            <Button variant="outline" size="sm" onClick={() => beginConnect()}>
-              Reconnect
-            </Button>
-          </div>
-        ) : isPending ? (
-          <div className="space-y-2">
-            <CompactSteps current={stepIndex} />
-            <Button variant="outline" size="sm" onClick={() => beginConnect()}>
-              Continue setup
-            </Button>
-          </div>
-        ) : (
-          <Button variant="outline" size="sm" onClick={() => beginConnect()}>
-            Connect Slack
-          </Button>
-        )}
+          )}
+        </section>
       </PanelContent>
 
       {/* Connect wizard */}
@@ -258,10 +495,12 @@ export function SlackConnect({
         <DialogContent className="sm:max-w-2xl">
           <DialogHeader>
             <DialogTitle>
-              {step === 'done' ? 'Slack connected' : 'Connect Slack'}
+              {step === 'done'
+                ? 'Your Slack app is connected'
+                : 'Connect your own Slack app'}
             </DialogTitle>
             <DialogDescription className="sr-only">
-              Connect this agent’s own Slack app so members can @-mention it.
+              Connect a Slack app you operate so members can message this agent.
             </DialogDescription>
             <WizardSteps current={stepIndex} />
           </DialogHeader>
@@ -470,6 +709,16 @@ export function SlackConnect({
         onConfirm={() => disconnectMutation.mutate()}
       />
 
+      <ConfirmDialog
+        open={confirmManagedDisconnect}
+        onOpenChange={setConfirmManagedDisconnect}
+        title="Disconnect OpenComputer Slack?"
+        description="This agent will stop receiving messages from the OpenComputer app. The app stays installed in the workspace."
+        confirmLabel="Disconnect"
+        destructive
+        pending={disconnectManagedMutation.isPending}
+        onConfirm={() => disconnectManagedMutation.mutate()}
+      />
     </Panel>
   )
 }

--- a/web/src/components/slack-connect.tsx
+++ b/web/src/components/slack-connect.tsx
@@ -6,6 +6,7 @@ import { notifyError } from '@/lib/errors'
 import {
   authorizeManagedSlack,
   disconnectManagedSlack,
+  getAgent,
   getManagedSlackConnection,
   getSlackConnection,
   startSlackConnect,
@@ -54,7 +55,11 @@ function WizardSteps({ current }: { current: number }) {
         const done = i < current
         const active = i === current
         return (
-          <li key={label} className="flex min-w-0 items-center gap-2">
+          <li
+            key={label}
+            className="flex min-w-0 items-center gap-2"
+            aria-current={active ? 'step' : undefined}
+          >
             <span
               className={cn(
                 'flex size-5 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold',
@@ -63,7 +68,7 @@ function WizardSteps({ current }: { current: number }) {
                   : 'bg-secondary text-muted-foreground',
               )}
             >
-              {done ? <Check className="size-3" /> : i + 1}
+              {done ? <Check className="size-3" aria-hidden /> : i + 1}
             </span>
             <span
               className={cn(
@@ -73,6 +78,7 @@ function WizardSteps({ current }: { current: number }) {
                   : 'text-muted-foreground',
               )}
             >
+              {done ? <span className="sr-only">Completed: </span> : null}
               {label}
             </span>
             {i < WIZARD_STEPS.length - 1 ? (
@@ -231,14 +237,34 @@ export function SlackConnect({
   const managedActive = managed?.status === 'active'
   const managedNeedsReconnect =
     managed?.status === 'error' || managed?.status === 'revoked'
+  const managedDisconnected = managed?.status === 'disconnected'
   const managedWorkspace = managed?.workspace?.name || managed?.workspace?.id
   const oauthResult = searchParams.get('slack')
   const connectedAgentId = searchParams.get('connected_agent')
-  const notice = managedSlackNotice(oauthResult, managedWorkspace, agentName)
-  const connectedAgentHref =
+  const sameOwnerConnectedAgentId =
     oauthResult === 'workspace_already_connected' &&
-    connectedAgentId?.startsWith('agt_')
-      ? `/agents/${encodeURIComponent(connectedAgentId)}`
+    connectedAgentId &&
+    /^agt_[0-9a-f]{24}$/.test(connectedAgentId)
+      ? connectedAgentId
+      : null
+  const connectedAgentQuery = useQuery({
+    queryKey: ['agent', sameOwnerConnectedAgentId],
+    queryFn: () => getAgent(sameOwnerConnectedAgentId!),
+    enabled: !!sameOwnerConnectedAgentId,
+  })
+  const connectedAgentName = connectedAgentQuery.data?.name ?? null
+  const notice =
+    sameOwnerConnectedAgentId && connectedAgentQuery.isLoading
+      ? null
+      : managedSlackNotice(
+          oauthResult,
+          managedWorkspace,
+          agentName,
+          connectedAgentName,
+        )
+  const connectedAgentHref =
+    connectedAgentQuery.data && sameOwnerConnectedAgentId
+      ? `/agents/${encodeURIComponent(sameOwnerConnectedAgentId)}`
       : null
   const dismissNotice = () => {
     const next = new URLSearchParams(searchParams)
@@ -295,7 +321,7 @@ export function SlackConnect({
             <h3 id="managed-slack-title" className="text-sm font-medium">
               OpenComputer app
             </h3>
-            {!managedActive ? (
+            {!managedActive && !managedDisconnected ? (
               <p className="text-muted-foreground text-xs leading-relaxed">
                 Connect the shared app to try this agent in Slack.
               </p>
@@ -375,6 +401,26 @@ export function SlackConnect({
                 {authorizeManagedMutation.isPending
                   ? 'Connecting…'
                   : 'Reconnect Slack'}
+              </Button>
+            </div>
+          ) : managedDisconnected ? (
+            <div className="space-y-3">
+              <p className="text-muted-foreground text-xs leading-relaxed">
+                Disconnected. This agent no longer receives messages from the
+                OpenComputer app.
+              </p>
+              <p className="text-muted-foreground text-xs leading-relaxed">
+                Anyone in this Slack workspace who can message the app can use
+                this agent after you reconnect it.
+              </p>
+              <Button
+                size="sm"
+                onClick={() => authorizeManagedMutation.mutate()}
+                disabled={authorizeManagedMutation.isPending}
+              >
+                {authorizeManagedMutation.isPending
+                  ? 'Connecting…'
+                  : 'Connect Slack again'}
               </Button>
             </div>
           ) : (

--- a/web/src/components/slack-connect.tsx
+++ b/web/src/components/slack-connect.tsx
@@ -185,8 +185,12 @@ export function SlackConnect({
 
   const authorizeManagedMutation = useMutation({
     mutationFn: () => authorizeManagedSlack(agentId),
-    onSuccess: ({ authorize_url }) => {
-      window.location.assign(authorize_url)
+    onSuccess: (result) => {
+      if ('authorize_url' in result) {
+        window.location.assign(result.authorize_url)
+        return
+      }
+      void invalidateManaged()
     },
     onError: (error) =>
       notifyError("Couldn't start the Slack connection.", error),

--- a/web/src/components/slack-connect.tsx
+++ b/web/src/components/slack-connect.tsx
@@ -253,8 +253,10 @@ export function SlackConnect({
     enabled: !!sameOwnerConnectedAgentId,
   })
   const connectedAgentName = connectedAgentQuery.data?.name ?? null
+  const waitingForConnectedState = oauthResult === 'connected' && !managedActive
   const notice =
-    sameOwnerConnectedAgentId && connectedAgentQuery.isLoading
+    (sameOwnerConnectedAgentId && connectedAgentQuery.isLoading) ||
+    waitingForConnectedState
       ? null
       : managedSlackNotice(
           oauthResult,

--- a/web/src/lib/managed-slack-notice.ts
+++ b/web/src/lib/managed-slack-notice.ts
@@ -1,0 +1,72 @@
+const MANAGED_SLACK_RESULTS = new Set([
+  'connected',
+  'oauth_denied',
+  'oauth_state_invalid',
+  'oauth_state_expired',
+  'oauth_exchange_failed',
+  'oauth_scope_missing',
+  'enterprise_install_unsupported',
+  'slack_upstream_unavailable',
+  'agent_not_ready',
+  'workspace_already_connected',
+])
+
+export function managedSlackNotice(
+  result: string | null,
+  workspace: string | null | undefined,
+  agentName: string,
+): { title: string; description?: string; destructive?: boolean } | null {
+  if (!result || !MANAGED_SLACK_RESULTS.has(result)) return null
+  switch (result) {
+    case 'connected':
+      return {
+        title: 'Slack connected',
+        description: workspace
+          ? `OpenComputer will send messages in ${workspace} to ${agentName}.`
+          : `OpenComputer will send Slack messages to ${agentName}.`,
+      }
+    case 'oauth_denied':
+      return { title: 'Slack connection was canceled' }
+    case 'oauth_state_invalid':
+    case 'oauth_state_expired':
+      return {
+        title: 'Slack connection session expired',
+        description: 'Connect Slack again.',
+        destructive: true,
+      }
+    case 'oauth_scope_missing':
+      return {
+        title: 'Slack permissions are incomplete',
+        description: 'Reconnect and approve the requested permissions.',
+        destructive: true,
+      }
+    case 'enterprise_install_unsupported':
+      return {
+        title: 'Enterprise Grid installation is not supported yet',
+        description: 'Install the app in a single Slack workspace instead.',
+        destructive: true,
+      }
+    case 'agent_not_ready':
+      return {
+        title: 'This agent cannot connect to Slack yet',
+        description: 'Finish its initial setup, then try again.',
+        destructive: true,
+      }
+    case 'workspace_already_connected':
+      return {
+        title: 'This Slack workspace is already connected',
+        description:
+          'Open its connected agent, or use your own Slack app for this one.',
+        destructive: true,
+      }
+    case 'oauth_exchange_failed':
+    case 'slack_upstream_unavailable':
+      return {
+        title: "Slack couldn't complete the connection",
+        description: 'Try again in a moment.',
+        destructive: true,
+      }
+    default:
+      return null
+  }
+}

--- a/web/src/lib/managed-slack-notice.ts
+++ b/web/src/lib/managed-slack-notice.ts
@@ -15,6 +15,7 @@ export function managedSlackNotice(
   result: string | null,
   workspace: string | null | undefined,
   agentName: string,
+  connectedAgentName?: string | null,
 ): { title: string; description?: string; destructive?: boolean } | null {
   if (!result || !MANAGED_SLACK_RESULTS.has(result)) return null
   switch (result) {
@@ -55,8 +56,9 @@ export function managedSlackNotice(
     case 'workspace_already_connected':
       return {
         title: 'This Slack workspace is already connected',
-        description:
-          'Open its connected agent, or use your own Slack app for this one.',
+        description: connectedAgentName
+          ? `This workspace sends messages to ${connectedAgentName}.`
+          : 'Use your own Slack app for this agent.',
         destructive: true,
       }
     case 'oauth_exchange_failed':

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -548,7 +548,11 @@ export default function AgentDetail() {
               {agent.runtime !== 'flue' ? (
                 <AgentDeploySource agentId={agent.id} />
               ) : null}
-              <SlackConnect agentId={agent.id} agentName={agent.name} />
+              <SlackConnect
+                agentId={agent.id}
+                agentName={agent.name}
+                canOpenSlack={canStartNewSession}
+              />
             </div>
           </div>
         )}


### PR DESCRIPTION
## TL;DR

Adds the dashboard, TypeScript SDK, and public docs for the managed Slack
control-plane implemented by sessions-api PR #82.

### Consequential decisions

- Managed Slack and builder-owned Slack stay separate API resources and UI rows.
  Their credentials and lifecycle cannot overwrite or hide one another.
- OAuth is full-page and browser-safe: the API returns connection identity,
  status, and authorize/open URLs; no Slack credential is returned.
- The panel shows **Open Slack** only when ordinary agent readiness permits a
  conversation. OAuth success is shown only after the authoritative managed
  connection query reports `active`, so first paint cannot claim success or omit
  a still-loading workspace.
- This PR does not duplicate repository/deployment onboarding state. Work 028
  owns the eventual combined first-run shell; this PR owns only connector-local
  states and OAuth return handling.
- Managed-Slack-only mock API routes were removed. Schema and render tests seed
  explicit states instead of making preview mode look connected by default.
- No Flue package change is required. SDK publication remains gated on the real
  Slack acceptance run.

## Review map

1. Public SDK/schema contract: `sdks/typescript/src/agents/agents.ts`,
   `web/src/api/schemas.ts`, `web/src/api/client.ts`.
2. Connector state and OAuth UX: `web/src/components/slack-connect.tsx` and
   `web/src/lib/managed-slack-notice.ts`.
3. User-facing boundaries: `docs/agent-sessions/slack.mdx` and
   `docs/agent-sessions/api-reference.mdx`.

## Verification and status

- dashboard: 41/41 tests, changed-file ESLint/Prettier, production build
- TypeScript SDK: 25 tests and `tsc --noEmit`
- `git diff --check`

Launch still depends on sessions-api PR #82's final deployment/acceptance and
publishing the reviewed SDK version. This remains a long-lived evergreen; the
repository owner decides when to merge it.
