### PR TITLE
Clock Skew

### DIFF
--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -3269,6 +3269,12 @@ func (m *Manager) CreateCheckpoint(ctx context.Context, sandboxID, checkpointID 
 		// any more customer work. Without this, writes can block indefinitely on
 		// the guest fsfreeze semaphore even though QEMU has resumed.
 		m.agentFsThawAfterWake(context.Background(), sandboxID, agentClient)
+		// vCPUs were stopped for the whole savevm write (seconds for a large-RAM
+		// box), so the guest clock is now behind wall-clock. Re-sync to host time
+		// — same as wake/resume — so a checkpoint doesn't leave the source skewed.
+		if err := syncGuestClock(context.Background(), agentClient); err != nil {
+			log.Printf("qemu: CreateCheckpoint %s/%s: clock sync failed: %v", sandboxID, checkpointID, err)
+		}
 	} else {
 		// Agent didn't come back after savevm — the VM is unmanageable. Full
 		// teardown via destroyVM, not the partial QMP-quit-only cleanup that
@@ -3487,6 +3493,14 @@ func (m *Manager) CreateDiskOnlyCheckpoint(ctx context.Context, sandboxID, check
 	}
 	m.agentFsThawAfterWake(context.Background(), sandboxID, vm.agent)
 	frozen = false
+	// vCPUs were stopped for the disk copy (usually sub-second reflink, but a
+	// non-reflink fallback copy can run longer) — re-sync the guest clock to
+	// host time, matching the full-checkpoint path.
+	if vm.agent != nil {
+		if err := syncGuestClock(context.Background(), vm.agent); err != nil {
+			log.Printf("qemu: DiskOnlyCheckpoint %s/%s: clock sync failed: %v", sandboxID, checkpointID, err)
+		}
+	}
 
 	rootfsKey = fmt.Sprintf("checkpoints/%s/%s/rootfs.tar.zst", sandboxID, checkpointID)
 	workspaceKey = fmt.Sprintf("checkpoints/%s/%s/workspace.tar.zst", sandboxID, checkpointID)

--- a/internal/qemu/pause.go
+++ b/internal/qemu/pause.go
@@ -98,6 +98,17 @@ func (m *Manager) Resume(_ context.Context, sandboxID string) error {
 	// migration (billingSuppressed), the touch flips it to a normal billed box.
 	vm.billingSuppressed = false
 
+	// The vCPUs were frozen for the entire pause, so the guest clock is now
+	// behind wall-clock by the pause duration. Re-sync it to host time — the
+	// same step every wake/restore/migration path runs — otherwise the box
+	// resumes with a skewed clock. Best-effort: a failed sync must not block the
+	// resume (the VM is already running).
+	if vm.agent != nil {
+		if err := syncGuestClock(context.Background(), vm.agent); err != nil {
+			log.Printf("qemu: resume %s: clock sync failed: %v", sandboxID, err)
+		}
+	}
+
 	// Resume billing (the VM is a live running sandbox again).
 	if m.lifecycleObs != nil {
 		m.lifecycleObs.OnSandboxWake(sandboxID)
@@ -131,6 +142,14 @@ func (m *Manager) ResumeUnbilled(_ context.Context, sandboxID string) error {
 			return fmt.Errorf("qmp cont: %w", err)
 		}
 		vm.pausedAt = time.Time{}
+		// Same clock resync as Resume — the box's vCPUs were frozen while paused.
+		// The migration target also re-syncs on arrival, but correct the source
+		// now so a stalled/aborted migration can't leave it skewed. Best-effort.
+		if vm.agent != nil {
+			if err := syncGuestClock(context.Background(), vm.agent); err != nil {
+				log.Printf("qemu: resume-unbilled %s: clock sync failed: %v", sandboxID, err)
+			}
+		}
 	}
 	vm.Status = types.SandboxStatusRunning
 	vm.billingSuppressed = true


### PR DESCRIPTION
Pausing a sandbox freezes its vCPUs, so the guest clock stops advancing; on resume nothing corrected it, leaving the guest behind by the pause duration. Resume (and the checkpoint stop-then-cont) now re-sync the guest clock to host time, the same step wake/migration already run. Validated on dev: a 40s pause showed ~40s skew before the fix, ~0 after.