### PR TITLE
Add Flue GitHub capability

### DIFF
--- a/docs/agent-sessions/agents.mdx
+++ b/docs/agent-sessions/agents.mdx
@@ -84,6 +84,12 @@ workspace, or disconnect it in place after reviewing the routing impact. A
 completed first conversation adds direct exits to the agent home, full session,
 session history, and Slack.
 
+For a Flue agent, setup also offers **Working repositories** without blocking
+Slack or chat. Choose all repositories granted to the OpenComputer GitHub App,
+an explicit subset, or an empty subset for chat-only use. The same policy is
+available later under **Agent → Settings → Repository access**. This policy is
+separate from the repository that deploys the Flue app.
+
 The repository picker marks roots already used by another agent before review.
 An exact linked root cannot be reviewed again: open its owning agent, choose a
 different monorepo root, or unlink it in place after confirming that

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -11,7 +11,7 @@ Each section toggles between the **TypeScript SDK** (`@opencomputer/sdk`), **RES
 import { OpenComputer, connectSession } from "@opencomputer/sdk";
 
 const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
-const session = await oc.sessions.get("ses_...");        // server, org key
+const session = await oc.sessions.get("ses_..."); // server, org key
 // or, in a browser:  await connectSession({ sessionId, clientToken })
 ```
 
@@ -22,7 +22,13 @@ oc agent deploy        # deploy the agent directory in the cwd
 oc agent build --dir . --check-only --json  # validate a Flue app without credentials or deployment
 ```
 
-<Note>The SDK uses **camelCase** for fields and params (`last_turn` → `lastTurn`, `idempotency_key` → `idempotencyKey`); the wire shapes below are raw JSON. Opaque blobs — session `metadata`, event `refs`/`raw` — pass through **verbatim**; everything else (incl. event `body`) is camelCased. The CLI prints a table, or raw JSON with `--json`.</Note>
+<Note>
+  The SDK uses **camelCase** for fields and params (`last_turn` → `lastTurn`,
+  `idempotency_key` → `idempotencyKey`); the wire shapes below are raw JSON.
+  Opaque blobs — session `metadata`, event `refs`/`raw` — pass through
+  **verbatim**; everything else (incl. event `body`) is camelCased. The CLI
+  prints a table, or raw JSON with `--json`.
+</Note>
 
 ## Sessions
 
@@ -30,47 +36,47 @@ oc agent build --dir . --check-only --json  # validate a Flue app without creden
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.sessions.create(params)` | Start a session → a `Session` handle (carries `.clientToken`). |
-| `oc.sessions.get(id)` | Fetch a session. |
-| `oc.sessions.list(params)` | List sessions (filtered, paginated). |
-| `session.archive()` | Cancel any active turn, then close (read-only). |
-| `session.cancel()` | Cooperatively stop the active turn (no-op if not running). |
-| `session.result()` | `{ lastTurn, result? }` — the resolved final event. |
-| `session.turns()` · `session.turn(id)` | Per-turn history: timing, error. |
-| `session.sources` · `session.listSources()` | Source checkout status — create snapshot · live poll. |
-| `session.mintClientToken(opts)` | Mint a client token. |
+| Call                                        | Purpose                                                        |
+| ------------------------------------------- | -------------------------------------------------------------- |
+| `oc.sessions.create(params)`                | Start a session → a `Session` handle (carries `.clientToken`). |
+| `oc.sessions.get(id)`                       | Fetch a session.                                               |
+| `oc.sessions.list(params)`                  | List sessions (filtered, paginated).                           |
+| `session.archive()`                         | Cancel any active turn, then close (read-only).                |
+| `session.cancel()`                          | Cooperatively stop the active turn (no-op if not running).     |
+| `session.result()`                          | `{ lastTurn, result? }` — the resolved final event.            |
+| `session.turns()` · `session.turn(id)`      | Per-turn history: timing, error.                               |
+| `session.sources` · `session.listSources()` | Source checkout status — create snapshot · live poll.          |
+| `session.mintClientToken(opts)`             | Mint a client token.                                           |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /sessions` | Start a session → `{ session, client_token }`. |
-| `GET /sessions/:id` | Fetch a session. |
+| Method · Path                                                     | Purpose                                                       |
+| ----------------------------------------------------------------- | ------------------------------------------------------------- |
+| `POST /sessions`                                                  | Start a session → `{ session, client_token }`.                |
+| `GET /sessions/:id`                                               | Fetch a session.                                              |
 | `GET /sessions?status=&agent=&key=&after=&before=&limit=&cursor=` | List sessions (filtered, paginated; `cursor` = `nextCursor`). |
-| `POST /sessions/:id/archive` | Cancel any active turn, then close (read-only). |
-| `POST /sessions/:id/cancel` | Cooperatively stop the active turn (no-op if not running). |
-| `GET /sessions/:id/result` | The result helper — `{ last_turn, result? }`. |
-| `GET /sessions/:id/turns` · `…/turns/:turnId` | Per-turn history: timing, error. |
-| `GET /sessions/:id/sources` | Source checkout status (`SourceSummary[]`). |
-| `POST /sessions/:id/client-tokens` | Mint a client token. |
+| `POST /sessions/:id/archive`                                      | Cancel any active turn, then close (read-only).               |
+| `POST /sessions/:id/cancel`                                       | Cooperatively stop the active turn (no-op if not running).    |
+| `GET /sessions/:id/result`                                        | The result helper — `{ last_turn, result? }`.                 |
+| `GET /sessions/:id/turns` · `…/turns/:turnId`                     | Per-turn history: timing, error.                              |
+| `GET /sessions/:id/sources`                                       | Source checkout status (`SourceSummary[]`).                   |
+| `POST /sessions/:id/client-tokens`                                | Mint a client token.                                          |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
+| Command                                                                  | Purpose                                                                    |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
 | `oc session create --agent <id\|name> [--revision <n>] [--input <text>]` | Start a session (`--revision` pins a specific revision; default = active). |
-| `oc session get <id>` | Fetch a session. |
-| `oc session list [--agent <id>] [--status <s>]` | List sessions. |
-| `oc session cancel <id>` | Cooperatively stop the active turn. |
-| `oc session result <id>` | The resolved final result. |
-| `oc session steer <id> <text>` | Send input to a running or waiting session. |
-| *(archive · turns · sources · client tokens — REST/SDK only)* | |
+| `oc session get <id>`                                                    | Fetch a session.                                                           |
+| `oc session list [--agent <id>] [--status <s>]`                          | List sessions.                                                             |
+| `oc session cancel <id>`                                                 | Cooperatively stop the active turn.                                        |
+| `oc session result <id>`                                                 | The resolved final result.                                                 |
+| `oc session steer <id> <text>`                                           | Send input to a running or waiting session.                                |
+| _(archive · turns · sources · client tokens — REST/SDK only)_            |                                                                            |
 
 </Tab>
 
@@ -84,56 +90,57 @@ oc agent build --dir . --check-only --json  # validate a Flue app without creden
 - `key?` — get-or-create (one session per key). Keyless: an `Idempotency-Key` header makes create retry-safe.
 - `metadata?` — opaque routing state (≤ 16 KB); on get/list + **verbatim in webhooks**; never sent to the model, not indexed.
 - `limits?` `{ tokens, turn_seconds, turns }`: non-monetary; tripping one ends a built-in runtime turn with the matching `yield_reason`. These limits are stored but not yet enforced for Flue sessions.
-- `sources?`: repos checked out before turn 1 for built-in runtimes (the token never enters the sandbox; see [GitHub](#github-apps-and-repos)). Each registered `{ repo, ref, sha?, name? }` or inline `{ url, ref, sha, name?, auth }`. `ref` is required; `sha` is required for inline sources but **optional for a registered repo**. Flue sessions reject `sources` with `422 sources_not_supported`.
+- `sources?`: working repositories (the token never enters the agent sandbox; see [GitHub](#github-apps-and-repos)). Built-in runtimes prepare them before turn one; Flue materializes them lazily. Each registered `{ repo, ref, sha?, name? }` or inline `{ url, ref, sha, name?, auth }`. `ref` is required; `sha` is required for inline sources but **optional for a registered repo**. Flue accepts only repositories allowed by the agent's repository-access policy.
 - Client tokens: `scopes?` (`read`/`steer`), `ttl?` 60–86400 s (SDK `ttlSeconds`).
 
 A built-in runtime session pins the agent's active revision for its whole life. A Flue session records its selected deployment but executes on the agent's one live Worker; deploying that Worker can therefore affect an existing session.
 
 **`Session`**
 
-| Field | Type | Notes |
-|---|---|---|
-| `id` `status` `head` `input_cursor` | | id, [lifecycle](/agent-sessions/sessions#lifecycle) status, latest event seq, input cursor |
-| `agent_id` `credential_id` | string | resolved + pinned at create |
-| `agent_snapshot` | object | `{ prompt_hash, model, runtime, revision }` — `revision` = the pinned revision number |
-| `last_turn` | `Turn`-ish | `{ id, state, yield_reason?, result_event_id? }` |
-| `limits?` | object | `{ tokens?, turn_seconds?, turns? }` |
-| `metadata?` | object | opaque app routing state |
-| `key?` `created_at` | | get-or-create key, timestamp |
+| Field                               | Type       | Notes                                                                                      |
+| ----------------------------------- | ---------- | ------------------------------------------------------------------------------------------ |
+| `id` `status` `head` `input_cursor` |            | id, [lifecycle](/agent-sessions/sessions#lifecycle) status, latest event seq, input cursor |
+| `agent_id` `credential_id`          | string     | resolved + pinned at create                                                                |
+| `agent_snapshot`                    | object     | `{ prompt_hash, model, runtime, revision }` — `revision` = the pinned revision number      |
+| `last_turn`                         | `Turn`-ish | `{ id, state, yield_reason?, result_event_id? }`                                           |
+| `limits?`                           | object     | `{ tokens?, turn_seconds?, turns? }`                                                       |
+| `metadata?`                         | object     | opaque app routing state                                                                   |
+| `key?` `created_at`                 |            | get-or-create key, timestamp                                                               |
 
 **`Turn`**
 
-| Field | Notes |
-|---|---|
-| `id` `state` | turn id, current state |
-| `yield_reason?` | why it ended (below) |
-| `result_event_id?` | the event carrying the result |
-| `error?` | failure detail, if any |
-| `started_at?` `completed_at?` | timing |
+| Field                         | Notes                         |
+| ----------------------------- | ----------------------------- |
+| `id` `state`                  | turn id, current state        |
+| `yield_reason?`               | why it ended (below)          |
+| `result_event_id?`            | the event carrying the result |
+| `error?`                      | failure detail, if any        |
+| `started_at?` `completed_at?` | timing                        |
 
 A turn's **`yield_reason`** tells you why it stopped:
 
-| Value | Meaning |
-|---|---|
-| `completed` | finished normally |
-| `needs_input` | the agent asked a question — answer it by [steering](#steer) |
-| `error` | the turn failed (see `error`) |
+| Value                                                 | Meaning                                                        |
+| ----------------------------------------------------- | -------------------------------------------------------------- |
+| `completed`                                           | finished normally                                              |
+| `needs_input`                                         | the agent asked a question — answer it by [steering](#steer)   |
+| `error`                                               | the turn failed (see `error`)                                  |
 | `budget_exceeded` / `deadline_exceeded` / `max_turns` | a [limit](#sessions) tripped — tokens / wall-clock / auto-runs |
-| `canceled` | you cancelled it |
+| `canceled`                                            | you cancelled it                                               |
 
 **`SessionSource`** — one of two variants:
 
-| Variant | Shape |
-|---|---|
+| Variant    | Shape                                                                                                                                                                             |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | registered | `{ repo, ref, sha?, name? }` — `repo` is a `repo_…` id or `"owner/repo"`; App-backed auth. `sha` is **optional** (omit → control plane resolves `ref`→HEAD and pins it at create) |
-| inline | `{ url, ref, sha, name?, auth }` — `sha` **required**; `auth = { type:"risky_short_lived_token", token, expires_at }` (can't refresh) |
+| inline     | `{ url, ref, sha, name?, auth }` — `sha` **required**; `auth = { type:"risky_short_lived_token", token, expires_at }` (can't refresh)                                             |
 
 **`SourceSummary`** (sanitized; on create + `GET …/sources`)
 
-| Field | Notes |
-|---|---|
-| `name` `path` `sha` `resolved_sha?` | checkout identity + resolved commit |
-| `status` | `pending · materializing · resolved · failed · unavailable · auth_required` |
+| Field                                       | Notes                                                                                                                                                                                                                                                                               |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name` `path` `sha` `resolved_sha?`         | local identity + pinned commit + observed commit                                                                                                                                                                                                                                    |
+| `repo_id?` `full_name?` `requested_ref?`    | stable repository id, current display name, and requested ref                                                                                                                                                                                                                       |
+| `status`                                    | `pending · materializing · resolved · failed · unavailable · auth_required`                                                                                                                                                                                                         |
 | `error_code?` `error_message?` `retryable?` | on failure — `source.`-prefixed, e.g. `source.auth_required` (App not installed), `source.repo_not_selected` (install doesn't cover the repo), `source.permission_missing`, `source.mint_failed`, `source.ref_not_found`, `source.sha_mismatch`. [Full list](/agent-sessions/repos) |
 
 ## Events
@@ -142,34 +149,34 @@ A turn's **`yield_reason`** tells you why it stopped:
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `session.listEvents(opts)` | Read events since a cursor. |
-| `session.events(opts)` | Live stream from a cursor — a self-resuming async iterator. |
-| `session.event(id)` | Fetch one event (resolve `resultEventId`). |
-| `session.eventContent(id)` | Fetch a blob-backed body (large outputs). |
-| `session.messages(opts)` | User-message history. |
+| Call                       | Purpose                                                     |
+| -------------------------- | ----------------------------------------------------------- |
+| `session.listEvents(opts)` | Read events since a cursor.                                 |
+| `session.events(opts)`     | Live stream from a cursor — a self-resuming async iterator. |
+| `session.event(id)`        | Fetch one event (resolve `resultEventId`).                  |
+| `session.eventContent(id)` | Fetch a blob-backed body (large outputs).                   |
+| `session.messages(opts)`   | User-message history.                                       |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `GET /sessions/:id/events?after=<seq>&level=<lvl>` | Read events since a cursor. |
-| `GET /sessions/:id/events?…&stream=sse` | Live SSE stream from a cursor. |
-| `GET /sessions/:id/events/:eventId` | Fetch one event. |
-| `GET /sessions/:id/events/:eventId/content` | Fetch a blob-backed body. |
-| `GET /sessions/:id/messages` | User-message history. |
+| Method · Path                                      | Purpose                        |
+| -------------------------------------------------- | ------------------------------ |
+| `GET /sessions/:id/events?after=<seq>&level=<lvl>` | Read events since a cursor.    |
+| `GET /sessions/:id/events?…&stream=sse`            | Live SSE stream from a cursor. |
+| `GET /sessions/:id/events/:eventId`                | Fetch one event.               |
+| `GET /sessions/:id/events/:eventId/content`        | Fetch a blob-backed body.      |
+| `GET /sessions/:id/messages`                       | User-message history.          |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
+| Command                                                        | Purpose                     |
+| -------------------------------------------------------------- | --------------------------- |
 | `oc session logs <id> [--follow] [--level <lvl>] [--type <t>]` | Read or live-stream events. |
-| *(single event · event content · messages — REST/SDK only)* | |
+| _(single event · event content · messages — REST/SDK only)_    |                             |
 
 </Tab>
 
@@ -179,13 +186,13 @@ Filter by `type` (exact or `prefix.*`), `turn_id`, `limit`. `after` resumes from
 
 **`Event`**
 
-| Field | Notes |
-|---|---|
-| `id` `seq` `ts` `session` | id, monotonic seq, timestamp, session id |
-| `actor` `type` `level` | source, event [type](/agent-sessions/events#event-shape), visibility level |
-| `body` | the payload (camelCased; switch on `type`, don't parse prose) |
-| `turn_id?` | the turn it belongs to |
-| `content_ref?` `body_truncated?` `body_bytes?` | large bodies are offloaded — fetch via `…/events/:id/content` |
+| Field                                          | Notes                                                                      |
+| ---------------------------------------------- | -------------------------------------------------------------------------- |
+| `id` `seq` `ts` `session`                      | id, monotonic seq, timestamp, session id                                   |
+| `actor` `type` `level`                         | source, event [type](/agent-sessions/events#event-shape), visibility level |
+| `body`                                         | the payload (camelCased; switch on `type`, don't parse prose)              |
+| `turn_id?`                                     | the turn it belongs to                                                     |
+| `content_ref?` `body_truncated?` `body_bytes?` | large bodies are offloaded — fetch via `…/events/:id/content`              |
 
 ## Steer
 
@@ -193,24 +200,24 @@ Filter by `type` (exact or `prefix.*`), `turn_id`, `limit`. `after` resumes from
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
+| Call                                      | Purpose                                     |
+| ----------------------------------------- | ------------------------------------------- |
 | `session.steer(text, { idempotencyKey })` | Append an input message; wakes the session. |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
+| Method · Path                 | Purpose                                     |
+| ----------------------------- | ------------------------------------------- |
 | `POST /sessions/:id/messages` | Append an input message; wakes the session. |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
+| Command                        | Purpose                                     |
+| ------------------------------ | ------------------------------------------- |
 | `oc session steer <id> <text>` | Append an input message; wakes the session. |
 
 </Tab>
@@ -221,27 +228,27 @@ Body: `{ text, idempotency_key? }` or `{ envelope }`. Returns `202` (or `200` on
 
 ## Watches
 
-*Managed with the SDK (`session.watches.create/list/delete`), the CLI (`oc session watch/watches/unwatch`), or REST — authenticate with your **org API key** (server-side). The agent-facing path is the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool. Full guide: [Watches](/agent-sessions/watches).*
+_Managed with the SDK (`session.watches.create/list/delete`), the CLI (`oc session watch/watches/unwatch`), or REST — authenticate with your **org API key** (server-side). The agent-facing path is the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool. Full guide: [Watches](/agent-sessions/watches)._
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /sessions/:id/watches` | Declare a watch → `201 { watch }`. Body: `{ type:"github_pr", repo?, pr?, wake_on, intent? }`. |
-| `GET /sessions/:id/watches` | List watches → `{ data: [watch] }`. |
-| `DELETE /sessions/:id/watches/:watchId` | Remove a watch → `{ ok: true }`. |
+| Method · Path                           | Purpose                                                                                        |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `POST /sessions/:id/watches`            | Declare a watch → `201 { watch }`. Body: `{ type:"github_pr", repo?, pr?, wake_on, intent? }`. |
+| `GET /sessions/:id/watches`             | List watches → `{ data: [watch] }`.                                                            |
+| `DELETE /sessions/:id/watches/:watchId` | Remove a watch → `{ ok: true }`.                                                               |
 
 `wake_on` is the wake condition (`checks` default · `review` · `comment` · `merge`); `intent` is the freeform "why," replayed on wake. `repo`/`pr` are optional — omitted, they resolve to the PR this session opened. A watch fires only on PRs the **same session** opened, on Connected-App (`oc_app`) repos. Limits: **10** active watches per session, **30-day** TTL (and never outlives the PR).
 
 **`Watch`**
 
-| Field | Notes |
-|---|---|
-| `id` `type` | `wch_…`; `type` = `github_pr` |
-| `repo` `pr` | watched repo · PR number |
-| `wake_on` | wake condition: `checks` (default) · `review` (a review decision) · `comment` · `merge` (merged/closed) |
-| `intent?` | freeform note ("why"), replayed on wake |
-| `status` | `active · closed · revoked · auth_required` |
-| `origin` | how it was declared (runtime tool / management API) |
-| `last_snapshot_at?` `expires_at` `created_at` | last authoritative PR re-read · 30-day TTL lapse · timestamp |
+| Field                                         | Notes                                                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `id` `type`                                   | `wch_…`; `type` = `github_pr`                                                                           |
+| `repo` `pr`                                   | watched repo · PR number                                                                                |
+| `wake_on`                                     | wake condition: `checks` (default) · `review` (a review decision) · `comment` · `merge` (merged/closed) |
+| `intent?`                                     | freeform note ("why"), replayed on wake                                                                 |
+| `status`                                      | `active · closed · revoked · auth_required`                                                             |
+| `origin`                                      | how it was declared (runtime tool / management API)                                                     |
+| `last_snapshot_at?` `expires_at` `created_at` | last authoritative PR re-read · 30-day TTL lapse · timestamp                                            |
 
 **Delivered events** — appended into the session log at level `user` with `source: "github"`, carrying a normalized summary (not the raw webhook): `github.pr.checks_completed` · `github.pr.review_submitted` · `github.pr.comment` · `github.pr.merged` · `github.pr.closed`.
 
@@ -251,37 +258,41 @@ Body: `{ text, idempotency_key? }` or `{ envelope }`. Returns `202` (or `200` on
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.agents.create(params)` | Create a reusable agent. |
-| `oc.agents.repository.review(params)` | Resolve and interpret an exact repository source without running it. |
-| `oc.agents.repository.import(params)` | Import an exact reviewed source and enqueue its first deployment. |
-| `oc.agents.get(id)` · `oc.agents.list()` | Fetch / list. |
-| `oc.agents.update(id, params)` | Update bindings (credential / limits) — `prompt`/`model` deploy a revision. |
-| `oc.agents.delete(id)` | Delete an agent. |
+| Call                                           | Purpose                                                                       |
+| ---------------------------------------------- | ----------------------------------------------------------------------------- |
+| `oc.agents.create(params)`                     | Create a reusable agent.                                                      |
+| `oc.agents.repository.review(params)`          | Resolve and interpret an exact repository source without running it.          |
+| `oc.agents.repository.import(params)`          | Import an exact reviewed source and enqueue its first deployment.             |
+| `oc.agents.get(id)` · `oc.agents.list()`       | Fetch / list.                                                                 |
+| `oc.agents.update(id, params)`                 | Update bindings (credential / limits) — `prompt`/`model` deploy a revision.   |
+| `oc.agents.getRepositoryAccess(id)`            | Read a Flue agent's GitHub grant, policy, and effective working repositories. |
+| `oc.agents.updateRepositoryAccess(id, policy)` | Atomically replace that policy.                                               |
+| `oc.agents.delete(id)`                         | Delete an agent.                                                              |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /agents` | Create a reusable agent. |
-| `POST /agents/import` | Atomically create an agent from an exact reviewed GitHub source and enqueue its first deployment. |
-| `GET /agents/:id` · `GET /agents` | Fetch / list. |
-| `PATCH /agents/:id` | Update bindings; `prompt`/`model` deploy a revision. |
-| `DELETE /agents/:id` | Delete an agent. |
+| Method · Path                       | Purpose                                                                                           |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `POST /agents`                      | Create a reusable agent.                                                                          |
+| `POST /agents/import`               | Atomically create an agent from an exact reviewed GitHub source and enqueue its first deployment. |
+| `GET /agents/:id` · `GET /agents`   | Fetch / list.                                                                                     |
+| `PATCH /agents/:id`                 | Update bindings; `prompt`/`model` deploy a revision.                                              |
+| `GET /agents/:id/repository-access` | Read working-repository access for a Flue agent.                                                  |
+| `PUT /agents/:id/repository-access` | Atomically replace its policy.                                                                    |
+| `DELETE /agents/:id`                | Delete an agent.                                                                                  |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
+| Command                                                        | Purpose                  |
+| -------------------------------------------------------------- | ------------------------ |
 | `oc agent create <name> --model <m> [--runtime claude\|codex]` | Create a reusable agent. |
-| `oc agent get <id\|name>` · `oc agent list` | Fetch / list. |
-| `oc agent update <id> [--credential <c>] [--limits …]` | Update bindings. |
-| `oc agent delete <id>` | Delete an agent. |
+| `oc agent get <id\|name>` · `oc agent list`                    | Fetch / list.            |
+| `oc agent update <id> [--credential <c>] [--limits …]`         | Update bindings.         |
+| `oc agent delete <id>`                                         | Delete an agent.         |
 
 </Tab>
 
@@ -294,6 +305,61 @@ Body: `name`, `prompt`, `model`, `runtime?` (`claude`|`codex`), `key?`, `credent
 `POST /agents/import` is the reviewed repository-import command described below. It deliberately creates
 an agent with no active revision; revision #1 appears only after the queued build and live deployment
 verify successfully.
+
+### Flue repository access
+
+Repository access is separate from the repository used to deploy the Flue app.
+It bounds which repositories the running agent may check out and publish to:
+
+```ts TypeScript SDK
+const access = await oc.agents.getRepositoryAccess(agent.id);
+
+await oc.agents.updateRepositoryAccess(agent.id, {
+  mode: "selected",
+  repositoryIds: [access.effectiveRepositories![0].id],
+});
+```
+
+```http REST API
+GET /agents/agt_.../repository-access
+
+PUT /agents/agt_.../repository-access
+Content-Type: application/json
+
+{ "mode": "selected", "repository_ids": ["repo_..."] }
+```
+
+The wire response is:
+
+```json
+{
+  "policy": { "mode": "selected", "repository_ids": ["repo_..."] },
+  "grant": {
+    "status": "active",
+    "account": "acme",
+    "repository_selection": "selected",
+    "install_url": "https://github.com/apps/opencomputerdev/installations/new",
+    "configure_url": "https://github.com/settings/installations/123",
+    "truncated": false
+  },
+  "effective_repositories": [
+    {
+      "id": "repo_...",
+      "full_name": "acme/app",
+      "default_branch": "main",
+      "private": true
+    }
+  ],
+  "unavailable_selected_repositories": []
+}
+```
+
+Use `{ "mode": "all" }` for every repository in the current and future App
+grant. An empty selected list disables repository work but not chat. When the
+grant is `not_installed`, `effective_repositories` is the known-empty `[]`.
+Only a transient `unavailable` grant uses `null`, because no complete set was
+read. The owner-bound
+OpenComputer App is the only authority for this Flue capability.
 
 ## Deployments and revisions
 
@@ -339,7 +405,11 @@ The response always includes repository identity, normalized `root`, `production
 
 ```json Exact Flue review
 {
-  "repository": { "id": "repo_...", "full_name": "acme/agents", "default_branch": "main" },
+  "repository": {
+    "id": "repo_...",
+    "full_name": "acme/agents",
+    "default_branch": "main"
+  },
   "root": "agents/support",
   "production_ref": "main",
   "sha": "0123456789abcdef0123456789abcdef01234567",
@@ -355,8 +425,18 @@ The response always includes repository identity, normalized `root`, `production
   "profile": {
     "source_profile": "flue-app-v1",
     "source_profile_version": 1,
-    "manifest": { "schema_version": 1, "entrypoint": "support-triage", "model": "anthropic/claude-haiku-4-5", "runtime": { "family": "flue", "type": "default" }, "vars": {} },
-    "package": { "name": "support-agent", "node_engine": ">=22.19 <23", "flue_cli": "1.0.0-beta.9" },
+    "manifest": {
+      "schema_version": 1,
+      "entrypoint": "support-triage",
+      "model": "anthropic/claude-haiku-4-5",
+      "runtime": { "family": "flue", "type": "default" },
+      "vars": {}
+    },
+    "package": {
+      "name": "support-agent",
+      "node_engine": ">=22.19 <23",
+      "flue_cli": "1.0.0-beta.9"
+    },
     "lockfile": { "version": 3 },
     "builder": { "node": "22.19.0" },
     "source": { "files": 12, "bytes": 4096 },
@@ -472,32 +552,32 @@ the current active revision remains unchanged.
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.agents.deployments.create(id, { input, activate?, idempotencyKey? })` | Deploy (`input.type: "inline" \| "github"`). |
-| `oc.agents.deployments.list(id)` · `.get(id, depId)` | Deployment history · one deployment. |
-| `oc.agents.deploy(dir)` *(Node)* | Bundle a local directory → inline deployment. |
+| Call                                                                      | Purpose                                       |
+| ------------------------------------------------------------------------- | --------------------------------------------- |
+| `oc.agents.deployments.create(id, { input, activate?, idempotencyKey? })` | Deploy (`input.type: "inline" \| "github"`).  |
+| `oc.agents.deployments.list(id)` · `.get(id, depId)`                      | Deployment history · one deployment.          |
+| `oc.agents.deploy(dir)` _(Node)_                                          | Bundle a local directory → inline deployment. |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /agents/:id/deployments` | Deploy → `{ deployment }`. Body: `{ input, activate?=true, idempotency_key?, client_context? }`. |
-| `GET /agents/:id/deployments?before=&limit=` | Newest-first history with an opaque `next_cursor`. |
-| `GET /agents/:id/deployments/:deploymentId` | One attempt; poll asynchronous states until terminal. |
-| `GET /agents/:id/deployments/:deploymentId/logs?after=&limit=` | Ordered durable log chunks with opaque resume cursors. |
+| Method · Path                                                  | Purpose                                                                                          |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `POST /agents/:id/deployments`                                 | Deploy → `{ deployment }`. Body: `{ input, activate?=true, idempotency_key?, client_context? }`. |
+| `GET /agents/:id/deployments?before=&limit=`                   | Newest-first history with an opaque `next_cursor`.                                               |
+| `GET /agents/:id/deployments/:deploymentId`                    | One attempt; poll asynchronous states until terminal.                                            |
+| `GET /agents/:id/deployments/:deploymentId/logs?after=&limit=` | Ordered durable log chunks with opaque resume cursors.                                           |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
-| `oc agent deploy [dir] [--agent <id\|name>] [--no-activate]` | Bundle a local directory → inline deployment. |
+| Command                                                                            | Purpose                                                                                       |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `oc agent deploy [dir] [--agent <id\|name>] [--no-activate]`                       | Bundle a local directory → inline deployment.                                                 |
 | `oc agent build --dir <dir> [--check-only] [--target cloudflare] [--output <dir>]` | Validate or build a Flue artifact without fetching, installing, authenticating, or deploying. |
-| `oc agent deployments [--agent <id>]` · `oc agent deployments get <id>` | History · one deployment. |
+| `oc agent deployments [--agent <id>]` · `oc agent deployments get <id>`            | History · one deployment.                                                                     |
 
 </Tab>
 
@@ -513,18 +593,18 @@ and subsequent production-branch pushes deploy automatically. Flue has no previe
 
 **`Deployment`**
 
-| Field | Notes |
-|---|---|
-| `id` `created_at` `updated_at` | Attempt identity and timestamps. |
-| `state` `phase` `terminal` | Internal state plus stable UI phase. Repository states: `accepted`, `queued`, `fetching`, `validating`, `installing`, `building`, `uploading`, `deploying`, `verifying`; terminals: `ready`, `failed`, `canceled`, `superseded`, `skipped`. |
-| `result` `error_class` `error?` | Terminal outcome and bounded, redacted failure detail. |
-| `revision_id` `revision?` `active` | Successful revision relation; absent for an unsuccessful attempt. |
-| `source_relation?` | Repository id/name, path, production ref, exact SHA, and commit URL. |
-| `build?` `configuration?` | Safe builder/artifact metadata and non-secret runtime configuration; variables are names only. |
-| `timing` | Accepted/started/finished coordinates plus queue/run/total durations. |
-| `log_bytes` `log_truncated` | Bounded log accounting. |
-| `live_touched` `agent_live?` | Whether deployment crossed the live Worker boundary and the current guarded/verified state. |
-| `allowed_actions` | Server-derived actions such as `view_commit`, `deploy_latest`, `open_agent`, or `start_session`. |
+| Field                              | Notes                                                                                                                                                                                                                                       |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id` `created_at` `updated_at`     | Attempt identity and timestamps.                                                                                                                                                                                                            |
+| `state` `phase` `terminal`         | Internal state plus stable UI phase. Repository states: `accepted`, `queued`, `fetching`, `validating`, `installing`, `building`, `uploading`, `deploying`, `verifying`; terminals: `ready`, `failed`, `canceled`, `superseded`, `skipped`. |
+| `result` `error_class` `error?`    | Terminal outcome and bounded, redacted failure detail.                                                                                                                                                                                      |
+| `revision_id` `revision?` `active` | Successful revision relation; absent for an unsuccessful attempt.                                                                                                                                                                           |
+| `source_relation?`                 | Repository id/name, path, production ref, exact SHA, and commit URL.                                                                                                                                                                        |
+| `build?` `configuration?`          | Safe builder/artifact metadata and non-secret runtime configuration; variables are names only.                                                                                                                                              |
+| `timing`                           | Accepted/started/finished coordinates plus queue/run/total durations.                                                                                                                                                                       |
+| `log_bytes` `log_truncated`        | Bounded log accounting.                                                                                                                                                                                                                     |
+| `live_touched` `agent_live?`       | Whether deployment crossed the live Worker boundary and the current guarded/verified state.                                                                                                                                                 |
+| `allowed_actions`                  | Server-derived actions such as `view_commit`, `deploy_latest`, `open_agent`, or `start_session`.                                                                                                                                            |
 
 List returns `{ data, next_cursor }`. Log reads return
 `{ data: [{ seq, cursor, recorded_at, phase, stream, chunk }], next_cursor, has_more }`; treat `seq`
@@ -538,31 +618,31 @@ responses, and operator telemetry are never projected through these APIs.
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.agents.revisions.list(id)` · `.get(id, n)` | History · one revision (+ skill manifest). |
-| `oc.agents.revisions.activate(id, n)` | Set the active revision (rollback **or** promote). |
-| `oc.agents.activations.list(id)` | Active-pointer audit log. |
+| Call                                           | Purpose                                            |
+| ---------------------------------------------- | -------------------------------------------------- |
+| `oc.agents.revisions.list(id)` · `.get(id, n)` | History · one revision (+ skill manifest).         |
+| `oc.agents.revisions.activate(id, n)`          | Set the active revision (rollback **or** promote). |
+| `oc.agents.activations.list(id)`               | Active-pointer audit log.                          |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `GET /agents/:id/revisions` · `…/:rev` | History · one revision (+ skill manifest). |
+| Method · Path                              | Purpose                                       |
+| ------------------------------------------ | --------------------------------------------- |
+| `GET /agents/:id/revisions` · `…/:rev`     | History · one revision (+ skill manifest).    |
 | `POST /agents/:id/revisions/:rev/activate` | Set the active revision (rollback / promote). |
-| `GET /agents/:id/activations` | Active-pointer audit log. |
+| `GET /agents/:id/activations`              | Active-pointer audit log.                     |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
-| `oc agent revisions [--agent <id>]` · `oc agent revisions get <n>` | History · one revision. |
-| `oc agent rollback <n\|rev_…>` | Set the active revision (rollback / promote). |
-| `oc agent activations` | Active-pointer audit log. |
+| Command                                                            | Purpose                                       |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `oc agent revisions [--agent <id>]` · `oc agent revisions get <n>` | History · one revision.                       |
+| `oc agent rollback <n\|rev_…>`                                     | Set the active revision (rollback / promote). |
+| `oc agent activations`                                             | Active-pointer audit log.                     |
 
 </Tab>
 
@@ -572,14 +652,14 @@ Revisions are **linear** (numbered, immutable). `:rev` is a `number` or `rev_…
 
 **`Revision`**
 
-| Field | Notes |
-|---|---|
-| `id` `number` `created_at` `active` | id, monotonic number, timestamp, is-active flag |
-| `prompt` `model` | the behavior |
-| `skill_bundle_digest?` | content-addressed skills bundle (`null` = no skills) |
-| `digest` | behavior content hash (change detection) |
-| `runtime_ref` | `floating` (latest shared runtime) — `pinned` later (custom runtime) |
-| `files?` | `[{ path, mode, size }]` — only on `GET …/revisions/:rev` |
+| Field                               | Notes                                                                |
+| ----------------------------------- | -------------------------------------------------------------------- |
+| `id` `number` `created_at` `active` | id, monotonic number, timestamp, is-active flag                      |
+| `prompt` `model`                    | the behavior                                                         |
+| `skill_bundle_digest?`              | content-addressed skills bundle (`null` = no skills)                 |
+| `digest`                            | behavior content hash (change detection)                             |
+| `runtime_ref`                       | `floating` (latest shared runtime) — `pinned` later (custom runtime) |
+| `files?`                            | `[{ path, mode, size }]` — only on `GET …/revisions/:rev`            |
 
 ### Skills
 
@@ -587,28 +667,28 @@ Revisions are **linear** (numbered, immutable). `:rev` is a `number` or `rev_…
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.agents.skills.get(id)` | List the active revision's skills (name, description, files). |
-| `oc.agents.skills.put(id, zip)` | Replace skills from a `.zip` → new revision. |
-| `oc.agents.skills.delete(id)` | Remove all skills → new revision. |
+| Call                            | Purpose                                                       |
+| ------------------------------- | ------------------------------------------------------------- |
+| `oc.agents.skills.get(id)`      | List the active revision's skills (name, description, files). |
+| `oc.agents.skills.put(id, zip)` | Replace skills from a `.zip` → new revision.                  |
+| `oc.agents.skills.delete(id)`   | Remove all skills → new revision.                             |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `GET /agents/:id/skills` | List the active revision's skills. |
-| `PUT /agents/:id/skills` | Replace skills from a `.zip` (`Content-Type: application/zip`) → new revision. |
-| `DELETE /agents/:id/skills` | Remove all skills → new revision. |
+| Method · Path               | Purpose                                                                        |
+| --------------------------- | ------------------------------------------------------------------------------ |
+| `GET /agents/:id/skills`    | List the active revision's skills.                                             |
+| `PUT /agents/:id/skills`    | Replace skills from a `.zip` (`Content-Type: application/zip`) → new revision. |
+| `DELETE /agents/:id/skills` | Remove all skills → new revision.                                              |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
+| Command                 | Purpose                                                                          |
+| ----------------------- | -------------------------------------------------------------------------------- |
 | `oc agent deploy <dir>` | Deploy a directory; a `skills/` folder inside it ships as skills → new revision. |
 
 Skills have no dedicated CLI verb yet — deploy a directory that contains a `skills/` folder, or use the REST endpoints / dashboard.
@@ -625,31 +705,31 @@ A skill is a folder with a `SKILL.md`; PUT/DELETE are **deployments** (versioned
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.agents.deploymentSource.link(id, params)` | Link a repo directory → push-to-deploy. |
-| `oc.agents.deploymentSource.get(id)` | The link + status. |
-| `oc.agents.deploymentSource.unlink(id)` | Remove the link (shared App webhook untouched). |
+| Call                                          | Purpose                                         |
+| --------------------------------------------- | ----------------------------------------------- |
+| `oc.agents.deploymentSource.link(id, params)` | Link a repo directory → push-to-deploy.         |
+| `oc.agents.deploymentSource.get(id)`          | The link + status.                              |
+| `oc.agents.deploymentSource.unlink(id)`       | Remove the link (shared App webhook untouched). |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /agents/:id/deployment-source` | Link a repo directory. Body: `{ repo, path, production_ref?, deploy_now?=true }`. |
-| `GET /agents/:id/deployment-source` | The link + status. |
-| `DELETE /agents/:id/deployment-source` | Remove the link. |
+| Method · Path                          | Purpose                                                                           |
+| -------------------------------------- | --------------------------------------------------------------------------------- |
+| `POST /agents/:id/deployment-source`   | Link a repo directory. Body: `{ repo, path, production_ref?, deploy_now?=true }`. |
+| `GET /agents/:id/deployment-source`    | The link + status.                                                                |
+| `DELETE /agents/:id/deployment-source` | Remove the link.                                                                  |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
-| `oc agent link <owner/repo> --path <p> [--branch <ref>] [--no-deploy]` | Link a repo directory. |
-| `oc agent status [id\|name]` | The agent's active revision + link status. |
-| `oc agent unlink` | Remove the link. |
+| Command                                                                | Purpose                                    |
+| ---------------------------------------------------------------------- | ------------------------------------------ |
+| `oc agent link <owner/repo> --path <p> [--branch <ref>] [--no-deploy]` | Link a repo directory.                     |
+| `oc agent status [id\|name]`                                           | The agent's active revision + link status. |
+| `oc agent unlink`                                                      | Remove the link.                           |
 
 </Tab>
 
@@ -667,57 +747,57 @@ that deploy auto-activates. Repo/path are server-anchored to the link. Deploymen
 
 **`DeploymentSource`**
 
-| Field | Notes |
-|---|---|
-| `agent_id` `repo_id` `path` | the linked agent · repo · directory within it |
-| `production_ref` | branch that auto-activates on push |
-| `status` | `active`, or a problem: `source_profile_changed`, `path_missing`, `ref_missing` (production branch deleted), `auth_required`, `repo_not_selected`, `app_suspended`, `error` |
-| `latest_seen_sha?` `active_deployed_sha?` | newest sha observed · sha behind the active revision |
-| `source_profile?` `source_profile_version?` | server-selected repository interpretation pinned for this link (`flue-app-v1`, version `1`) |
-| `review_fingerprint?` | digest of the latest accepted, exact-SHA reviewed plan; never source bytes or a credential |
+| Field                                       | Notes                                                                                                                                                                       |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent_id` `repo_id` `path`                 | the linked agent · repo · directory within it                                                                                                                               |
+| `production_ref`                            | branch that auto-activates on push                                                                                                                                          |
+| `status`                                    | `active`, or a problem: `source_profile_changed`, `path_missing`, `ref_missing` (production branch deleted), `auth_required`, `repo_not_selected`, `app_suspended`, `error` |
+| `latest_seen_sha?` `active_deployed_sha?`   | newest sha observed · sha behind the active revision                                                                                                                        |
+| `source_profile?` `source_profile_version?` | server-selected repository interpretation pinned for this link (`flue-app-v1`, version `1`)                                                                                 |
+| `review_fingerprint?`                       | digest of the latest accepted, exact-SHA reviewed plan; never source bytes or a credential                                                                                  |
 
 ## Schedules
 
-*Run an agent on a cron — each firing starts a session. Managed with the SDK, the `oc` CLI, or REST (org key). Full guide: [Schedules](/agent-sessions/schedules).*
+_Run an agent on a cron — each firing starts a session. Managed with the SDK, the `oc` CLI, or REST (org key). Full guide: [Schedules](/agent-sessions/schedules)._
 
 <Tabs>
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.agents.schedules.create(id, params)` | Create a schedule (`{ name, cron, tz?, input, overlap? }`). |
-| `oc.agents.schedules.list(id)` · `.get(id, sid)` | List / fetch. |
-| `oc.agents.schedules.update(id, sid, params)` | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`. |
-| `oc.agents.schedules.delete(id, sid)` | Delete (run history kept). |
-| `oc.agents.schedules.fire(id, sid)` | Fire now → a run; doesn't advance the cron. |
-| `oc.agents.schedules.runs(id, sid, { cursor?, limit? })` | Run history (each carries `sessionId`). |
+| Call                                                     | Purpose                                                     |
+| -------------------------------------------------------- | ----------------------------------------------------------- |
+| `oc.agents.schedules.create(id, params)`                 | Create a schedule (`{ name, cron, tz?, input, overlap? }`). |
+| `oc.agents.schedules.list(id)` · `.get(id, sid)`         | List / fetch.                                               |
+| `oc.agents.schedules.update(id, sid, params)`            | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`.        |
+| `oc.agents.schedules.delete(id, sid)`                    | Delete (run history kept).                                  |
+| `oc.agents.schedules.fire(id, sid)`                      | Fire now → a run; doesn't advance the cron.                 |
+| `oc.agents.schedules.runs(id, sid, { cursor?, limit? })` | Run history (each carries `sessionId`).                     |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /agents/:id/schedules` | Create → `201 { schedule }`. Body `{ name, cron, tz?, input, overlap? }`. |
-| `GET /agents/:id/schedules` · `…/:sid` | List / fetch. |
-| `PATCH /agents/:id/schedules/:sid` | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`. |
-| `DELETE /agents/:id/schedules/:sid` | Delete → `204` (runs kept). |
-| `POST /agents/:id/schedules/:sid/fire` | Fire now → `201 { run }`; doesn't advance the cron. |
-| `GET /agents/:id/schedules/:sid/runs?cursor=&limit=` | Run history → `{ runs, next_cursor }`. |
+| Method · Path                                        | Purpose                                                                   |
+| ---------------------------------------------------- | ------------------------------------------------------------------------- |
+| `POST /agents/:id/schedules`                         | Create → `201 { schedule }`. Body `{ name, cron, tz?, input, overlap? }`. |
+| `GET /agents/:id/schedules` · `…/:sid`               | List / fetch.                                                             |
+| `PATCH /agents/:id/schedules/:sid`                   | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`.                      |
+| `DELETE /agents/:id/schedules/:sid`                  | Delete → `204` (runs kept).                                               |
+| `POST /agents/:id/schedules/:sid/fire`               | Fire now → `201 { run }`; doesn't advance the cron.                       |
+| `GET /agents/:id/schedules/:sid/runs?cursor=&limit=` | Run history → `{ runs, next_cursor }`.                                    |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
-| `oc agent schedule create <name> --agent <id> --cron <c> [--tz <z>] --input <s>` | Create a schedule. |
-| `oc agent schedules [--agent <id>]` · `oc agent schedule get <name>` | List / fetch. |
-| `oc agent schedule pause\|resume <name>` | Pause / resume. |
-| `oc agent schedule delete <name>` | Delete. |
-| `oc agent schedule fire <name>` | Fire now (prints the `ses_…`). |
-| `oc agent schedule runs <name>` | Run history. |
+| Command                                                                          | Purpose                        |
+| -------------------------------------------------------------------------------- | ------------------------------ |
+| `oc agent schedule create <name> --agent <id> --cron <c> [--tz <z>] --input <s>` | Create a schedule.             |
+| `oc agent schedules [--agent <id>]` · `oc agent schedule get <name>`             | List / fetch.                  |
+| `oc agent schedule pause\|resume <name>`                                         | Pause / resume.                |
+| `oc agent schedule delete <name>`                                                | Delete.                        |
+| `oc agent schedule fire <name>`                                                  | Fire now (prints the `ses_…`). |
+| `oc agent schedule runs <name>`                                                  | Run history.                   |
 
 </Tab>
 
@@ -727,14 +807,14 @@ that deploy auto-activates. Repo/path are server-anchored to the link. Deploymen
 
 **`Schedule`**
 
-| Field | Notes |
-|---|---|
-| `id` `agent_id` | `sch_…` · the owning agent |
-| `name` `cron` `tz?` `input` | handle (unique per agent) · 5-field cron · IANA tz · first message |
-| `overlap` | `skip` (default) · `allow` |
-| `state` | `active · paused · auto_paused` (five straight scheduled-firing failures auto-pause) |
-| `next_fire_at` `last_fired_at?` | next occurrence · last fire |
-| `consecutive_failures` `last_error?` | in-a-row enactment failures · last error (cleared on success) |
+| Field                                | Notes                                                                                |
+| ------------------------------------ | ------------------------------------------------------------------------------------ |
+| `id` `agent_id`                      | `sch_…` · the owning agent                                                           |
+| `name` `cron` `tz?` `input`          | handle (unique per agent) · 5-field cron · IANA tz · first message                   |
+| `overlap`                            | `skip` (default) · `allow`                                                           |
+| `state`                              | `active · paused · auto_paused` (five straight scheduled-firing failures auto-pause) |
+| `next_fire_at` `last_fired_at?`      | next occurrence · last fire                                                          |
+| `consecutive_failures` `last_error?` | in-a-row enactment failures · last error (cleared on success)                        |
 
 **`Run`** — one per firing decision, newest-first: `srn_…` with `outcome` (`enacted` · `skipped` · `failed`), `scheduled_for?` (`null` for a manual fire), `fired_at`, `session_id?` (when enacted), `error?`. Chain `session_id` into `GET /sessions/:id`.
 
@@ -749,23 +829,23 @@ context, not a redirect URL. Status responses never contain credentials.
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.agents.authorizeManagedSlack(id, { returnDeploymentId? })` | Start managed-app OAuth. |
-| `oc.agents.getManagedSlack(id)` | Read workspace, app identity, state, and `openUrl`. |
-| `oc.agents.listManagedSlackConnections()` | List this owner's current workspace claims and owning agents before OAuth. |
-| `oc.agents.disconnectManagedSlack(id)` | Stop routing this agent without uninstalling the workspace app. |
+| Call                                                           | Purpose                                                                    |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `oc.agents.authorizeManagedSlack(id, { returnDeploymentId? })` | Start managed-app OAuth.                                                   |
+| `oc.agents.getManagedSlack(id)`                                | Read workspace, app identity, state, and `openUrl`.                        |
+| `oc.agents.listManagedSlackConnections()`                      | List this owner's current workspace claims and owning agents before OAuth. |
+| `oc.agents.disconnectManagedSlack(id)`                         | Stop routing this agent without uninstalling the workspace app.            |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /agents/:id/slack/managed/authorize` | Start managed-app OAuth; accepts `return_deployment_id?`. |
-| `GET /agents/:id/slack/managed` | Read the managed connection. |
-| `DELETE /agents/:id/slack/managed` | Disconnect the agent from the shared app. |
-| `GET /slack/managed/connections` | List current owner-scoped workspace claims with safe agent id/name projections. |
+| Method · Path                              | Purpose                                                                         |
+| ------------------------------------------ | ------------------------------------------------------------------------------- |
+| `POST /agents/:id/slack/managed/authorize` | Start managed-app OAuth; accepts `return_deployment_id?`.                       |
+| `GET /agents/:id/slack/managed`            | Read the managed connection.                                                    |
+| `DELETE /agents/:id/slack/managed`         | Disconnect the agent from the shared app.                                       |
+| `GET /slack/managed/connections`           | List current owner-scoped workspace claims with safe agent id/name projections. |
 
 </Tab>
 
@@ -782,41 +862,41 @@ enforces the one-workspace-to-one-agent claim transactionally.
 Builder-owned Slack apps remain a separate resource and can overlap during an
 explicit handoff:
 
-| TypeScript SDK | REST API |
-| --- | --- |
-| `oc.agents.slackManifest(id)` | `POST /agents/:id/slack/manifest` |
-| `oc.agents.connectSlack(id, values)` | `POST /agents/:id/slack` |
-| `oc.agents.getSlack(id)` | `GET /agents/:id/slack` |
-| `oc.agents.disconnectSlack(id)` | `DELETE /agents/:id/slack` |
+| TypeScript SDK                       | REST API                          |
+| ------------------------------------ | --------------------------------- |
+| `oc.agents.slackManifest(id)`        | `POST /agents/:id/slack/manifest` |
+| `oc.agents.connectSlack(id, values)` | `POST /agents/:id/slack`          |
+| `oc.agents.getSlack(id)`             | `GET /agents/:id/slack`           |
+| `oc.agents.disconnectSlack(id)`      | `DELETE /agents/:id/slack`        |
 
 See [Slack](/agent-sessions/slack) for installation, trust boundaries, and
 conversation behavior.
 
 ## Destinations
 
-*Webhooks are configured via SDK/REST (no `oc` command).*
+_Webhooks are configured via SDK/REST (no `oc` command)._
 
 <Tabs>
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `session.destinations.create(params)` | Register a webhook destination. |
-| `session.destinations.list()` · `.get(did)` | List / fetch. |
-| `session.destinations.update(did, params)` | Pause/resume (`enabled`), retune `level`/`types`, rotate `secret`. |
-| `session.destinations.delete(did)` | Remove. |
+| Call                                        | Purpose                                                            |
+| ------------------------------------------- | ------------------------------------------------------------------ |
+| `session.destinations.create(params)`       | Register a webhook destination.                                    |
+| `session.destinations.list()` · `.get(did)` | List / fetch.                                                      |
+| `session.destinations.update(did, params)`  | Pause/resume (`enabled`), retune `level`/`types`, rotate `secret`. |
+| `session.destinations.delete(did)`          | Remove.                                                            |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /sessions/:id/destinations` | Register a webhook destination. |
-| `GET /sessions/:id/destinations` · `…/:did` | List / fetch. |
-| `PATCH /sessions/:id/destinations/:did` | Pause/resume, retune, rotate. |
-| `DELETE /sessions/:id/destinations/:did` | Remove. |
+| Method · Path                               | Purpose                         |
+| ------------------------------------------- | ------------------------------- |
+| `POST /sessions/:id/destinations`           | Register a webhook destination. |
+| `GET /sessions/:id/destinations` · `…/:did` | List / fetch.                   |
+| `PATCH /sessions/:id/destinations/:did`     | Pause/resume, retune, rotate.   |
+| `DELETE /sessions/:id/destinations/:did`    | Remove.                         |
 
 </Tab>
 
@@ -826,27 +906,27 @@ Destination body: `url`, `secret?`, `level?` (`user`), `types?[]`, `include_raw?
 
 ## Deliveries
 
-*Delivery records are read via SDK/REST (no `oc` command).*
+_Delivery records are read via SDK/REST (no `oc` command)._
 
 <Tabs>
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `session.deliveries.list(opts)` | List deliveries — status, attempts, last response/error. |
-| `session.deliveries.get(id)` | One delivery, in detail. |
-| `session.deliveries.redeliver(id)` | Re-send any delivery. |
+| Call                               | Purpose                                                  |
+| ---------------------------------- | -------------------------------------------------------- |
+| `session.deliveries.list(opts)`    | List deliveries — status, attempts, last response/error. |
+| `session.deliveries.get(id)`       | One delivery, in detail.                                 |
+| `session.deliveries.redeliver(id)` | Re-send any delivery.                                    |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `GET /sessions/:id/deliveries?destination=&status=&after=&limit=` | List deliveries. |
-| `GET /sessions/:id/deliveries/:id` | One delivery. |
-| `POST /sessions/:id/deliveries/:id/redeliver` | Re-send any delivery. |
+| Method · Path                                                     | Purpose               |
+| ----------------------------------------------------------------- | --------------------- |
+| `GET /sessions/:id/deliveries?destination=&status=&after=&limit=` | List deliveries.      |
+| `GET /sessions/:id/deliveries/:id`                                | One delivery.         |
+| `POST /sessions/:id/deliveries/:id/redeliver`                     | Re-send any delivery. |
 
 </Tab>
 
@@ -856,61 +936,61 @@ See [Webhooks](/agent-sessions/webhooks#signing-retries-and-dedupe) for signing,
 
 **`Destination`**
 
-| Field | Notes |
-|---|---|
-| `id` `session` `kind` `created_at` `updated_at` | |
-| `url` | webhook target |
-| `level` `types` | visibility threshold · event-type filter |
-| `include_raw` `enabled` `has_secret` | include raw bodies · paused/active · whether a signing secret is set |
-| `created_after_seq` | only events after this seq are delivered |
+| Field                                           | Notes                                                                |
+| ----------------------------------------------- | -------------------------------------------------------------------- |
+| `id` `session` `kind` `created_at` `updated_at` |                                                                      |
+| `url`                                           | webhook target                                                       |
+| `level` `types`                                 | visibility threshold · event-type filter                             |
+| `include_raw` `enabled` `has_secret`            | include raw bodies · paused/active · whether a signing secret is set |
+| `created_after_seq`                             | only events after this seq are delivered                             |
 
 **`Delivery`**
 
-| Field | Notes |
-|---|---|
-| `id` `session` `destination` `created_at` `updated_at` | |
-| `event_id` `event_seq` | the event delivered |
-| `status` `attempts` `last_attempt_at` | delivery state, retry count, last try |
-| `response_code?` `error?` | last response · failure detail |
+| Field                                                  | Notes                                 |
+| ------------------------------------------------------ | ------------------------------------- |
+| `id` `session` `destination` `created_at` `updated_at` |                                       |
+| `event_id` `event_seq`                                 | the event delivered                   |
+| `status` `attempts` `last_attempt_at`                  | delivery state, retry count, last try |
+| `response_code?` `error?`                              | last response · failure detail        |
 
 ## GitHub Apps and Repos
 
-A GitHub App lets OpenComputer mint short-lived, repo-scoped tokens; a **Repo** is a stable handle resolving to your configured App (the OpenComputer App by default). Used for session [sources](#sessions) (work repos) and [deploy-from-a-repo](#deploy-from-a-repo) (the agent's definition repo). Install the [OpenComputer App](https://github.com/apps/opencomputerdev/installations/new). **Bring-your-own** Apps apply to **session sources / PR publishing** (your users acting on their own repos) — **deployment sources always use the OpenComputer App**.
+A GitHub App lets OpenComputer mint short-lived, repo-scoped tokens; a **Repo** is a stable handle resolving to your configured App (the OpenComputer App by default). Used for session [sources](#sessions) (work repos) and [deploy-from-a-repo](#deploy-from-a-repo) (the agent's definition repo). Install the [OpenComputer App](https://github.com/apps/opencomputerdev/installations/new). **Bring-your-own** Apps may back built-in-runtime session sources and PR publishing. Hosted Flue repository tools and deployment sources always use the owner-bound OpenComputer App.
 
 <Tabs>
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.repos.create(params)` · `.get(id)` · `.list()` · `.update(id, params)` | Register / fetch / list / rename a repo. |
-| `oc.github.apps.list()` | List GitHub Apps available to your org. |
-| `oc.github.apps.register(params)` | Register your own App (`byo_stored_key` / `byo_broker`). |
-| `oc.github.apps.createManifestUrl(params)` | One-click: a link to open; OpenComputer hosts the flow + key capture. |
-| `oc.github.apps.createManifest/completeManifest(params)` | Developer-driven manifest flow. |
-| `oc.github.apps.update(id, params)` · `delete(id)` | Update / rotate / remove an App. |
-| `oc.github.installations.list()` | List installations visible to OpenComputer. |
+| Call                                                                       | Purpose                                                               |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `oc.repos.create(params)` · `.get(id)` · `.list()` · `.update(id, params)` | Register / fetch / list / rename a repo.                              |
+| `oc.github.apps.list()`                                                    | List GitHub Apps available to your org.                               |
+| `oc.github.apps.register(params)`                                          | Register your own App (`byo_stored_key` / `byo_broker`).              |
+| `oc.github.apps.createManifestUrl(params)`                                 | One-click: a link to open; OpenComputer hosts the flow + key capture. |
+| `oc.github.apps.createManifest/completeManifest(params)`                   | Developer-driven manifest flow.                                       |
+| `oc.github.apps.update(id, params)` · `delete(id)`                         | Update / rotate / remove an App.                                      |
+| `oc.github.installations.list()`                                           | List installations visible to OpenComputer.                           |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /repos` · `GET /repos/:id` · `GET /repos` · `PATCH /repos/:id` | Register / fetch / list / rename a repo. |
-| `GET /github/apps` · `POST /github/apps` | List · register your own App. |
-| `PATCH /github/apps/:id` · `DELETE /github/apps/:id` | Update / rotate / remove. |
+| Method · Path                                                                      | Purpose                                     |
+| ---------------------------------------------------------------------------------- | ------------------------------------------- |
+| `POST /repos` · `GET /repos/:id` · `GET /repos` · `PATCH /repos/:id`               | Register / fetch / list / rename a repo.    |
+| `GET /github/apps` · `POST /github/apps`                                           | List · register your own App.               |
+| `PATCH /github/apps/:id` · `DELETE /github/apps/:id`                               | Update / rotate / remove.                   |
 | `POST /github/apps/manifest` · `…/manifest/start` · `…/callback` · `…/conversions` | Manifest flow (hosted or developer-driven). |
-| `GET /github/installations` | List installations visible to OpenComputer. |
+| `GET /github/installations`                                                        | List installations visible to OpenComputer. |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
-| `oc repo add <owner/repo>` · `oc repo list` · `oc repo get <id>` | Register / list / fetch a repo. |
-| *(App install + manifest — browser flow; manage in the dashboard or via SDK/REST)* | |
+| Command                                                                            | Purpose                         |
+| ---------------------------------------------------------------------------------- | ------------------------------- |
+| `oc repo add <owner/repo>` · `oc repo list` · `oc repo get <id>`                   | Register / list / fetch a repo. |
+| _(App install + manifest — browser flow; manage in the dashboard or via SDK/REST)_ |                                 |
 
 </Tab>
 
@@ -928,31 +1008,31 @@ Repo = { id, provider, owner, repo, name?, created_at, updated_at }
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.credentials.create(params)` | Add a provider key. |
-| `oc.credentials.list()` · `oc.credentials.delete(id)` | List / remove. |
-| `oc.credentials.setDefault(params)` | Set the org default. |
+| Call                                                  | Purpose              |
+| ----------------------------------------------------- | -------------------- |
+| `oc.credentials.create(params)`                       | Add a provider key.  |
+| `oc.credentials.list()` · `oc.credentials.delete(id)` | List / remove.       |
+| `oc.credentials.setDefault(params)`                   | Set the org default. |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /credentials` | Add a provider key. |
-| `GET /credentials` · `DELETE /credentials/:id` | List / remove. |
-| `PUT /credentials/default` | Set the org default (provider derived). |
+| Method · Path                                  | Purpose                                 |
+| ---------------------------------------------- | --------------------------------------- |
+| `POST /credentials`                            | Add a provider key.                     |
+| `GET /credentials` · `DELETE /credentials/:id` | List / remove.                          |
+| `PUT /credentials/default`                     | Set the org default (provider derived). |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
-| `oc credential add --provider <p> --key <k> [--default]` | Add a provider key. |
-| `oc credential list` · `oc credential remove <id>` | List / remove. |
-| `oc credential set-default <id>` | Set the org default. |
+| Command                                                  | Purpose              |
+| -------------------------------------------------------- | -------------------- |
+| `oc credential add --provider <p> --key <k> [--default]` | Add a provider key.  |
+| `oc credential list` · `oc credential remove <id>`       | List / remove.       |
+| `oc credential set-default <id>`                         | Set the org default. |
 
 </Tab>
 

--- a/docs/agent-sessions/flue.mdx
+++ b/docs/agent-sessions/flue.mdx
@@ -287,7 +287,7 @@ Custom tools in the Worker can currently reach only platform-managed outbound ho
 external `fetch` destinations are not part of the supported profile. Commands run through an
 optional OpenComputer sandbox follow the sandbox's separate network policy.
 
-## Optional sandbox
+## Optional sandbox and working repositories
 
 Add `ocSandbox` only when the agent needs a Linux shell or durable files:
 
@@ -295,6 +295,7 @@ Add `ocSandbox` only when the agent needs a Linux shell or durable files:
 import { defineAgent, defineAgentProfile } from "@flue/runtime";
 import {
   DEFAULT_MODEL,
+  ocRepoTools,
   ocSandbox,
   route,
   useOcGateway,
@@ -312,6 +313,7 @@ export default defineAgent((ctx) => {
     }),
     model: DEFAULT_MODEL,
     sandbox: ocSandbox(ctx.env),
+    tools: [...ocRepoTools(ctx)],
   };
 });
 ```
@@ -320,8 +322,16 @@ Declaring `ocSandbox` performs no provisioning during Worker startup or Flue run
 The first real shell or file operation resolves one sandbox for the session; later operations and
 turns reuse it.
 
-The workspace starts empty. Repository sources and workspace skill discovery are not implemented for
-Flue sessions, so passing `sources` at session creation is rejected.
+The workspace starts empty. Add a [working repository](/agent-sessions/repos#choose-working-repositories-for-a-flue-agent)
+at session creation or with `add_source`. Flue pins the requested ref immediately but creates the
+session sandbox and materializes files only when the app first uses a repository tool. The agent may
+edit those files and call `github_publish_pull_request`; OpenComputer performs authenticated Git
+operations outside the tenant Worker and session sandbox.
+
+`ocRepoTools` adds `list_working_repos`, `add_source`, and
+`github_publish_pull_request`. Tell the agent to list first, state the exact
+`owner/repo` it resolved, and ask when the user's target is ambiguous. Repository
+names do not need to be embedded in the prompt.
 
 ## Variables and secrets
 
@@ -408,8 +418,8 @@ and dashboard as the other runtimes. The important differences are:
 
 - Dashboard sessions and the OpenComputer-managed Slack app deliver direct text through the hosted
   session wire. Native Flue channel bindings and workflows are not exposed by this hosting path.
-- Repository sources, checkout, pull-request publishing, watches, and repo-backed workspaces are not
-  supported for Flue sessions.
+- Working-repository checkout and pull-request publishing are available through the owner-bound
+  OpenComputer GitHub App. Pull-request watches are not part of the current Flue profile.
 - Repository deployment accepts one self-contained npm root with a committed npm lockfile. Pushes
   to its linked production branch deploy automatically; preview branches and staged Flue Workers are
   not supported.

--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -7,8 +7,8 @@ Use Repos when a session needs private code. Giving an agent a GitHub token,
 authenticated remote, or `gh` session gives it whatever that token can do; hiding the
 token behind a proxy does not narrow that authority.
 
-Repos make GitHub access operation-scoped. A **Repo** is a stable repository handle
-(owner/repo) that resolves to your configured GitHub App (the OpenComputer App by default);
+Repos make GitHub access operation-scoped. A **Repo** is a stable `repo_…` handle
+with a current `owner/repo` display name that resolves to your configured GitHub App;
 a **Source** pins `ref` and `sha`.
 OpenComputer checks out the exact commit in a short-lived **Git operations sandbox**,
 copies only files into `/workspace/sources/<name>`, and destroys the token. For writes, the
@@ -41,6 +41,38 @@ sandbox, and deploys the resulting artifact. Repository credentials reach neithe
   their own auth surface while sessions continue to reference repos and sources
   the same way.
 </Note>
+
+## Choose working repositories for a Flue agent
+
+A Flue agent's **repository access policy** limits which repositories it may
+check out and publish to. It is independent of the [deployment source](#use-a-repo-to-deploy-a-flue-agent):
+the deployment source supplies the app, while working repositories supply code
+for a session task.
+
+In guided setup or **Agent → Settings → Repository access**, choose:
+
+- **All granted repositories** — every repository currently granted to the
+  owner-bound OpenComputer GitHub App, including repositories added later.
+- **Only selected repositories** — an explicit set stored by stable `repo_…`
+  id. An empty set disables repository work without disabling chat.
+
+The effective set is the intersection of that policy and the App installation's
+current grant. Removing a repository from GitHub takes effect on the next
+checkout or publish. OpenComputer preserves selected ids that are hidden by a
+truncated GitHub listing and shows unavailable selections separately instead of
+calling them revoked.
+
+Choose a working repository when starting a dashboard session, pass it in
+`sources`, or let the Flue app call `add_source`. A ref is pinned to one commit;
+reusing the source name in that session returns the same pin. OpenComputer
+checks files out lazily into the session sandbox and keeps the GitHub token in a
+separate, short-lived Git operations sandbox.
+
+To publish, the agent calls `github_publish_pull_request`. OpenComputer pushes a
+new `oc/…` branch and opens a PR; it never writes directly to the default branch.
+The managed Flue capability uses the OpenComputer App selected for the agent's
+owner. A bring-your-own App is not used as an alternative authority for this
+policy.
 
 ## How it works
 

--- a/docs/agent-sessions/runtime-tools.mdx
+++ b/docs/agent-sessions/runtime-tools.mdx
@@ -55,13 +55,17 @@ commits as usual; calling the tool hands the requested outcome to the platform, 
 commits the agent's edits to an `oc/<session>/<source>-<id>` branch and opens the PR with a
 just-in-time, write-scoped token — outside the agent sandbox. It returns the PR URL.
 
-| Argument | Required | What it is                                                                      |
-| -------- | -------- | ------------------------------------------------------------------------------- |
-| `source` | yes      | The checked-out source's local name (its directory under `/workspace/sources`). |
-| `title`  | yes      | PR title.                                                                       |
-| `body`   | no       | PR description.                                                                 |
-| `base`   | no       | PR base branch. Defaults to the source's checked-out ref.                       |
-| `draft`  | no       | Open the PR as a draft.                                                         |
+| Argument | Required                 | What it is                                                                                                      |
+| -------- | ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `source` | yes                      | The checked-out source's local name (its directory under `/workspace/sources`).                                 |
+| `title`  | yes                      | PR title.                                                                                                       |
+| `body`   | no                       | PR description.                                                                                                 |
+| `base`   | built-in: no · Flue: yes | PR base branch. Built-in runtimes default to the checked-out ref; hosted Flue requires the exact target branch. |
+| `draft`  | no                       | Open the PR as a draft.                                                                                         |
+
+Hosted Flue uses an object input:
+`github_publish_pull_request({ source, title, body?, base, draft? })`. `base` is
+required. Built-in runtimes keep their existing tool input and may omit `base`.
 
 <Note>
   `github_publish_pull_request` requires a **configured GitHub App** (the
@@ -74,13 +78,16 @@ just-in-time, write-scoped token — outside the agent sandbox. It returns the P
   App; they never fall back to a bring-your-own App.
 </Note>
 
-`add_source(repo, ref, name?)` checks out an **additional** repo into
-`/workspace/sources/<name>` mid-session. `repo` is `"owner/repo"` (or a `repo_…` id), `ref` a
-branch or `refs/pull/N/head`, `name` defaults to the repo name. Same zero-credential model as
-the initial checkout — a Git operations sandbox mints a just-in-time, read-only token; the
-agent never sees it. **Connected-App (`oc_app`) repos only.**
+`add_source` checks out an **additional** repo into
+`/workspace/sources/<name>` mid-session. Built-in runtimes use
+`add_source(repo, ref, name?)`. Hosted Flue uses the object input
+`add_source({ repository, ref, name? })`. `repo`/`repository` is exact
+`"owner/repo"` coordinates (or a `repo_…` id), `ref` is a branch, tag, commit,
+or `refs/pull/N/head`, and `name` defaults to the repo name. The Git operations
+sandbox mints a just-in-time read token; the agent never sees it.
+**Connected-App (`oc_app`) repos only.**
 
-For Flue, `repo` must be within the agent's current
+For Flue, `repository` must be within the agent's current
 [repository access policy](/agent-sessions/repos#choose-working-repositories-for-a-flue-agent).
 Checkout is lazy and uses the session's shared hands sandbox. Publishing always
 creates an `oc/…` branch and pull request; it never pushes directly to the

--- a/docs/agent-sessions/runtime-tools.mdx
+++ b/docs/agent-sessions/runtime-tools.mdx
@@ -4,40 +4,50 @@ title: "Runtime tools"
 description: "The tools a runtime can use — what to rely on when you write prompts"
 ---
 
-When you write a prompt for a [runtime](/agent-sessions/runtimes) (`claude` or `codex`), it's useful to know exactly what the agent can do. Both runtimes act through the same fixed set of tools against the session's **sandbox** — the agent has no direct filesystem, shell, or network of its own. The runtime's built-in local tools are disabled; only these remote tools are available.
+When you write a prompt for a built-in [runtime](/agent-sessions/runtimes) (`claude` or `codex`), it's useful to know exactly what the agent can do. Both runtimes act through the same fixed set of tools against the session's **sandbox** — the agent has no direct filesystem, shell, or network of its own. A hosted [Flue](/agent-sessions/flue) app defines its own tool surface; OpenComputer adds exactly `list_working_repos`, `add_source`, and `github_publish_pull_request` for repository work.
 
 ## Sandbox tools
 
-| Tool | What it does |
-| --- | --- |
-| `bash` | Run a shell command in the sandbox. |
-| `read` | Read a file from the sandbox. |
-| `write` | Write a file to the sandbox. |
-| `ls` | List a directory in the sandbox. |
+| Tool    | What it does                        |
+| ------- | ----------------------------------- |
+| `bash`  | Run a shell command in the sandbox. |
+| `read`  | Read a file from the sandbox.       |
+| `write` | Write a file to the sandbox.        |
+| `ls`    | List a directory in the sandbox.    |
 
 `bash` is the only place commands run. Each call is a fresh shell, so use absolute paths or `cd /workspace && ...`. A run surfaces as an [`exec.completed`](/agent-sessions/events#event-shape) event (`{ command, exit_code, summary }`), with large output available via `content_ref`.
 
 To work on a **public** repo, the agent `git clone`s it via `bash` — the sandbox has open outbound internet (below). For **private** repos, register a [Repo](/agent-sessions/repos) and reference it in the session's `sources`: it's checked out before the first turn and the GitHub credential never enters the sandbox.
 
-<Note>**Network:** the sandbox has **open outbound internet** by default (so `git clone`, package installs, and API calls just work), with private, loopback, link-local, and cloud-metadata addresses blocked.</Note>
+<Note>
+  **Network:** the sandbox has **open outbound internet** by default (so `git
+  clone`, package installs, and API calls just work), with private, loopback,
+  link-local, and cloud-metadata addresses blocked.
+</Note>
 
 ## User-facing tools
 
-| Tool | What it does |
-| --- | --- |
-| `say` | Emit a `user`-level message. |
+| Tool  | What it does                       |
+| ----- | ---------------------------------- |
+| `say` | Emit a `user`-level message.       |
 | `ask` | Ask a question and pause the turn. |
 
 The agent's final `say` is the session result. `ask` ends the turn with `yield_reason: "needs_input"`; answer by [steering](/agent-sessions/messaging) a reply, which wakes the session.
 
 ## GitHub tools
 
-| Tool | What it does |
-| --- | --- |
-| `github_publish_pull_request` | Open a pull request from a checked-out [Repo](/agent-sessions/repos) source. |
-| `add_source` | Check out an additional repo into `/workspace/sources/<name>` mid-session. |
-| `watch_pull_request` | Subscribe to events on a PR the session opened — the session is woken when checks finish, a review or comment lands, or it merges. |
-| `unwatch_pull_request` | Stop watching a PR. |
+| Tool                          | Availability           | What it does                                                                                                                       |
+| ----------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `list_working_repos`          | Hosted Flue            | List the repositories currently effective under the agent's policy and GitHub grant.                                               |
+| `github_publish_pull_request` | Built-in + hosted Flue | Open a pull request from a checked-out [Repo](/agent-sessions/repos) source.                                                       |
+| `add_source`                  | Built-in + hosted Flue | Check out an additional repo into `/workspace/sources/<name>` mid-session.                                                         |
+| `watch_pull_request`          | Built-in               | Subscribe to events on a PR the session opened — the session is woken when checks finish, a review or comment lands, or it merges. |
+| `unwatch_pull_request`        | Built-in               | Stop watching a PR.                                                                                                                |
+
+`list_working_repos()` is the hosted Flue discovery surface. It returns exact
+stable ids, current `owner/repo` names, and default branches; the model chooses
+from that structured result instead of relying on repository names embedded in
+a prompt.
 
 `github_publish_pull_request` lets the agent open a PR **without ever holding a GitHub
 credential**. The agent edits files in `/workspace/sources/<source>` and makes local
@@ -45,19 +55,23 @@ commits as usual; calling the tool hands the requested outcome to the platform, 
 commits the agent's edits to an `oc/<session>/<source>-<id>` branch and opens the PR with a
 just-in-time, write-scoped token — outside the agent sandbox. It returns the PR URL.
 
-| Argument | Required | What it is |
-| --- | --- | --- |
-| `source` | yes | The checked-out source's local name (its directory under `/workspace/sources`). |
-| `title` | yes | PR title. |
-| `body` | no | PR description. |
-| `base` | no | PR base branch. Defaults to the source's checked-out ref. |
-| `draft` | no | Open the PR as a draft. |
+| Argument | Required | What it is                                                                      |
+| -------- | -------- | ------------------------------------------------------------------------------- |
+| `source` | yes      | The checked-out source's local name (its directory under `/workspace/sources`). |
+| `title`  | yes      | PR title.                                                                       |
+| `body`   | no       | PR description.                                                                 |
+| `base`   | no       | PR base branch. Defaults to the source's checked-out ref.                       |
+| `draft`  | no       | Open the PR as a draft.                                                         |
 
 <Note>
-`github_publish_pull_request` requires a **configured GitHub App** (the OpenComputer App or
-a [bring-your-own App](/agent-sessions/repos#bring-your-own-app)). It does **not** work with
-inline (`risky_short_lived_token`) auth, which is **checkout-only** — see
-[Repos & GitHub](/agent-sessions/repos#inline-short-lived-token).
+  `github_publish_pull_request` requires a **configured GitHub App** (the
+  OpenComputer App or a [bring-your-own
+  App](/agent-sessions/repos#bring-your-own-app)). It does **not** work with
+  inline (`risky_short_lived_token`) auth, which is **checkout-only** — see
+  [Repos & GitHub](/agent-sessions/repos#inline-short-lived-token). Built-in
+  sessions may resolve through the configured OpenComputer or bring-your-own
+  App. Hosted Flue repository tools always use the agent owner's OpenComputer
+  App; they never fall back to a bring-your-own App.
 </Note>
 
 `add_source(repo, ref, name?)` checks out an **additional** repo into
@@ -66,16 +80,22 @@ branch or `refs/pull/N/head`, `name` defaults to the repo name. Same zero-creden
 the initial checkout — a Git operations sandbox mints a just-in-time, read-only token; the
 agent never sees it. **Connected-App (`oc_app`) repos only.**
 
+For Flue, `repo` must be within the agent's current
+[repository access policy](/agent-sessions/repos#choose-working-repositories-for-a-flue-agent).
+Checkout is lazy and uses the session's shared hands sandbox. Publishing always
+creates an `oc/…` branch and pull request; it never pushes directly to the
+default branch.
+
 `watch_pull_request(wake_on?, repo?, pr?, intent?)` subscribes the session to a PR it opened;
 OpenComputer wakes the session when the wake condition is met. It does **not** block — call it,
 then finish the turn.
 
-| Argument | Required | What it is |
-| --- | --- | --- |
-| `wake_on` | no | The wake condition: `checks` (default), `review` (a review decision), `comment` (a new comment), `merge` (merged/closed). |
-| `repo` | no | The watched repo. Defaults to the most recent PR the session opened. |
-| `pr` | no | The PR number. Defaults with `repo`. |
-| `intent` | no | Freeform note (the *why*), replayed on wake. |
+| Argument  | Required | What it is                                                                                                                |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `wake_on` | no       | The wake condition: `checks` (default), `review` (a review decision), `comment` (a new comment), `merge` (merged/closed). |
+| `repo`    | no       | The watched repo. Defaults to the most recent PR the session opened.                                                      |
+| `pr`      | no       | The PR number. Defaults with `repo`.                                                                                      |
+| `intent`  | no       | Freeform note (the _why_), replayed on wake.                                                                              |
 
 Watches cover PRs the **same session** opened, on **Connected-App (`oc_app`) repos only**.
 `unwatch_pull_request(repo?, pr?)` stops watching; both args default to the session's only

--- a/docs/agent-sessions/sessions.mdx
+++ b/docs/agent-sessions/sessions.mdx
@@ -6,7 +6,11 @@ description: "Durable, resumable agent execution"
 
 A **session** is an [agent](/agent-sessions/agents) run with an append-only [event log](/agent-sessions/events), a pinned configuration snapshot, and a lifecycle status. The execution substrate depends on the [runtime](/agent-sessions/runtimes): built-in runtimes use managed sandboxes, while [Flue](/agent-sessions/flue) uses a deployed Worker and one Durable Object per session.
 
-<Note>The [dashboard](https://app.opencomputer.dev) lists your sessions and opens each with a live event stream you can watch and steer — handy for following or debugging a run without building UI.</Note>
+<Note>
+  The [dashboard](https://app.opencomputer.dev) lists your sessions and opens
+  each with a live event stream you can watch and steer — handy for following or
+  debugging a run without building UI.
+</Note>
 
 ## Session flow
 
@@ -15,20 +19,25 @@ A **session** is an [agent](/agent-sessions/agents) run with an append-only [eve
 3. The runtime appends [events](/agent-sessions/events) as it works. Built-in runtimes execute in managed sandboxes. Flue executes in its Worker and Durable Object, with no sandbox unless the app explicitly uses `ocSandbox`.
 4. With nothing left to do, the session becomes **idle**. A [steer](/agent-sessions/messaging) message starts the next ordered turn with the same conversation context.
 
-Pass [`sources`](/agent-sessions/repos) to prepare `/workspace/sources/` for a built-in runtime. Flue does not yet support repository sources and rejects that parameter.
+Pass [`sources`](/agent-sessions/repos) to give a session working repositories. Built-in runtimes prepare them before turn one. Flue keeps the same pinned source contract but materializes a repository lazily, when its app first uses the repository tools.
 
-<Note>The built-in runtimes restart from checkpointed state, enforce a turn deadline, and survive sandbox reclaim. Flue relies on Durable Object recovery and event projection instead; its current limit and recovery differences are listed on the [Flue page](/agent-sessions/flue#session-behavior).</Note>
+<Note>
+  The built-in runtimes restart from checkpointed state, enforce a turn
+  deadline, and survive sandbox reclaim. Flue relies on Durable Object recovery
+  and event projection instead; its current limit and recovery differences are
+  listed on the [Flue page](/agent-sessions/flue#session-behavior).
+</Note>
 
 ## Lifecycle
 
-| Status | Meaning |
-| --- | --- |
-| `queued` | Scheduled; no turn is running. |
-| `running` | A turn is executing. |
+| Status           | Meaning                                                            |
+| ---------------- | ------------------------------------------------------------------ |
+| `queued`         | Scheduled; no turn is running.                                     |
+| `running`        | A turn is executing.                                               |
 | `awaiting_input` | A turn ended asking you a question — steerable; reply to continue. |
-| `idle` | No turn running; steerable; runtime state is retained. |
-| `failed` | The session errored out. |
-| `archived` | Closed; read-only. |
+| `idle`           | No turn running; steerable; runtime state is retained.             |
+| `failed`         | The session errored out.                                           |
+| `archived`       | Closed; read-only.                                                 |
 
 A session also carries `last_turn = { id, state, yield_reason?, result_event_id? }`; the fuller turn record (`started_at`, `completed_at`, `error`) comes from [`GET …/result`](/agent-sessions/api-reference) and `…/turns`. The **`yield_reason`** tells you why the last turn ended: `completed`, `needs_input` (the agent asked a question and the session is now `awaiting_input`), `budget_exceeded`, `deadline_exceeded`, `max_turns`, or `canceled`. Limit outcomes require runtime enforcement; the current Flue path does not enforce the generic session limits below.
 
@@ -71,21 +80,31 @@ Response:
 }
 ```
 
-<Tip>**For background jobs, register a [destination](/agent-sessions/webhooks).** Polling `GET /…/result` ties up a request and doesn't survive your process restarting. Create the session with `metadata` and a `destination`; handle `turn.completed` in your webhook, then fetch the result. Reserve `result()` polling for synchronous or interactive flows.</Tip>
+<Tip>
+  **For background jobs, register a [destination](/agent-sessions/webhooks).**
+  Polling `GET /…/result` ties up a request and doesn't survive your process
+  restarting. Create the session with `metadata` and a `destination`; handle
+  `turn.completed` in your webhook, then fetch the result. Reserve `result()`
+  polling for synchronous or interactive flows.
+</Tip>
 
 ## Idempotency & routing
 
 Three independent knobs — don't overload one for another:
 
-- **`key`** — *get-or-create*. One session per natural key (e.g. one per PR). A second create with the same `key` returns the same session; reusing a `key` with a **different** request body is rejected (`create key already used with a different request`).
-- **`Idempotency-Key`** (header) — *retry-safe create*. Makes a keyless create safe to retry (e.g. on a webhook redelivery) without spawning duplicates.
-- **`metadata`** — *routing / app state*. Opaque JSON (≤ 16 KB) echoed back on get/list and **verbatim in webhooks**, so your callback can route to the right record. Never use `key` for routing — that's what `metadata` is for.
+- **`key`** — _get-or-create_. One session per natural key (e.g. one per PR). A second create with the same `key` returns the same session; reusing a `key` with a **different** request body is rejected (`create key already used with a different request`).
+- **`Idempotency-Key`** (header) — _retry-safe create_. Makes a keyless create safe to retry (e.g. on a webhook redelivery) without spawning duplicates.
+- **`metadata`** — _routing / app state_. Opaque JSON (≤ 16 KB) echoed back on get/list and **verbatim in webhooks**, so your callback can route to the right record. Never use `key` for routing — that's what `metadata` is for.
 
 ## Limits
 
 Cap a session at create (or default it on the [agent](/agent-sessions/agents)) with `limits: { tokens, turn_seconds, turns }` — a token budget, per-turn wall-clock, and auto-run count. These are runtime limits, not spend controls; model usage is billed to your provider key (BYO) or to your OpenComputer credits (Managed). Hitting one ends the turn with the matching `yield_reason`.
 
-<Warning>These limits are not yet enforced for [Flue](/agent-sessions/flue) sessions. Do not use them as a deadline, turn-count, or token safety boundary for that runtime.</Warning>
+<Warning>
+  These limits are not yet enforced for [Flue](/agent-sessions/flue) sessions.
+  Do not use them as a deadline, turn-count, or token safety boundary for that
+  runtime.
+</Warning>
 
 ## Model
 
@@ -126,6 +145,14 @@ Content-Type: application/json
 For Flue, archive also retains the conversation in the session's Durable Object storage. See
 [Flue session behavior](/agent-sessions/flue#session-behavior).
 
-<Note>When the agent needs input, the turn ends with `yield_reason: "needs_input"` and the session status becomes `awaiting_input`; reply by [steering](/agent-sessions/messaging).</Note>
+<Note>
+  When the agent needs input, the turn ends with `yield_reason: "needs_input"`
+  and the session status becomes `awaiting_input`; reply by
+  [steering](/agent-sessions/messaging).
+</Note>
 
-<Note>**No cross-session memory.** Each session starts from the agent's prompt + that session's `input` — a durable log is *session history*, not memory the agent carries between sessions.</Note>
+<Note>
+  **No cross-session memory.** Each session starts from the agent's prompt +
+  that session's `input` — a durable log is *session history*, not memory the
+  agent carries between sessions.
+</Note>

--- a/docs/agent-sessions/slack.mdx
+++ b/docs/agent-sessions/slack.mdx
@@ -35,6 +35,10 @@ session, setup changes automatically from “waiting for a message” to a compa
 conversation preview with links to the full session and the agent's session
 history.
 
+For Flue agents, setup may also offer working-repository access and a concrete
+first task such as opening a pull request. GitHub access is optional: Slack chat
+continues to work when repository access is empty or disconnected.
+
 <Warning>
   Anyone in the connected Slack workspace who can message the app can use this
   agent. Use the shared app for evaluation with an agent whose tools and spend

--- a/sdks/flue/README.md
+++ b/sdks/flue/README.md
@@ -77,7 +77,9 @@ OpenComputer policy and GitHub App grant. `add_source` pins the selected ref to
 an exact commit and returns its `/workspace/sources/...` path.
 `github_publish_pull_request` publishes that source's inspected changes on an
 `oc/...` branch. The tools do not default to the deployment repository, expose
-credentials, or perform fuzzy repository selection.
+credentials, or perform fuzzy repository selection. A session supports up to
+eight sources; reuse an existing source or start a new session after reaching
+that limit.
 
 Direct text sessions, managed Slack, workflows, and optional demand-driven
 sandboxes continue to use ordinary Flue behavior.

--- a/sdks/flue/README.md
+++ b/sdks/flue/README.md
@@ -12,6 +12,8 @@ package supplies the OpenComputer-specific wiring the app opts into. Deployments
 - **`route`** — the HTTP-transport opt-in every OC-hosted agent must export (`export { route }`).
 - **`ocSandbox(env)`** — optional, demand-driven Linux shell/files. Declaring it makes no network
   request; the first actual sandbox operation resolves the persistent session sandbox.
+- **`ocRepoTools(ctx)`** — managed repository discovery, exact-SHA checkout into the session
+  sandbox, and OpenComputer-authored GitHub pull requests.
 - **`@opencomputer/flue/app`** — a default hosting app (`flue()` routes + `/health` + telemetry). Or
   `import '@opencomputer/flue/wire'` from your own `app.ts` for telemetry only.
 
@@ -40,13 +42,50 @@ export { default } from "@opencomputer/flue/app";
 
 Then `flue build --target cloudflare` and `oc agent deploy`. See `oc-flue-starter` for a full example.
 
-The current profile supports direct text sessions and optional demand-driven sandboxes. Channels,
-workflows, repository sources, pull-request publishing, attachments, and arbitrary Worker egress are
-not supported yet.
+## Repository work
+
+Give a hosted agent the standard repository tools beside its sandbox:
+
+```ts
+import { defineAgent, defineAgentProfile } from "@flue/runtime";
+import {
+  DEFAULT_MODEL,
+  ocRepoTools,
+  ocSandbox,
+  route,
+  useOcGateway,
+} from "@opencomputer/flue";
+
+export { route };
+
+export default defineAgent((ctx) => {
+  useOcGateway(ctx);
+  return {
+    profile: defineAgentProfile({
+      instructions:
+        "List working repositories, resolve an exact owner/repository, add it, edit and test only in the returned source path, then open a pull request.",
+    }),
+    model: DEFAULT_MODEL,
+    sandbox: ocSandbox(ctx.env),
+    tools: ocRepoTools(ctx),
+  };
+});
+```
+
+`list_working_repos` returns only repositories allowed by the agent's current
+OpenComputer policy and GitHub App grant. `add_source` pins the selected ref to
+an exact commit and returns its `/workspace/sources/...` path.
+`github_publish_pull_request` publishes that source's inspected changes on an
+`oc/...` branch. The tools do not default to the deployment repository, expose
+credentials, or perform fuzzy repository selection.
+
+Direct text sessions, managed Slack, workflows, and optional demand-driven
+sandboxes continue to use ordinary Flue behavior.
 
 ## Environment (set on the tenant script by the OC deploy)
 
-`OC_GATEWAY` and `OC_SESSION_TOKEN` are always managed by OpenComputer. Agents that explicitly use
-`ocSandbox` use the managed `OC_SANDBOX_API`. User variables come from `agent.toml [vars]`; write-only
-secrets are set with `oc agent secret` and both take effect on the next deployment. Reserved
-`OC_`/`FLUE_` prefixes are platform-managed.
+`OC_GATEWAY`, `OC_SESSION_TOKEN`, and `OC_REPO_API` are managed by
+OpenComputer. Agents that explicitly use `ocSandbox` use the managed
+`OC_SANDBOX_API`. User variables come from `agent.toml [vars]`; write-only
+secrets are set with `oc agent secret` and both take effect on the next
+deployment. Reserved `OC_`/`FLUE_` prefixes are platform-managed.

--- a/sdks/flue/package-lock.json
+++ b/sdks/flue/package-lock.json
@@ -1,16 +1,20 @@
 {
   "name": "@opencomputer/flue",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/flue",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "valibot": "^1.4.2"
+      },
       "devDependencies": {
         "@flue/runtime": "1.0.0-beta.9",
         "@types/node": "^22.10.0",
+        "esbuild": "^0.28.1",
         "typescript": "^5.9.3",
         "vitest": "^3.0.0"
       },
@@ -4997,7 +5001,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -5062,7 +5066,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
       "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5"

--- a/sdks/flue/package-lock.json
+++ b/sdks/flue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/flue",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/flue",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "valibot": "^1.4.2"

--- a/sdks/flue/package.json
+++ b/sdks/flue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/flue",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Run a Flue app as an OpenComputer agent with managed models, repository tools, and demand-driven sandboxes.",
   "keywords": [
     "agents",

--- a/sdks/flue/package.json
+++ b/sdks/flue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencomputer/flue",
-  "version": "0.2.0",
-  "description": "Run a Flue app as an OpenComputer agent with managed models and optional demand-driven sandboxes.",
+  "version": "0.3.0",
+  "description": "Run a Flue app as an OpenComputer agent with managed models, repository tools, and demand-driven sandboxes.",
   "keywords": [
     "agents",
     "flue",
@@ -48,7 +48,8 @@
     "build": "npm run clean && tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
-    "prepublishOnly": "npm test && npm run build"
+    "check:workerd": "node scripts/check-workerd.mjs",
+    "prepublishOnly": "npm test && npm run build && npm run check:workerd"
   },
   "sideEffects": [
     "./dist/wire.js"
@@ -59,9 +60,13 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "valibot": "^1.4.2"
+  },
   "devDependencies": {
     "@flue/runtime": "1.0.0-beta.9",
     "@types/node": "^22.10.0",
+    "esbuild": "^0.28.1",
     "typescript": "^5.9.3",
     "vitest": "^3.0.0"
   }

--- a/sdks/flue/scripts/check-workerd.mjs
+++ b/sdks/flue/scripts/check-workerd.mjs
@@ -1,0 +1,12 @@
+import { build } from "esbuild";
+
+await build({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  write: false,
+  format: "esm",
+  platform: "browser",
+  target: "es2022",
+  external: ["@flue/runtime", "cloudflare:workers"],
+  logLevel: "warning",
+});

--- a/sdks/flue/src/cf-env.test.ts
+++ b/sdks/flue/src/cf-env.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { layerOcEnv } from "./cf-env.js";
+
+describe("Cloudflare env layering", () => {
+  it("prefers ambient values and reads request secrets without enumerating the fallback proxy", () => {
+    const fallback = new Proxy<Record<string, unknown>>(
+      {},
+      {
+        get(_target, property) {
+          if (property === "OC_REPO_API") return "https://fallback.invalid";
+          if (property === "OC_SESSION_TOKEN") return "request-token";
+          return undefined;
+        },
+        ownKeys() {
+          throw new Error("runtime env must not be enumerated");
+        },
+      },
+    );
+    const ambient = {
+      OC_REPO_API: "https://repositories.test",
+      OC_SESSION_TOKEN: undefined,
+    };
+
+    const resolved = layerOcEnv(ambient, fallback);
+
+    expect(resolved.OC_REPO_API).toBe("https://repositories.test");
+    expect(resolved.OC_SESSION_TOKEN).toBe("request-token");
+    expect(layerOcEnv(ambient, undefined)).toBe(ambient);
+  });
+});

--- a/sdks/flue/src/cf-env.ts
+++ b/sdks/flue/src/cf-env.ts
@@ -1,8 +1,9 @@
 // Ambient Cloudflare-Workers env access (design 013 §4). On the `flue build --target cloudflare`
-// build the real Worker bindings (`OC_GATEWAY`, `OC_SESSION_TOKEN`, `OC_SANDBOX_*`, `OC_INGEST`, …)
-// live on the AMBIENT env exported by `cloudflare:workers` — the same one Flue's generated entry reads
-// (`import { env } from 'cloudflare:workers'`). The per-agent `ctx.env` Flue threads into the
-// initializer is EMPTY for these bindings, so OC helpers must read the ambient env instead.
+// build, plain Worker bindings (`OC_GATEWAY`, `OC_SANDBOX_*`, `OC_INGEST`, …) are available on the
+// AMBIENT env exported by `cloudflare:workers` — the same one Flue's generated entry reads
+// (`import { env } from 'cloudflare:workers'`). Worker secrets such as `OC_SESSION_TOKEN` can instead
+// arrive through the runtime-owned env reference at request time. Helpers therefore retain that
+// fallback reference and resolve it lazily, layering ambient plain bindings over its current values.
 //
 // `cloudflare:workers` only resolves inside workerd, so importing it statically would break local
 // `flue dev` on the node target and the package's own vitest. Load it lazily + guarded: on CF the
@@ -23,8 +24,8 @@ try {
 
 /**
  * Resolve the effective OC env: the Cloudflare ambient bindings layered over `fallback` (ambient wins).
- * On CF this returns the real Worker bindings even though `ctx.env` is empty; off CF (local dev / node /
- * tests) it returns `fallback` unchanged so an explicitly-passed env still works.
+ * On CF this adds ambient plain Worker bindings without discarding request-time values from `fallback`;
+ * off CF (local dev / node / tests) it returns `fallback` unchanged.
  */
 export function ocResolveEnv<T extends Record<string, unknown>>(fallback: T | undefined): T {
   const base = (fallback ?? {}) as T;

--- a/sdks/flue/src/cf-env.ts
+++ b/sdks/flue/src/cf-env.ts
@@ -2,8 +2,8 @@
 // build, plain Worker bindings (`OC_GATEWAY`, `OC_SANDBOX_*`, `OC_INGEST`, …) are available on the
 // AMBIENT env exported by `cloudflare:workers` — the same one Flue's generated entry reads
 // (`import { env } from 'cloudflare:workers'`). Worker secrets such as `OC_SESSION_TOKEN` can instead
-// arrive through the runtime-owned env reference at request time. Helpers therefore retain that
-// fallback reference and resolve it lazily, layering ambient plain bindings over its current values.
+// arrive through the runtime-owned env reference at request time. That reference can be a proxy that
+// supports direct property reads but not enumeration, so helpers retain it and never spread it.
 //
 // `cloudflare:workers` only resolves inside workerd, so importing it statically would break local
 // `flue dev` on the node target and the package's own vitest. Load it lazily + guarded: on CF the
@@ -23,12 +23,33 @@ try {
 }
 
 /**
- * Resolve the effective OC env: the Cloudflare ambient bindings layered over `fallback` (ambient wins).
- * On CF this adds ambient plain Worker bindings without discarding request-time values from `fallback`;
- * off CF (local dev / node / tests) it returns `fallback` unchanged.
+ * Layer ambient plain bindings over a runtime-owned fallback without enumerating
+ * the fallback. Defined ambient values win; missing ambient values are read
+ * directly from the fallback at access time.
  */
-export function ocResolveEnv<T extends Record<string, unknown>>(fallback: T | undefined): T {
-  const base = (fallback ?? {}) as T;
-  if (!ambientEnv) return base;
-  return { ...base, ...ambientEnv } as T;
+export function layerOcEnv<T extends Record<string, unknown>>(
+  ambient: Record<string, unknown> | undefined,
+  fallback: T | undefined,
+): T {
+  if (!ambient) return (fallback ?? {}) as T;
+  if (!fallback) return ambient as T;
+  return new Proxy(ambient, {
+    get(target, property) {
+      const value = Reflect.get(target, property, target);
+      return value === undefined
+        ? Reflect.get(fallback, property, fallback)
+        : value;
+    },
+  }) as T;
+}
+
+/**
+ * Resolve the effective OC env. On Cloudflare this layers ambient plain
+ * bindings over the lazily read runtime env; off Cloudflare it returns the
+ * fallback unchanged.
+ */
+export function ocResolveEnv<T extends Record<string, unknown>>(
+  fallback: T | undefined,
+): T {
+  return layerOcEnv(ambientEnv, fallback);
 }

--- a/sdks/flue/src/gateway.ts
+++ b/sdks/flue/src/gateway.ts
@@ -5,7 +5,8 @@
 // SECRET. Secrets are NOT on the CF ambient env (`cloudflare:workers`) at all — only plain vars like
 // OC_GATEWAY are — and `ctx.env` at defineAgent-init is empty for the OC bindings too. So an init-time
 // registerProvider reads the token falsy and every model call throws "No API key for provider: anthropic".
-// The secret DOES live on the per-REQUEST env (`c.env`) — the same source ocSandbox reads at run time.
+// The secret DOES live on the per-REQUEST env (`c.env`); repository and sandbox helpers likewise read
+// their runtime-owned request env references directly rather than enumerating or spreading them.
 // Fix: bind the apiKey at RUN scope from the exported `route` middleware, reading OC_SESSION_TOKEN from
 // `c.env` by DIRECT property access (NEVER spread c.env — the CF env is a proxy and spreading it throws)
 // and OC_GATEWAY from the ambient snapshot, once per isolate. The token is per-DEPLOY (identical for
@@ -52,9 +53,9 @@ function bindOcProvider(env: OcEnv): boolean {
  * initializer** — top-level module code is stripped by the CF build (proven in 1a). This runs at INIT
  * scope, where the per-deploy OC_SESSION_TOKEN (a secret) is typically not yet readable, so it registers
  * the baseUrl (model specifier resolves) and defers the apiKey to `route` (run scope) — see the token-seam
- * note above. Binds the apiKey here too if the token happens to already be present. Reads the CF ambient
- * env (`cloudflare:workers`), not `ctx.env`: on the `--target cloudflare` build the real Worker bindings
- * live on the ambient env and `ctx.env` is empty for them.
+ * note above. Binds the apiKey here too if the token happens to already be present. Plain Worker
+ * bindings come from the CF ambient env; the runtime-owned `ctx.env` is read directly only for values
+ * absent there and may still be tokenless during initialization.
  */
 export function useOcGateway(ctx: AgentInitializerContext<OcEnv>): void {
   bindOcProvider(ocResolveEnv<OcEnv>(ctx.env));

--- a/sdks/flue/src/index.ts
+++ b/sdks/flue/src/index.ts
@@ -1,6 +1,7 @@
 // @opencomputer/flue — make a stock Flue agent OpenComputer-native (design 013 §4/§5).
 // - useOcGateway + route + DEFAULT_MODEL: point managed anthropic at the OC gateway; HTTP-transport opt-in.
 // - ocSandbox: optional, demand-driven durable shell/files as the agent's SandboxApi.
+// - ocRepoTools: exact working-repository discovery, materialization, and pull-request publishing.
 // - installOcObserver: forward lifecycle/usage to OC_INGEST.
 // Default hosting app is at `@opencomputer/flue/app`; `@opencomputer/flue/wire` is the telemetry-only
 // side-effect for apps with their own app.ts.
@@ -9,4 +10,15 @@ export { useOcGateway, route, DEFAULT_MODEL } from "./gateway.js";
 export type { OcEnv } from "./gateway.js";
 export { ocSandbox, WORKSPACE_CWD } from "./sandbox.js";
 export type { OcSandboxEnv } from "./sandbox.js";
+export { ocRepoTools } from "./repo.js";
+export type {
+  AddSourceResult,
+  ListWorkingReposResult,
+  OcRepoEnv,
+  OcRepoError,
+  OcRepoErrorCode,
+  OcRepoFailure,
+  PublishPullRequestResult,
+  WorkingRepository,
+} from "./repo.js";
 export { installOcObserver } from "./observe.js";

--- a/sdks/flue/src/repo.test.ts
+++ b/sdks/flue/src/repo.test.ts
@@ -58,6 +58,9 @@ describe("ocRepoTools contract", () => {
     expect(list?.description).toMatch(/otherwise ask/);
     expect(add?.description).toMatch(/await this tool before filesystem work/);
     expect(add?.description).toMatch(/returned \/workspace\/sources/);
+    expect(add?.description).toMatch(
+      /reuse an existing source or start a new session/,
+    );
     expect(publish?.description).toMatch(/inspect and test the diff/);
     expect(publish?.description).toMatch(
       /exact repository, base branch, and intended diff/,
@@ -162,6 +165,7 @@ describe("list_working_repos HTTP fixtures", () => {
     ["repository_not_found", 404, false],
     ["repository_rate_limited", 429, true],
     ["source_name_taken", 409, false],
+    ["source_limit_reached", 409, false],
     ["source_unresolved", 422, true],
     ["source_materialization_failed", 503, true],
     ["source_not_ready", 409, true],

--- a/sdks/flue/src/repo.test.ts
+++ b/sdks/flue/src/repo.test.ts
@@ -79,13 +79,19 @@ describe("ocRepoTools contract", () => {
     const add = tool("add_source");
     expect(
       v.safeParse(add.input, {
-        repository: "repo_1",
+        repository: "repo_0123456789abcdef01234567",
         ref: "main",
         name: "app",
       }).success,
     ).toBe(true);
     expect(
       v.safeParse(add.input, { repository: "", ref: "main" }).success,
+    ).toBe(false);
+    expect(
+      v.safeParse(add.input, {
+        repository: "owner/repo",
+        ref: "x".repeat(256),
+      }).success,
     ).toBe(false);
 
     const publish = tool("github_publish_pull_request");
@@ -104,6 +110,21 @@ describe("ocRepoTools contract", () => {
         idempotency_key: "model-controlled",
       }).success,
     ).toBe(false);
+    for (const invalid of [
+      { source: "Bad Source", title: "Document setup", base: "main" },
+      { source: "app", title: " ", base: "main" },
+      { source: "app", title: "x".repeat(257), base: "main" },
+      {
+        source: "app",
+        title: "Document setup",
+        body: "x".repeat(65_537),
+        base: "main",
+      },
+      { source: "app", title: "Document setup", base: "../main" },
+      { source: "app", title: "Document setup", base: "bad ref" },
+    ]) {
+      expect(v.safeParse(publish.input, invalid).success).toBe(false);
+    }
   });
 });
 
@@ -308,7 +329,11 @@ describe("add_source HTTP fixture", () => {
     vi.stubGlobal("fetch", fetchSpy);
 
     const result = await tool("add_source").run({
-      input: { repository: "repo_1", ref: "main", name: "app" },
+      input: {
+        repository: "repo_0123456789abcdef01234567",
+        ref: "main",
+        name: "app",
+      },
     });
 
     expect(result).toEqual({
@@ -332,7 +357,7 @@ describe("add_source HTTP fixture", () => {
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        repository: "repo_1",
+        repository: "repo_0123456789abcdef01234567",
         ref: "main",
         name: "app",
       }),
@@ -357,7 +382,11 @@ describe("add_source HTTP fixture", () => {
 
     await expect(
       tool("add_source").run({
-        input: { repository: "repo_1", ref: "main", name: "app" },
+        input: {
+          repository: "repo_0123456789abcdef01234567",
+          ref: "main",
+          name: "app",
+        },
       }),
     ).rejects.toThrow("repository API returned an invalid response");
   });

--- a/sdks/flue/src/repo.test.ts
+++ b/sdks/flue/src/repo.test.ts
@@ -135,7 +135,7 @@ describe("ocRepoTools contract", () => {
 });
 
 describe("list_working_repos HTTP fixtures", () => {
-  it("resolves request-time env and encodes the session and query", async () => {
+  it("reads the captured env lazily at tool run and encodes the request", async () => {
     const env: OcRepoEnv = {};
     const list = tool("list_working_repos", env, "ses_/customer space");
     const fetchSpy = vi.fn(async () =>
@@ -146,9 +146,11 @@ describe("list_working_repos HTTP fixtures", () => {
             id: "repo_1",
             full_name: "diggerhq/example app",
             default_branch: "main",
+            visibility: "private",
           },
         ],
         truncated: true,
+        server_revision: 2,
       }),
     );
     vi.stubGlobal("fetch", fetchSpy);
@@ -215,13 +217,80 @@ describe("list_working_repos HTTP fixtures", () => {
             : {}),
         },
       };
-      vi.stubGlobal("fetch", vi.fn(async () => json(body, status)));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          json(
+            {
+              ...body,
+              server_trace_id: "trace_1",
+              error: { ...body.error, provider_detail: "ignored" },
+            },
+            status,
+          ),
+        ),
+      );
 
       await expect(
         tool("list_working_repos").run({ input: {} }),
       ).resolves.toEqual(body);
     },
   );
+
+  it("accepts additive response growth without freezing list or message size", async () => {
+    const repositories = Array.from({ length: 51 }, (_, index) => ({
+      id: `repo_${index}`,
+      full_name: `owner/repository-${index}`,
+      default_branch: "main",
+      future_field: index,
+    }));
+    const list = tool("list_working_repos");
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          json({
+            ok: true,
+            repositories,
+            truncated: false,
+            next_cursor: null,
+          }),
+        )
+        .mockResolvedValueOnce(
+          json(
+            {
+              ok: false,
+              error: {
+                code: "github_unavailable",
+                message: "x".repeat(501),
+                retryable: true,
+                future_recovery: "retry",
+              },
+            },
+            503,
+          ),
+        ),
+    );
+
+    await expect(list.run({ input: {} })).resolves.toEqual({
+      ok: true,
+      repositories: repositories.map(({ id, full_name, default_branch }) => ({
+        id,
+        full_name,
+        default_branch,
+      })),
+      truncated: false,
+    });
+    await expect(list.run({ input: {} })).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "github_unavailable",
+        message: "x".repeat(501),
+        retryable: true,
+      },
+    });
+  });
 
   it("rejects status, retryability, and retry-after contract drift", async () => {
     const list = tool("list_working_repos");
@@ -330,6 +399,7 @@ describe("add_source HTTP fixture", () => {
         ref: "main",
         sha: "a".repeat(40),
         path: "/workspace/sources/app",
+        materialized_at: "2026-07-21T00:00:00Z",
       }),
     );
     vi.stubGlobal("fetch", fetchSpy);
@@ -418,7 +488,9 @@ describe("github_publish_pull_request HTTP fixtures", () => {
           pull_request: {
             number: 42,
             url: "https://github.com/diggerhq/example-app/pull/42",
+            state: "open",
           },
+          provider_request_id: "request_1",
         });
       }),
     );
@@ -435,9 +507,11 @@ describe("github_publish_pull_request HTTP fixtures", () => {
       signal: controller.signal,
     });
 
-    expect(result).toMatchObject({
+    expect(result).toEqual({
       ok: true,
       no_changes: false,
+      branch: "oc/ses_1/document-setup",
+      commit: "d".repeat(40),
       pull_request: {
         number: 42,
         url: "https://github.com/diggerhq/example-app/pull/42",
@@ -462,7 +536,13 @@ describe("github_publish_pull_request HTTP fixtures", () => {
   it("returns no_changes as a successful terminal result", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => json({ ok: true, no_changes: true })),
+      vi.fn(async () =>
+        json({
+          ok: true,
+          no_changes: true,
+          compared_commit: "a".repeat(40),
+        }),
+      ),
     );
     await expect(
       tool("github_publish_pull_request").run({

--- a/sdks/flue/src/repo.test.ts
+++ b/sdks/flue/src/repo.test.ts
@@ -1,0 +1,498 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as v from "valibot";
+import { ocRepoTools } from "./repo.js";
+import type { OcRepoEnv } from "./repo.js";
+
+type RunnableTool = {
+  name: string;
+  description: string;
+  input: v.GenericSchema<Record<string, unknown>, unknown>;
+  run(context: {
+    input: Record<string, unknown>;
+    signal?: AbortSignal;
+  }): Promise<unknown>;
+};
+
+function tools(
+  env: OcRepoEnv = {
+    OC_REPO_API: "https://sessions.opencomputer.test/",
+    OC_SESSION_TOKEN: "deploy-token",
+  },
+  id = "ses_1",
+): RunnableTool[] {
+  return ocRepoTools({ id, env }) as RunnableTool[];
+}
+
+function tool(
+  name: string,
+  env?: OcRepoEnv,
+  id?: string,
+): RunnableTool {
+  const found = tools(env, id).find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`missing tool ${name}`);
+  return found;
+}
+
+function json(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("ocRepoTools contract", () => {
+  it("returns exactly the three stable tools in workflow order", () => {
+    expect(tools().map(({ name }) => name)).toEqual([
+      "list_working_repos",
+      "add_source",
+      "github_publish_pull_request",
+    ]);
+  });
+
+  it("keeps exact-target and safe-publish guidance in model context", () => {
+    const [list, add, publish] = tools();
+    expect(list?.description).toMatch(/exact owner\/repository/);
+    expect(list?.description).toMatch(/Never assume the deployment source/);
+    expect(list?.description).toMatch(/otherwise ask/);
+    expect(add?.description).toMatch(/await this tool before filesystem work/);
+    expect(add?.description).toMatch(/returned \/workspace\/sources/);
+    expect(publish?.description).toMatch(/inspect and test the diff/);
+    expect(publish?.description).toMatch(
+      /exact repository, base branch, and intended diff/,
+    );
+    expect(publish?.description).toMatch(/pull-request URL/);
+  });
+
+  it("uses strict bounded input schemas", () => {
+    const list = tool("list_working_repos");
+    expect(v.safeParse(list.input, { q: "owner/repo" }).success).toBe(true);
+    expect(v.safeParse(list.input, { q: "x".repeat(101) }).success).toBe(
+      false,
+    );
+    expect(v.safeParse(list.input, { surprise: true }).success).toBe(false);
+
+    const add = tool("add_source");
+    expect(
+      v.safeParse(add.input, {
+        repository: "repo_1",
+        ref: "main",
+        name: "app",
+      }).success,
+    ).toBe(true);
+    expect(
+      v.safeParse(add.input, { repository: "", ref: "main" }).success,
+    ).toBe(false);
+
+    const publish = tool("github_publish_pull_request");
+    expect(
+      v.safeParse(publish.input, {
+        source: "app",
+        title: "Document setup",
+        base: "main",
+      }).success,
+    ).toBe(true);
+    expect(
+      v.safeParse(publish.input, {
+        source: "app",
+        title: "Document setup",
+        base: "main",
+        idempotency_key: "model-controlled",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("list_working_repos HTTP fixtures", () => {
+  it("resolves request-time env and encodes the session and query", async () => {
+    const env: OcRepoEnv = {};
+    const list = tool("list_working_repos", env, "ses_/customer space");
+    const fetchSpy = vi.fn(async () =>
+      json({
+        ok: true,
+        repositories: [
+          {
+            id: "repo_1",
+            full_name: "diggerhq/example app",
+            default_branch: "main",
+          },
+        ],
+        truncated: true,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    env.OC_REPO_API = "https://sessions.opencomputer.test///";
+    env.OC_SESSION_TOKEN = "request-token";
+    const result = await list.run({ input: { q: "diggerhq/example app" } });
+
+    expect(result).toEqual({
+      ok: true,
+      repositories: [
+        {
+          id: "repo_1",
+          full_name: "diggerhq/example app",
+          default_branch: "main",
+        },
+      ],
+      truncated: true,
+    });
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, init] = fetchSpy.mock.calls[0] ?? [];
+    expect(url).toBe(
+      "https://sessions.opencomputer.test/flue/sessions/ses_%2Fcustomer%20space/repositories?q=diggerhq%2Fexample+app",
+    );
+    expect(init).toMatchObject({
+      method: "GET",
+      headers: {
+        accept: "application/json",
+        authorization: "Bearer request-token",
+      },
+    });
+  });
+
+  it.each([
+    ["github_not_connected", 409, false],
+    ["github_unavailable", 503, true],
+    ["github_permission_missing", 409, false],
+    ["repository_scope_empty", 403, false],
+    ["repository_not_allowed", 403, false],
+    ["repository_not_granted", 403, false],
+    ["repository_not_found", 404, false],
+    ["repository_rate_limited", 429, true],
+    ["source_name_taken", 409, false],
+    ["source_unresolved", 422, true],
+    ["source_materialization_failed", 503, true],
+    ["source_not_ready", 409, true],
+    ["publish_in_progress", 409, true],
+    ["publish_failed", 502, false],
+    ["stale_deployment_token", 409, false],
+    ["deployment_updating", 503, true],
+    ["deployment_unverified", 409, false],
+  ] as const)(
+    "returns the canonical %s product failure as tool data",
+    async (code, status, retryable) => {
+      const body = {
+        ok: false as const,
+        error: {
+          code,
+          message: `Safe recovery for ${code}`,
+          retryable,
+          ...(code === "repository_rate_limited"
+            ? { retry_after_seconds: 17 }
+            : {}),
+        },
+      };
+      vi.stubGlobal("fetch", vi.fn(async () => json(body, status)));
+
+      await expect(
+        tool("list_working_repos").run({ input: {} }),
+      ).resolves.toEqual(body);
+    },
+  );
+
+  it("rejects status, retryability, and retry-after contract drift", async () => {
+    const list = tool("list_working_repos");
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        json(
+          {
+            ok: false,
+            error: {
+              code: "repository_not_allowed",
+              message: "Choose another repository.",
+              retryable: false,
+            },
+          },
+          500,
+        ),
+      )
+      .mockResolvedValueOnce(
+        json(
+          {
+            ok: false,
+            error: {
+              code: "github_unavailable",
+              message: "Retry later.",
+              retryable: false,
+            },
+          },
+          503,
+        ),
+      )
+      .mockResolvedValueOnce(
+        json(
+          {
+            ok: false,
+            error: {
+              code: "repository_rate_limited",
+              message: "Wait before retrying.",
+              retryable: true,
+            },
+          },
+          429,
+        ),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    for (let i = 0; i < 3; i++) {
+      await expect(list.run({ input: {} })).rejects.toThrow(
+        "repository API returned an invalid response",
+      );
+    }
+  });
+
+  it("throws secret-safe errors for malformed platform responses", async () => {
+    const leaked = "ghs_should-never-appear";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(`provider said ${leaked}`, { status: 502 })),
+    );
+
+    let thrown: unknown;
+    try {
+      await tool("list_working_repos").run({ input: {} });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toBe(
+      "[oc-flue] repository API returned an invalid response (status 502).",
+    );
+    expect((thrown as Error).message).not.toContain(leaked);
+    expect((thrown as Error).message).not.toContain("deploy-token");
+    expect((thrown as Error).message).not.toContain(
+      "sessions.opencomputer.test",
+    );
+  });
+
+  it("preserves cancellation while reading a response body", async () => {
+    const aborted = new DOMException("cancelled while reading", "AbortError");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return {
+          status: 200,
+          json: async () => {
+            throw aborted;
+          },
+        } as Response;
+      }),
+    );
+
+    await expect(
+      tool("list_working_repos").run({ input: {} }),
+    ).rejects.toBe(aborted);
+  });
+});
+
+describe("add_source HTTP fixture", () => {
+  it("posts the exact target and returns a usable pinned source path", async () => {
+    const fetchSpy = vi.fn(async () =>
+      json({
+        ok: true,
+        name: "app",
+        repository_id: "repo_1",
+        full_name: "diggerhq/example-app",
+        ref: "main",
+        sha: "a".repeat(40),
+        path: "/workspace/sources/app",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await tool("add_source").run({
+      input: { repository: "repo_1", ref: "main", name: "app" },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      name: "app",
+      repository_id: "repo_1",
+      full_name: "diggerhq/example-app",
+      ref: "main",
+      sha: "a".repeat(40),
+      path: "/workspace/sources/app",
+    });
+    const [url, init] = fetchSpy.mock.calls[0] ?? [];
+    expect(url).toBe(
+      "https://sessions.opencomputer.test/flue/sessions/ses_1/sources",
+    );
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        authorization: "Bearer deploy-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        repository: "repo_1",
+        ref: "main",
+        name: "app",
+      }),
+    });
+  });
+
+  it("rejects a success response whose path is outside the managed source root", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        json({
+          ok: true,
+          name: "app",
+          repository_id: "repo_1",
+          full_name: "diggerhq/example-app",
+          ref: "main",
+          sha: "a".repeat(40),
+          path: "/tmp/app",
+        }),
+      ),
+    );
+
+    await expect(
+      tool("add_source").run({
+        input: { repository: "repo_1", ref: "main", name: "app" },
+      }),
+    ).rejects.toThrow("repository API returned an invalid response");
+  });
+});
+
+describe("github_publish_pull_request HTTP fixtures", () => {
+  it("reuses one random idempotency key across an ambiguous transport retry", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    const signals: Array<AbortSignal | null | undefined> = [];
+    let calls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        signals.push(init?.signal);
+        calls++;
+        if (calls === 1) throw new TypeError("network reset at secret host");
+        return json({
+          ok: true,
+          no_changes: false,
+          branch: "oc/ses_1/document-setup",
+          commit: "d".repeat(40),
+          pull_request: {
+            number: 42,
+            url: "https://github.com/diggerhq/example-app/pull/42",
+          },
+        });
+      }),
+    );
+    const controller = new AbortController();
+
+    const result = await tool("github_publish_pull_request").run({
+      input: {
+        source: "app",
+        title: "Document setup",
+        body: "Adds setup notes.",
+        base: "main",
+        draft: true,
+      },
+      signal: controller.signal,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      no_changes: false,
+      pull_request: {
+        number: 42,
+        url: "https://github.com/diggerhq/example-app/pull/42",
+      },
+    });
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]).toEqual(bodies[1]);
+    expect(bodies[0]).toMatchObject({
+      source: "app",
+      title: "Document setup",
+      body: "Adds setup notes.",
+      base: "main",
+      draft: true,
+    });
+    expect(bodies[0]?.idempotency_key).toEqual(expect.any(String));
+    expect(String(bodies[0]?.idempotency_key).length).toBeGreaterThanOrEqual(
+      32,
+    );
+    expect(signals).toEqual([controller.signal, controller.signal]);
+  });
+
+  it("returns no_changes as a successful terminal result", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => json({ ok: true, no_changes: true })),
+    );
+    await expect(
+      tool("github_publish_pull_request").run({
+        input: {
+          source: "app",
+          title: "Document setup",
+          base: "main",
+        },
+      }),
+    ).resolves.toEqual({ ok: true, no_changes: true });
+  });
+
+  it("propagates AbortSignal cancellation without retrying or wrapping it", async () => {
+    const aborted = new DOMException("cancelled", "AbortError");
+    const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect(init?.signal?.aborted).toBe(true);
+      throw aborted;
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      tool("github_publish_pull_request").run({
+        input: {
+          source: "app",
+          title: "Document setup",
+          base: "main",
+        },
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(aborted);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("sanitizes exhausted transport errors", async () => {
+    const fetchSpy = vi.fn(async () => {
+      throw new TypeError(
+        "request to https://secret.internal/?token=deploy-token failed",
+      );
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(
+      tool("github_publish_pull_request").run({
+        input: {
+          source: "app",
+          title: "Document setup",
+          base: "main",
+        },
+      }),
+    ).rejects.toThrow(
+      "[oc-flue] repository API request failed before a response was received.",
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("managed binding failures", () => {
+  it("fails before fetch without printing missing or present binding values", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    await expect(
+      tool("list_working_repos", {
+        OC_SESSION_TOKEN: "secret-token",
+      }).run({ input: {} }),
+    ).rejects.toThrow(
+      "[oc-flue] ocRepoTools requires managed repository API bindings.",
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/sdks/flue/src/repo.test.ts
+++ b/sdks/flue/src/repo.test.ts
@@ -93,6 +93,12 @@ describe("ocRepoTools contract", () => {
         ref: "x".repeat(256),
       }).success,
     ).toBe(false);
+    expect(
+      v.safeParse(add.input, {
+        repository: "owner/repo",
+        ref: " \t ",
+      }).success,
+    ).toBe(false);
 
     const publish = tool("github_publish_pull_request");
     expect(

--- a/sdks/flue/src/repo.test.ts
+++ b/sdks/flue/src/repo.test.ts
@@ -237,7 +237,7 @@ describe("list_working_repos HTTP fixtures", () => {
     },
   );
 
-  it("accepts additive response growth without freezing list or message size", async () => {
+  it("accepts additive response growth while bounding model-visible list and message size", async () => {
     const repositories = Array.from({ length: 51 }, (_, index) => ({
       id: `repo_${index}`,
       full_name: `owner/repository-${index}`,
@@ -275,18 +275,20 @@ describe("list_working_repos HTTP fixtures", () => {
 
     await expect(list.run({ input: {} })).resolves.toEqual({
       ok: true,
-      repositories: repositories.map(({ id, full_name, default_branch }) => ({
-        id,
-        full_name,
-        default_branch,
-      })),
-      truncated: false,
+      repositories: repositories
+        .slice(0, 50)
+        .map(({ id, full_name, default_branch }) => ({
+          id,
+          full_name,
+          default_branch,
+        })),
+      truncated: true,
     });
     await expect(list.run({ input: {} })).resolves.toEqual({
       ok: false,
       error: {
         code: "github_unavailable",
-        message: "x".repeat(501),
+        message: "x".repeat(500),
         retryable: true,
       },
     });

--- a/sdks/flue/src/repo.ts
+++ b/sdks/flue/src/repo.ts
@@ -98,6 +98,7 @@ const RefSchema = v.pipe(
   v.string(),
   v.minLength(1),
   v.maxLength(255),
+  v.check((ref) => ref.trim().length > 0, "ref cannot be blank"),
 );
 
 const PullRequestBaseSchema = v.pipe(

--- a/sdks/flue/src/repo.ts
+++ b/sdks/flue/src/repo.ts
@@ -22,6 +22,7 @@ const ERROR_CODES = [
   "repository_not_found",
   "repository_rate_limited",
   "source_name_taken",
+  "source_limit_reached",
   "source_unresolved",
   "source_materialization_failed",
   "source_not_ready",
@@ -236,6 +237,7 @@ const HTTP_BY_ERROR: Readonly<
   repository_not_found: [404],
   repository_rate_limited: [429],
   source_name_taken: [409],
+  source_limit_reached: [409],
   source_unresolved: [422],
   source_materialization_failed: [502, 503],
   source_not_ready: [409],
@@ -258,6 +260,7 @@ const RETRYABLE_BY_ERROR: Readonly<
   repository_not_found: false,
   repository_rate_limited: true,
   source_name_taken: false,
+  source_limit_reached: false,
   source_not_ready: true,
   publish_in_progress: true,
   stale_deployment_token: false,
@@ -438,7 +441,7 @@ export function ocRepoTools(
   const addSource = defineTool({
     name: "add_source",
     description:
-      "Pin and materialize one exact repository source after list_working_repos resolved it. Tell the user the exact owner/repository first, await this tool before filesystem work, then use only the returned /workspace/sources/... path. On a product error, explain its stated recovery instead of guessing another target.",
+      "Pin and materialize one exact repository source after list_working_repos resolved it. Tell the user the exact owner/repository first, await this tool before filesystem work, then use only the returned /workspace/sources/... path. If the session has reached its source limit, reuse an existing source or start a new session. On any product error, explain its stated recovery instead of guessing another target.",
     input: AddSourceInputSchema,
     output: AddSourceResultSchema,
     async run({ input, signal }) {

--- a/sdks/flue/src/repo.ts
+++ b/sdks/flue/src/repo.ts
@@ -1,0 +1,478 @@
+import { defineTool } from "@flue/runtime";
+import type {
+  AgentInitializerContext,
+  ToolDefinition,
+} from "@flue/runtime";
+import * as v from "valibot";
+import { ocResolveEnv } from "./cf-env.js";
+import type { OcEnv } from "./gateway.js";
+
+export interface OcRepoEnv extends OcEnv {
+  /** Managed repository API base injected by OpenComputer. */
+  OC_REPO_API?: string;
+}
+
+const ERROR_CODES = [
+  "github_not_connected",
+  "github_unavailable",
+  "github_permission_missing",
+  "repository_scope_empty",
+  "repository_not_allowed",
+  "repository_not_granted",
+  "repository_not_found",
+  "repository_rate_limited",
+  "source_name_taken",
+  "source_unresolved",
+  "source_materialization_failed",
+  "source_not_ready",
+  "publish_in_progress",
+  "publish_failed",
+  "stale_deployment_token",
+  "deployment_updating",
+  "deployment_unverified",
+] as const;
+
+export type OcRepoErrorCode = (typeof ERROR_CODES)[number];
+
+export interface OcRepoError {
+  code: OcRepoErrorCode;
+  message: string;
+  retryable: boolean;
+  retry_after_seconds?: number;
+}
+
+export type OcRepoFailure = {
+  ok: false;
+  error: OcRepoError;
+};
+
+const RepoErrorSchema = v.strictObject({
+  code: v.picklist(ERROR_CODES),
+  message: v.pipe(v.string(), v.minLength(1), v.maxLength(500)),
+  retryable: v.boolean(),
+  retry_after_seconds: v.optional(
+    v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(600)),
+  ),
+});
+
+const RepoFailureSchema = v.strictObject({
+  ok: v.literal(false),
+  error: RepoErrorSchema,
+});
+
+const WorkingRepositorySchema = v.strictObject({
+  id: v.pipe(v.string(), v.minLength(1)),
+  full_name: v.pipe(v.string(), v.minLength(3)),
+  default_branch: v.pipe(v.string(), v.minLength(1)),
+});
+
+export interface WorkingRepository {
+  id: string;
+  full_name: string;
+  default_branch: string;
+}
+
+const ListWorkingReposSuccessSchema = v.strictObject({
+  ok: v.literal(true),
+  repositories: v.pipe(
+    v.array(WorkingRepositorySchema),
+    v.maxLength(50),
+  ),
+  truncated: v.boolean(),
+});
+
+const SourceNameSchema = v.pipe(
+  v.string(),
+  v.regex(/^[a-z0-9][a-z0-9_-]{0,63}$/),
+);
+
+const AddSourceSuccessSchema = v.pipe(
+  v.strictObject({
+    ok: v.literal(true),
+    name: SourceNameSchema,
+    repository_id: v.pipe(v.string(), v.startsWith("repo_")),
+    full_name: v.pipe(v.string(), v.minLength(3)),
+    ref: v.pipe(v.string(), v.minLength(1)),
+    sha: v.pipe(v.string(), v.regex(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/i)),
+    path: v.pipe(v.string(), v.startsWith("/workspace/sources/")),
+  }),
+  v.check(
+    (result) => result.path === `/workspace/sources/${result.name}`,
+    "source path does not match source name",
+  ),
+);
+
+const PublishNoChangesSchema = v.strictObject({
+  ok: v.literal(true),
+  no_changes: v.literal(true),
+});
+
+const PublishPullRequestSuccessSchema = v.strictObject({
+  ok: v.literal(true),
+  no_changes: v.literal(false),
+  branch: v.pipe(v.string(), v.minLength(1)),
+  commit: v.pipe(
+    v.string(),
+    v.regex(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/i),
+  ),
+  pull_request: v.strictObject({
+    number: v.pipe(v.number(), v.integer(), v.minValue(1)),
+    url: v.pipe(v.string(), v.url()),
+  }),
+});
+
+const ListWorkingReposResultSchema = v.union([
+  ListWorkingReposSuccessSchema,
+  RepoFailureSchema,
+]);
+const AddSourceResultSchema = v.union([
+  AddSourceSuccessSchema,
+  RepoFailureSchema,
+]);
+const PublishPullRequestResultSchema = v.union([
+  PublishNoChangesSchema,
+  PublishPullRequestSuccessSchema,
+  RepoFailureSchema,
+]);
+
+export type ListWorkingReposResult =
+  | {
+      ok: true;
+      repositories: WorkingRepository[];
+      truncated: boolean;
+    }
+  | OcRepoFailure;
+
+export type AddSourceResult =
+  | {
+      ok: true;
+      name: string;
+      repository_id: string;
+      full_name: string;
+      ref: string;
+      sha: string;
+      path: string;
+    }
+  | OcRepoFailure;
+
+export type PublishPullRequestResult =
+  | { ok: true; no_changes: true }
+  | {
+      ok: true;
+      no_changes: false;
+      branch: string;
+      commit: string;
+      pull_request: { number: number; url: string };
+    }
+  | OcRepoFailure;
+
+const ListWorkingReposInputSchema = v.strictObject({
+  q: v.optional(
+    v.pipe(
+      v.string(),
+      v.maxLength(100),
+      v.description(
+        "Optional case-insensitive owner/repository substring. Use the returned exact id or owner/repository; never guess from a bare name.",
+      ),
+    ),
+  ),
+});
+
+const AddSourceInputSchema = v.strictObject({
+  repository: v.pipe(
+    v.string(),
+    v.minLength(1),
+    v.description(
+      "An exact repo_… id returned by list_working_repos, or exact owner/repository coordinates from that list.",
+    ),
+  ),
+  ref: v.pipe(
+    v.string(),
+    v.minLength(1),
+    v.description("The branch, tag, or commit to pin."),
+  ),
+  name: v.optional(
+    v.pipe(
+      SourceNameSchema,
+      v.description(
+        "Optional stable source name used by later repository operations.",
+      ),
+    ),
+  ),
+});
+
+const PublishPullRequestInputSchema = v.strictObject({
+  source: v.pipe(
+    v.string(),
+    v.minLength(1),
+    v.description(
+      "The source name returned by add_source, not a path or repository guess.",
+    ),
+  ),
+  title: v.pipe(v.string(), v.minLength(1)),
+  body: v.optional(v.string()),
+  base: v.pipe(
+    v.string(),
+    v.minLength(1),
+    v.description("Exact target branch for the pull request."),
+  ),
+  draft: v.optional(v.boolean()),
+});
+
+type RepoResultSchema =
+  | typeof ListWorkingReposResultSchema
+  | typeof AddSourceResultSchema
+  | typeof PublishPullRequestResultSchema;
+
+const HTTP_BY_ERROR: Readonly<
+  Record<OcRepoErrorCode, readonly number[]>
+> = {
+  github_not_connected: [409],
+  github_unavailable: [503],
+  github_permission_missing: [409],
+  repository_scope_empty: [403],
+  repository_not_allowed: [403],
+  repository_not_granted: [403],
+  repository_not_found: [404],
+  repository_rate_limited: [429],
+  source_name_taken: [409],
+  source_unresolved: [422],
+  source_materialization_failed: [502, 503],
+  source_not_ready: [409],
+  publish_in_progress: [409],
+  publish_failed: [502, 503],
+  stale_deployment_token: [409],
+  deployment_updating: [503],
+  deployment_unverified: [409],
+};
+
+const RETRYABLE_BY_ERROR: Readonly<
+  Partial<Record<OcRepoErrorCode, boolean>>
+> = {
+  github_not_connected: false,
+  github_unavailable: true,
+  github_permission_missing: false,
+  repository_scope_empty: false,
+  repository_not_allowed: false,
+  repository_not_granted: false,
+  repository_not_found: false,
+  repository_rate_limited: true,
+  source_name_taken: false,
+  source_not_ready: true,
+  publish_in_progress: true,
+  stale_deployment_token: false,
+  deployment_updating: true,
+  deployment_unverified: false,
+};
+
+function invalidResponse(status: number): Error {
+  return new Error(
+    `[oc-flue] repository API returned an invalid response (status ${status}).`,
+  );
+}
+
+function validateResult<TSchema extends RepoResultSchema>(
+  schema: TSchema,
+  status: number,
+  payload: unknown,
+): v.InferOutput<TSchema> {
+  const parsed = v.safeParse(schema, payload);
+  if (!parsed.success) throw invalidResponse(status);
+
+  const result = parsed.output;
+  if (result.ok) {
+    if (status < 200 || status >= 300) throw invalidResponse(status);
+    return result;
+  }
+
+  if (!HTTP_BY_ERROR[result.error.code].includes(status)) {
+    throw invalidResponse(status);
+  }
+  const expectedRetryable = RETRYABLE_BY_ERROR[result.error.code];
+  if (
+    expectedRetryable !== undefined &&
+    result.error.retryable !== expectedRetryable
+  ) {
+    throw invalidResponse(status);
+  }
+  if (
+    result.error.code === "repository_rate_limited" !==
+    (result.error.retry_after_seconds !== undefined)
+  ) {
+    throw invalidResponse(status);
+  }
+  return result;
+}
+
+function endpoint(
+  env: OcRepoEnv,
+  sessionId: string,
+  resource: string,
+  query?: URLSearchParams,
+): string {
+  const base = env.OC_REPO_API?.replace(/\/+$/, "");
+  if (!base || !env.OC_SESSION_TOKEN) {
+    throw new Error(
+      "[oc-flue] ocRepoTools requires managed repository API bindings.",
+    );
+  }
+  const suffix = query && query.size > 0 ? `?${query.toString()}` : "";
+  return `${base}/flue/sessions/${encodeURIComponent(sessionId)}/${resource}${suffix}`;
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "AbortError"
+  );
+}
+
+async function fetchWithOneTransportRetry(
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      return await fetch(url, init);
+    } catch (error) {
+      if (init.signal?.aborted || isAbortError(error)) {
+        throw error;
+      }
+      if (attempt === 1) {
+        throw new Error(
+          "[oc-flue] repository API request failed before a response was received.",
+        );
+      }
+    }
+  }
+  throw new Error("[oc-flue] repository API request failed.");
+}
+
+async function request<TSchema extends RepoResultSchema>(
+  schema: TSchema,
+  env: OcRepoEnv,
+  sessionId: string,
+  resource: string,
+  options: {
+    method?: "GET" | "POST";
+    query?: URLSearchParams;
+    body?: unknown;
+    signal?: AbortSignal;
+  },
+): Promise<v.InferOutput<TSchema>> {
+  const url = endpoint(env, sessionId, resource, options.query);
+  const response = await fetchWithOneTransportRetry(url, {
+    method: options.method ?? "GET",
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${env.OC_SESSION_TOKEN}`,
+      ...(options.body === undefined
+        ? {}
+        : { "content-type": "application/json" }),
+    },
+    ...(options.body === undefined
+      ? {}
+      : { body: JSON.stringify(options.body) }),
+    signal: options.signal,
+  });
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    if (options.signal?.aborted || isAbortError(error)) throw error;
+    throw invalidResponse(response.status);
+  }
+  return validateResult(schema, response.status, payload);
+}
+
+function randomIdempotencyKey(): string {
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+
+  const bytes = new Uint8Array(16);
+  globalThis.crypto?.getRandomValues(bytes);
+  if (bytes.every((byte) => byte === 0)) {
+    throw new Error(
+      "[oc-flue] secure randomness is unavailable for pull-request publishing.",
+    );
+  }
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+}
+
+/**
+ * Standard hosted-repository tools for an OpenComputer Flue session.
+ *
+ * The initializer captures only the session id and environment reference.
+ * Managed bindings are resolved inside each tool run because Cloudflare
+ * secrets are request-scoped.
+ */
+export function ocRepoTools(
+  ctx: AgentInitializerContext<OcRepoEnv>,
+): ToolDefinition[] {
+  const sessionId = ctx.id;
+  const env = ctx.env;
+
+  const listWorkingRepos = defineTool({
+    name: "list_working_repos",
+    description:
+      "List repositories this agent may use. Call this before repository work. Match the user's exact owner/repository or returned repo_ id; a bare name may be selected only when this list has exactly one match, otherwise ask. Never assume the deployment source is the target. State the resolved owner/repository before adding it.",
+    input: ListWorkingReposInputSchema,
+    output: ListWorkingReposResultSchema,
+    async run({ input, signal }) {
+      const query = new URLSearchParams();
+      if (input.q !== undefined) query.set("q", input.q);
+      return request(
+        ListWorkingReposResultSchema,
+        ocResolveEnv<OcRepoEnv>(env),
+        sessionId,
+        "repositories",
+        { query, signal },
+      );
+    },
+  });
+
+  const addSource = defineTool({
+    name: "add_source",
+    description:
+      "Pin and materialize one exact repository source after list_working_repos resolved it. Tell the user the exact owner/repository first, await this tool before filesystem work, then use only the returned /workspace/sources/... path. On a product error, explain its stated recovery instead of guessing another target.",
+    input: AddSourceInputSchema,
+    output: AddSourceResultSchema,
+    async run({ input, signal }) {
+      return request(
+        AddSourceResultSchema,
+        ocResolveEnv<OcRepoEnv>(env),
+        sessionId,
+        "sources",
+        { method: "POST", body: input, signal },
+      );
+    },
+  });
+
+  const publishPullRequest = defineTool({
+    name: "github_publish_pull_request",
+    description:
+      "Publish the inspected changes from one added source as an OpenComputer-authored GitHub pull request. First inspect and test the diff, then restate the exact repository, base branch, and intended diff. Report the returned pull-request URL; if there are no changes or a product error, report that result and its recovery exactly.",
+    input: PublishPullRequestInputSchema,
+    output: PublishPullRequestResultSchema,
+    async run({ input, signal }) {
+      const idempotencyKey = randomIdempotencyKey();
+      return request(
+        PublishPullRequestResultSchema,
+        ocResolveEnv<OcRepoEnv>(env),
+        sessionId,
+        "pull-requests",
+        {
+          method: "POST",
+          body: { ...input, idempotency_key: idempotencyKey },
+          signal,
+        },
+      );
+    },
+  });
+
+  return [listWorkingRepos, addSource, publishPullRequest];
+}

--- a/sdks/flue/src/repo.ts
+++ b/sdks/flue/src/repo.ts
@@ -33,6 +33,9 @@ const ERROR_CODES = [
   "deployment_unverified",
 ] as const;
 
+const RESPONSE_ERROR_MESSAGE_MAX = 500;
+const RESPONSE_REPOSITORY_MAX = 50;
+
 export type OcRepoErrorCode = (typeof ERROR_CODES)[number];
 
 export interface OcRepoError {
@@ -51,14 +54,20 @@ export type OcRepoFailure = {
 // semantic fields while ignoring additive fields from a newer server. Tool
 // inputs below remain strict and bounded so the model cannot smuggle extra
 // authority or unbounded work.
-const RepoErrorSchema = v.object({
-  code: v.picklist(ERROR_CODES),
-  message: v.pipe(v.string(), v.minLength(1)),
-  retryable: v.boolean(),
-  retry_after_seconds: v.optional(
-    v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(600)),
-  ),
-});
+const RepoErrorSchema = v.pipe(
+  v.object({
+    code: v.picklist(ERROR_CODES),
+    message: v.pipe(v.string(), v.minLength(1)),
+    retryable: v.boolean(),
+    retry_after_seconds: v.optional(
+      v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(600)),
+    ),
+  }),
+  v.transform((error) => ({
+    ...error,
+    message: error.message.slice(0, RESPONSE_ERROR_MESSAGE_MAX),
+  })),
+);
 
 const RepoFailureSchema = v.object({
   ok: v.literal(false),
@@ -77,11 +86,19 @@ export interface WorkingRepository {
   default_branch: string;
 }
 
-const ListWorkingReposSuccessSchema = v.object({
-  ok: v.literal(true),
-  repositories: v.array(WorkingRepositorySchema),
-  truncated: v.boolean(),
-});
+const ListWorkingReposSuccessSchema = v.pipe(
+  v.object({
+    ok: v.literal(true),
+    repositories: v.array(WorkingRepositorySchema),
+    truncated: v.boolean(),
+  }),
+  v.transform((result) => ({
+    ...result,
+    repositories: result.repositories.slice(0, RESPONSE_REPOSITORY_MAX),
+    truncated:
+      result.truncated || result.repositories.length > RESPONSE_REPOSITORY_MAX,
+  })),
+);
 
 const SourceNameSchema = v.pipe(
   v.string(),
@@ -432,8 +449,8 @@ function randomIdempotencyKey(): string {
  *
  * The initializer captures only the session id and the runtime-owned
  * environment reference, not a spread/snapshot. Managed bindings are resolved
- * inside each tool run so request-time secrets on that reference are visible;
- * ambient plain bindings are layered in by `ocResolveEnv`.
+ * inside each tool run so request-time secrets on that reference are visible
+ * through direct property reads; `ocResolveEnv` never enumerates that proxy.
  */
 export function ocRepoTools(
   ctx: AgentInitializerContext<OcRepoEnv>,

--- a/sdks/flue/src/repo.ts
+++ b/sdks/flue/src/repo.ts
@@ -47,21 +47,25 @@ export type OcRepoFailure = {
   error: OcRepoError;
 };
 
-const RepoErrorSchema = v.strictObject({
+// Platform responses are forward-extensible: validate and return the known
+// semantic fields while ignoring additive fields from a newer server. Tool
+// inputs below remain strict and bounded so the model cannot smuggle extra
+// authority or unbounded work.
+const RepoErrorSchema = v.object({
   code: v.picklist(ERROR_CODES),
-  message: v.pipe(v.string(), v.minLength(1), v.maxLength(500)),
+  message: v.pipe(v.string(), v.minLength(1)),
   retryable: v.boolean(),
   retry_after_seconds: v.optional(
     v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(600)),
   ),
 });
 
-const RepoFailureSchema = v.strictObject({
+const RepoFailureSchema = v.object({
   ok: v.literal(false),
   error: RepoErrorSchema,
 });
 
-const WorkingRepositorySchema = v.strictObject({
+const WorkingRepositorySchema = v.object({
   id: v.pipe(v.string(), v.minLength(1)),
   full_name: v.pipe(v.string(), v.minLength(3)),
   default_branch: v.pipe(v.string(), v.minLength(1)),
@@ -73,12 +77,9 @@ export interface WorkingRepository {
   default_branch: string;
 }
 
-const ListWorkingReposSuccessSchema = v.strictObject({
+const ListWorkingReposSuccessSchema = v.object({
   ok: v.literal(true),
-  repositories: v.pipe(
-    v.array(WorkingRepositorySchema),
-    v.maxLength(50),
-  ),
+  repositories: v.array(WorkingRepositorySchema),
   truncated: v.boolean(),
 });
 
@@ -108,7 +109,7 @@ const PullRequestBaseSchema = v.pipe(
 );
 
 const AddSourceSuccessSchema = v.pipe(
-  v.strictObject({
+  v.object({
     ok: v.literal(true),
     name: SourceNameSchema,
     repository_id: v.pipe(v.string(), v.startsWith("repo_")),
@@ -123,12 +124,12 @@ const AddSourceSuccessSchema = v.pipe(
   ),
 );
 
-const PublishNoChangesSchema = v.strictObject({
+const PublishNoChangesSchema = v.object({
   ok: v.literal(true),
   no_changes: v.literal(true),
 });
 
-const PublishPullRequestSuccessSchema = v.strictObject({
+const PublishPullRequestSuccessSchema = v.object({
   ok: v.literal(true),
   no_changes: v.literal(false),
   branch: v.pipe(v.string(), v.minLength(1)),
@@ -136,7 +137,7 @@ const PublishPullRequestSuccessSchema = v.strictObject({
     v.string(),
     v.regex(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/i),
   ),
-  pull_request: v.strictObject({
+  pull_request: v.object({
     number: v.pipe(v.number(), v.integer(), v.minValue(1)),
     url: v.pipe(v.string(), v.url()),
   }),
@@ -429,9 +430,10 @@ function randomIdempotencyKey(): string {
 /**
  * Standard hosted-repository tools for an OpenComputer Flue session.
  *
- * The initializer captures only the session id and environment reference.
- * Managed bindings are resolved inside each tool run because Cloudflare
- * secrets are request-scoped.
+ * The initializer captures only the session id and the runtime-owned
+ * environment reference, not a spread/snapshot. Managed bindings are resolved
+ * inside each tool run so request-time secrets on that reference are visible;
+ * ambient plain bindings are layered in by `ocResolveEnv`.
  */
 export function ocRepoTools(
   ctx: AgentInitializerContext<OcRepoEnv>,

--- a/sdks/flue/src/repo.ts
+++ b/sdks/flue/src/repo.ts
@@ -87,6 +87,25 @@ const SourceNameSchema = v.pipe(
   v.regex(/^[a-z0-9][a-z0-9_-]{0,63}$/),
 );
 
+const RepositoryTargetSchema = v.pipe(
+  v.string(),
+  v.regex(
+    /^(?:repo_[a-z0-9]{24}|[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})\/[A-Za-z0-9._-]{1,100})$/,
+  ),
+);
+
+const RefSchema = v.pipe(
+  v.string(),
+  v.minLength(1),
+  v.maxLength(255),
+);
+
+const PullRequestBaseSchema = v.pipe(
+  v.string(),
+  v.regex(/^[A-Za-z0-9][A-Za-z0-9._/-]{0,254}$/),
+  v.check((ref) => !ref.includes(".."), "base cannot contain '..'"),
+);
+
 const AddSourceSuccessSchema = v.pipe(
   v.strictObject({
     ok: v.literal(true),
@@ -181,15 +200,13 @@ const ListWorkingReposInputSchema = v.strictObject({
 
 const AddSourceInputSchema = v.strictObject({
   repository: v.pipe(
-    v.string(),
-    v.minLength(1),
+    RepositoryTargetSchema,
     v.description(
       "An exact repo_… id returned by list_working_repos, or exact owner/repository coordinates from that list.",
     ),
   ),
   ref: v.pipe(
-    v.string(),
-    v.minLength(1),
+    RefSchema,
     v.description("The branch, tag, or commit to pin."),
   ),
   name: v.optional(
@@ -204,17 +221,19 @@ const AddSourceInputSchema = v.strictObject({
 
 const PublishPullRequestInputSchema = v.strictObject({
   source: v.pipe(
-    v.string(),
-    v.minLength(1),
+    SourceNameSchema,
     v.description(
       "The source name returned by add_source, not a path or repository guess.",
     ),
   ),
-  title: v.pipe(v.string(), v.minLength(1)),
-  body: v.optional(v.string()),
-  base: v.pipe(
+  title: v.pipe(
     v.string(),
-    v.minLength(1),
+    v.maxLength(256),
+    v.check((title) => title.trim().length > 0, "title cannot be blank"),
+  ),
+  body: v.optional(v.pipe(v.string(), v.maxLength(65_536))),
+  base: v.pipe(
+    PullRequestBaseSchema,
     v.description("Exact target branch for the pull request."),
   ),
   draft: v.optional(v.boolean()),

--- a/sdks/flue/src/sandbox.ts
+++ b/sdks/flue/src/sandbox.ts
@@ -267,9 +267,9 @@ async function resolveSandboxId(
  * Linux shell or durable files. The default starter intentionally omits it.
  *
  * Resolves the captured runtime env lazily and layers in plain bindings from the CF ambient env
- * (`cloudflare:workers`). The request-time `OC_SESSION_TOKEN` remains on the captured env reference;
- * it is not assumed to exist in the ambient snapshot. `createSessionEnv` validates local configuration
- * and returns a lazy environment without fetching or provisioning anything.
+ * (`cloudflare:workers`). The request-time `OC_SESSION_TOKEN` remains on the captured env proxy and is
+ * read directly; that proxy is never spread or enumerated. `createSessionEnv` validates local
+ * configuration and returns a lazy environment without fetching or provisioning anything.
  */
 export function ocSandbox(
   env: OcSandboxEnv,

--- a/sdks/flue/src/sandbox.ts
+++ b/sdks/flue/src/sandbox.ts
@@ -266,10 +266,10 @@ async function resolveSandboxId(
  * The optional OC-fleet sandbox factory. Add `sandbox: ocSandbox(env)` only when an agent needs a
  * Linux shell or durable files. The default starter intentionally omits it.
  *
- * Reads the CF ambient env (`cloudflare:workers`), not the passed `ctx.env`: on the `--target
- * cloudflare` build the real `OC_SANDBOX_*`/`OC_SESSION_TOKEN` bindings live on the ambient env and
- * `ctx.env` is empty for them (same reason as `useOcGateway`). `createSessionEnv` validates local
- * configuration and returns a lazy environment without fetching or provisioning anything.
+ * Resolves the captured runtime env lazily and layers in plain bindings from the CF ambient env
+ * (`cloudflare:workers`). The request-time `OC_SESSION_TOKEN` remains on the captured env reference;
+ * it is not assumed to exist in the ambient snapshot. `createSessionEnv` validates local configuration
+ * and returns a lazy environment without fetching or provisioning anything.
  */
 export function ocSandbox(
   env: OcSandboxEnv,

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -101,6 +101,28 @@ const { agent, deployment } = await oc.agents.repository.import({
 });
 ```
 
+### Configure repository access
+
+Flue agents can use repositories granted to your OpenComputer GitHub App as working sources. Read
+the current grant and policy, or narrow the agent to explicit repository ids from that view:
+
+```typescript
+const access = await oc.agents.getRepositoryAccess(agent.id);
+const target = access.effectiveRepositories?.find(
+  (repo) => repo.fullName === "your-org/your-repo",
+);
+if (!target) throw new Error("Repository is not currently available to this agent");
+
+await oc.agents.updateRepositoryAccess(agent.id, {
+  mode: "selected",
+  repositoryIds: [target.id],
+});
+```
+
+Use `{ mode: "all" }` for every currently and subsequently granted repository, or
+`{ mode: "selected", repositoryIds: [] }` to disable repository work. An `unavailable` grant has
+`effectiveRepositories: null`; an empty array is a successfully read, known-empty view.
+
 ### Credentials
 
 Sessions run **Managed** (via OpenComputer, billed to your credits — `credential: "managed"`, no key, the default for new orgs) or on **your own** model-provider key (Anthropic for `claude`, OpenAI for `codex`). An inline `key` stores one and attaches it to the agent; manage keys directly to reuse one across agents, set an org default, or rotate/remove:

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.12.4",
+      "version": "0.13.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/agents/agents.ts
+++ b/sdks/typescript/src/agents/agents.ts
@@ -83,6 +83,45 @@ export interface ManagedSlackWorkspaceConnection extends ManagedSlackConnection 
   agent: { id: string; name: string };
 }
 
+/** Which repositories a Flue agent may use as working sources. */
+export type RepositoryAccessPolicy =
+  | { mode: "all" }
+  | { mode: "selected"; repositoryIds: string[] };
+
+/** Current state of the owner-bound OpenComputer GitHub App grant. */
+export interface RepositoryAccessGrant {
+  status: "active" | "not_installed" | "unavailable";
+  account: string | null;
+  repositorySelection: "all" | "selected" | null;
+  installUrl: string;
+  configureUrl: string | null;
+  truncated: boolean;
+}
+
+/** One repository currently usable under both the GitHub grant and agent policy. */
+export interface RepositoryAccessRepository {
+  id: string;
+  fullName: string;
+  defaultBranch: string;
+  private: boolean;
+}
+
+/** A selected repository absent from the current complete GitHub grant view. */
+export interface UnavailableSelectedRepository {
+  id: string;
+  fullName: string;
+}
+
+/** Agent policy composed with the owner's current GitHub App grant. */
+export interface RepositoryAccess {
+  policy: RepositoryAccessPolicy;
+  grant: RepositoryAccessGrant;
+  /** `null` means the grant could not be read; an empty array is a known-empty view. */
+  effectiveRepositories: RepositoryAccessRepository[] | null;
+  /** Authoritative only when `grant.truncated` is false. */
+  unavailableSelectedRepositories: UnavailableSelectedRepository[];
+}
+
 /** Reusable agents — the "what" a session runs. */
 export class Agents {
   /** Deploy behavior (inline or from a linked repo) — each deployment produces a revision. */
@@ -122,6 +161,24 @@ export class Agents {
   }
   list(params: { limit?: number; cursor?: string } = {}): Promise<Page<Agent>> {
     return this.http.request("GET", "/agents", { query: params as Query });
+  }
+
+  // ── Working repositories (agent policy ∩ owner GitHub App grant) ──
+
+  /** Read the agent's working-repository policy and current effective grant view. */
+  getRepositoryAccess(agentId: string): Promise<RepositoryAccess> {
+    return this.http.request("GET", `/agents/${agentId}/repository-access`);
+  }
+
+  /** Atomically replace the agent's working-repository policy. */
+  updateRepositoryAccess(
+    agentId: string,
+    policy: RepositoryAccessPolicy,
+  ): Promise<RepositoryAccess> {
+    return this.http.request("PUT", `/agents/${agentId}/repository-access`, {
+      body: policy,
+      idempotent: true,
+    });
   }
 
   // ── Slack (give the agent its own @handle; BYO app, 1 app ⟷ 1 agent ⟷ 1 workspace) ──

--- a/sdks/typescript/src/agents/index.ts
+++ b/sdks/typescript/src/agents/index.ts
@@ -12,6 +12,8 @@ export type {
   CreateAgentParams, UpdateAgentParams, Page,
   SlackManifest, SlackConnection, ConnectSlackParams,
   ManagedSlackAuthorization, ManagedSlackConnection, ManagedSlackWorkspaceConnection,
+  RepositoryAccessPolicy, RepositoryAccessGrant, RepositoryAccessRepository,
+  UnavailableSelectedRepository, RepositoryAccess,
 } from "./agents.js";
 export { AgentRepository } from "./repository-agents.js";
 export type {

--- a/sdks/typescript/src/agents/repository-access.test.ts
+++ b/sdks/typescript/src/agents/repository-access.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RepositoryAccessPolicy } from "../index.js";
+import { OpenComputer } from "./client.js";
+import { ConflictError, NotFoundError } from "./errors.js";
+
+// @ts-expect-error selected policy requires an explicit repository list
+const selectedWithoutRepositories: RepositoryAccessPolicy = { mode: "selected" };
+void selectedWithoutRepositories;
+
+const allWithRepositories: RepositoryAccessPolicy = {
+  mode: "all",
+  // @ts-expect-error all policy cannot carry a selected repository list
+  repositoryIds: ["repo_0123456789abcdef01234567"],
+};
+void allWithRepositories;
+
+const wireAccess = {
+  policy: {
+    mode: "selected",
+    repository_ids: ["repo_0123456789abcdef01234567"],
+  },
+  grant: {
+    status: "active",
+    account: "example",
+    repository_selection: "selected",
+    install_url: "https://github.com/apps/opencomputer/installations/new?state=opaque",
+    configure_url: "https://github.com/settings/installations/123",
+    truncated: false,
+  },
+  effective_repositories: [
+    {
+      id: "repo_0123456789abcdef01234567",
+      full_name: "example/support-agent",
+      default_branch: "main",
+      private: true,
+    },
+  ],
+  unavailable_selected_repositories: [
+    {
+      id: "repo_89abcdef0123456701234567",
+      full_name: "example/retired-agent",
+    },
+  ],
+};
+
+function client(fetcher: typeof fetch): OpenComputer {
+  return new OpenComputer({
+    apiKey: "oc_test",
+    baseUrl: "https://api.example.test/v3",
+    fetch: fetcher,
+    maxRetries: 0,
+  });
+}
+
+describe("agent repository access", () => {
+  it("reads and camel-cases policy, grant, and repository state", async () => {
+    const fetcher = vi.fn(async () => Response.json(wireAccess));
+    const oc = client(fetcher as typeof fetch);
+
+    const access = await oc.agents.getRepositoryAccess("agt_1");
+
+    expect(access).toEqual({
+      policy: {
+        mode: "selected",
+        repositoryIds: ["repo_0123456789abcdef01234567"],
+      },
+      grant: {
+        status: "active",
+        account: "example",
+        repositorySelection: "selected",
+        installUrl: "https://github.com/apps/opencomputer/installations/new?state=opaque",
+        configureUrl: "https://github.com/settings/installations/123",
+        truncated: false,
+      },
+      effectiveRepositories: [
+        {
+          id: "repo_0123456789abcdef01234567",
+          fullName: "example/support-agent",
+          defaultBranch: "main",
+          private: true,
+        },
+      ],
+      unavailableSelectedRepositories: [
+        {
+          id: "repo_89abcdef0123456701234567",
+          fullName: "example/retired-agent",
+        },
+      ],
+    });
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.example.test/v3/agents/agt_1/repository-access",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("preserves an unavailable grant's null effective view", async () => {
+    const fetcher = vi.fn(async () => Response.json({
+      ...wireAccess,
+      grant: {
+        ...wireAccess.grant,
+        status: "unavailable",
+        account: null,
+        repository_selection: null,
+        configure_url: null,
+      },
+      effective_repositories: null,
+      unavailable_selected_repositories: [],
+    }));
+    const oc = client(fetcher as typeof fetch);
+
+    const access = await oc.agents.getRepositoryAccess("agt_1");
+
+    expect(access.grant.status).toBe("unavailable");
+    expect(access.effectiveRepositories).toBeNull();
+    expect(access.unavailableSelectedRepositories).toEqual([]);
+  });
+
+  it("replaces the policy with the exact snake-case wire body", async () => {
+    const fetcher = vi.fn(async () => Response.json(wireAccess));
+    const oc = client(fetcher as typeof fetch);
+
+    const access = await oc.agents.updateRepositoryAccess("agt_1", {
+      mode: "selected",
+      repositoryIds: ["repo_0123456789abcdef01234567"],
+    });
+
+    expect(access.policy).toEqual({
+      mode: "selected",
+      repositoryIds: ["repo_0123456789abcdef01234567"],
+    });
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.example.test/v3/agents/agt_1/repository-access",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({
+          mode: "selected",
+          repository_ids: ["repo_0123456789abcdef01234567"],
+        }),
+      }),
+    );
+  });
+
+  it("sends the all policy without a repository list", async () => {
+    const fetcher = vi.fn(async () => Response.json({
+      ...wireAccess,
+      policy: { mode: "all" },
+    }));
+    const oc = client(fetcher as typeof fetch);
+
+    const access = await oc.agents.updateRepositoryAccess("agt_1", {
+      mode: "all",
+    });
+
+    expect(access.policy).toEqual({ mode: "all" });
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.example.test/v3/agents/agt_1/repository-access",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ mode: "all" }),
+      }),
+    );
+  });
+
+  it.each([
+    [404, "not_found", NotFoundError],
+    [409, "repository_access_not_supported", ConflictError],
+  ] as const)("maps a %s boundary error through the standard SDK error", async (
+    status,
+    type,
+    ErrorClass,
+  ) => {
+    const fetcher = vi.fn(async () => Response.json(
+      { error: { type, message: "repository access unavailable", request_id: "req_1" } },
+      { status },
+    ));
+    const oc = client(fetcher as typeof fetch);
+
+    const request = oc.agents.getRepositoryAccess("agt_1");
+
+    await expect(request).rejects.toBeInstanceOf(ErrorClass);
+    await expect(request).rejects.toMatchObject({
+      status,
+      type,
+      requestId: "req_1",
+    });
+  });
+});

--- a/sdks/typescript/src/agents/session-sources.test.ts
+++ b/sdks/typescript/src/agents/session-sources.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { OpenComputer } from "./client.js";
+
+const wireSource = {
+  name: "target",
+  status: "resolved",
+  path: "/workspace/sources/target",
+  repo_id: "repo_0123456789abcdef01234567",
+  full_name: "example/support-agent",
+  requested_ref: "main",
+  sha: "a".repeat(40),
+  resolved_sha: "a".repeat(40),
+};
+
+describe("managed session source summaries", () => {
+  it("camel-cases repository identity on create and live source reads", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({
+        session: { id: "ses_1", status: "queued" },
+        sources: [wireSource],
+      }))
+      .mockResolvedValueOnce(Response.json([wireSource]));
+    const oc = new OpenComputer({
+      apiKey: "oc_test",
+      baseUrl: "https://api.example.test/v3",
+      fetch: fetcher as typeof fetch,
+      maxRetries: 0,
+    });
+
+    const session = await oc.sessions.create({
+      agent: "agt_1",
+      input: "Inspect the target repository",
+    });
+
+    expect(session.sources[0]).toMatchObject({
+      repoId: "repo_0123456789abcdef01234567",
+      fullName: "example/support-agent",
+      requestedRef: "main",
+      resolvedSha: "a".repeat(40),
+    });
+    await expect(session.listSources()).resolves.toEqual([
+      expect.objectContaining({
+        repoId: "repo_0123456789abcdef01234567",
+        fullName: "example/support-agent",
+        requestedRef: "main",
+      }),
+    ]);
+    expect(fetcher).toHaveBeenNthCalledWith(
+      2,
+      "https://api.example.test/v3/sessions/ses_1/sources",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+});

--- a/sdks/typescript/src/agents/sessions.ts
+++ b/sdks/typescript/src/agents/sessions.ts
@@ -119,6 +119,12 @@ export interface SourceSummary {
   name: string;
   status: SourceStatus;
   path: string;
+  /** Stable registered repository id when the source came from a managed repository. */
+  repoId?: string;
+  /** Current provider coordinates for a managed repository. */
+  fullName?: string;
+  /** Branch, tag, or commit expression requested before it was pinned. */
+  requestedRef?: string;
   /** Requested commit from create; kept for correlation while materialization is pending. */
   sha: string;
   /** Actual checked-out commit after materialization succeeds. Usually equals `sha`. */

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -40,6 +40,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.7.0",
+        "happy-dom": "^20.11.0",
         "prettier": "^3.8.5",
         "prettier-plugin-tailwindcss": "^0.8.0",
         "shadcn": "^4.12.0",
@@ -3964,6 +3965,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -3997,6 +4008,23 @@
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.62.0",
@@ -4851,6 +4879,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -5655,6 +5696,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -7009,6 +7063,25 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.0.tgz",
+      "integrity": "sha512-XogN4asPd1a56di9prVG6bZxteNcXsZxxKmAvcEfc5Px5Ca2hMyMgk8wvqK2K1V8zXg40j9VANXsDaJYh9DeNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -10878,6 +10951,13 @@
         "node": ">=20.18.1"
       }
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -11196,6 +11276,16 @@
       "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
       "license": "Apache-2.0"
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
@@ -11334,6 +11424,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.3.1",

--- a/web/package.json
+++ b/web/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.7.0",
+    "happy-dom": "^20.11.0",
     "prettier": "^3.8.5",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "shadcn": "^4.12.0",

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -35,12 +35,16 @@ export type {
   AgentDeployment,
   AgentDeploymentLog,
   DeployApp,
+  RepositoryAccess,
+  RepositoryAccessPolicy,
+  RepositoryAccessRepository,
   RepositorySourceInspection,
   ManagedSlackAuthorizeResponse,
   ManagedSlackConnection,
   ManagedSlackWorkspaceConnection,
   ManagedSlackDisconnectResponse,
   Session,
+  SessionSource,
   AgentSnapshot,
   SessionEvent,
   Turn,
@@ -666,6 +670,23 @@ export const deleteAgentSkills = (agentId: string) =>
 export const getDeployApp = () =>
   apiFetch('/v3/github/deploy-app', {}, S.DeployAppSchema)
 
+export const getRepositoryAccess = (agentId: string) =>
+  apiFetch(
+    `/v3/agents/${encodeURIComponent(agentId)}/repository-access`,
+    {},
+    S.RepositoryAccessSchema,
+  )
+
+export const updateRepositoryAccess = (
+  agentId: string,
+  policy: S.RepositoryAccessPolicy,
+) =>
+  apiFetch(
+    `/v3/agents/${encodeURIComponent(agentId)}/repository-access`,
+    { method: 'PUT', body: JSON.stringify(policy) },
+    S.RepositoryAccessSchema,
+  )
+
 export const reviewRepositoryAgent = (body: {
   repo: string
   path: string
@@ -850,7 +871,12 @@ export async function getManagedSlackConnection(agentId: string) {
       S.ManagedSlackConnectionSchema,
     )
   } catch (error) {
-    if (error instanceof ApiError && error.status === 404) return null
+    if (
+      (error instanceof ApiError ||
+        (error instanceof Error && 'status' in error)) &&
+      (error as { status: unknown }).status === 404
+    )
+      return null
     throw error
   }
 }
@@ -933,6 +959,13 @@ export const getSessions = (
 
 export const getSession = (id: string) =>
   apiFetch(`/v3/sessions/${id}`, {}, S.SessionSchema)
+
+export const getSessionSources = (id: string) =>
+  apiFetch(
+    `/v3/sessions/${encodeURIComponent(id)}/sources`,
+    {},
+    S.SessionSourceListSchema,
+  )
 
 // The API wants { agent: <id>, input } (input required). An optional `sources[]` attaches
 // a WORKING repo the agent checks out + opens PRs from — the control plane pins the ref's

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,6 +1,9 @@
 import posthog from 'posthog-js'
 import { z } from 'zod'
 import * as S from './schemas'
+import { ApiError } from './errors'
+
+export { ApiError } from './errors'
 
 // Re-export the inferred response types (schemas are the single source of
 // truth) so existing `import { type Sandbox } from '@/api/client'` keeps working.
@@ -117,20 +120,6 @@ function errorDetails(body: unknown): Record<string, unknown> | undefined {
   return error && typeof error === 'object' && !Array.isArray(error)
     ? (error as Record<string, unknown>)
     : undefined
-}
-
-/** An error carrying the HTTP status + the API's typed reason, so callers can branch
- *  (e.g. 404 = not-found; 402 `insufficient_credits` = out of credits → top-up CTA). */
-export class ApiError extends Error {
-  constructor(
-    message: string,
-    readonly status: number,
-    readonly type?: string,
-    readonly details?: Record<string, unknown>,
-  ) {
-    super(message)
-    this.name = 'ApiError'
-  }
 }
 
 export async function apiFetch<T>(
@@ -871,12 +860,7 @@ export async function getManagedSlackConnection(agentId: string) {
       S.ManagedSlackConnectionSchema,
     )
   } catch (error) {
-    if (
-      (error instanceof ApiError ||
-        (error instanceof Error && 'status' in error)) &&
-      (error as { status: unknown }).status === 404
-    )
-      return null
+    if (error instanceof ApiError && error.status === 404) return null
     throw error
   }
 }

--- a/web/src/api/errors.ts
+++ b/web/src/api/errors.ts
@@ -1,0 +1,12 @@
+/** An API failure with the HTTP status and optional typed product reason. */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly type?: string,
+    readonly details?: Record<string, unknown>,
+  ) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}

--- a/web/src/api/managed-slack-client.test.ts
+++ b/web/src/api/managed-slack-client.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ApiError, getManagedSlackConnection } from './client'
+import { mockFetch } from './mock'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('managed Slack missing-resource handling', () => {
+  it('maps a real API 404 to no managed connection', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(Response.json({ error: 'Not found' }, { status: 404 })),
+      ),
+    )
+
+    await expect(
+      getManagedSlackConnection('agt_aaaaaaaaaaaaaaaaaaaaaaaa'),
+    ).resolves.toBeNull()
+  })
+
+  it('does not swallow an unrelated status-bearing Error', async () => {
+    const transportError = Object.assign(new Error('Proxy failed'), {
+      status: 404,
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(transportError)),
+    )
+
+    await expect(
+      getManagedSlackConnection('agt_aaaaaaaaaaaaaaaaaaaaaaaa'),
+    ).rejects.toBe(transportError)
+  })
+
+  it('uses the same ApiError contract in preview mocks', () => {
+    expect(() =>
+      mockFetch('/v3/agents/agt_aaaaaaaaaaaaaaaaaaaaaaaa/slack/managed'),
+    ).toThrow(ApiError)
+  })
+})

--- a/web/src/api/mock-contracts.test.ts
+++ b/web/src/api/mock-contracts.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { mockFetch } from './mock'
-import { RepositorySourceInspectionSchema } from './schemas'
+import {
+  RepositoryAccessSchema,
+  RepositorySourceInspectionSchema,
+  SessionSourceListSchema,
+} from './schemas'
 
 describe('preview API contracts', () => {
   it('keeps the repository review fixture valid against the live schema', () => {
@@ -9,5 +13,18 @@ describe('preview API contracts', () => {
     })
 
     expect(() => RepositorySourceInspectionSchema.parse(response)).not.toThrow()
+  })
+
+  it('keeps repository access and source-detail fixtures valid', () => {
+    expect(() =>
+      RepositoryAccessSchema.parse(
+        mockFetch('/v3/agents/agt_flue_import/repository-access'),
+      ),
+    ).not.toThrow()
+    expect(() =>
+      SessionSourceListSchema.parse(
+        mockFetch('/v3/sessions/ses_a1b2c3/sources'),
+      ),
+    ).not.toThrow()
   })
 })

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -10,6 +10,8 @@
 // Returns are cast to the caller's T — mock objects only need the fields a
 // screen actually reads, not the full interface.
 
+import { ApiError } from './errors'
+
 // Fixed clock so screenshots are deterministic.
 const BASE = new Date('2026-06-26T17:00:00Z').getTime()
 const at = (daysAgo: number, hoursAgo = 0) =>
@@ -1309,9 +1311,7 @@ export function mockFetch<T>(path: string, options: RequestInit = {}): T {
     if (re.test(path)) {
       const out = handler()
       if (out === NOT_FOUND) {
-        const error = new Error('Not found') as Error & { status: number }
-        error.status = 404
-        throw error
+        throw new ApiError('Not found', 404)
       }
       return out as T
     }

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -512,7 +512,7 @@ const deployAppInstalled = {
     },
     {
       id: 'repo_01k0supportbot00000000',
-      full_name: 'acme/support-bot',
+      full_name: 'acme/customer-support-automation-and-triage',
       default_branch: 'main',
       private: false,
     },
@@ -536,6 +536,34 @@ const deployApp =
   DEPLOY_PREVIEW === 'not_installed'
     ? deployAppNotInstalled
     : deployAppInstalled
+
+const repositoryAccess = {
+  policy: {
+    mode: 'selected' as const,
+    repository_ids: [
+      'repo_01k0acmeagents000000000',
+      'repo_01k0supportbot00000000',
+    ],
+  },
+  grant: {
+    status: 'active' as const,
+    account: 'acme',
+    repository_selection: 'selected' as const,
+    install_url: 'https://github.com/apps/opencomputerdev/installations/new',
+    configure_url:
+      'https://github.com/apps/opencomputerdev/installations/select_target',
+    truncated: false,
+  },
+  effective_repositories: deployAppInstalled.repositories
+    .slice(0, 2)
+    .map((repo) => ({
+      id: repo.id,
+      full_name: repo.full_name,
+      default_branch: repo.default_branch,
+      private: repo.private,
+    })),
+  unavailable_selected_repositories: [],
+}
 
 // The linked source for the 'connected' preview (echoed for any agent id).
 const deploymentSource = {
@@ -944,6 +972,19 @@ const sessions = [
   },
 ]
 
+const sessionSources = [
+  {
+    name: 'app',
+    repo_id: 'repo_01k0acmeagents000000000',
+    full_name: 'acme/agents',
+    requested_ref: 'main',
+    status: 'ready',
+    path: '/workspace/sources/app',
+    sha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+    resolved_sha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+  },
+]
+
 const sessionEvents = [
   {
     id: 'evt_1',
@@ -1157,8 +1198,11 @@ const ROUTES: Array<[RegExp, Handler]> = [
   [/^\/org$/, () => org],
   [/^\/agents$/, () => []],
   // Durable Agent Sessions — lists return the { data: [...] } envelope.
+  [/^\/v3\/slack\/managed\/connections$/, () => ({ data: [] })],
+  [/^\/v3\/agents\/[^/]+\/slack\/managed$/, () => NOT_FOUND],
   [/^\/v3\/agents\/[^/]+\/slack$/, () => slackConnection],
   [/^\/v3\/github\/deploy-app$/, () => deployApp],
+  [/^\/v3\/agents\/[^/]+\/repository-access$/, () => repositoryAccess],
   [
     /^\/v3\/agents\/[^/]+\/deployments\/[^/]+\/logs(?:\?.*)?$/,
     () => ({
@@ -1199,6 +1243,7 @@ const ROUTES: Array<[RegExp, Handler]> = [
   [/^\/v3\/agents\/[^/]+$/, () => agents[0]],
   [/^\/v3\/agents$/, () => ({ data: [...agents, importedAgent] })],
   [/^\/v3\/credentials$/, () => ({ data: credentials })],
+  [/^\/v3\/sessions\/[^/]+\/sources$/, () => sessionSources],
   [/^\/v3\/sessions\/[^/]+\/events/, () => ({ data: sessionEvents })],
   [/^\/v3\/sessions\/[^/]+\/turns$/, () => ({ data: sessionTurns })],
   [
@@ -1223,6 +1268,7 @@ const ROUTES: Array<[RegExp, Handler]> = [
 // Mutations the preview needs to echo something parseable (e.g. the Slack
 // wizard's POST …/slack/manifest → manifest+steps). Everything else 204-ish.
 const POST_ROUTES: [RegExp, () => unknown][] = [
+  [/^\/v3\/agents\/[^/]+\/repository-access$/, () => repositoryAccess],
   [/^\/v3\/github\/deploy-app\/inspect$/, () => flueInspection],
   [
     /^\/v3\/agents\/import$/,
@@ -1262,7 +1308,11 @@ export function mockFetch<T>(path: string, options: RequestInit = {}): T {
   for (const [re, handler] of ROUTES) {
     if (re.test(path)) {
       const out = handler()
-      if (out === NOT_FOUND) throw new Error('Not found') // mimic a 404
+      if (out === NOT_FOUND) {
+        const error = new Error('Not found') as Error & { status: number }
+        error.status = 404
+        throw error
+      }
       return out as T
     }
   }

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -978,7 +978,7 @@ const sessionSources = [
     repo_id: 'repo_01k0acmeagents000000000',
     full_name: 'acme/agents',
     requested_ref: 'main',
-    status: 'ready',
+    status: 'resolved',
     path: '/workspace/sources/app',
     sha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
     resolved_sha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',

--- a/web/src/api/repository-access-client.test.ts
+++ b/web/src/api/repository-access-client.test.ts
@@ -69,7 +69,7 @@ describe('repository access client', () => {
         repo_id: 'repo_1',
         full_name: 'acme/app',
         requested_ref: 'main',
-        status: 'ready',
+        status: 'resolved',
         path: '/workspace/sources/app',
         sha: 'a'.repeat(40),
         resolved_sha: 'b'.repeat(40),

--- a/web/src/api/repository-access-client.test.ts
+++ b/web/src/api/repository-access-client.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  getRepositoryAccess,
+  getSessionSources,
+  updateRepositoryAccess,
+} from './client'
+
+const access = {
+  policy: { mode: 'selected' as const, repository_ids: ['repo_1'] },
+  grant: {
+    status: 'active' as const,
+    account: 'acme',
+    repository_selection: 'selected' as const,
+    install_url: 'https://github.test/install',
+    configure_url: 'https://github.test/configure',
+    truncated: false,
+  },
+  effective_repositories: [
+    {
+      id: 'repo_1',
+      full_name: 'acme/app',
+      default_branch: 'main',
+      private: true,
+    },
+  ],
+  unavailable_selected_repositories: [],
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('repository access client', () => {
+  it('reads and atomically replaces an agent policy', async () => {
+    const calls: Array<{ input: string; init?: RequestInit }> = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url
+        calls.push({ input: url, init })
+        return Promise.resolve(Response.json(access))
+      }),
+    )
+
+    await expect(getRepositoryAccess('agt_/unsafe')).resolves.toEqual(access)
+    await expect(
+      updateRepositoryAccess('agt_/unsafe', {
+        mode: 'selected',
+        repository_ids: ['repo_1'],
+      }),
+    ).resolves.toEqual(access)
+
+    expect(calls[0]?.input).toBe(
+      '/api/dashboard/v3/agents/agt_%2Funsafe/repository-access',
+    )
+    expect(calls[1]?.init?.method).toBe('PUT')
+    expect(calls[1]?.init?.body).toBe(
+      JSON.stringify({ mode: 'selected', repository_ids: ['repo_1'] }),
+    )
+  })
+
+  it('reads source identity and the pinned ref from session detail', async () => {
+    const sources = [
+      {
+        name: 'app',
+        repo_id: 'repo_1',
+        full_name: 'acme/app',
+        requested_ref: 'main',
+        status: 'ready',
+        path: '/workspace/sources/app',
+        sha: 'a'.repeat(40),
+        resolved_sha: 'b'.repeat(40),
+      },
+    ]
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(Response.json(sources))),
+    )
+
+    await expect(getSessionSources('ses_1')).resolves.toEqual(sources)
+  })
+})

--- a/web/src/api/repository-access-schemas.test.ts
+++ b/web/src/api/repository-access-schemas.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { RepositoryAccessSchema, SessionSourceListSchema } from './schemas'
+
+describe('repository access schemas', () => {
+  it('accepts an intentionally empty selected policy and a truncated grant', () => {
+    expect(
+      RepositoryAccessSchema.parse({
+        policy: { mode: 'selected', repository_ids: [] },
+        grant: {
+          status: 'active',
+          account: 'acme',
+          repository_selection: 'selected',
+          install_url: 'https://github.test/install',
+          configure_url: null,
+          truncated: true,
+        },
+        effective_repositories: [],
+        unavailable_selected_repositories: [
+          { id: 'repo_hidden', full_name: 'acme/hidden' },
+        ],
+      }).grant.truncated,
+    ).toBe(true)
+  })
+
+  it('requires null effective repositories when the server reports no list', () => {
+    const result = RepositoryAccessSchema.safeParse({
+      policy: { mode: 'all' },
+      grant: {
+        status: 'unavailable',
+        account: null,
+        repository_selection: null,
+        install_url: 'https://github.test/install',
+        configure_url: null,
+        truncated: false,
+      },
+      effective_repositories: null,
+      unavailable_selected_repositories: [],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('keeps new source identity fields optional for older responses', () => {
+    expect(
+      SessionSourceListSchema.parse([
+        {
+          name: 'app',
+          status: 'ready',
+          path: '/workspace/sources/app',
+          sha: 'a'.repeat(40),
+        },
+      ]),
+    ).toHaveLength(1)
+  })
+})

--- a/web/src/api/repository-access-schemas.test.ts
+++ b/web/src/api/repository-access-schemas.test.ts
@@ -44,7 +44,7 @@ describe('repository access schemas', () => {
       SessionSourceListSchema.parse([
         {
           name: 'app',
-          status: 'ready',
+          status: 'pending',
           path: '/workspace/sources/app',
           sha: 'a'.repeat(40),
         },

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -650,6 +650,39 @@ export const DeployAppSchema = z.object({
   repository_selection: z.enum(['all', 'selected']).nullish(),
   repositories: z.array(DeployAppRepoSchema).default([]),
 })
+
+// GitHub repositories a Flue agent may use as working sources. This is
+// intentionally separate from DeploymentSourceSchema: a deployment source
+// provides the agent's code, while this policy bounds repositories the running
+// agent may check out and publish to.
+export const RepositoryAccessPolicySchema = z.union([
+  z.object({ mode: z.literal('all') }),
+  z.object({
+    mode: z.literal('selected'),
+    repository_ids: z.array(z.string()),
+  }),
+])
+export const RepositoryAccessRepositorySchema = z.object({
+  id: z.string(),
+  full_name: z.string(),
+  default_branch: z.string(),
+  private: z.boolean(),
+})
+export const RepositoryAccessSchema = z.object({
+  policy: RepositoryAccessPolicySchema,
+  grant: z.object({
+    status: z.enum(['active', 'not_installed', 'unavailable']),
+    account: z.string().nullable(),
+    repository_selection: z.enum(['all', 'selected']).nullable(),
+    install_url: z.string(),
+    configure_url: z.string().nullable(),
+    truncated: z.boolean(),
+  }),
+  effective_repositories: z.array(RepositoryAccessRepositorySchema).nullable(),
+  unavailable_selected_repositories: z
+    .array(z.object({ id: z.string(), full_name: z.string() }))
+    .default([]),
+})
 export const LinkResultSchema = z.object({
   source: DeploymentSourceSchema,
   deployment_id: z.string().nullish(),
@@ -896,6 +929,21 @@ export const SessionListSchema = z.object({
   next_cursor: z.string().nullish(),
 })
 
+export const SessionSourceSchema = z.object({
+  name: z.string(),
+  status: z.string(),
+  path: z.string(),
+  sha: z.string(),
+  resolved_sha: z.string().optional(),
+  repo_id: z.string().optional(),
+  full_name: z.string().optional(),
+  requested_ref: z.string().optional(),
+  error_code: z.string().optional(),
+  error_message: z.string().optional(),
+  retryable: z.boolean().optional(),
+})
+export const SessionSourceListSchema = z.array(SessionSourceSchema)
+
 export const ActorSchema = z.object({
   id: z.string().optional(),
   display: z.string().optional(),
@@ -985,6 +1033,13 @@ export type AgentDeployment = z.infer<typeof AgentDeploymentSchema>
 export type AgentDeploymentLog = z.infer<typeof AgentDeploymentLogSchema>
 export type DeploymentSource = z.infer<typeof DeploymentSourceSchema>
 export type DeployApp = z.infer<typeof DeployAppSchema>
+export type RepositoryAccessPolicy = z.infer<
+  typeof RepositoryAccessPolicySchema
+>
+export type RepositoryAccessRepository = z.infer<
+  typeof RepositoryAccessRepositorySchema
+>
+export type RepositoryAccess = z.infer<typeof RepositoryAccessSchema>
 export type RepositorySourceInspection = z.infer<
   typeof RepositorySourceInspectionSchema
 >
@@ -1004,6 +1059,7 @@ export type ManagedSlackDisconnectResponse = z.infer<
   typeof ManagedSlackDisconnectResponseSchema
 >
 export type Session = z.infer<typeof SessionSchema>
+export type SessionSource = z.infer<typeof SessionSourceSchema>
 export type AgentSnapshot = z.infer<typeof AgentSnapshotSchema>
 export type SessionEvent = z.infer<typeof SessionEventSchema>
 export type Turn = z.infer<typeof TurnSchema>

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -931,7 +931,14 @@ export const SessionListSchema = z.object({
 
 export const SessionSourceSchema = z.object({
   name: z.string(),
-  status: z.string(),
+  status: z.enum([
+    'pending',
+    'materializing',
+    'resolved',
+    'failed',
+    'unavailable',
+    'auth_required',
+  ]),
   path: z.string(),
   sha: z.string(),
   resolved_sha: z.string().optional(),

--- a/web/src/components/repository-access-agent-switch.test.tsx
+++ b/web/src/components/repository-access-agent-switch.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { RepositoryAccess } from '@/api/client'
+import { repositoryAccessQueryKey } from '@/lib/repository-access'
+import { RepositoryAccessPanel } from './repository-access'
+
+const agentA = 'agt_aaaaaaaaaaaaaaaaaaaaaaaa'
+const agentB = 'agt_bbbbbbbbbbbbbbbbbbbbbbbb'
+
+const repository = {
+  id: 'repo_1',
+  full_name: 'acme/support-agent',
+  default_branch: 'main',
+  private: true,
+}
+
+function access(policy: RepositoryAccess['policy']): RepositoryAccess {
+  return {
+    policy,
+    grant: {
+      status: 'active',
+      account: 'acme',
+      repository_selection: 'all',
+      install_url: 'https://github.test/install',
+      configure_url: 'https://github.test/configure',
+      truncated: false,
+    },
+    effective_repositories: policy.mode === 'all' ? [repository] : [],
+    unavailable_selected_repositories: [],
+  }
+}
+
+function button(container: ParentNode, label: string): HTMLButtonElement {
+  const match = [...container.querySelectorAll('button')].find((element) =>
+    element.textContent?.includes(label),
+  )
+  if (!(match instanceof HTMLButtonElement))
+    throw new Error(`Button not found: ${label}`)
+  return match
+}
+
+function radio(container: ParentNode, label: string): HTMLInputElement {
+  const match = [
+    ...container.querySelectorAll<HTMLInputElement>('input[type="radio"]'),
+  ].find((element) => element.closest('label')?.textContent?.includes(label))
+  if (!match) throw new Error(`Radio not found: ${label}`)
+  return match
+}
+
+describe('RepositoryAccessPanel agent scoping', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let client: QueryClient
+
+  beforeEach(() => {
+    ;(
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    })
+    client.setQueryData(
+      repositoryAccessQueryKey(agentA),
+      access({ mode: 'all' }),
+    )
+    client.setQueryData(
+      repositoryAccessQueryKey(agentB),
+      access({ mode: 'selected', repository_ids: [] }),
+    )
+    client.setQueryData(['deploy-app'], {
+      installed: true,
+      install_url: 'https://github.test/install',
+      configure_url: 'https://github.test/configure',
+      account: 'acme',
+      repository_selection: 'all',
+      repositories: [repository],
+    })
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    client.clear()
+    container.remove()
+    document.body.replaceChildren()
+  })
+
+  function renderAgent(agentId: string) {
+    act(() => {
+      root.render(
+        <QueryClientProvider client={client}>
+          <RepositoryAccessPanel agentId={agentId} />
+        </QueryClientProvider>,
+      )
+    })
+  }
+
+  it('discards Agent A draft, search, and confirmation when rerendered for Agent B', () => {
+    renderAgent(agentA)
+
+    const allPolicy = radio(container, 'All granted repositories')
+    const selectedPolicyA = radio(container, 'Only selected repositories')
+    expect(allPolicy.name).toBe(selectedPolicyA.name)
+    expect(allPolicy.checked).toBe(true)
+    act(() => selectedPolicyA.click())
+    expect(selectedPolicyA.checked).toBe(true)
+    const search = container.querySelector<HTMLInputElement>(
+      'input[aria-label="Find a repository"]',
+    )
+    expect(search).not.toBeNull()
+    act(() => {
+      search!.value = 'support'
+      search!.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    expect(search!.value).toBe('support')
+
+    act(() => button(container, 'Save access').click())
+    expect(document.body.textContent).toContain('Narrow repository access?')
+
+    renderAgent(agentB)
+
+    const selectedPolicy = radio(container, 'Only selected repositories')
+    expect(selectedPolicy.checked).toBe(true)
+    expect(button(container, 'Save access').disabled).toBe(true)
+    expect(
+      container.querySelector<HTMLInputElement>(
+        'input[aria-label="Find a repository"]',
+      )?.value,
+    ).toBe('')
+    expect(document.body.textContent).not.toContain('Narrow repository access?')
+  })
+})

--- a/web/src/components/repository-access.test.tsx
+++ b/web/src/components/repository-access.test.tsx
@@ -1,0 +1,150 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type { RepositoryAccess } from '@/api/client'
+import { repositoryAccessQueryKey } from '@/lib/repository-access'
+import {
+  RepositoryAccessPanel,
+  RepositoryAccessSummary,
+} from './repository-access'
+
+const agentId = 'agt_aaaaaaaaaaaaaaaaaaaaaaaa'
+
+function renderAccess(access: RepositoryAccess, summary = false) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  })
+  client.setQueryData(repositoryAccessQueryKey(agentId), access)
+  client.setQueryData(['deploy-app'], {
+    installed: true,
+    install_url: access.grant.install_url,
+    configure_url: access.grant.configure_url,
+    account: access.grant.account,
+    repository_selection: access.grant.repository_selection,
+    repositories: access.effective_repositories ?? [],
+  })
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      {summary ? (
+        <RepositoryAccessSummary agentId={agentId} onOpenSettings={() => {}} />
+      ) : (
+        <RepositoryAccessPanel agentId={agentId} />
+      )}
+    </QueryClientProvider>,
+  )
+}
+
+const selected: RepositoryAccess = {
+  policy: { mode: 'selected', repository_ids: ['repo_1'] },
+  grant: {
+    status: 'active',
+    account: 'acme',
+    repository_selection: 'selected',
+    install_url: 'https://github.test/install',
+    configure_url: 'https://github.test/configure',
+    truncated: false,
+  },
+  effective_repositories: [
+    {
+      id: 'repo_1',
+      full_name: 'acme/a-very-long-repository-name',
+      default_branch: 'main',
+      private: true,
+    },
+  ],
+  unavailable_selected_repositories: [],
+}
+
+describe('repository access UI', () => {
+  it('renders the default all-granted policy without requiring a save', () => {
+    const html = renderAccess({ ...selected, policy: { mode: 'all' } })
+    expect(html).toContain('All granted repositories')
+    expect(html).toContain('Includes repositories added')
+    expect(html).toContain('Save access')
+    expect(html).toContain('disabled=""')
+  })
+
+  it('renders a selected policy, current repository and settings action', () => {
+    const html = renderAccess(selected)
+    expect(html).toContain('Only selected repositories')
+    expect(html).toContain('acme/a-very-long-repository-name')
+    expect(html).toContain('Configure GitHub app')
+    expect(html).toContain('Save access')
+  })
+
+  it('renders selected-empty as disabled repository work', () => {
+    const html = renderAccess({
+      ...selected,
+      policy: { mode: 'selected', repository_ids: [] },
+      effective_repositories: [],
+    })
+    expect(html).toContain('Repository work is disabled')
+    expect(html).toContain('This agent can still chat')
+  })
+
+  it('warns on a partial catalog and keeps unavailable selections visible', () => {
+    const html = renderAccess({
+      ...selected,
+      grant: { ...selected.grant, truncated: true },
+      policy: {
+        mode: 'selected',
+        repository_ids: ['repo_1', 'repo_hidden'],
+      },
+      unavailable_selected_repositories: [
+        { id: 'repo_hidden', full_name: 'acme/removed' },
+      ],
+    })
+    expect(html).toContain('partial repository list')
+    expect(html).toContain('Hidden selections are preserved')
+    expect(html).toContain('acme/removed')
+    expect(html).toContain('Unavailable')
+  })
+
+  it('distinguishes an unavailable grant from a valid empty grant', () => {
+    const html = renderAccess({
+      ...selected,
+      grant: { ...selected.grant, status: 'unavailable' },
+      effective_repositories: null,
+    })
+    expect(html).toContain('GitHub access needs attention')
+    expect(html).toContain('Reconnect GitHub')
+    expect(html).not.toContain('No repositories are available')
+  })
+
+  it('offers GitHub installation without making chat unavailable', () => {
+    const html = renderAccess({
+      ...selected,
+      grant: {
+        ...selected.grant,
+        status: 'not_installed',
+        account: null,
+        repository_selection: null,
+        configure_url: null,
+      },
+      effective_repositories: [],
+    })
+    expect(html).toContain('Connect GitHub to work in repositories')
+    expect(html).toContain('Chat still works without GitHub')
+    expect(html).toContain('>Connect GitHub<')
+  })
+
+  it('summarizes access without duplicating the full editor', () => {
+    const html = renderAccess(selected, true)
+    expect(html).toContain('1 selected repository')
+    expect(html).toContain('Manage access')
+    expect(html).not.toContain('Find a repository')
+  })
+
+  it('distinguishes an unavailable summary from a missing installation', () => {
+    const html = renderAccess(
+      {
+        ...selected,
+        grant: { ...selected.grant, status: 'unavailable' },
+        effective_repositories: null,
+      },
+      true,
+    )
+    expect(html).toContain('GitHub access is unavailable')
+    expect(html).not.toContain('GitHub is not connected')
+  })
+})

--- a/web/src/components/repository-access.test.tsx
+++ b/web/src/components/repository-access.test.tsx
@@ -95,9 +95,21 @@ describe('repository access UI', () => {
       ],
     })
     expect(html).toContain('partial repository list')
-    expect(html).toContain('Hidden selections are preserved')
+    expect(html).toContain('Hidden existing selections are preserved')
     expect(html).toContain('acme/removed')
     expect(html).toContain('Unavailable')
+  })
+
+  it('explains that switching from a truncated all grant is intentionally narrowing', () => {
+    const html = renderAccess({
+      ...selected,
+      grant: { ...selected.grant, truncated: true },
+      policy: { mode: 'all' },
+    })
+    expect(html).toContain(
+      'Switching to selected access limits the agent to repositories you choose from this partial list.',
+    )
+    expect(html).not.toContain('Hidden existing selections are preserved')
   })
 
   it('distinguishes an unavailable grant from a valid empty grant', () => {

--- a/web/src/components/repository-access.test.tsx
+++ b/web/src/components/repository-access.test.tsx
@@ -118,8 +118,10 @@ describe('repository access UI', () => {
       grant: { ...selected.grant, status: 'unavailable' },
       effective_repositories: null,
     })
-    expect(html).toContain('GitHub access needs attention')
-    expect(html).toContain('Reconnect GitHub')
+    expect(html).toContain('GitHub access is temporarily unavailable')
+    expect(html).toContain('Nothing changed')
+    expect(html).toContain('>Retry<')
+    expect(html).not.toContain('Reconnect GitHub')
     expect(html).not.toContain('No repositories are available')
   })
 

--- a/web/src/components/repository-access.tsx
+++ b/web/src/components/repository-access.tsx
@@ -103,13 +103,28 @@ function AccessUnavailable({ access }: { access: RepositoryAccess }) {
   )
 }
 
+interface RepositoryAccessPanelProps {
+  agentId: string
+  context?: 'setup' | 'settings'
+}
+
 export function RepositoryAccessPanel({
   agentId,
   context = 'settings',
-}: {
-  agentId: string
-  context?: 'setup' | 'settings'
-}) {
+}: RepositoryAccessPanelProps) {
+  return (
+    <RepositoryAccessPanelForAgent
+      key={agentId}
+      agentId={agentId}
+      context={context}
+    />
+  )
+}
+
+function RepositoryAccessPanelForAgent({
+  agentId,
+  context = 'settings',
+}: RepositoryAccessPanelProps) {
   const queryClient = useQueryClient()
   const accessQuery = useRepositoryAccess(agentId)
   const deployAppQuery = useQuery({
@@ -248,22 +263,24 @@ export function RepositoryAccessPanel({
           <AccessUnavailable access={access} />
         ) : access && draft ? (
           <div className="space-y-4">
-            <div
-              className="grid gap-2 sm:grid-cols-2"
-              role="radiogroup"
-              aria-label="Repository policy"
-            >
-              <button
-                type="button"
-                role="radio"
-                aria-checked={draft.mode === 'all'}
-                onClick={() => setDraft({ mode: 'all' })}
+            <fieldset className="grid gap-2 sm:grid-cols-2">
+              <legend className="sr-only">Repository policy</legend>
+              <label
                 className={cn(
-                  'hover:border-foreground/20 flex min-h-16 min-w-0 items-start gap-3 rounded-lg border p-3 text-left transition-colors',
+                  'hover:border-foreground/20 focus-within:ring-foreground/20 flex min-h-16 min-w-0 cursor-pointer items-start gap-3 rounded-lg border p-3 text-left transition-colors focus-within:ring-2 focus-within:ring-offset-2',
                   draft.mode === 'all' && 'border-foreground/30 bg-muted/50',
                 )}
               >
+                <input
+                  type="radio"
+                  name={`repository-policy-${agentId}`}
+                  value="all"
+                  checked={draft.mode === 'all'}
+                  onChange={() => setDraft({ mode: 'all' })}
+                  className="sr-only"
+                />
                 <span
+                  aria-hidden
                   className={cn(
                     'mt-0.5 grid size-4 place-items-center rounded-full border',
                     draft.mode === 'all' &&
@@ -280,29 +297,34 @@ export function RepositoryAccessPanel({
                     Includes repositories added to the installation later.
                   </span>
                 </span>
-              </button>
-              <button
-                type="button"
-                role="radio"
-                aria-checked={draft.mode === 'selected'}
-                onClick={() =>
-                  setDraft({
-                    mode: 'selected',
-                    repository_ids:
-                      access.policy.mode === 'selected'
-                        ? selectedRepositoryIds(access.policy)
-                        : (access.effective_repositories ?? []).map(
-                            (repo) => repo.id,
-                          ),
-                  })
-                }
+              </label>
+              <label
                 className={cn(
-                  'hover:border-foreground/20 flex min-h-16 min-w-0 items-start gap-3 rounded-lg border p-3 text-left transition-colors',
+                  'hover:border-foreground/20 focus-within:ring-foreground/20 flex min-h-16 min-w-0 cursor-pointer items-start gap-3 rounded-lg border p-3 text-left transition-colors focus-within:ring-2 focus-within:ring-offset-2',
                   draft.mode === 'selected' &&
                     'border-foreground/30 bg-muted/50',
                 )}
               >
+                <input
+                  type="radio"
+                  name={`repository-policy-${agentId}`}
+                  value="selected"
+                  checked={draft.mode === 'selected'}
+                  onChange={() =>
+                    setDraft({
+                      mode: 'selected',
+                      repository_ids:
+                        access.policy.mode === 'selected'
+                          ? selectedRepositoryIds(access.policy)
+                          : (access.effective_repositories ?? []).map(
+                              (repo) => repo.id,
+                            ),
+                    })
+                  }
+                  className="sr-only"
+                />
                 <span
+                  aria-hidden
                   className={cn(
                     'mt-0.5 grid size-4 place-items-center rounded-full border',
                     draft.mode === 'selected' &&
@@ -321,8 +343,8 @@ export function RepositoryAccessPanel({
                     An empty selection disables repository work.
                   </span>
                 </span>
-              </button>
-            </div>
+              </label>
+            </fieldset>
 
             {access.grant.truncated ? (
               <div className="border-border bg-muted/40 rounded-md border px-3 py-2 text-xs">
@@ -330,8 +352,10 @@ export function RepositoryAccessPanel({
                   GitHub returned a partial repository list
                 </p>
                 <p className="text-muted-foreground mt-0.5">
-                  Hidden selections are preserved when you save. Configure the
-                  GitHub app to see the full grant.
+                  {access.policy.mode === 'selected'
+                    ? 'Hidden existing selections are preserved when you save.'
+                    : 'Switching to selected access limits the agent to repositories you choose from this partial list.'}{' '}
+                  Configure the GitHub app to see the full grant.
                 </p>
               </div>
             ) : null}

--- a/web/src/components/repository-access.tsx
+++ b/web/src/components/repository-access.tsx
@@ -1,0 +1,585 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  ArrowUpRight,
+  Check,
+  ChevronRight,
+  GitPullRequest,
+  LoaderCircle,
+  Search,
+  ShieldCheck,
+} from 'lucide-react'
+import {
+  getDeployApp,
+  updateRepositoryAccess,
+  type RepositoryAccess,
+  type RepositoryAccessPolicy,
+} from '@/api/client'
+import { GithubMark } from '@/components/github-mark'
+import {
+  Panel,
+  PanelContent,
+  PanelDescription,
+  PanelFooter,
+  PanelHeader,
+  PanelTitle,
+} from '@/components/panel'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/skeleton'
+import { notifyError, notifySuccess } from '@/lib/errors'
+import { useRepositoryAccess } from '@/hooks/use-repository-access'
+import {
+  isNarrowingRepositoryAccess,
+  repositoryAccessCandidates,
+  repositoryAccessQueryKey,
+  sameRepositoryAccessPolicy,
+  selectedRepositoryIds,
+  toggleSelectedRepository,
+} from '@/lib/repository-access'
+import { cn } from '@/lib/utils'
+
+function ExternalAction({
+  href,
+  children,
+}: {
+  href: string
+  children: string
+}) {
+  return (
+    <Button asChild size="sm" variant="outline">
+      <a href={href} target="_blank" rel="noreferrer">
+        {children}
+        <ArrowUpRight />
+      </a>
+    </Button>
+  )
+}
+
+function AccessUnavailable({ access }: { access: RepositoryAccess }) {
+  if (access.grant.status === 'not_installed') {
+    return (
+      <div className="flex flex-col items-start gap-3 py-1">
+        <div>
+          <p className="text-sm font-medium">
+            Connect GitHub to work in repositories
+          </p>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Chat still works without GitHub. Connect the OpenComputer app when
+            this agent needs to read code or open pull requests.
+          </p>
+        </div>
+        <ExternalAction href={access.grant.install_url}>
+          Connect GitHub
+        </ExternalAction>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-3 py-1">
+      <div>
+        <p className="text-sm font-medium">GitHub access needs attention</p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          The installation is unavailable. Reconnect it before this agent works
+          in a repository.
+        </p>
+      </div>
+      <ExternalAction href={access.grant.install_url}>
+        Reconnect GitHub
+      </ExternalAction>
+    </div>
+  )
+}
+
+export function RepositoryAccessPanel({
+  agentId,
+  context = 'settings',
+}: {
+  agentId: string
+  context?: 'setup' | 'settings'
+}) {
+  const queryClient = useQueryClient()
+  const accessQuery = useRepositoryAccess(agentId)
+  const deployAppQuery = useQuery({
+    queryKey: ['deploy-app'],
+    queryFn: getDeployApp,
+    enabled:
+      accessQuery.data?.grant.status === 'active' &&
+      accessQuery.data.policy.mode === 'selected',
+    staleTime: 30_000,
+    refetchOnWindowFocus: 'always',
+  })
+  const [draft, setDraft] = useState<RepositoryAccessPolicy | null>(
+    () => accessQuery.data?.policy ?? null,
+  )
+  const baselinePolicy = useRef<RepositoryAccessPolicy | null>(null)
+  const [search, setSearch] = useState('')
+  const [confirming, setConfirming] = useState(false)
+
+  const access = accessQuery.data
+  useEffect(() => {
+    if (!access) return
+    setDraft((current) => {
+      const clean =
+        current === null ||
+        baselinePolicy.current === null ||
+        sameRepositoryAccessPolicy(current, baselinePolicy.current)
+      baselinePolicy.current = access.policy
+      return clean ? access.policy : current
+    })
+  }, [access])
+
+  const candidates = useMemo(
+    () =>
+      access ? repositoryAccessCandidates(access, deployAppQuery.data) : [],
+    [access, deployAppQuery.data],
+  )
+  const visibleCandidates = useMemo(() => {
+    const term = search.trim().toLocaleLowerCase()
+    return term
+      ? candidates.filter((repo) =>
+          repo.full_name.toLocaleLowerCase().includes(term),
+        )
+      : candidates
+  }, [candidates, search])
+
+  const saveMutation = useMutation({
+    mutationFn: (policy: RepositoryAccessPolicy) =>
+      updateRepositoryAccess(agentId, policy),
+    onMutate: async (policy) => {
+      const key = repositoryAccessQueryKey(agentId)
+      await queryClient.cancelQueries({ queryKey: key })
+      const previous = queryClient.getQueryData<RepositoryAccess>(key)
+      if (previous) queryClient.setQueryData(key, { ...previous, policy })
+      return { previous }
+    },
+    onError: (error, _policy, contextValue) => {
+      if (contextValue?.previous) {
+        queryClient.setQueryData(
+          repositoryAccessQueryKey(agentId),
+          contextValue.previous,
+        )
+        setDraft(contextValue.previous.policy)
+        baselinePolicy.current = contextValue.previous.policy
+      }
+      notifyError("Couldn't save repository access.", error)
+    },
+    onSuccess: (next) => {
+      queryClient.setQueryData(repositoryAccessQueryKey(agentId), next)
+      setDraft(next.policy)
+      baselinePolicy.current = next.policy
+      notifySuccess('Repository access saved.')
+    },
+    onSettled: () =>
+      queryClient.invalidateQueries({
+        queryKey: repositoryAccessQueryKey(agentId),
+      }),
+  })
+
+  const save = () => {
+    if (!access || !draft) return
+    if (isNarrowingRepositoryAccess(access.policy, draft)) {
+      setConfirming(true)
+      return
+    }
+    saveMutation.mutate(draft)
+  }
+
+  const title =
+    context === 'setup' ? 'Choose working repositories' : 'Repository access'
+  const description =
+    context === 'setup'
+      ? 'Optional. Let this agent check out code and open pull requests.'
+      : 'Choose where this agent can check out code and open pull requests.'
+
+  return (
+    <Panel className="min-w-0 overflow-hidden">
+      <PanelHeader className="flex-wrap">
+        <div className="min-w-0">
+          <PanelTitle className="flex items-center gap-2">
+            <GithubMark className="size-4" />
+            {title}
+          </PanelTitle>
+          <PanelDescription className="mt-1">{description}</PanelDescription>
+        </div>
+        {access?.grant.status === 'active' && access.grant.account ? (
+          <span className="text-muted-foreground max-w-40 truncate text-xs">
+            {access.grant.account}
+          </span>
+        ) : null}
+      </PanelHeader>
+      <PanelContent>
+        {accessQuery.isLoading ? (
+          <div className="space-y-3" aria-label="Loading repository access">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-24 w-full" />
+          </div>
+        ) : accessQuery.isError ? (
+          <div className="flex flex-col items-start gap-3 py-1">
+            <div>
+              <p className="text-sm font-medium">
+                Couldn’t load repository access
+              </p>
+              <p className="text-muted-foreground mt-1 text-sm">
+                Nothing changed. Try loading it again.
+              </p>
+            </div>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => void accessQuery.refetch()}
+            >
+              Retry
+            </Button>
+          </div>
+        ) : access && access.grant.status !== 'active' ? (
+          <AccessUnavailable access={access} />
+        ) : access && draft ? (
+          <div className="space-y-4">
+            <div
+              className="grid gap-2 sm:grid-cols-2"
+              role="radiogroup"
+              aria-label="Repository policy"
+            >
+              <button
+                type="button"
+                role="radio"
+                aria-checked={draft.mode === 'all'}
+                onClick={() => setDraft({ mode: 'all' })}
+                className={cn(
+                  'hover:border-foreground/20 flex min-h-16 min-w-0 items-start gap-3 rounded-lg border p-3 text-left transition-colors',
+                  draft.mode === 'all' && 'border-foreground/30 bg-muted/50',
+                )}
+              >
+                <span
+                  className={cn(
+                    'mt-0.5 grid size-4 place-items-center rounded-full border',
+                    draft.mode === 'all' &&
+                      'border-foreground bg-foreground text-background',
+                  )}
+                >
+                  {draft.mode === 'all' ? <Check className="size-3" /> : null}
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-sm font-medium">
+                    All granted repositories
+                  </span>
+                  <span className="text-muted-foreground mt-0.5 block text-xs">
+                    Includes repositories added to the installation later.
+                  </span>
+                </span>
+              </button>
+              <button
+                type="button"
+                role="radio"
+                aria-checked={draft.mode === 'selected'}
+                onClick={() =>
+                  setDraft({
+                    mode: 'selected',
+                    repository_ids:
+                      access.policy.mode === 'selected'
+                        ? selectedRepositoryIds(access.policy)
+                        : (access.effective_repositories ?? []).map(
+                            (repo) => repo.id,
+                          ),
+                  })
+                }
+                className={cn(
+                  'hover:border-foreground/20 flex min-h-16 min-w-0 items-start gap-3 rounded-lg border p-3 text-left transition-colors',
+                  draft.mode === 'selected' &&
+                    'border-foreground/30 bg-muted/50',
+                )}
+              >
+                <span
+                  className={cn(
+                    'mt-0.5 grid size-4 place-items-center rounded-full border',
+                    draft.mode === 'selected' &&
+                      'border-foreground bg-foreground text-background',
+                  )}
+                >
+                  {draft.mode === 'selected' ? (
+                    <Check className="size-3" />
+                  ) : null}
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-sm font-medium">
+                    Only selected repositories
+                  </span>
+                  <span className="text-muted-foreground mt-0.5 block text-xs">
+                    An empty selection disables repository work.
+                  </span>
+                </span>
+              </button>
+            </div>
+
+            {access.grant.truncated ? (
+              <div className="border-border bg-muted/40 rounded-md border px-3 py-2 text-xs">
+                <p className="font-medium">
+                  GitHub returned a partial repository list
+                </p>
+                <p className="text-muted-foreground mt-0.5">
+                  Hidden selections are preserved when you save. Configure the
+                  GitHub app to see the full grant.
+                </p>
+              </div>
+            ) : null}
+
+            {draft.mode === 'selected' ? (
+              <div className="space-y-2">
+                <div className="relative">
+                  <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+                  <Input
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                    placeholder="Find a repository"
+                    aria-label="Find a repository"
+                    className="h-8 pl-8"
+                  />
+                </div>
+                {deployAppQuery.isLoading ? (
+                  <div
+                    className="space-y-2"
+                    aria-label="Loading repository catalog"
+                  >
+                    <Skeleton className="h-10 w-full" />
+                    <Skeleton className="h-10 w-full" />
+                  </div>
+                ) : null}
+                {deployAppQuery.isError ? (
+                  <div className="flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-xs">
+                    <span className="text-muted-foreground">
+                      Couldn’t load the full repository list.
+                    </span>
+                    <Button
+                      size="xs"
+                      variant="ghost"
+                      onClick={() => void deployAppQuery.refetch()}
+                    >
+                      Retry
+                    </Button>
+                  </div>
+                ) : null}
+                {!deployAppQuery.isLoading ? (
+                  <div className="max-h-64 overflow-y-auto rounded-lg border">
+                    {visibleCandidates.length ? (
+                      visibleCandidates.map((repo) => {
+                        const checked = draft.repository_ids.includes(repo.id)
+                        const unavailable =
+                          access.unavailable_selected_repositories.some(
+                            (item) => item.id === repo.id,
+                          )
+                        return (
+                          <label
+                            key={repo.id}
+                            className="hover:bg-muted/40 flex min-w-0 cursor-pointer items-center gap-3 overflow-hidden border-b px-3 py-2.5 last:border-b-0"
+                          >
+                            <Checkbox
+                              checked={checked}
+                              onCheckedChange={(next) =>
+                                setDraft(
+                                  toggleSelectedRepository(
+                                    draft,
+                                    repo.id,
+                                    next === true,
+                                  ),
+                                )
+                              }
+                            />
+                            <GithubMark className="text-muted-foreground size-3.5 shrink-0" />
+                            <span
+                              className="min-w-0 flex-1 truncate text-sm"
+                              title={repo.full_name}
+                            >
+                              {repo.full_name}
+                            </span>
+                            {unavailable ? (
+                              <span className="text-muted-foreground shrink-0 text-xs">
+                                Unavailable
+                              </span>
+                            ) : repo.private ? (
+                              <span className="text-muted-foreground shrink-0 text-xs">
+                                Private
+                              </span>
+                            ) : null}
+                          </label>
+                        )
+                      })
+                    ) : (
+                      <p className="text-muted-foreground px-3 py-5 text-center text-sm">
+                        {candidates.length
+                          ? 'No repositories match.'
+                          : deployAppQuery.isError
+                            ? 'Current selections are unavailable until the repository list reloads.'
+                            : 'No repositories are available.'}
+                      </p>
+                    )}
+                  </div>
+                ) : null}
+                {draft.repository_ids.length === 0 ? (
+                  <p className="text-muted-foreground text-xs">
+                    Repository work is disabled. This agent can still chat.
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </PanelContent>
+      {access?.grant.status === 'active' && draft ? (
+        <PanelFooter className="flex-wrap justify-between">
+          <div className="min-w-0">
+            {access.grant.configure_url ? (
+              <a
+                href={access.grant.configure_url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs underline underline-offset-4"
+              >
+                Configure GitHub app <ArrowUpRight className="size-3" />
+              </a>
+            ) : null}
+          </div>
+          <Button
+            size="sm"
+            className="ml-auto"
+            onClick={save}
+            disabled={
+              saveMutation.isPending ||
+              sameRepositoryAccessPolicy(access.policy, draft)
+            }
+          >
+            {saveMutation.isPending ? (
+              <LoaderCircle className="animate-spin" />
+            ) : null}
+            Save access
+          </Button>
+        </PanelFooter>
+      ) : null}
+
+      <AlertDialog open={confirming} onOpenChange={setConfirming}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Narrow repository access?</AlertDialogTitle>
+            <AlertDialogDescription>
+              New checkouts and publishes to removed repositories will be
+              blocked. Files already copied into an active session remain in its
+              sandbox until that session is archived.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep current access</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setConfirming(false)
+                if (draft) saveMutation.mutate(draft)
+              }}
+            >
+              Save narrower access
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Panel>
+  )
+}
+
+export function RepositoryAccessSummary({
+  agentId,
+  onOpenSettings,
+}: {
+  agentId: string
+  onOpenSettings: () => void
+}) {
+  const accessQuery = useRepositoryAccess(agentId)
+  const access = accessQuery.data
+  const effective = access?.effective_repositories ?? []
+  const selected =
+    access?.policy.mode === 'selected'
+      ? access.policy.repository_ids.length
+      : null
+
+  return (
+    <Panel>
+      <PanelHeader className="border-b-0 pb-2">
+        <PanelTitle className="flex items-center gap-2">
+          <GithubMark className="size-4" /> Repository access
+        </PanelTitle>
+      </PanelHeader>
+      <PanelContent className="pt-1">
+        {accessQuery.isLoading ? (
+          <Skeleton className="h-10 w-full" />
+        ) : accessQuery.isError ? (
+          <button
+            className="text-muted-foreground hover:text-foreground text-sm underline"
+            onClick={() => void accessQuery.refetch()}
+          >
+            Couldn’t load access — retry
+          </button>
+        ) : access?.grant.status !== 'active' ? (
+          <p className="text-sm">
+            {access?.grant.status === 'unavailable'
+              ? 'GitHub access is unavailable.'
+              : 'GitHub is not connected.'}
+          </p>
+        ) : (
+          <div className="flex items-start gap-2.5">
+            <ShieldCheck className="text-status-running mt-0.5 size-4 shrink-0" />
+            <div className="min-w-0">
+              <p className="text-sm font-medium">
+                {access.policy.mode === 'all'
+                  ? 'All granted repositories'
+                  : selected === 0
+                    ? 'Repository work disabled'
+                    : `${selected} selected ${selected === 1 ? 'repository' : 'repositories'}`}
+              </p>
+              {effective[0] ? (
+                <p className="text-muted-foreground mt-0.5 truncate text-xs">
+                  {effective[0].full_name}
+                  {effective.length > 1 ? ` +${effective.length - 1}` : ''}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={onOpenSettings}
+          className="text-muted-foreground hover:text-foreground mt-3 inline-flex items-center gap-1 text-xs font-medium"
+        >
+          Manage access <ChevronRight className="size-3" />
+        </button>
+      </PanelContent>
+    </Panel>
+  )
+}
+
+export function RepositoryTaskSuggestion({ agentId }: { agentId: string }) {
+  const { data } = useRepositoryAccess(agentId)
+  const repo = data?.effective_repositories?.[0]
+  if (!repo) return null
+  return (
+    <div className="border-border bg-muted/30 flex items-start gap-3 rounded-lg border px-3 py-2.5">
+      <GitPullRequest className="text-muted-foreground mt-0.5 size-4 shrink-0" />
+      <div>
+        <p className="text-xs font-medium">Try a repository task</p>
+        <p className="text-muted-foreground mt-0.5 text-xs">
+          In{' '}
+          <span className="text-foreground font-mono">{repo.full_name},</span>{' '}
+          add a setup note and open a pull request.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/repository-access.tsx
+++ b/web/src/components/repository-access.tsx
@@ -67,7 +67,13 @@ function ExternalAction({
   )
 }
 
-function AccessUnavailable({ access }: { access: RepositoryAccess }) {
+function AccessUnavailable({
+  access,
+  onRetry,
+}: {
+  access: RepositoryAccess
+  onRetry: () => void
+}) {
   if (access.grant.status === 'not_installed') {
     return (
       <div className="flex flex-col items-start gap-3 py-1">
@@ -90,15 +96,16 @@ function AccessUnavailable({ access }: { access: RepositoryAccess }) {
   return (
     <div className="flex flex-col items-start gap-3 py-1">
       <div>
-        <p className="text-sm font-medium">GitHub access needs attention</p>
+        <p className="text-sm font-medium">
+          GitHub access is temporarily unavailable
+        </p>
         <p className="text-muted-foreground mt-1 text-sm">
-          The installation is unavailable. Reconnect it before this agent works
-          in a repository.
+          Nothing changed. Try loading the installation again.
         </p>
       </div>
-      <ExternalAction href={access.grant.install_url}>
-        Reconnect GitHub
-      </ExternalAction>
+      <Button size="sm" variant="outline" onClick={onRetry}>
+        Retry
+      </Button>
     </div>
   )
 }
@@ -260,7 +267,10 @@ function RepositoryAccessPanelForAgent({
             </Button>
           </div>
         ) : access && access.grant.status !== 'active' ? (
-          <AccessUnavailable access={access} />
+          <AccessUnavailable
+            access={access}
+            onRetry={() => void accessQuery.refetch()}
+          />
         ) : access && draft ? (
           <div className="space-y-4">
             <fieldset className="grid gap-2 sm:grid-cols-2">

--- a/web/src/components/status-badge.tsx
+++ b/web/src/components/status-badge.tsx
@@ -28,6 +28,7 @@ const STATUS: Record<string, Meta> = {
   ready: { tone: 'running', label: 'Ready', icon: CircleCheck },
   active: { tone: 'running', label: 'Active', icon: CircleCheck },
   success: { tone: 'running', label: 'Success', icon: CircleCheck },
+  resolved: { tone: 'running', label: 'Resolved', icon: CircleCheck },
   stopped: { tone: 'stopped', label: 'Stopped', icon: CircleSlash },
   not_deployed: {
     tone: 'stopped',
@@ -45,6 +46,12 @@ const STATUS: Record<string, Meta> = {
   queued: { tone: 'pending', label: 'Queued', icon: Clock },
   accepted: { tone: 'pending', label: 'Queued', icon: Clock },
   fetching: { tone: 'pending', label: 'Fetching', icon: Loader2, spin: true },
+  materializing: {
+    tone: 'pending',
+    label: 'Materializing',
+    icon: Loader2,
+    spin: true,
+  },
   validating: {
     tone: 'pending',
     label: 'Validating',
@@ -93,6 +100,8 @@ const STATUS: Record<string, Meta> = {
   deleting: { tone: 'pending', label: 'Deleting', icon: Loader2, spin: true },
   error: { tone: 'error', label: 'Error', icon: CircleAlert },
   failed: { tone: 'error', label: 'Failed', icon: CircleAlert },
+  unavailable: { tone: 'error', label: 'Unavailable', icon: CircleAlert },
+  auth_required: { tone: 'error', label: 'Auth required', icon: CircleAlert },
   unverified: { tone: 'error', label: 'Unverified', icon: CircleAlert },
   verified: { tone: 'running', label: 'Verified', icon: CircleCheck },
   superseded: { tone: 'stopped', label: 'Superseded', icon: CircleSlash },

--- a/web/src/components/working-repo-field-state.test.tsx
+++ b/web/src/components/working-repo-field-state.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RepositoryAccess } from '@/api/client'
+import { repositoryAccessQueryKey } from '@/lib/repository-access'
+import { WorkingRepoField, type WorkingRepo } from './working-repo-field'
+
+const agentA = 'agt_aaaaaaaaaaaaaaaaaaaaaaaa'
+const agentB = 'agt_bbbbbbbbbbbbbbbbbbbbbbbb'
+const value: WorkingRepo = {
+  repo: 'repo_1',
+  fullName: 'acme/app',
+  ref: 'main',
+}
+
+function access(
+  repositories: RepositoryAccess['effective_repositories'],
+  truncated = false,
+): RepositoryAccess {
+  return {
+    policy: { mode: 'all' },
+    grant: {
+      status: repositories === null ? 'unavailable' : 'active',
+      account: 'acme',
+      repository_selection: 'all',
+      install_url: 'https://github.test/install',
+      configure_url: 'https://github.test/configure',
+      truncated,
+    },
+    effective_repositories: repositories,
+    unavailable_selected_repositories: [],
+  }
+}
+
+const repository = {
+  id: 'repo_1',
+  full_name: 'acme/app',
+  default_branch: 'main',
+  private: true,
+}
+
+describe('WorkingRepoField selection validity', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let client: QueryClient
+
+  beforeEach(() => {
+    ;(
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    })
+    client.setQueryData(repositoryAccessQueryKey(agentA), access([repository]))
+    client.setQueryData(repositoryAccessQueryKey(agentB), access([repository]))
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    client.clear()
+    container.remove()
+  })
+
+  function renderField(
+    agentId: string,
+    onChange: (next: WorkingRepo | null) => void,
+  ) {
+    act(() => {
+      root.render(
+        <QueryClientProvider client={client}>
+          <WorkingRepoField
+            agentId={agentId}
+            runtime="flue"
+            value={value}
+            onChange={onChange}
+          />
+        </QueryClientProvider>,
+      )
+    })
+  }
+
+  it('clears a selection immediately when the agent scope changes', () => {
+    const onChange = vi.fn()
+    renderField(agentA, onChange)
+    expect(onChange).not.toHaveBeenCalled()
+
+    renderField(agentB, onChange)
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it('clears a selection removed from the loaded effective policy', () => {
+    const onChange = vi.fn()
+    renderField(agentA, onChange)
+
+    act(() => {
+      client.setQueryData(repositoryAccessQueryKey(agentA), access([]))
+    })
+    renderField(agentA, onChange)
+
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it('keeps the selection when an unavailable grant makes the set unknown', () => {
+    const onChange = vi.fn()
+    renderField(agentA, onChange)
+
+    act(() => {
+      client.setQueryData(repositoryAccessQueryKey(agentA), access(null))
+    })
+    renderField(agentA, onChange)
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('keeps the selection when a truncated grant makes absence ambiguous', () => {
+    const onChange = vi.fn()
+    renderField(agentA, onChange)
+
+    act(() => {
+      client.setQueryData(repositoryAccessQueryKey(agentA), access([], true))
+    })
+    renderField(agentA, onChange)
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/working-repo-field.test.ts
+++ b/web/src/components/working-repo-field.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { selectedWorkingRepo } from '@/lib/working-repo'
+
+describe('working repository selection', () => {
+  const repo = {
+    id: 'repo_123',
+    full_name: 'acme/renamed-app',
+    default_branch: 'trunk',
+  }
+
+  it('submits stable repository identity for Flue and keeps the slug for display', () => {
+    expect(selectedWorkingRepo(repo, true, null)).toEqual({
+      repo: 'repo_123',
+      fullName: 'acme/renamed-app',
+      ref: 'trunk',
+    })
+  })
+
+  it('preserves legacy slug behavior for non-Flue agents', () => {
+    expect(selectedWorkingRepo(repo, false, null)).toEqual({
+      repo: 'acme/renamed-app',
+      ref: 'trunk',
+    })
+  })
+
+  it('keeps an explicitly edited branch when the same repository is reselected', () => {
+    expect(
+      selectedWorkingRepo(repo, true, {
+        repo: 'repo_123',
+        fullName: 'acme/renamed-app',
+        ref: 'feature/test',
+      }),
+    ).toMatchObject({ ref: 'feature/test' })
+  })
+})

--- a/web/src/components/working-repo-field.tsx
+++ b/web/src/components/working-repo-field.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Select as SelectPrimitive } from 'radix-ui'
 import { Check, ChevronDown, GitBranch, X } from 'lucide-react'
@@ -53,6 +53,7 @@ export function WorkingRepoField({
     data: app,
     isLoading: appLoading,
     isError: appError,
+    isSuccess: appSuccess,
     refetch: refetchApp,
   } = useQuery({
     queryKey: ['deploy-app'],
@@ -64,6 +65,7 @@ export function WorkingRepoField({
     data: access,
     isLoading: accessLoading,
     isError: accessError,
+    isSuccess: accessSuccess,
     refetch: refetchAccess,
   } = useQuery({
     queryKey: repositoryAccessQueryKey(agentId ?? ''),
@@ -93,6 +95,27 @@ export function WorkingRepoField({
     access?.policy.mode === 'selected' &&
     access.policy.repository_ids.length === 0
   const disabled = !installed || repoOptions.length === 0
+  const scope = `${runtime ?? ''}:${agentId ?? ''}`
+  const previousScope = useRef(scope)
+
+  useEffect(() => {
+    if (previousScope.current === scope) return
+    previousScope.current = scope
+    if (value) onChange(null)
+  }, [onChange, scope, value])
+
+  const optionsAreAuthoritative = useFluePolicy
+    ? accessSuccess &&
+      access?.effective_repositories !== null &&
+      !access?.grant.truncated
+    : appSuccess
+  useEffect(() => {
+    if (!value || !optionsAreAuthoritative) return
+    const stillAvailable = repoOptions.some(
+      (repo) => workingRepoValue(repo, useFluePolicy) === value.repo,
+    )
+    if (!stillAvailable) onChange(null)
+  }, [onChange, optionsAreAuthoritative, repoOptions, useFluePolicy, value])
 
   const pickRepo = (repoValue: string) => {
     const r = repoOptions.find((x) =>

--- a/web/src/components/working-repo-field.tsx
+++ b/web/src/components/working-repo-field.tsx
@@ -2,18 +2,25 @@ import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Select as SelectPrimitive } from 'radix-ui'
 import { Check, ChevronDown, GitBranch, X } from 'lucide-react'
-import { getDeployApp } from '@/api/client'
+import { getDeployApp, getRepositoryAccess } from '@/api/client'
 import { GithubMark } from '@/components/github-mark'
 import { markFloatingLayerPointerDismiss } from '@/components/ui/floating-layer'
 import { cn } from '@/lib/utils'
+import { repositoryAccessQueryKey } from '@/lib/repository-access'
+import {
+  selectedWorkingRepo,
+  workingRepoValue,
+  type WorkingRepoValue,
+} from '@/lib/working-repo'
 
 // The WORKING repo a session checks out and opens PRs from (design 010 §2). Deliberately SEPARATE
 // from the agent's config/"connected" repo (prompt + skills) — an agent is typically configured
 // from one repo and works across others, so this never defaults to the connected repo. Optional:
-// a session starts fine with none; when set, the agent can publish (and later watch) PRs.
+// a session starts fine with none; when set, the agent can publish PRs.
 
-export interface WorkingRepo {
-  repo: string // "owner/repo"
+export interface WorkingRepo extends WorkingRepoValue {
+  repo: string // stable repo_ id for Flue; "owner/repo" for legacy runtimes
+  fullName?: string // display coordinate when repo is a stable id
   ref: string // branch
 }
 
@@ -26,35 +33,74 @@ function splitRepo(full: string): [owner: string, name: string] {
  * Inline, secondary working-repo control for the session composer. A compact, GitHub-marked
  * dropdown — unselected by default (short "Working repo" placeholder); starting a session works
  * empty. Selecting a repo reveals a branch pill (prefilled with the repo's default branch) and a
- * clear (✕). Repos come from what the OpenComputer App can reach (getDeployApp). Custom-styled
- * on the Radix primitive (no new dependency) so it reads as a deliberate control, not stock.
+ * clear (✕). Flue reads the agent's effective repository policy; legacy runtimes retain the
+ * installation-wide getDeployApp list. Custom-styled on the Radix primitive (no new dependency)
+ * so it reads as a deliberate control, not stock.
  */
 export function WorkingRepoField({
+  agentId,
+  runtime,
   value,
   onChange,
 }: {
+  agentId?: string
+  runtime?: string | null
   value: WorkingRepo | null
   onChange: (v: WorkingRepo | null) => void
 }) {
+  const useFluePolicy = runtime === 'flue' && Boolean(agentId)
   const {
     data: app,
-    isLoading,
-    isError,
-    refetch,
+    isLoading: appLoading,
+    isError: appError,
+    refetch: refetchApp,
   } = useQuery({
     queryKey: ['deploy-app'],
     queryFn: getDeployApp,
+    enabled: !useFluePolicy,
     staleTime: 30_000,
   })
-  const repoOptions = useMemo(() => app?.repositories ?? [], [app])
-  const installed = app?.installed !== false // treat "still loading" as installed
+  const {
+    data: access,
+    isLoading: accessLoading,
+    isError: accessError,
+    refetch: refetchAccess,
+  } = useQuery({
+    queryKey: repositoryAccessQueryKey(agentId ?? ''),
+    queryFn: () => getRepositoryAccess(agentId!),
+    enabled: useFluePolicy,
+    staleTime: 15_000,
+    refetchOnWindowFocus: 'always',
+  })
+  const repoOptions = useMemo(
+    () =>
+      useFluePolicy
+        ? (access?.effective_repositories ?? [])
+        : (app?.repositories ?? []),
+    [access, app, useFluePolicy],
+  )
+  const isLoading = useFluePolicy ? accessLoading : appLoading
+  const isError = useFluePolicy ? accessError : appError
+  const refetch = useFluePolicy ? refetchAccess : refetchApp
+  const installed = useFluePolicy
+    ? access?.grant.status === 'active'
+    : app?.installed !== false // treat "still loading" as installed
+  const installUrl = useFluePolicy
+    ? access?.grant.install_url
+    : app?.install_url
+  const policyDisabled =
+    useFluePolicy &&
+    access?.policy.mode === 'selected' &&
+    access.policy.repository_ids.length === 0
   const disabled = !installed || repoOptions.length === 0
 
-  const pickRepo = (fullName: string) => {
-    const r = repoOptions.find((x) => x.full_name === fullName)
+  const pickRepo = (repoValue: string) => {
+    const r = repoOptions.find((x) =>
+      useFluePolicy ? x.id === repoValue : x.full_name === repoValue,
+    )
+    if (!r) return
     // Keep the current branch when re-picking the same repo; else the repo's default.
-    const ref = value?.repo === fullName ? value.ref : r?.default_branch || 'main'
-    onChange({ repo: fullName, ref })
+    onChange(selectedWorkingRepo(r, useFluePolicy, value))
   }
 
   // Load failed → an explicit retry, not a silent "No repos available" dead-end.
@@ -73,31 +119,41 @@ export function WorkingRepoField({
   }
 
   // Not installed → a quiet connect affordance instead of a dead control.
-  if (installed === false && app?.install_url) {
+  if (installed === false && installUrl) {
+    const unavailable = useFluePolicy && access?.grant.status === 'unavailable'
     return (
       <a
-        href={app.install_url}
+        href={installUrl}
         target="_blank"
         rel="noreferrer"
         className="border-border text-muted-foreground hover:text-foreground hover:border-foreground/25 inline-flex h-8 items-center gap-2 rounded-md border border-dashed px-2.5 text-sm transition-colors"
-        title="Connect the OpenComputer GitHub App to work in a repo"
+        title={
+          unavailable
+            ? 'The GitHub installation is unavailable — reconnect it to work in a repo'
+            : 'Connect the OpenComputer GitHub App to work in a repo'
+        }
       >
         <GithubMark className="size-3.5" />
-        Connect GitHub
+        {unavailable ? 'GitHub unavailable' : 'Connect GitHub'}
       </a>
     )
   }
 
-  const [owner, name] = value ? splitRepo(value.repo) : ['', '']
+  const displayRepo = value?.fullName ?? value?.repo ?? ''
+  const [owner, name] = value ? splitRepo(displayRepo) : ['', '']
 
   return (
     <div className="flex flex-wrap items-center gap-1.5">
-      <SelectPrimitive.Root value={value?.repo ?? ''} onValueChange={pickRepo} disabled={disabled}>
+      <SelectPrimitive.Root
+        value={value?.repo ?? ''}
+        onValueChange={pickRepo}
+        disabled={disabled}
+      >
         <SelectPrimitive.Trigger
           aria-label="Working repo"
           title="Optional — the repo the agent works in and opens PRs from"
           className={cn(
-            'border-border bg-panel-2 hover:border-foreground/25 focus-visible:border-foreground/40 data-[state=open]:border-foreground/35 group inline-flex h-8 max-w-64 min-w-40 items-center gap-2 rounded-md border px-2.5 text-sm outline-none transition-colors disabled:cursor-not-allowed disabled:opacity-60',
+            'border-border bg-panel-2 hover:border-foreground/25 focus-visible:border-foreground/40 data-[state=open]:border-foreground/35 group inline-flex h-8 max-w-64 min-w-40 items-center gap-2 rounded-md border px-2.5 text-sm transition-colors outline-none disabled:cursor-not-allowed disabled:opacity-60',
           )}
         >
           <GithubMark className="text-muted-foreground group-hover:text-foreground/70 size-3.5 shrink-0 transition-colors" />
@@ -109,7 +165,13 @@ export function WorkingRepoField({
               </span>
             ) : (
               <span className="text-muted-foreground">
-                {disabled ? (isLoading ? 'Loading repos…' : 'No repos available') : 'Working repo'}
+                {disabled
+                  ? isLoading
+                    ? 'Loading repos…'
+                    : policyDisabled
+                      ? 'Repository access disabled'
+                      : 'No repos available'
+                  : 'Working repo'}
               </span>
             )}
           </span>
@@ -125,10 +187,11 @@ export function WorkingRepoField({
             <SelectPrimitive.Viewport>
               {repoOptions.map((r) => {
                 const [o, n] = splitRepo(r.full_name)
+                const repoValue = workingRepoValue(r, useFluePolicy)
                 return (
                   <SelectPrimitive.Item
-                    key={r.full_name}
-                    value={r.full_name}
+                    key={repoValue}
+                    value={repoValue}
                     className="focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2 text-sm outline-hidden select-none"
                   >
                     <GithubMark className="text-muted-foreground size-3.5 shrink-0" />

--- a/web/src/hooks/use-repository-access.ts
+++ b/web/src/hooks/use-repository-access.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query'
+import { getRepositoryAccess } from '@/api/client'
+import { repositoryAccessQueryKey } from '@/lib/repository-access'
+
+export function useRepositoryAccess(agentId: string, enabled = true) {
+  return useQuery({
+    queryKey: repositoryAccessQueryKey(agentId),
+    queryFn: () => getRepositoryAccess(agentId),
+    enabled: enabled && Boolean(agentId),
+    staleTime: 15_000,
+    refetchOnWindowFocus: 'always',
+  })
+}

--- a/web/src/lib/repository-access.test.ts
+++ b/web/src/lib/repository-access.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isNarrowingRepositoryAccess,
+  repositoryAccessCandidates,
+  repositoryAccessQueryKey,
+  toggleSelectedRepository,
+} from './repository-access'
+
+describe('repository access helpers', () => {
+  it('uses the documented agent-scoped query key', () => {
+    expect(repositoryAccessQueryKey('agt_1')).toEqual([
+      'agent-repository-access',
+      'agt_1',
+    ])
+  })
+
+  it('detects narrowing without treating expansion as narrowing', () => {
+    expect(
+      isNarrowingRepositoryAccess(
+        { mode: 'all' },
+        { mode: 'selected', repository_ids: ['repo_1'] },
+      ),
+    ).toBe(true)
+    expect(
+      isNarrowingRepositoryAccess(
+        { mode: 'selected', repository_ids: ['repo_1'] },
+        { mode: 'all' },
+      ),
+    ).toBe(false)
+    expect(
+      isNarrowingRepositoryAccess(
+        { mode: 'selected', repository_ids: ['repo_1', 'repo_hidden'] },
+        { mode: 'selected', repository_ids: ['repo_1'] },
+      ),
+    ).toBe(true)
+  })
+
+  it('preserves a hidden selection when toggling a visible repository', () => {
+    expect(
+      toggleSelectedRepository(
+        {
+          mode: 'selected',
+          repository_ids: ['repo_hidden', 'repo_visible'],
+        },
+        'repo_new',
+        true,
+      ),
+    ).toEqual({
+      mode: 'selected',
+      repository_ids: ['repo_hidden', 'repo_new', 'repo_visible'],
+    })
+  })
+
+  it('merges candidates by stable id and ignores unregistered rows', () => {
+    const candidates = repositoryAccessCandidates(
+      {
+        policy: { mode: 'selected', repository_ids: ['repo_1'] },
+        grant: {
+          status: 'active',
+          account: 'acme',
+          repository_selection: 'selected',
+          install_url: 'https://github.test/install',
+          configure_url: null,
+          truncated: false,
+        },
+        effective_repositories: [
+          {
+            id: 'repo_1',
+            full_name: 'acme/renamed',
+            default_branch: 'main',
+            private: true,
+          },
+        ],
+        unavailable_selected_repositories: [],
+      },
+      {
+        installed: true,
+        install_url: null,
+        configure_url: null,
+        account: 'acme',
+        repository_selection: 'selected',
+        repositories: [
+          {
+            id: 'repo_1',
+            full_name: 'acme/old-name',
+            default_branch: 'trunk',
+            private: true,
+            linked_sources: [],
+          },
+          {
+            id: null,
+            full_name: 'acme/unregistered',
+            default_branch: 'main',
+            private: false,
+            linked_sources: [],
+          },
+        ],
+      },
+    )
+    expect(candidates).toEqual([
+      {
+        id: 'repo_1',
+        full_name: 'acme/renamed',
+        default_branch: 'main',
+        private: true,
+      },
+    ])
+  })
+})

--- a/web/src/lib/repository-access.ts
+++ b/web/src/lib/repository-access.ts
@@ -1,0 +1,82 @@
+import type {
+  DeployApp,
+  RepositoryAccess,
+  RepositoryAccessPolicy,
+  RepositoryAccessRepository,
+} from '@/api/client'
+
+export const repositoryAccessQueryKey = (agentId: string) =>
+  ['agent-repository-access', agentId] as const
+
+export function selectedRepositoryIds(
+  policy: RepositoryAccessPolicy,
+): string[] {
+  return policy.mode === 'selected' ? policy.repository_ids : []
+}
+
+export function isNarrowingRepositoryAccess(
+  previous: RepositoryAccessPolicy,
+  next: RepositoryAccessPolicy,
+): boolean {
+  if (previous.mode === 'all') return next.mode === 'selected'
+  if (next.mode === 'all') return false
+  const nextIds = new Set(next.repository_ids)
+  return previous.repository_ids.some((id) => !nextIds.has(id))
+}
+
+export function sameRepositoryAccessPolicy(
+  left: RepositoryAccessPolicy,
+  right: RepositoryAccessPolicy,
+): boolean {
+  if (left.mode !== right.mode) return false
+  if (left.mode === 'all' || right.mode === 'all') return true
+  if (left.repository_ids.length !== right.repository_ids.length) return false
+  const rightIds = new Set(right.repository_ids)
+  return left.repository_ids.every((id) => rightIds.has(id))
+}
+
+/**
+ * Repository-access is authoritative for policy and effective access. The
+ * org-scoped deploy-app response only fills the editor's candidate catalog so
+ * selected mode can be expanded. Identity is always the stable repo id.
+ */
+export function repositoryAccessCandidates(
+  access: RepositoryAccess,
+  deployApp?: DeployApp,
+): RepositoryAccessRepository[] {
+  const byId = new Map<string, RepositoryAccessRepository>()
+  for (const repo of deployApp?.repositories ?? []) {
+    if (!repo.id) continue
+    byId.set(repo.id, {
+      id: repo.id,
+      full_name: repo.full_name,
+      default_branch: repo.default_branch ?? 'main',
+      private: repo.private ?? true,
+    })
+  }
+  for (const repo of access.effective_repositories ?? [])
+    byId.set(repo.id, repo)
+  for (const repo of access.unavailable_selected_repositories) {
+    if (!byId.has(repo.id)) {
+      byId.set(repo.id, {
+        ...repo,
+        default_branch: 'main',
+        private: true,
+      })
+    }
+  }
+  return [...byId.values()].sort((a, b) =>
+    a.full_name.localeCompare(b.full_name),
+  )
+}
+
+export function toggleSelectedRepository(
+  policy: RepositoryAccessPolicy,
+  repositoryId: string,
+  checked: boolean,
+): RepositoryAccessPolicy {
+  const ids = new Set(selectedRepositoryIds(policy))
+  if (checked) ids.add(repositoryId)
+  else ids.delete(repositoryId)
+  return { mode: 'selected', repository_ids: [...ids].sort() }
+}

--- a/web/src/lib/session-source-polling.ts
+++ b/web/src/lib/session-source-polling.ts
@@ -1,6 +1,25 @@
-import type { SessionSource } from '@/api/client'
+import type { Session, SessionSource } from '@/api/client'
 
 const ACTIVE_SOURCE_STATUSES = new Set(['pending', 'materializing'])
+const LIVE_SESSION_STATUSES = new Set([
+  'queued',
+  'running',
+  'awaiting_input',
+  'idle',
+])
+
+export function isFlueSession(
+  session: Pick<Session, 'agent_snapshot'> | undefined,
+): boolean {
+  return session?.agent_snapshot?.runtime === 'flue'
+}
+
+export function canSessionChangeFlueSources(
+  session: Pick<Session, 'status' | 'agent_snapshot'> | undefined,
+): boolean {
+  if (!session || !isFlueSession(session)) return false
+  return LIVE_SESSION_STATUSES.has(session.status)
+}
 
 /**
  * Empty sessions keep a slow watch for the first lazy Flue checkout. Active

--- a/web/src/lib/session-source-polling.ts
+++ b/web/src/lib/session-source-polling.ts
@@ -1,0 +1,17 @@
+import type { SessionSource } from '@/api/client'
+
+const ACTIVE_SOURCE_STATUSES = new Set(['pending', 'materializing'])
+
+/**
+ * Empty sessions keep a slow watch for the first lazy Flue checkout. Active
+ * materialization polls quickly. Terminal sources return to the slow watch so
+ * a later turn adding another source still appears. React Query pauses these
+ * intervals while the page is backgrounded.
+ */
+export function sessionSourcesRefetchInterval(
+  sources: SessionSource[] | undefined,
+): number {
+  if (sources?.some((source) => ACTIVE_SOURCE_STATUSES.has(source.status)))
+    return 1_500
+  return 5_000
+}

--- a/web/src/lib/working-repo.ts
+++ b/web/src/lib/working-repo.ts
@@ -1,0 +1,34 @@
+export interface WorkingRepoValue {
+  repo: string
+  fullName?: string
+  ref: string
+}
+
+export interface WorkingRepoOption {
+  id?: string | null
+  full_name: string
+  default_branch?: string | null
+}
+
+export function workingRepoValue(
+  repo: WorkingRepoOption,
+  flue: boolean,
+): string {
+  return flue ? (repo.id ?? repo.full_name) : repo.full_name
+}
+
+export function selectedWorkingRepo(
+  repo: WorkingRepoOption,
+  flue: boolean,
+  current: WorkingRepoValue | null,
+): WorkingRepoValue {
+  const repoValue = workingRepoValue(repo, flue)
+  return {
+    repo: repoValue,
+    ...(flue ? { fullName: repo.full_name } : {}),
+    ref:
+      current?.repo === repoValue
+        ? current.ref
+        : (repo.default_branch ?? 'main'),
+  }
+}

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -41,6 +41,10 @@ import { AgentSchedulesTab } from '@/components/agent-schedules'
 import { AgentRevisions } from '@/components/agent-revisions'
 import { AgentDeployments } from '@/components/agent-deployments'
 import {
+  RepositoryAccessPanel,
+  RepositoryAccessSummary,
+} from '@/components/repository-access'
+import {
   WorkingRepoField,
   type WorkingRepo,
 } from '@/components/working-repo-field'
@@ -597,12 +601,20 @@ export default function AgentDetail() {
               </Panel>
               <AgentSkills agentId={agent.id} />
             </div>
-            {/* Right rail: connect-or-status for the agent's source + Slack. */}
+            {/* Right rail: deployment source, working-repo scope, and Slack. */}
             <div className="space-y-4">
               <AgentDeploySource
                 agentId={agent.id}
                 profilePinned={agent.runtime === 'flue'}
               />
+              {agent.runtime === 'flue' ? (
+                <RepositoryAccessSummary
+                  agentId={agent.id}
+                  onOpenSettings={() => {
+                    void navigate(`${base}/settings`)
+                  }}
+                />
+              ) : null}
               <SlackConnect
                 agentId={agent.id}
                 agentName={agent.name}
@@ -652,6 +664,8 @@ export default function AgentDetail() {
                   />
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <WorkingRepoField
+                      agentId={agent.id}
+                      runtime={agent.runtime}
                       value={workingRepo}
                       onChange={setWorkingRepo}
                     />
@@ -704,6 +718,9 @@ export default function AgentDetail() {
 
         {active === 'settings' && (
           <div className="space-y-6">
+            {agent.runtime === 'flue' ? (
+              <RepositoryAccessPanel agentId={agent.id} />
+            ) : null}
             {/* Credential — which key the agent runs on. */}
             <Panel>
               <PanelHeader>

--- a/web/src/pages/AgentSetup.tsx
+++ b/web/src/pages/AgentSetup.tsx
@@ -44,6 +44,10 @@ import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useAgentDeploymentLogs } from '@/hooks/use-agent-deployment-logs'
 import {
+  RepositoryAccessPanel,
+  RepositoryTaskSuggestion,
+} from '@/components/repository-access'
+import {
   agentSetupStage,
   agentSetupPresentation,
 } from '@/lib/agent-setup-presentation'
@@ -647,6 +651,15 @@ export default function AgentSetup() {
           </div>
         ) : null}
       </Panel>
+
+      {agent.runtime === 'flue' && managedSlackStatus === 'active' ? (
+        <div className="space-y-3">
+          <RepositoryAccessPanel agentId={agentId} context="setup" />
+          {stage === 'ready' ? (
+            <RepositoryTaskSuggestion agentId={agentId} />
+          ) : null}
+        </div>
+      ) : null}
 
       {deployment ? (
         <Panel>

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -16,12 +16,14 @@ import { notifyError } from '@/lib/errors'
 import { useHalted } from '@/hooks/useHalted'
 import {
   getSession,
+  getSessionSources,
   getSessionEvents,
   sendMessage,
   cancelSession,
   archiveSession,
   ApiError,
   type SessionEvent,
+  type SessionSource,
 } from '@/api/client'
 import { SessionEventSchema } from '@/api/schemas'
 import { Panel } from '@/components/panel'
@@ -38,6 +40,7 @@ import { SessionWebhooks } from '@/components/session-webhooks'
 import { ApiHint } from '@/components/api-hint'
 import { MessagesSquare } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { GithubMark } from '@/components/github-mark'
 import { formatSpend, usageTokens } from '@/lib/usage'
 import {
   MessageBubble,
@@ -243,6 +246,12 @@ for await (const event of session.events()) {
     queryKey: ['session-events', sessionId],
     queryFn: () => getSessionEvents(sessionId),
     refetchInterval: streamOk ? false : 5000,
+  })
+  const sourcesQuery = useQuery({
+    queryKey: ['session-sources', sessionId],
+    queryFn: () => getSessionSources(sessionId),
+    staleTime: 15_000,
+    refetchOnWindowFocus: 'always',
   })
 
   // Live events over SSE through the dashboard proxy (the proxy injects auth;
@@ -502,6 +511,13 @@ for await (const event of session.events()) {
         </div>
       </Panel>
 
+      <SessionSourcesPanel
+        sources={sourcesQuery.data}
+        loading={sourcesQuery.isLoading}
+        error={sourcesQuery.isError}
+        onRetry={() => void sourcesQuery.refetch()}
+      />
+
       {/* Spend / usage — derived from the session's opaque usage object (no dedicated
           spend endpoint). Tokens shown only when the runtime reports them (flue meters
           at the gateway and reports none here). */}
@@ -667,6 +683,96 @@ for await (const event of session.events()) {
         }
       />
     </div>
+  )
+}
+
+export function SessionSourcesPanel({
+  sources,
+  loading,
+  error,
+  onRetry,
+}: {
+  sources?: SessionSource[]
+  loading: boolean
+  error: boolean
+  onRetry: () => void
+}) {
+  if (!loading && !error && !sources?.length) return null
+  return (
+    <Panel className="mb-4 min-w-0 overflow-hidden">
+      <div className="flex min-w-0 flex-wrap items-center justify-between gap-2 border-b px-4 py-2.5">
+        <h2 className="flex items-center gap-2 text-sm font-semibold">
+          <GithubMark className="size-3.5" /> Working sources
+        </h2>
+        <span className="text-muted-foreground text-xs">
+          {sources?.length ?? 0}{' '}
+          {sources?.length === 1 ? 'repository' : 'repositories'}
+        </span>
+      </div>
+      {loading ? (
+        <div className="space-y-2 p-4">
+          <Skeleton className="h-10 w-full" />
+        </div>
+      ) : error ? (
+        <div className="flex items-center justify-between gap-3 px-4 py-3 text-sm">
+          <span className="text-muted-foreground">
+            Couldn’t load working sources.
+          </span>
+          <Button size="sm" variant="outline" onClick={onRetry}>
+            Retry
+          </Button>
+        </div>
+      ) : (
+        <ul className="divide-y">
+          {sources?.map((source) => {
+            const observedDiffers =
+              source.resolved_sha && source.resolved_sha !== source.sha
+            return (
+              <li
+                key={source.name}
+                className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 gap-y-1 px-4 py-3 text-xs sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,auto)]"
+              >
+                <div className="min-w-48 flex-1">
+                  <p
+                    className="truncate text-sm font-medium"
+                    title={source.full_name ?? source.repo_id ?? source.name}
+                  >
+                    {source.full_name ?? source.repo_id ?? source.name}
+                  </p>
+                  <p
+                    className="text-muted-foreground mt-0.5 truncate font-mono"
+                    title={`Pinned commit ${source.sha}`}
+                  >
+                    {source.requested_ref ? `${source.requested_ref} · ` : ''}
+                    {source.sha.slice(0, 8)}
+                  </p>
+                  {observedDiffers ? (
+                    <p
+                      className="text-status-error mt-0.5 font-mono text-[11px]"
+                      title={`Observed commit ${source.resolved_sha}`}
+                    >
+                      observed {source.resolved_sha?.slice(0, 8)}
+                    </p>
+                  ) : null}
+                </div>
+                <StatusBadge status={source.status} />
+                <code
+                  className="text-muted-foreground col-span-2 min-w-0 truncate sm:col-span-1 sm:max-w-52"
+                  title={source.path}
+                >
+                  {source.path}
+                </code>
+                {source.error_message ? (
+                  <p className="text-status-error col-span-2 w-full sm:col-span-3">
+                    {source.error_message}
+                  </p>
+                ) : null}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </Panel>
   )
 }
 

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -52,7 +52,11 @@ import {
   isOutOfCredits,
   isTurnInput,
 } from '@/lib/session-turns'
-import { sessionSourcesRefetchInterval } from '@/lib/session-source-polling'
+import {
+  canSessionChangeFlueSources,
+  isFlueSession,
+  sessionSourcesRefetchInterval,
+} from '@/lib/session-source-polling'
 
 function toolSummary(ev: SessionEvent): string {
   const b = (ev.body ?? {}) as Record<string, unknown>
@@ -248,13 +252,18 @@ for await (const event of session.events()) {
     queryFn: () => getSessionEvents(sessionId),
     refetchInterval: streamOk ? false : 5000,
   })
+  const sourcesEnabled = isFlueSession(session)
+  const sourcesCanChange = canSessionChangeFlueSources(session)
   const sourcesQuery = useQuery({
     queryKey: ['session-sources', sessionId],
     queryFn: () => getSessionSources(sessionId),
+    enabled: sourcesEnabled,
     staleTime: 15_000,
-    refetchInterval: (query) => sessionSourcesRefetchInterval(query.state.data),
+    refetchInterval: sourcesCanChange
+      ? (query) => sessionSourcesRefetchInterval(query.state.data)
+      : false,
     refetchIntervalInBackground: false,
-    refetchOnWindowFocus: 'always',
+    refetchOnWindowFocus: sourcesCanChange ? 'always' : false,
   })
 
   // Live events over SSE through the dashboard proxy (the proxy injects auth;

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -52,6 +52,7 @@ import {
   isOutOfCredits,
   isTurnInput,
 } from '@/lib/session-turns'
+import { sessionSourcesRefetchInterval } from '@/lib/session-source-polling'
 
 function toolSummary(ev: SessionEvent): string {
   const b = (ev.body ?? {}) as Record<string, unknown>
@@ -251,6 +252,8 @@ for await (const event of session.events()) {
     queryKey: ['session-sources', sessionId],
     queryFn: () => getSessionSources(sessionId),
     staleTime: 15_000,
+    refetchInterval: (query) => sessionSourcesRefetchInterval(query.state.data),
+    refetchIntervalInBackground: false,
     refetchOnWindowFocus: 'always',
   })
 

--- a/web/src/pages/Sessions.tsx
+++ b/web/src/pages/Sessions.tsx
@@ -198,7 +198,9 @@ export default function Sessions() {
                   size="sm"
                   onClick={openStart}
                   disabled={halted}
-                  title={halted ? 'Out of credits — top up to resume' : undefined}
+                  title={
+                    halted ? 'Out of credits — top up to resume' : undefined
+                  }
                 >
                   <Plus className="size-4" />
                   Start session
@@ -294,6 +296,8 @@ export default function Sessions() {
               ) : null}
               {agentId ? (
                 <WorkingRepoField
+                  agentId={agentId}
+                  runtime={selectedAgent?.runtime}
                   value={workingRepo}
                   onChange={setWorkingRepo}
                 />

--- a/web/src/pages/agent-setup.test.tsx
+++ b/web/src/pages/agent-setup.test.tsx
@@ -9,6 +9,7 @@ import type {
   SessionEvent,
 } from '@/api/client'
 import { managedSlackConnectionsQueryKey } from '@/lib/managed-slack-connections'
+import { repositoryAccessQueryKey } from '@/lib/repository-access'
 import AgentSetup from './AgentSetup'
 
 const agentId = 'agt_aaaaaaaaaaaaaaaaaaaaaaaa'
@@ -97,6 +98,44 @@ function renderSetup(input: {
       active_revision_id: 'rev_aaaaaaaaaaaaaaaaaaaaaaaa',
     },
   )
+  if (input.agent?.runtime === 'flue') {
+    queryClient.setQueryData(repositoryAccessQueryKey(agentId), {
+      policy: { mode: 'selected', repository_ids: ['repo_1'] },
+      grant: {
+        status: 'active',
+        account: 'acme',
+        repository_selection: 'selected',
+        install_url: 'https://github.test/install',
+        configure_url: 'https://github.test/configure',
+        truncated: false,
+      },
+      effective_repositories: [
+        {
+          id: 'repo_1',
+          full_name: 'acme/support-agent',
+          default_branch: 'main',
+          private: true,
+        },
+      ],
+      unavailable_selected_repositories: [],
+    })
+    queryClient.setQueryData(['deploy-app'], {
+      installed: true,
+      install_url: 'https://github.test/install',
+      configure_url: 'https://github.test/configure',
+      account: 'acme',
+      repository_selection: 'selected',
+      repositories: [
+        {
+          id: 'repo_1',
+          full_name: 'acme/support-agent',
+          default_branch: 'main',
+          private: true,
+          linked_sources: [],
+        },
+      ],
+    })
+  }
   if (input.deployment) {
     queryClient.setQueryData(
       ['agent-deployment', agentId, deploymentId],
@@ -154,6 +193,53 @@ describe('agent setup', () => {
     expect(markup).toContain('Preparing your agent')
     expect(markup).toContain('<details')
     expect(markup).not.toContain('<details open=""')
+  })
+
+  it('does not let optional Flue repository setup compete with Connect Slack', () => {
+    const html = renderSetup({
+      agent: {
+        id: agentId,
+        name: 'Support triage',
+        runtime: 'flue',
+        revision: 1,
+        active_revision_id: 'rev_aaaaaaaaaaaaaaaaaaaaaaaa',
+      },
+      deployment: buildingDeployment,
+      managed: null,
+      search: `?deployment=${deploymentId}`,
+    })
+
+    expect(html).toContain('Connect Slack while we prepare Support triage')
+    expect(html).not.toContain('Choose working repositories')
+  })
+
+  it('keeps Slack first and offers an exact Flue repository task when ready', () => {
+    const html = renderSetup({
+      agent: {
+        id: agentId,
+        name: 'Support triage',
+        runtime: 'flue',
+        revision: 1,
+        active_revision_id: 'rev_aaaaaaaaaaaaaaaaaaaaaaaa',
+      },
+      deployment: {
+        ...buildingDeployment,
+        state: 'ready',
+        phase: 'verify',
+        terminal: true,
+        active: true,
+        allowed_actions: ['open_agent', 'start_session'],
+      },
+      managed: activeSlack,
+      search: `?deployment=${deploymentId}`,
+    })
+
+    expect(html.indexOf('Send your first message')).toBeLessThan(
+      html.indexOf('Choose working repositories'),
+    )
+    expect(html).toContain(
+      'In <span class="text-foreground font-mono">acme/support-agent,</span> add a setup note and open a pull request.',
+    )
   })
 
   it('waits visibly after Slack connects and promotes chat when ready', () => {

--- a/web/src/pages/session-sources.test.tsx
+++ b/web/src/pages/session-sources.test.tsx
@@ -1,0 +1,46 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { SessionSourcesPanel } from './SessionDetail'
+
+describe('session working sources', () => {
+  it('shows stable identity, requested ref, pinned SHA, status, and path', () => {
+    const html = renderToStaticMarkup(
+      <SessionSourcesPanel
+        sources={[
+          {
+            name: 'app',
+            repo_id: 'repo_1',
+            full_name: 'acme/app',
+            requested_ref: 'main',
+            status: 'ready',
+            path: '/workspace/sources/app',
+            sha: 'a'.repeat(40),
+            resolved_sha: 'b'.repeat(40),
+          },
+        ]}
+        loading={false}
+        error={false}
+        onRetry={() => {}}
+      />,
+    )
+    expect(html).toContain('acme/app')
+    expect(html).toContain('main · aaaaaaaa')
+    expect(html).toContain('observed bbbbbbbb')
+    expect(html).toContain(`title="Pinned commit ${'a'.repeat(40)}"`)
+    expect(html).toContain('Ready')
+    expect(html).toContain('/workspace/sources/app')
+  })
+
+  it('stays absent when the session has no sources', () => {
+    expect(
+      renderToStaticMarkup(
+        <SessionSourcesPanel
+          sources={[]}
+          loading={false}
+          error={false}
+          onRetry={() => {}}
+        />,
+      ),
+    ).toBe('')
+  })
+})

--- a/web/src/pages/session-sources.test.tsx
+++ b/web/src/pages/session-sources.test.tsx
@@ -1,6 +1,10 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { sessionSourcesRefetchInterval } from '@/lib/session-source-polling'
+import {
+  canSessionChangeFlueSources,
+  isFlueSession,
+  sessionSourcesRefetchInterval,
+} from '@/lib/session-source-polling'
 import { SessionSourcesPanel } from './SessionDetail'
 
 describe('session working sources', () => {
@@ -116,5 +120,32 @@ describe('session working sources', () => {
         },
       ]),
     ).toBe(5_000)
+  })
+
+  it('loads only Flue sources and polls only while the session can change', () => {
+    for (const status of ['queued', 'running', 'awaiting_input', 'idle']) {
+      const session = {
+        status,
+        agent_snapshot: { runtime: 'flue' },
+      }
+      expect(isFlueSession(session)).toBe(true)
+      expect(canSessionChangeFlueSources(session)).toBe(true)
+    }
+    expect(isFlueSession(undefined)).toBe(false)
+    expect(canSessionChangeFlueSources(undefined)).toBe(false)
+    const builtIn = {
+      status: 'running',
+      agent_snapshot: { runtime: 'claude' },
+    }
+    expect(isFlueSession(builtIn)).toBe(false)
+    expect(canSessionChangeFlueSources(builtIn)).toBe(false)
+    for (const status of ['failed', 'archived']) {
+      const terminalFlue = {
+        status,
+        agent_snapshot: { runtime: 'flue' },
+      }
+      expect(isFlueSession(terminalFlue)).toBe(true)
+      expect(canSessionChangeFlueSources(terminalFlue)).toBe(false)
+    }
   })
 })

--- a/web/src/pages/session-sources.test.tsx
+++ b/web/src/pages/session-sources.test.tsx
@@ -1,5 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
+import { sessionSourcesRefetchInterval } from '@/lib/session-source-polling'
 import { SessionSourcesPanel } from './SessionDetail'
 
 describe('session working sources', () => {
@@ -12,10 +13,43 @@ describe('session working sources', () => {
             repo_id: 'repo_1',
             full_name: 'acme/app',
             requested_ref: 'main',
-            status: 'ready',
+            status: 'resolved',
             path: '/workspace/sources/app',
             sha: 'a'.repeat(40),
             resolved_sha: 'b'.repeat(40),
+          },
+          {
+            name: 'docs',
+            repo_id: 'repo_2',
+            full_name: 'acme/docs',
+            requested_ref: 'main',
+            status: 'materializing',
+            path: '/workspace/sources/docs',
+            sha: 'c'.repeat(40),
+          },
+          {
+            name: 'pending',
+            status: 'pending',
+            path: '/workspace/sources/pending',
+            sha: 'd'.repeat(40),
+          },
+          {
+            name: 'failed',
+            status: 'failed',
+            path: '/workspace/sources/failed',
+            sha: 'e'.repeat(40),
+          },
+          {
+            name: 'unavailable',
+            status: 'unavailable',
+            path: '/workspace/sources/unavailable',
+            sha: 'f'.repeat(40),
+          },
+          {
+            name: 'auth',
+            status: 'auth_required',
+            path: '/workspace/sources/auth',
+            sha: '0'.repeat(40),
           },
         ]}
         loading={false}
@@ -27,7 +61,12 @@ describe('session working sources', () => {
     expect(html).toContain('main · aaaaaaaa')
     expect(html).toContain('observed bbbbbbbb')
     expect(html).toContain(`title="Pinned commit ${'a'.repeat(40)}"`)
-    expect(html).toContain('Ready')
+    expect(html).toContain('Resolved')
+    expect(html).toContain('Materializing')
+    expect(html).toContain('Pending')
+    expect(html).toContain('Failed')
+    expect(html).toContain('Unavailable')
+    expect(html).toContain('Auth required')
     expect(html).toContain('/workspace/sources/app')
   })
 
@@ -42,5 +81,40 @@ describe('session working sources', () => {
         />,
       ),
     ).toBe('')
+  })
+
+  it('watches for new sources and accelerates while materialization is active', () => {
+    expect(sessionSourcesRefetchInterval([])).toBe(5_000)
+    expect(
+      sessionSourcesRefetchInterval([
+        {
+          name: 'app',
+          status: 'pending',
+          path: '/workspace/sources/app',
+          sha: 'a'.repeat(40),
+        },
+      ]),
+    ).toBe(1_500)
+    expect(
+      sessionSourcesRefetchInterval([
+        {
+          name: 'app',
+          status: 'materializing',
+          path: '/workspace/sources/app',
+          sha: 'a'.repeat(40),
+        },
+      ]),
+    ).toBe(1_500)
+    expect(
+      sessionSourcesRefetchInterval([
+        {
+          name: 'app',
+          status: 'resolved',
+          path: '/workspace/sources/app',
+          sha: 'a'.repeat(40),
+          resolved_sha: 'a'.repeat(40),
+        },
+      ]),
+    ).toBe(5_000)
   })
 })


### PR DESCRIPTION
## Summary

Evergreen implementation PR for work 029. This branch contains the complete OpenComputer package, SDK, dashboard, and public-documentation surface for hosted Flue repository work:

- `@opencomputer/flue` tools: `list_working_repos`, `add_source`, and `github_publish_pull_request`
- request-time managed environment/session resolution, strict bounded inputs, stable publish idempotency, and typed safe errors
- TypeScript SDK repository-access GET/PUT methods and additive session-source identity/ref fields
- guided setup, Agent Overview summary, Agent Settings all/selected policy editor, optional Flue session repository picker, and live Session Detail source state
- public docs separating deployment source from working repositories and promising pull requests rather than default-branch writes

## User experience

- Slack remains the primary setup action; repository access is optional and configurable after Slack connects.
- Flue agents default to all repositories granted through the owner's OpenComputer GitHub App, or can be narrowed to an explicit searchable selection. Selected-empty disables repository work without disabling chat.
- Agent Overview summarizes access; Settings owns the full editor and grant recovery. New-session UI displays current names but submits stable `repo_…` identities.
- Session Detail labels requested refs, immutable pinned commits, observed commits, materialization state/path, and safe errors. Only live Flue sessions poll; archived/failed sessions fetch once, and non-Flue sessions never issue source requests.

The deployment-source repo remains separate from working-repository policy throughout.

## Launch-hardening review

Delta PR #542 is folded into this head:

- production Slack/API handling and previews share the exact `ApiError` boundary; arbitrary status-bearing mocks no longer widen production 404 handling
- transient repository discovery now offers retry rather than misleading reconnect copy
- response objects tolerate additive server fields while projecting model-visible output to at most 50 repositories (`truncated=true` when sliced) and 500 message characters; model-authored inputs remain strict and bounded
- runtime-owned Cloudflare env proxies are never spread or enumerated; ambient bindings win when defined and request-time secrets are read by direct property access, with a throwing-`ownKeys` workerd/Node regression fixture
- comments across gateway, sandbox, and repository helpers now describe the same token location contract

## Verification

- dashboard: 33 files / 138 tests, typecheck, production build, lint/format checks
- TypeScript SDK: 8 files / 38 tests, build, and typecheck
- Flue SDK `0.3.1`: 38 tests, build, workerd compatibility, package prepublish check, and clean diff
- desktop and narrow-width visual review; true 390px document width remains contained

## Publication and deployment

- `@opencomputer/flue@0.3.1` was published from exact head `4fb0230` with npm provenance in workflow run 29847432486; registry integrity is `sha512-UtYDDLqkAXPidYw1t8LR720N9tgq+p9Ebh0z+vflX/gSHy6GoJC1V+ZVxyOX16DwAjtoPCIvoxr3OZiLtRo9Zg==`
- dashboard/API-edge head `4fb0230` was deployed in workflow run 29847432570 as `opencomputer-edge-prod` version `0b924ea7-ac2e-41d4-b4a8-67293c2e65df`
- production Worker root returns 200 after deployment
- starter delta `oc-flue-starter#8@5bdcb98` is merged into evergreen `447fee5`; live agent `agt_ae013a0693c54b999eecfb0f` deployed it successfully

## Coordination

Frozen contracts, ownership, production evidence, and the live resume ledger are in `oc-bg-agents/.agents/work/029-flue-github-capability.md`. Keep this evergreen open until the remaining adverse production proofs and launch review are complete.

