### PR TITLE
Add repository access to the TypeScript SDK

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -101,6 +101,28 @@ const { agent, deployment } = await oc.agents.repository.import({
 });
 ```
 
+### Configure repository access
+
+Flue agents can use repositories granted to your OpenComputer GitHub App as working sources. Read
+the current grant and policy, or narrow the agent to explicit repository ids from that view:
+
+```typescript
+const access = await oc.agents.getRepositoryAccess(agent.id);
+const target = access.effectiveRepositories?.find(
+  (repo) => repo.fullName === "your-org/your-repo",
+);
+if (!target) throw new Error("Repository is not currently available to this agent");
+
+await oc.agents.updateRepositoryAccess(agent.id, {
+  mode: "selected",
+  repositoryIds: [target.id],
+});
+```
+
+Use `{ mode: "all" }` for every currently and subsequently granted repository, or
+`{ mode: "selected", repositoryIds: [] }` to disable repository work. An `unavailable` grant has
+`effectiveRepositories: null`; an empty array is a successfully read, known-empty view.
+
 ### Credentials
 
 Sessions run **Managed** (via OpenComputer, billed to your credits — `credential: "managed"`, no key, the default for new orgs) or on **your own** model-provider key (Anthropic for `claude`, OpenAI for `codex`). An inline `key` stores one and attaches it to the agent; manage keys directly to reuse one across agents, set an org default, or rotate/remove:

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.12.4",
+      "version": "0.13.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/agents/agents.ts
+++ b/sdks/typescript/src/agents/agents.ts
@@ -83,6 +83,45 @@ export interface ManagedSlackWorkspaceConnection extends ManagedSlackConnection 
   agent: { id: string; name: string };
 }
 
+/** Which repositories a Flue agent may use as working sources. */
+export type RepositoryAccessPolicy =
+  | { mode: "all" }
+  | { mode: "selected"; repositoryIds: string[] };
+
+/** Current state of the owner-bound OpenComputer GitHub App grant. */
+export interface RepositoryAccessGrant {
+  status: "active" | "not_installed" | "unavailable";
+  account: string | null;
+  repositorySelection: "all" | "selected" | null;
+  installUrl: string;
+  configureUrl: string | null;
+  truncated: boolean;
+}
+
+/** One repository currently usable under both the GitHub grant and agent policy. */
+export interface RepositoryAccessRepository {
+  id: string;
+  fullName: string;
+  defaultBranch: string;
+  private: boolean;
+}
+
+/** A selected repository absent from the current complete GitHub grant view. */
+export interface UnavailableSelectedRepository {
+  id: string;
+  fullName: string;
+}
+
+/** Agent policy composed with the owner's current GitHub App grant. */
+export interface RepositoryAccess {
+  policy: RepositoryAccessPolicy;
+  grant: RepositoryAccessGrant;
+  /** `null` means the grant could not be read; an empty array is a known-empty view. */
+  effectiveRepositories: RepositoryAccessRepository[] | null;
+  /** Authoritative only when `grant.truncated` is false. */
+  unavailableSelectedRepositories: UnavailableSelectedRepository[];
+}
+
 /** Reusable agents — the "what" a session runs. */
 export class Agents {
   /** Deploy behavior (inline or from a linked repo) — each deployment produces a revision. */
@@ -122,6 +161,24 @@ export class Agents {
   }
   list(params: { limit?: number; cursor?: string } = {}): Promise<Page<Agent>> {
     return this.http.request("GET", "/agents", { query: params as Query });
+  }
+
+  // ── Working repositories (agent policy ∩ owner GitHub App grant) ──
+
+  /** Read the agent's working-repository policy and current effective grant view. */
+  getRepositoryAccess(agentId: string): Promise<RepositoryAccess> {
+    return this.http.request("GET", `/agents/${agentId}/repository-access`);
+  }
+
+  /** Atomically replace the agent's working-repository policy. */
+  updateRepositoryAccess(
+    agentId: string,
+    policy: RepositoryAccessPolicy,
+  ): Promise<RepositoryAccess> {
+    return this.http.request("PUT", `/agents/${agentId}/repository-access`, {
+      body: policy,
+      idempotent: true,
+    });
   }
 
   // ── Slack (give the agent its own @handle; BYO app, 1 app ⟷ 1 agent ⟷ 1 workspace) ──

--- a/sdks/typescript/src/agents/index.ts
+++ b/sdks/typescript/src/agents/index.ts
@@ -12,6 +12,8 @@ export type {
   CreateAgentParams, UpdateAgentParams, Page,
   SlackManifest, SlackConnection, ConnectSlackParams,
   ManagedSlackAuthorization, ManagedSlackConnection, ManagedSlackWorkspaceConnection,
+  RepositoryAccessPolicy, RepositoryAccessGrant, RepositoryAccessRepository,
+  UnavailableSelectedRepository, RepositoryAccess,
 } from "./agents.js";
 export { AgentRepository } from "./repository-agents.js";
 export type {

--- a/sdks/typescript/src/agents/repository-access.test.ts
+++ b/sdks/typescript/src/agents/repository-access.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RepositoryAccessPolicy } from "../index.js";
+import { OpenComputer } from "./client.js";
+import { ConflictError, NotFoundError } from "./errors.js";
+
+// @ts-expect-error selected policy requires an explicit repository list
+const selectedWithoutRepositories: RepositoryAccessPolicy = { mode: "selected" };
+void selectedWithoutRepositories;
+
+const allWithRepositories: RepositoryAccessPolicy = {
+  mode: "all",
+  // @ts-expect-error all policy cannot carry a selected repository list
+  repositoryIds: ["repo_0123456789abcdef01234567"],
+};
+void allWithRepositories;
+
+const wireAccess = {
+  policy: {
+    mode: "selected",
+    repository_ids: ["repo_0123456789abcdef01234567"],
+  },
+  grant: {
+    status: "active",
+    account: "example",
+    repository_selection: "selected",
+    install_url: "https://github.com/apps/opencomputer/installations/new?state=opaque",
+    configure_url: "https://github.com/settings/installations/123",
+    truncated: false,
+  },
+  effective_repositories: [
+    {
+      id: "repo_0123456789abcdef01234567",
+      full_name: "example/support-agent",
+      default_branch: "main",
+      private: true,
+    },
+  ],
+  unavailable_selected_repositories: [
+    {
+      id: "repo_89abcdef0123456701234567",
+      full_name: "example/retired-agent",
+    },
+  ],
+};
+
+function client(fetcher: typeof fetch): OpenComputer {
+  return new OpenComputer({
+    apiKey: "oc_test",
+    baseUrl: "https://api.example.test/v3",
+    fetch: fetcher,
+    maxRetries: 0,
+  });
+}
+
+describe("agent repository access", () => {
+  it("reads and camel-cases policy, grant, and repository state", async () => {
+    const fetcher = vi.fn(async () => Response.json(wireAccess));
+    const oc = client(fetcher as typeof fetch);
+
+    const access = await oc.agents.getRepositoryAccess("agt_1");
+
+    expect(access).toEqual({
+      policy: {
+        mode: "selected",
+        repositoryIds: ["repo_0123456789abcdef01234567"],
+      },
+      grant: {
+        status: "active",
+        account: "example",
+        repositorySelection: "selected",
+        installUrl: "https://github.com/apps/opencomputer/installations/new?state=opaque",
+        configureUrl: "https://github.com/settings/installations/123",
+        truncated: false,
+      },
+      effectiveRepositories: [
+        {
+          id: "repo_0123456789abcdef01234567",
+          fullName: "example/support-agent",
+          defaultBranch: "main",
+          private: true,
+        },
+      ],
+      unavailableSelectedRepositories: [
+        {
+          id: "repo_89abcdef0123456701234567",
+          fullName: "example/retired-agent",
+        },
+      ],
+    });
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.example.test/v3/agents/agt_1/repository-access",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("preserves an unavailable grant's null effective view", async () => {
+    const fetcher = vi.fn(async () => Response.json({
+      ...wireAccess,
+      grant: {
+        ...wireAccess.grant,
+        status: "unavailable",
+        account: null,
+        repository_selection: null,
+        configure_url: null,
+      },
+      effective_repositories: null,
+      unavailable_selected_repositories: [],
+    }));
+    const oc = client(fetcher as typeof fetch);
+
+    const access = await oc.agents.getRepositoryAccess("agt_1");
+
+    expect(access.grant.status).toBe("unavailable");
+    expect(access.effectiveRepositories).toBeNull();
+    expect(access.unavailableSelectedRepositories).toEqual([]);
+  });
+
+  it("replaces the policy with the exact snake-case wire body", async () => {
+    const fetcher = vi.fn(async () => Response.json(wireAccess));
+    const oc = client(fetcher as typeof fetch);
+
+    const access = await oc.agents.updateRepositoryAccess("agt_1", {
+      mode: "selected",
+      repositoryIds: ["repo_0123456789abcdef01234567"],
+    });
+
+    expect(access.policy).toEqual({
+      mode: "selected",
+      repositoryIds: ["repo_0123456789abcdef01234567"],
+    });
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.example.test/v3/agents/agt_1/repository-access",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({
+          mode: "selected",
+          repository_ids: ["repo_0123456789abcdef01234567"],
+        }),
+      }),
+    );
+  });
+
+  it("sends the all policy without a repository list", async () => {
+    const fetcher = vi.fn(async () => Response.json({
+      ...wireAccess,
+      policy: { mode: "all" },
+    }));
+    const oc = client(fetcher as typeof fetch);
+
+    const access = await oc.agents.updateRepositoryAccess("agt_1", {
+      mode: "all",
+    });
+
+    expect(access.policy).toEqual({ mode: "all" });
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.example.test/v3/agents/agt_1/repository-access",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ mode: "all" }),
+      }),
+    );
+  });
+
+  it.each([
+    [404, "not_found", NotFoundError],
+    [409, "repository_access_not_supported", ConflictError],
+  ] as const)("maps a %s boundary error through the standard SDK error", async (
+    status,
+    type,
+    ErrorClass,
+  ) => {
+    const fetcher = vi.fn(async () => Response.json(
+      { error: { type, message: "repository access unavailable", request_id: "req_1" } },
+      { status },
+    ));
+    const oc = client(fetcher as typeof fetch);
+
+    const request = oc.agents.getRepositoryAccess("agt_1");
+
+    await expect(request).rejects.toBeInstanceOf(ErrorClass);
+    await expect(request).rejects.toMatchObject({
+      status,
+      type,
+      requestId: "req_1",
+    });
+  });
+});

--- a/sdks/typescript/src/agents/session-sources.test.ts
+++ b/sdks/typescript/src/agents/session-sources.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { OpenComputer } from "./client.js";
+
+const wireSource = {
+  name: "target",
+  status: "resolved",
+  path: "/workspace/sources/target",
+  repo_id: "repo_0123456789abcdef01234567",
+  full_name: "example/support-agent",
+  requested_ref: "main",
+  sha: "a".repeat(40),
+  resolved_sha: "a".repeat(40),
+};
+
+describe("managed session source summaries", () => {
+  it("camel-cases repository identity on create and live source reads", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({
+        session: { id: "ses_1", status: "queued" },
+        sources: [wireSource],
+      }))
+      .mockResolvedValueOnce(Response.json([wireSource]));
+    const oc = new OpenComputer({
+      apiKey: "oc_test",
+      baseUrl: "https://api.example.test/v3",
+      fetch: fetcher as typeof fetch,
+      maxRetries: 0,
+    });
+
+    const session = await oc.sessions.create({
+      agent: "agt_1",
+      input: "Inspect the target repository",
+    });
+
+    expect(session.sources[0]).toMatchObject({
+      repoId: "repo_0123456789abcdef01234567",
+      fullName: "example/support-agent",
+      requestedRef: "main",
+      resolvedSha: "a".repeat(40),
+    });
+    await expect(session.listSources()).resolves.toEqual([
+      expect.objectContaining({
+        repoId: "repo_0123456789abcdef01234567",
+        fullName: "example/support-agent",
+        requestedRef: "main",
+      }),
+    ]);
+    expect(fetcher).toHaveBeenNthCalledWith(
+      2,
+      "https://api.example.test/v3/sessions/ses_1/sources",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+});

--- a/sdks/typescript/src/agents/sessions.ts
+++ b/sdks/typescript/src/agents/sessions.ts
@@ -119,6 +119,12 @@ export interface SourceSummary {
   name: string;
   status: SourceStatus;
   path: string;
+  /** Stable registered repository id when the source came from a managed repository. */
+  repoId?: string;
+  /** Current provider coordinates for a managed repository. */
+  fullName?: string;
+  /** Branch, tag, or commit expression requested before it was pinned. */
+  requestedRef?: string;
   /** Requested commit from create; kept for correlation while materialization is pending. */
   sha: string;
   /** Actual checked-out commit after materialization succeeds. Usually equals `sha`. */


### PR DESCRIPTION
## Summary

- expose camelCase repository-access policy, grant, and effective-repository types on `@opencomputer/sdk`
- add `oc.agents.getRepositoryAccess(agentId)` and `updateRepositoryAccess(agentId, policy)` against the public GET/PUT resource
- preserve the SDK boundary conventions: snake-case wire serialization, camelCase response normalization, and standard 404/409 error classes
- expose managed source `repoId`, `fullName`, and `requestedRef` fields on session source summaries
- bump the publish-gated SDK from `0.12.4` to the next minor, `0.13.0`, with the lockfile in sync

## Contract notes

- PUT sends the policy itself: `{ mode: "all" }` or `{ mode: "selected", repository_ids: [...] }`
- `effectiveRepositories: null` means the GitHub grant could not be read; `[]` remains a known-empty view
- unavailable selected repositories are authoritative only when `grant.truncated` is false
- non-Flue agents surface the existing `ConflictError` with type `repository_access_not_supported`; missing/cross-owner agents remain `NotFoundError`

## Review map

- `src/agents/agents.ts` + `index.ts`: public types and methods
- `src/agents/repository-access.test.ts`: GET/PUT normalization, policy shape, null semantics, and typed errors
- `src/agents/sessions.ts` + `session-sources.test.ts`: additive managed-source identity
- `README.md`: concise SDK usage and policy semantics
- `package*.json`: publish-gated `0.13.0` bump

## Verification

- `npm ci --no-audit --no-fund`
- `npm test` — 38 passing
- `npm run lint`
- `npm run build`
- `npm pack --dry-run --json`
