### PR TITLE
Add Flue repository access UX and docs

### DIFF
--- a/docs/agent-sessions/agents.mdx
+++ b/docs/agent-sessions/agents.mdx
@@ -84,6 +84,12 @@ workspace, or disconnect it in place after reviewing the routing impact. A
 completed first conversation adds direct exits to the agent home, full session,
 session history, and Slack.
 
+For a Flue agent, setup also offers **Working repositories** without blocking
+Slack or chat. Choose all repositories granted to the OpenComputer GitHub App,
+an explicit subset, or an empty subset for chat-only use. The same policy is
+available later under **Agent → Settings → Repository access**. This policy is
+separate from the repository that deploys the Flue app.
+
 The repository picker marks roots already used by another agent before review.
 An exact linked root cannot be reviewed again: open its owning agent, choose a
 different monorepo root, or unlink it in place after confirming that

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -11,7 +11,7 @@ Each section toggles between the **TypeScript SDK** (`@opencomputer/sdk`), **RES
 import { OpenComputer, connectSession } from "@opencomputer/sdk";
 
 const oc = new OpenComputer({ apiKey: process.env.OPENCOMPUTER_API_KEY! });
-const session = await oc.sessions.get("ses_...");        // server, org key
+const session = await oc.sessions.get("ses_..."); // server, org key
 // or, in a browser:  await connectSession({ sessionId, clientToken })
 ```
 
@@ -22,7 +22,13 @@ oc agent deploy        # deploy the agent directory in the cwd
 oc agent build --dir . --check-only --json  # validate a Flue app without credentials or deployment
 ```
 
-<Note>The SDK uses **camelCase** for fields and params (`last_turn` → `lastTurn`, `idempotency_key` → `idempotencyKey`); the wire shapes below are raw JSON. Opaque blobs — session `metadata`, event `refs`/`raw` — pass through **verbatim**; everything else (incl. event `body`) is camelCased. The CLI prints a table, or raw JSON with `--json`.</Note>
+<Note>
+  The SDK uses **camelCase** for fields and params (`last_turn` → `lastTurn`,
+  `idempotency_key` → `idempotencyKey`); the wire shapes below are raw JSON.
+  Opaque blobs — session `metadata`, event `refs`/`raw` — pass through
+  **verbatim**; everything else (incl. event `body`) is camelCased. The CLI
+  prints a table, or raw JSON with `--json`.
+</Note>
 
 ## Sessions
 
@@ -30,47 +36,47 @@ oc agent build --dir . --check-only --json  # validate a Flue app without creden
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.sessions.create(params)` | Start a session → a `Session` handle (carries `.clientToken`). |
-| `oc.sessions.get(id)` | Fetch a session. |
-| `oc.sessions.list(params)` | List sessions (filtered, paginated). |
-| `session.archive()` | Cancel any active turn, then close (read-only). |
-| `session.cancel()` | Cooperatively stop the active turn (no-op if not running). |
-| `session.result()` | `{ lastTurn, result? }` — the resolved final event. |
-| `session.turns()` · `session.turn(id)` | Per-turn history: timing, error. |
-| `session.sources` · `session.listSources()` | Source checkout status — create snapshot · live poll. |
-| `session.mintClientToken(opts)` | Mint a client token. |
+| Call                                        | Purpose                                                        |
+| ------------------------------------------- | -------------------------------------------------------------- |
+| `oc.sessions.create(params)`                | Start a session → a `Session` handle (carries `.clientToken`). |
+| `oc.sessions.get(id)`                       | Fetch a session.                                               |
+| `oc.sessions.list(params)`                  | List sessions (filtered, paginated).                           |
+| `session.archive()`                         | Cancel any active turn, then close (read-only).                |
+| `session.cancel()`                          | Cooperatively stop the active turn (no-op if not running).     |
+| `session.result()`                          | `{ lastTurn, result? }` — the resolved final event.            |
+| `session.turns()` · `session.turn(id)`      | Per-turn history: timing, error.                               |
+| `session.sources` · `session.listSources()` | Source checkout status — create snapshot · live poll.          |
+| `session.mintClientToken(opts)`             | Mint a client token.                                           |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /sessions` | Start a session → `{ session, client_token }`. |
-| `GET /sessions/:id` | Fetch a session. |
+| Method · Path                                                     | Purpose                                                       |
+| ----------------------------------------------------------------- | ------------------------------------------------------------- |
+| `POST /sessions`                                                  | Start a session → `{ session, client_token }`.                |
+| `GET /sessions/:id`                                               | Fetch a session.                                              |
 | `GET /sessions?status=&agent=&key=&after=&before=&limit=&cursor=` | List sessions (filtered, paginated; `cursor` = `nextCursor`). |
-| `POST /sessions/:id/archive` | Cancel any active turn, then close (read-only). |
-| `POST /sessions/:id/cancel` | Cooperatively stop the active turn (no-op if not running). |
-| `GET /sessions/:id/result` | The result helper — `{ last_turn, result? }`. |
-| `GET /sessions/:id/turns` · `…/turns/:turnId` | Per-turn history: timing, error. |
-| `GET /sessions/:id/sources` | Source checkout status (`SourceSummary[]`). |
-| `POST /sessions/:id/client-tokens` | Mint a client token. |
+| `POST /sessions/:id/archive`                                      | Cancel any active turn, then close (read-only).               |
+| `POST /sessions/:id/cancel`                                       | Cooperatively stop the active turn (no-op if not running).    |
+| `GET /sessions/:id/result`                                        | The result helper — `{ last_turn, result? }`.                 |
+| `GET /sessions/:id/turns` · `…/turns/:turnId`                     | Per-turn history: timing, error.                              |
+| `GET /sessions/:id/sources`                                       | Source checkout status (`SourceSummary[]`).                   |
+| `POST /sessions/:id/client-tokens`                                | Mint a client token.                                          |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
+| Command                                                                  | Purpose                                                                    |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
 | `oc session create --agent <id\|name> [--revision <n>] [--input <text>]` | Start a session (`--revision` pins a specific revision; default = active). |
-| `oc session get <id>` | Fetch a session. |
-| `oc session list [--agent <id>] [--status <s>]` | List sessions. |
-| `oc session cancel <id>` | Cooperatively stop the active turn. |
-| `oc session result <id>` | The resolved final result. |
-| `oc session steer <id> <text>` | Send input to a running or waiting session. |
-| *(archive · turns · sources · client tokens — REST/SDK only)* | |
+| `oc session get <id>`                                                    | Fetch a session.                                                           |
+| `oc session list [--agent <id>] [--status <s>]`                          | List sessions.                                                             |
+| `oc session cancel <id>`                                                 | Cooperatively stop the active turn.                                        |
+| `oc session result <id>`                                                 | The resolved final result.                                                 |
+| `oc session steer <id> <text>`                                           | Send input to a running or waiting session.                                |
+| _(archive · turns · sources · client tokens — REST/SDK only)_            |                                                                            |
 
 </Tab>
 
@@ -84,56 +90,57 @@ oc agent build --dir . --check-only --json  # validate a Flue app without creden
 - `key?` — get-or-create (one session per key). Keyless: an `Idempotency-Key` header makes create retry-safe.
 - `metadata?` — opaque routing state (≤ 16 KB); on get/list + **verbatim in webhooks**; never sent to the model, not indexed.
 - `limits?` `{ tokens, turn_seconds, turns }`: non-monetary; tripping one ends a built-in runtime turn with the matching `yield_reason`. These limits are stored but not yet enforced for Flue sessions.
-- `sources?`: repos checked out before turn 1 for built-in runtimes (the token never enters the sandbox; see [GitHub](#github-apps-and-repos)). Each registered `{ repo, ref, sha?, name? }` or inline `{ url, ref, sha, name?, auth }`. `ref` is required; `sha` is required for inline sources but **optional for a registered repo**. Flue sessions reject `sources` with `422 sources_not_supported`.
+- `sources?`: working repositories (the token never enters the agent sandbox; see [GitHub](#github-apps-and-repos)). Built-in runtimes prepare them before turn one; Flue materializes them lazily. Each registered `{ repo, ref, sha?, name? }` or inline `{ url, ref, sha, name?, auth }`. `ref` is required; `sha` is required for inline sources but **optional for a registered repo**. Flue accepts only repositories allowed by the agent's repository-access policy.
 - Client tokens: `scopes?` (`read`/`steer`), `ttl?` 60–86400 s (SDK `ttlSeconds`).
 
 A built-in runtime session pins the agent's active revision for its whole life. A Flue session records its selected deployment but executes on the agent's one live Worker; deploying that Worker can therefore affect an existing session.
 
 **`Session`**
 
-| Field | Type | Notes |
-|---|---|---|
-| `id` `status` `head` `input_cursor` | | id, [lifecycle](/agent-sessions/sessions#lifecycle) status, latest event seq, input cursor |
-| `agent_id` `credential_id` | string | resolved + pinned at create |
-| `agent_snapshot` | object | `{ prompt_hash, model, runtime, revision }` — `revision` = the pinned revision number |
-| `last_turn` | `Turn`-ish | `{ id, state, yield_reason?, result_event_id? }` |
-| `limits?` | object | `{ tokens?, turn_seconds?, turns? }` |
-| `metadata?` | object | opaque app routing state |
-| `key?` `created_at` | | get-or-create key, timestamp |
+| Field                               | Type       | Notes                                                                                      |
+| ----------------------------------- | ---------- | ------------------------------------------------------------------------------------------ |
+| `id` `status` `head` `input_cursor` |            | id, [lifecycle](/agent-sessions/sessions#lifecycle) status, latest event seq, input cursor |
+| `agent_id` `credential_id`          | string     | resolved + pinned at create                                                                |
+| `agent_snapshot`                    | object     | `{ prompt_hash, model, runtime, revision }` — `revision` = the pinned revision number      |
+| `last_turn`                         | `Turn`-ish | `{ id, state, yield_reason?, result_event_id? }`                                           |
+| `limits?`                           | object     | `{ tokens?, turn_seconds?, turns? }`                                                       |
+| `metadata?`                         | object     | opaque app routing state                                                                   |
+| `key?` `created_at`                 |            | get-or-create key, timestamp                                                               |
 
 **`Turn`**
 
-| Field | Notes |
-|---|---|
-| `id` `state` | turn id, current state |
-| `yield_reason?` | why it ended (below) |
-| `result_event_id?` | the event carrying the result |
-| `error?` | failure detail, if any |
-| `started_at?` `completed_at?` | timing |
+| Field                         | Notes                         |
+| ----------------------------- | ----------------------------- |
+| `id` `state`                  | turn id, current state        |
+| `yield_reason?`               | why it ended (below)          |
+| `result_event_id?`            | the event carrying the result |
+| `error?`                      | failure detail, if any        |
+| `started_at?` `completed_at?` | timing                        |
 
 A turn's **`yield_reason`** tells you why it stopped:
 
-| Value | Meaning |
-|---|---|
-| `completed` | finished normally |
-| `needs_input` | the agent asked a question — answer it by [steering](#steer) |
-| `error` | the turn failed (see `error`) |
+| Value                                                 | Meaning                                                        |
+| ----------------------------------------------------- | -------------------------------------------------------------- |
+| `completed`                                           | finished normally                                              |
+| `needs_input`                                         | the agent asked a question — answer it by [steering](#steer)   |
+| `error`                                               | the turn failed (see `error`)                                  |
 | `budget_exceeded` / `deadline_exceeded` / `max_turns` | a [limit](#sessions) tripped — tokens / wall-clock / auto-runs |
-| `canceled` | you cancelled it |
+| `canceled`                                            | you cancelled it                                               |
 
 **`SessionSource`** — one of two variants:
 
-| Variant | Shape |
-|---|---|
+| Variant    | Shape                                                                                                                                                                             |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | registered | `{ repo, ref, sha?, name? }` — `repo` is a `repo_…` id or `"owner/repo"`; App-backed auth. `sha` is **optional** (omit → control plane resolves `ref`→HEAD and pins it at create) |
-| inline | `{ url, ref, sha, name?, auth }` — `sha` **required**; `auth = { type:"risky_short_lived_token", token, expires_at }` (can't refresh) |
+| inline     | `{ url, ref, sha, name?, auth }` — `sha` **required**; `auth = { type:"risky_short_lived_token", token, expires_at }` (can't refresh)                                             |
 
 **`SourceSummary`** (sanitized; on create + `GET …/sources`)
 
-| Field | Notes |
-|---|---|
-| `name` `path` `sha` `resolved_sha?` | checkout identity + resolved commit |
-| `status` | `pending · materializing · resolved · failed · unavailable · auth_required` |
+| Field                                       | Notes                                                                                                                                                                                                                                                                               |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name` `path` `sha` `resolved_sha?`         | local identity + pinned commit + observed commit                                                                                                                                                                                                                                    |
+| `repo_id?` `full_name?` `requested_ref?`    | stable repository id, current display name, and requested ref                                                                                                                                                                                                                       |
+| `status`                                    | `pending · materializing · resolved · failed · unavailable · auth_required`                                                                                                                                                                                                         |
 | `error_code?` `error_message?` `retryable?` | on failure — `source.`-prefixed, e.g. `source.auth_required` (App not installed), `source.repo_not_selected` (install doesn't cover the repo), `source.permission_missing`, `source.mint_failed`, `source.ref_not_found`, `source.sha_mismatch`. [Full list](/agent-sessions/repos) |
 
 ## Events
@@ -142,34 +149,34 @@ A turn's **`yield_reason`** tells you why it stopped:
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `session.listEvents(opts)` | Read events since a cursor. |
-| `session.events(opts)` | Live stream from a cursor — a self-resuming async iterator. |
-| `session.event(id)` | Fetch one event (resolve `resultEventId`). |
-| `session.eventContent(id)` | Fetch a blob-backed body (large outputs). |
-| `session.messages(opts)` | User-message history. |
+| Call                       | Purpose                                                     |
+| -------------------------- | ----------------------------------------------------------- |
+| `session.listEvents(opts)` | Read events since a cursor.                                 |
+| `session.events(opts)`     | Live stream from a cursor — a self-resuming async iterator. |
+| `session.event(id)`        | Fetch one event (resolve `resultEventId`).                  |
+| `session.eventContent(id)` | Fetch a blob-backed body (large outputs).                   |
+| `session.messages(opts)`   | User-message history.                                       |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `GET /sessions/:id/events?after=<seq>&level=<lvl>` | Read events since a cursor. |
-| `GET /sessions/:id/events?…&stream=sse` | Live SSE stream from a cursor. |
-| `GET /sessions/:id/events/:eventId` | Fetch one event. |
-| `GET /sessions/:id/events/:eventId/content` | Fetch a blob-backed body. |
-| `GET /sessions/:id/messages` | User-message history. |
+| Method · Path                                      | Purpose                        |
+| -------------------------------------------------- | ------------------------------ |
+| `GET /sessions/:id/events?after=<seq>&level=<lvl>` | Read events since a cursor.    |
+| `GET /sessions/:id/events?…&stream=sse`            | Live SSE stream from a cursor. |
+| `GET /sessions/:id/events/:eventId`                | Fetch one event.               |
+| `GET /sessions/:id/events/:eventId/content`        | Fetch a blob-backed body.      |
+| `GET /sessions/:id/messages`                       | User-message history.          |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
+| Command                                                        | Purpose                     |
+| -------------------------------------------------------------- | --------------------------- |
 | `oc session logs <id> [--follow] [--level <lvl>] [--type <t>]` | Read or live-stream events. |
-| *(single event · event content · messages — REST/SDK only)* | |
+| _(single event · event content · messages — REST/SDK only)_    |                             |
 
 </Tab>
 
@@ -179,13 +186,13 @@ Filter by `type` (exact or `prefix.*`), `turn_id`, `limit`. `after` resumes from
 
 **`Event`**
 
-| Field | Notes |
-|---|---|
-| `id` `seq` `ts` `session` | id, monotonic seq, timestamp, session id |
-| `actor` `type` `level` | source, event [type](/agent-sessions/events#event-shape), visibility level |
-| `body` | the payload (camelCased; switch on `type`, don't parse prose) |
-| `turn_id?` | the turn it belongs to |
-| `content_ref?` `body_truncated?` `body_bytes?` | large bodies are offloaded — fetch via `…/events/:id/content` |
+| Field                                          | Notes                                                                      |
+| ---------------------------------------------- | -------------------------------------------------------------------------- |
+| `id` `seq` `ts` `session`                      | id, monotonic seq, timestamp, session id                                   |
+| `actor` `type` `level`                         | source, event [type](/agent-sessions/events#event-shape), visibility level |
+| `body`                                         | the payload (camelCased; switch on `type`, don't parse prose)              |
+| `turn_id?`                                     | the turn it belongs to                                                     |
+| `content_ref?` `body_truncated?` `body_bytes?` | large bodies are offloaded — fetch via `…/events/:id/content`              |
 
 ## Steer
 
@@ -193,24 +200,24 @@ Filter by `type` (exact or `prefix.*`), `turn_id`, `limit`. `after` resumes from
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
+| Call                                      | Purpose                                     |
+| ----------------------------------------- | ------------------------------------------- |
 | `session.steer(text, { idempotencyKey })` | Append an input message; wakes the session. |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
+| Method · Path                 | Purpose                                     |
+| ----------------------------- | ------------------------------------------- |
 | `POST /sessions/:id/messages` | Append an input message; wakes the session. |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
+| Command                        | Purpose                                     |
+| ------------------------------ | ------------------------------------------- |
 | `oc session steer <id> <text>` | Append an input message; wakes the session. |
 
 </Tab>
@@ -221,27 +228,27 @@ Body: `{ text, idempotency_key? }` or `{ envelope }`. Returns `202` (or `200` on
 
 ## Watches
 
-*Managed with the SDK (`session.watches.create/list/delete`), the CLI (`oc session watch/watches/unwatch`), or REST — authenticate with your **org API key** (server-side). The agent-facing path is the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool. Full guide: [Watches](/agent-sessions/watches).*
+_Managed with the SDK (`session.watches.create/list/delete`), the CLI (`oc session watch/watches/unwatch`), or REST — authenticate with your **org API key** (server-side). The agent-facing path is the [`watch_pull_request`](/agent-sessions/runtime-tools#github-tools) runtime tool. Full guide: [Watches](/agent-sessions/watches)._
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /sessions/:id/watches` | Declare a watch → `201 { watch }`. Body: `{ type:"github_pr", repo?, pr?, wake_on, intent? }`. |
-| `GET /sessions/:id/watches` | List watches → `{ data: [watch] }`. |
-| `DELETE /sessions/:id/watches/:watchId` | Remove a watch → `{ ok: true }`. |
+| Method · Path                           | Purpose                                                                                        |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `POST /sessions/:id/watches`            | Declare a watch → `201 { watch }`. Body: `{ type:"github_pr", repo?, pr?, wake_on, intent? }`. |
+| `GET /sessions/:id/watches`             | List watches → `{ data: [watch] }`.                                                            |
+| `DELETE /sessions/:id/watches/:watchId` | Remove a watch → `{ ok: true }`.                                                               |
 
 `wake_on` is the wake condition (`checks` default · `review` · `comment` · `merge`); `intent` is the freeform "why," replayed on wake. `repo`/`pr` are optional — omitted, they resolve to the PR this session opened. A watch fires only on PRs the **same session** opened, on Connected-App (`oc_app`) repos. Limits: **10** active watches per session, **30-day** TTL (and never outlives the PR).
 
 **`Watch`**
 
-| Field | Notes |
-|---|---|
-| `id` `type` | `wch_…`; `type` = `github_pr` |
-| `repo` `pr` | watched repo · PR number |
-| `wake_on` | wake condition: `checks` (default) · `review` (a review decision) · `comment` · `merge` (merged/closed) |
-| `intent?` | freeform note ("why"), replayed on wake |
-| `status` | `active · closed · revoked · auth_required` |
-| `origin` | how it was declared (runtime tool / management API) |
-| `last_snapshot_at?` `expires_at` `created_at` | last authoritative PR re-read · 30-day TTL lapse · timestamp |
+| Field                                         | Notes                                                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `id` `type`                                   | `wch_…`; `type` = `github_pr`                                                                           |
+| `repo` `pr`                                   | watched repo · PR number                                                                                |
+| `wake_on`                                     | wake condition: `checks` (default) · `review` (a review decision) · `comment` · `merge` (merged/closed) |
+| `intent?`                                     | freeform note ("why"), replayed on wake                                                                 |
+| `status`                                      | `active · closed · revoked · auth_required`                                                             |
+| `origin`                                      | how it was declared (runtime tool / management API)                                                     |
+| `last_snapshot_at?` `expires_at` `created_at` | last authoritative PR re-read · 30-day TTL lapse · timestamp                                            |
 
 **Delivered events** — appended into the session log at level `user` with `source: "github"`, carrying a normalized summary (not the raw webhook): `github.pr.checks_completed` · `github.pr.review_submitted` · `github.pr.comment` · `github.pr.merged` · `github.pr.closed`.
 
@@ -251,37 +258,41 @@ Body: `{ text, idempotency_key? }` or `{ envelope }`. Returns `202` (or `200` on
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.agents.create(params)` | Create a reusable agent. |
-| `oc.agents.repository.review(params)` | Resolve and interpret an exact repository source without running it. |
-| `oc.agents.repository.import(params)` | Import an exact reviewed source and enqueue its first deployment. |
-| `oc.agents.get(id)` · `oc.agents.list()` | Fetch / list. |
-| `oc.agents.update(id, params)` | Update bindings (credential / limits) — `prompt`/`model` deploy a revision. |
-| `oc.agents.delete(id)` | Delete an agent. |
+| Call                                           | Purpose                                                                       |
+| ---------------------------------------------- | ----------------------------------------------------------------------------- |
+| `oc.agents.create(params)`                     | Create a reusable agent.                                                      |
+| `oc.agents.repository.review(params)`          | Resolve and interpret an exact repository source without running it.          |
+| `oc.agents.repository.import(params)`          | Import an exact reviewed source and enqueue its first deployment.             |
+| `oc.agents.get(id)` · `oc.agents.list()`       | Fetch / list.                                                                 |
+| `oc.agents.update(id, params)`                 | Update bindings (credential / limits) — `prompt`/`model` deploy a revision.   |
+| `oc.agents.getRepositoryAccess(id)`            | Read a Flue agent's GitHub grant, policy, and effective working repositories. |
+| `oc.agents.updateRepositoryAccess(id, policy)` | Atomically replace that policy.                                               |
+| `oc.agents.delete(id)`                         | Delete an agent.                                                              |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /agents` | Create a reusable agent. |
-| `POST /agents/import` | Atomically create an agent from an exact reviewed GitHub source and enqueue its first deployment. |
-| `GET /agents/:id` · `GET /agents` | Fetch / list. |
-| `PATCH /agents/:id` | Update bindings; `prompt`/`model` deploy a revision. |
-| `DELETE /agents/:id` | Delete an agent. |
+| Method · Path                       | Purpose                                                                                           |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `POST /agents`                      | Create a reusable agent.                                                                          |
+| `POST /agents/import`               | Atomically create an agent from an exact reviewed GitHub source and enqueue its first deployment. |
+| `GET /agents/:id` · `GET /agents`   | Fetch / list.                                                                                     |
+| `PATCH /agents/:id`                 | Update bindings; `prompt`/`model` deploy a revision.                                              |
+| `GET /agents/:id/repository-access` | Read working-repository access for a Flue agent.                                                  |
+| `PUT /agents/:id/repository-access` | Atomically replace its policy.                                                                    |
+| `DELETE /agents/:id`                | Delete an agent.                                                                                  |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
+| Command                                                        | Purpose                  |
+| -------------------------------------------------------------- | ------------------------ |
 | `oc agent create <name> --model <m> [--runtime claude\|codex]` | Create a reusable agent. |
-| `oc agent get <id\|name>` · `oc agent list` | Fetch / list. |
-| `oc agent update <id> [--credential <c>] [--limits …]` | Update bindings. |
-| `oc agent delete <id>` | Delete an agent. |
+| `oc agent get <id\|name>` · `oc agent list`                    | Fetch / list.            |
+| `oc agent update <id> [--credential <c>] [--limits …]`         | Update bindings.         |
+| `oc agent delete <id>`                                         | Delete an agent.         |
 
 </Tab>
 
@@ -294,6 +305,61 @@ Body: `name`, `prompt`, `model`, `runtime?` (`claude`|`codex`), `key?`, `credent
 `POST /agents/import` is the reviewed repository-import command described below. It deliberately creates
 an agent with no active revision; revision #1 appears only after the queued build and live deployment
 verify successfully.
+
+### Flue repository access
+
+Repository access is separate from the repository used to deploy the Flue app.
+It bounds which repositories the running agent may check out and publish to:
+
+```ts TypeScript SDK
+const access = await oc.agents.getRepositoryAccess(agent.id);
+
+await oc.agents.updateRepositoryAccess(agent.id, {
+  mode: "selected",
+  repositoryIds: [access.effectiveRepositories![0].id],
+});
+```
+
+```http REST API
+GET /agents/agt_.../repository-access
+
+PUT /agents/agt_.../repository-access
+Content-Type: application/json
+
+{ "mode": "selected", "repository_ids": ["repo_..."] }
+```
+
+The wire response is:
+
+```json
+{
+  "policy": { "mode": "selected", "repository_ids": ["repo_..."] },
+  "grant": {
+    "status": "active",
+    "account": "acme",
+    "repository_selection": "selected",
+    "install_url": "https://github.com/apps/opencomputerdev/installations/new",
+    "configure_url": "https://github.com/settings/installations/123",
+    "truncated": false
+  },
+  "effective_repositories": [
+    {
+      "id": "repo_...",
+      "full_name": "acme/app",
+      "default_branch": "main",
+      "private": true
+    }
+  ],
+  "unavailable_selected_repositories": []
+}
+```
+
+Use `{ "mode": "all" }` for every repository in the current and future App
+grant. An empty selected list disables repository work but not chat. When the
+grant is `not_installed`, `effective_repositories` is the known-empty `[]`.
+Only a transient `unavailable` grant uses `null`, because no complete set was
+read. The owner-bound
+OpenComputer App is the only authority for this Flue capability.
 
 ## Deployments and revisions
 
@@ -339,7 +405,11 @@ The response always includes repository identity, normalized `root`, `production
 
 ```json Exact Flue review
 {
-  "repository": { "id": "repo_...", "full_name": "acme/agents", "default_branch": "main" },
+  "repository": {
+    "id": "repo_...",
+    "full_name": "acme/agents",
+    "default_branch": "main"
+  },
   "root": "agents/support",
   "production_ref": "main",
   "sha": "0123456789abcdef0123456789abcdef01234567",
@@ -355,8 +425,18 @@ The response always includes repository identity, normalized `root`, `production
   "profile": {
     "source_profile": "flue-app-v1",
     "source_profile_version": 1,
-    "manifest": { "schema_version": 1, "entrypoint": "support-triage", "model": "anthropic/claude-haiku-4-5", "runtime": { "family": "flue", "type": "default" }, "vars": {} },
-    "package": { "name": "support-agent", "node_engine": ">=22.19 <23", "flue_cli": "1.0.0-beta.9" },
+    "manifest": {
+      "schema_version": 1,
+      "entrypoint": "support-triage",
+      "model": "anthropic/claude-haiku-4-5",
+      "runtime": { "family": "flue", "type": "default" },
+      "vars": {}
+    },
+    "package": {
+      "name": "support-agent",
+      "node_engine": ">=22.19 <23",
+      "flue_cli": "1.0.0-beta.9"
+    },
     "lockfile": { "version": 3 },
     "builder": { "node": "22.19.0" },
     "source": { "files": 12, "bytes": 4096 },
@@ -472,32 +552,32 @@ the current active revision remains unchanged.
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.agents.deployments.create(id, { input, activate?, idempotencyKey? })` | Deploy (`input.type: "inline" \| "github"`). |
-| `oc.agents.deployments.list(id)` · `.get(id, depId)` | Deployment history · one deployment. |
-| `oc.agents.deploy(dir)` *(Node)* | Bundle a local directory → inline deployment. |
+| Call                                                                      | Purpose                                       |
+| ------------------------------------------------------------------------- | --------------------------------------------- |
+| `oc.agents.deployments.create(id, { input, activate?, idempotencyKey? })` | Deploy (`input.type: "inline" \| "github"`).  |
+| `oc.agents.deployments.list(id)` · `.get(id, depId)`                      | Deployment history · one deployment.          |
+| `oc.agents.deploy(dir)` _(Node)_                                          | Bundle a local directory → inline deployment. |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /agents/:id/deployments` | Deploy → `{ deployment }`. Body: `{ input, activate?=true, idempotency_key?, client_context? }`. |
-| `GET /agents/:id/deployments?before=&limit=` | Newest-first history with an opaque `next_cursor`. |
-| `GET /agents/:id/deployments/:deploymentId` | One attempt; poll asynchronous states until terminal. |
-| `GET /agents/:id/deployments/:deploymentId/logs?after=&limit=` | Ordered durable log chunks with opaque resume cursors. |
+| Method · Path                                                  | Purpose                                                                                          |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `POST /agents/:id/deployments`                                 | Deploy → `{ deployment }`. Body: `{ input, activate?=true, idempotency_key?, client_context? }`. |
+| `GET /agents/:id/deployments?before=&limit=`                   | Newest-first history with an opaque `next_cursor`.                                               |
+| `GET /agents/:id/deployments/:deploymentId`                    | One attempt; poll asynchronous states until terminal.                                            |
+| `GET /agents/:id/deployments/:deploymentId/logs?after=&limit=` | Ordered durable log chunks with opaque resume cursors.                                           |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
-| `oc agent deploy [dir] [--agent <id\|name>] [--no-activate]` | Bundle a local directory → inline deployment. |
+| Command                                                                            | Purpose                                                                                       |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `oc agent deploy [dir] [--agent <id\|name>] [--no-activate]`                       | Bundle a local directory → inline deployment.                                                 |
 | `oc agent build --dir <dir> [--check-only] [--target cloudflare] [--output <dir>]` | Validate or build a Flue artifact without fetching, installing, authenticating, or deploying. |
-| `oc agent deployments [--agent <id>]` · `oc agent deployments get <id>` | History · one deployment. |
+| `oc agent deployments [--agent <id>]` · `oc agent deployments get <id>`            | History · one deployment.                                                                     |
 
 </Tab>
 
@@ -513,18 +593,18 @@ and subsequent production-branch pushes deploy automatically. Flue has no previe
 
 **`Deployment`**
 
-| Field | Notes |
-|---|---|
-| `id` `created_at` `updated_at` | Attempt identity and timestamps. |
-| `state` `phase` `terminal` | Internal state plus stable UI phase. Repository states: `accepted`, `queued`, `fetching`, `validating`, `installing`, `building`, `uploading`, `deploying`, `verifying`; terminals: `ready`, `failed`, `canceled`, `superseded`, `skipped`. |
-| `result` `error_class` `error?` | Terminal outcome and bounded, redacted failure detail. |
-| `revision_id` `revision?` `active` | Successful revision relation; absent for an unsuccessful attempt. |
-| `source_relation?` | Repository id/name, path, production ref, exact SHA, and commit URL. |
-| `build?` `configuration?` | Safe builder/artifact metadata and non-secret runtime configuration; variables are names only. |
-| `timing` | Accepted/started/finished coordinates plus queue/run/total durations. |
-| `log_bytes` `log_truncated` | Bounded log accounting. |
-| `live_touched` `agent_live?` | Whether deployment crossed the live Worker boundary and the current guarded/verified state. |
-| `allowed_actions` | Server-derived actions such as `view_commit`, `deploy_latest`, `open_agent`, or `start_session`. |
+| Field                              | Notes                                                                                                                                                                                                                                       |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id` `created_at` `updated_at`     | Attempt identity and timestamps.                                                                                                                                                                                                            |
+| `state` `phase` `terminal`         | Internal state plus stable UI phase. Repository states: `accepted`, `queued`, `fetching`, `validating`, `installing`, `building`, `uploading`, `deploying`, `verifying`; terminals: `ready`, `failed`, `canceled`, `superseded`, `skipped`. |
+| `result` `error_class` `error?`    | Terminal outcome and bounded, redacted failure detail.                                                                                                                                                                                      |
+| `revision_id` `revision?` `active` | Successful revision relation; absent for an unsuccessful attempt.                                                                                                                                                                           |
+| `source_relation?`                 | Repository id/name, path, production ref, exact SHA, and commit URL.                                                                                                                                                                        |
+| `build?` `configuration?`          | Safe builder/artifact metadata and non-secret runtime configuration; variables are names only.                                                                                                                                              |
+| `timing`                           | Accepted/started/finished coordinates plus queue/run/total durations.                                                                                                                                                                       |
+| `log_bytes` `log_truncated`        | Bounded log accounting.                                                                                                                                                                                                                     |
+| `live_touched` `agent_live?`       | Whether deployment crossed the live Worker boundary and the current guarded/verified state.                                                                                                                                                 |
+| `allowed_actions`                  | Server-derived actions such as `view_commit`, `deploy_latest`, `open_agent`, or `start_session`.                                                                                                                                            |
 
 List returns `{ data, next_cursor }`. Log reads return
 `{ data: [{ seq, cursor, recorded_at, phase, stream, chunk }], next_cursor, has_more }`; treat `seq`
@@ -538,31 +618,31 @@ responses, and operator telemetry are never projected through these APIs.
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.agents.revisions.list(id)` · `.get(id, n)` | History · one revision (+ skill manifest). |
-| `oc.agents.revisions.activate(id, n)` | Set the active revision (rollback **or** promote). |
-| `oc.agents.activations.list(id)` | Active-pointer audit log. |
+| Call                                           | Purpose                                            |
+| ---------------------------------------------- | -------------------------------------------------- |
+| `oc.agents.revisions.list(id)` · `.get(id, n)` | History · one revision (+ skill manifest).         |
+| `oc.agents.revisions.activate(id, n)`          | Set the active revision (rollback **or** promote). |
+| `oc.agents.activations.list(id)`               | Active-pointer audit log.                          |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `GET /agents/:id/revisions` · `…/:rev` | History · one revision (+ skill manifest). |
+| Method · Path                              | Purpose                                       |
+| ------------------------------------------ | --------------------------------------------- |
+| `GET /agents/:id/revisions` · `…/:rev`     | History · one revision (+ skill manifest).    |
 | `POST /agents/:id/revisions/:rev/activate` | Set the active revision (rollback / promote). |
-| `GET /agents/:id/activations` | Active-pointer audit log. |
+| `GET /agents/:id/activations`              | Active-pointer audit log.                     |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
-| `oc agent revisions [--agent <id>]` · `oc agent revisions get <n>` | History · one revision. |
-| `oc agent rollback <n\|rev_…>` | Set the active revision (rollback / promote). |
-| `oc agent activations` | Active-pointer audit log. |
+| Command                                                            | Purpose                                       |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `oc agent revisions [--agent <id>]` · `oc agent revisions get <n>` | History · one revision.                       |
+| `oc agent rollback <n\|rev_…>`                                     | Set the active revision (rollback / promote). |
+| `oc agent activations`                                             | Active-pointer audit log.                     |
 
 </Tab>
 
@@ -572,14 +652,14 @@ Revisions are **linear** (numbered, immutable). `:rev` is a `number` or `rev_…
 
 **`Revision`**
 
-| Field | Notes |
-|---|---|
-| `id` `number` `created_at` `active` | id, monotonic number, timestamp, is-active flag |
-| `prompt` `model` | the behavior |
-| `skill_bundle_digest?` | content-addressed skills bundle (`null` = no skills) |
-| `digest` | behavior content hash (change detection) |
-| `runtime_ref` | `floating` (latest shared runtime) — `pinned` later (custom runtime) |
-| `files?` | `[{ path, mode, size }]` — only on `GET …/revisions/:rev` |
+| Field                               | Notes                                                                |
+| ----------------------------------- | -------------------------------------------------------------------- |
+| `id` `number` `created_at` `active` | id, monotonic number, timestamp, is-active flag                      |
+| `prompt` `model`                    | the behavior                                                         |
+| `skill_bundle_digest?`              | content-addressed skills bundle (`null` = no skills)                 |
+| `digest`                            | behavior content hash (change detection)                             |
+| `runtime_ref`                       | `floating` (latest shared runtime) — `pinned` later (custom runtime) |
+| `files?`                            | `[{ path, mode, size }]` — only on `GET …/revisions/:rev`            |
 
 ### Skills
 
@@ -587,28 +667,28 @@ Revisions are **linear** (numbered, immutable). `:rev` is a `number` or `rev_…
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.agents.skills.get(id)` | List the active revision's skills (name, description, files). |
-| `oc.agents.skills.put(id, zip)` | Replace skills from a `.zip` → new revision. |
-| `oc.agents.skills.delete(id)` | Remove all skills → new revision. |
+| Call                            | Purpose                                                       |
+| ------------------------------- | ------------------------------------------------------------- |
+| `oc.agents.skills.get(id)`      | List the active revision's skills (name, description, files). |
+| `oc.agents.skills.put(id, zip)` | Replace skills from a `.zip` → new revision.                  |
+| `oc.agents.skills.delete(id)`   | Remove all skills → new revision.                             |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `GET /agents/:id/skills` | List the active revision's skills. |
-| `PUT /agents/:id/skills` | Replace skills from a `.zip` (`Content-Type: application/zip`) → new revision. |
-| `DELETE /agents/:id/skills` | Remove all skills → new revision. |
+| Method · Path               | Purpose                                                                        |
+| --------------------------- | ------------------------------------------------------------------------------ |
+| `GET /agents/:id/skills`    | List the active revision's skills.                                             |
+| `PUT /agents/:id/skills`    | Replace skills from a `.zip` (`Content-Type: application/zip`) → new revision. |
+| `DELETE /agents/:id/skills` | Remove all skills → new revision.                                              |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
+| Command                 | Purpose                                                                          |
+| ----------------------- | -------------------------------------------------------------------------------- |
 | `oc agent deploy <dir>` | Deploy a directory; a `skills/` folder inside it ships as skills → new revision. |
 
 Skills have no dedicated CLI verb yet — deploy a directory that contains a `skills/` folder, or use the REST endpoints / dashboard.
@@ -625,31 +705,31 @@ A skill is a folder with a `SKILL.md`; PUT/DELETE are **deployments** (versioned
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.agents.deploymentSource.link(id, params)` | Link a repo directory → push-to-deploy. |
-| `oc.agents.deploymentSource.get(id)` | The link + status. |
-| `oc.agents.deploymentSource.unlink(id)` | Remove the link (shared App webhook untouched). |
+| Call                                          | Purpose                                         |
+| --------------------------------------------- | ----------------------------------------------- |
+| `oc.agents.deploymentSource.link(id, params)` | Link a repo directory → push-to-deploy.         |
+| `oc.agents.deploymentSource.get(id)`          | The link + status.                              |
+| `oc.agents.deploymentSource.unlink(id)`       | Remove the link (shared App webhook untouched). |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /agents/:id/deployment-source` | Link a repo directory. Body: `{ repo, path, production_ref?, deploy_now?=true }`. |
-| `GET /agents/:id/deployment-source` | The link + status. |
-| `DELETE /agents/:id/deployment-source` | Remove the link. |
+| Method · Path                          | Purpose                                                                           |
+| -------------------------------------- | --------------------------------------------------------------------------------- |
+| `POST /agents/:id/deployment-source`   | Link a repo directory. Body: `{ repo, path, production_ref?, deploy_now?=true }`. |
+| `GET /agents/:id/deployment-source`    | The link + status.                                                                |
+| `DELETE /agents/:id/deployment-source` | Remove the link.                                                                  |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
-| `oc agent link <owner/repo> --path <p> [--branch <ref>] [--no-deploy]` | Link a repo directory. |
-| `oc agent status [id\|name]` | The agent's active revision + link status. |
-| `oc agent unlink` | Remove the link. |
+| Command                                                                | Purpose                                    |
+| ---------------------------------------------------------------------- | ------------------------------------------ |
+| `oc agent link <owner/repo> --path <p> [--branch <ref>] [--no-deploy]` | Link a repo directory.                     |
+| `oc agent status [id\|name]`                                           | The agent's active revision + link status. |
+| `oc agent unlink`                                                      | Remove the link.                           |
 
 </Tab>
 
@@ -667,57 +747,57 @@ that deploy auto-activates. Repo/path are server-anchored to the link. Deploymen
 
 **`DeploymentSource`**
 
-| Field | Notes |
-|---|---|
-| `agent_id` `repo_id` `path` | the linked agent · repo · directory within it |
-| `production_ref` | branch that auto-activates on push |
-| `status` | `active`, or a problem: `source_profile_changed`, `path_missing`, `ref_missing` (production branch deleted), `auth_required`, `repo_not_selected`, `app_suspended`, `error` |
-| `latest_seen_sha?` `active_deployed_sha?` | newest sha observed · sha behind the active revision |
-| `source_profile?` `source_profile_version?` | server-selected repository interpretation pinned for this link (`flue-app-v1`, version `1`) |
-| `review_fingerprint?` | digest of the latest accepted, exact-SHA reviewed plan; never source bytes or a credential |
+| Field                                       | Notes                                                                                                                                                                       |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent_id` `repo_id` `path`                 | the linked agent · repo · directory within it                                                                                                                               |
+| `production_ref`                            | branch that auto-activates on push                                                                                                                                          |
+| `status`                                    | `active`, or a problem: `source_profile_changed`, `path_missing`, `ref_missing` (production branch deleted), `auth_required`, `repo_not_selected`, `app_suspended`, `error` |
+| `latest_seen_sha?` `active_deployed_sha?`   | newest sha observed · sha behind the active revision                                                                                                                        |
+| `source_profile?` `source_profile_version?` | server-selected repository interpretation pinned for this link (`flue-app-v1`, version `1`)                                                                                 |
+| `review_fingerprint?`                       | digest of the latest accepted, exact-SHA reviewed plan; never source bytes or a credential                                                                                  |
 
 ## Schedules
 
-*Run an agent on a cron — each firing starts a session. Managed with the SDK, the `oc` CLI, or REST (org key). Full guide: [Schedules](/agent-sessions/schedules).*
+_Run an agent on a cron — each firing starts a session. Managed with the SDK, the `oc` CLI, or REST (org key). Full guide: [Schedules](/agent-sessions/schedules)._
 
 <Tabs>
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.agents.schedules.create(id, params)` | Create a schedule (`{ name, cron, tz?, input, overlap? }`). |
-| `oc.agents.schedules.list(id)` · `.get(id, sid)` | List / fetch. |
-| `oc.agents.schedules.update(id, sid, params)` | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`. |
-| `oc.agents.schedules.delete(id, sid)` | Delete (run history kept). |
-| `oc.agents.schedules.fire(id, sid)` | Fire now → a run; doesn't advance the cron. |
-| `oc.agents.schedules.runs(id, sid, { cursor?, limit? })` | Run history (each carries `sessionId`). |
+| Call                                                     | Purpose                                                     |
+| -------------------------------------------------------- | ----------------------------------------------------------- |
+| `oc.agents.schedules.create(id, params)`                 | Create a schedule (`{ name, cron, tz?, input, overlap? }`). |
+| `oc.agents.schedules.list(id)` · `.get(id, sid)`         | List / fetch.                                               |
+| `oc.agents.schedules.update(id, sid, params)`            | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`.        |
+| `oc.agents.schedules.delete(id, sid)`                    | Delete (run history kept).                                  |
+| `oc.agents.schedules.fire(id, sid)`                      | Fire now → a run; doesn't advance the cron.                 |
+| `oc.agents.schedules.runs(id, sid, { cursor?, limit? })` | Run history (each carries `sessionId`).                     |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /agents/:id/schedules` | Create → `201 { schedule }`. Body `{ name, cron, tz?, input, overlap? }`. |
-| `GET /agents/:id/schedules` · `…/:sid` | List / fetch. |
-| `PATCH /agents/:id/schedules/:sid` | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`. |
-| `DELETE /agents/:id/schedules/:sid` | Delete → `204` (runs kept). |
-| `POST /agents/:id/schedules/:sid/fire` | Fire now → `201 { run }`; doesn't advance the cron. |
-| `GET /agents/:id/schedules/:sid/runs?cursor=&limit=` | Run history → `{ runs, next_cursor }`. |
+| Method · Path                                        | Purpose                                                                   |
+| ---------------------------------------------------- | ------------------------------------------------------------------------- |
+| `POST /agents/:id/schedules`                         | Create → `201 { schedule }`. Body `{ name, cron, tz?, input, overlap? }`. |
+| `GET /agents/:id/schedules` · `…/:sid`               | List / fetch.                                                             |
+| `PATCH /agents/:id/schedules/:sid`                   | Edit `cron`/`tz`/`input`/`overlap`, or `{ paused }`.                      |
+| `DELETE /agents/:id/schedules/:sid`                  | Delete → `204` (runs kept).                                               |
+| `POST /agents/:id/schedules/:sid/fire`               | Fire now → `201 { run }`; doesn't advance the cron.                       |
+| `GET /agents/:id/schedules/:sid/runs?cursor=&limit=` | Run history → `{ runs, next_cursor }`.                                    |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
-| `oc agent schedule create <name> --agent <id> --cron <c> [--tz <z>] --input <s>` | Create a schedule. |
-| `oc agent schedules [--agent <id>]` · `oc agent schedule get <name>` | List / fetch. |
-| `oc agent schedule pause\|resume <name>` | Pause / resume. |
-| `oc agent schedule delete <name>` | Delete. |
-| `oc agent schedule fire <name>` | Fire now (prints the `ses_…`). |
-| `oc agent schedule runs <name>` | Run history. |
+| Command                                                                          | Purpose                        |
+| -------------------------------------------------------------------------------- | ------------------------------ |
+| `oc agent schedule create <name> --agent <id> --cron <c> [--tz <z>] --input <s>` | Create a schedule.             |
+| `oc agent schedules [--agent <id>]` · `oc agent schedule get <name>`             | List / fetch.                  |
+| `oc agent schedule pause\|resume <name>`                                         | Pause / resume.                |
+| `oc agent schedule delete <name>`                                                | Delete.                        |
+| `oc agent schedule fire <name>`                                                  | Fire now (prints the `ses_…`). |
+| `oc agent schedule runs <name>`                                                  | Run history.                   |
 
 </Tab>
 
@@ -727,14 +807,14 @@ that deploy auto-activates. Repo/path are server-anchored to the link. Deploymen
 
 **`Schedule`**
 
-| Field | Notes |
-|---|---|
-| `id` `agent_id` | `sch_…` · the owning agent |
-| `name` `cron` `tz?` `input` | handle (unique per agent) · 5-field cron · IANA tz · first message |
-| `overlap` | `skip` (default) · `allow` |
-| `state` | `active · paused · auto_paused` (five straight scheduled-firing failures auto-pause) |
-| `next_fire_at` `last_fired_at?` | next occurrence · last fire |
-| `consecutive_failures` `last_error?` | in-a-row enactment failures · last error (cleared on success) |
+| Field                                | Notes                                                                                |
+| ------------------------------------ | ------------------------------------------------------------------------------------ |
+| `id` `agent_id`                      | `sch_…` · the owning agent                                                           |
+| `name` `cron` `tz?` `input`          | handle (unique per agent) · 5-field cron · IANA tz · first message                   |
+| `overlap`                            | `skip` (default) · `allow`                                                           |
+| `state`                              | `active · paused · auto_paused` (five straight scheduled-firing failures auto-pause) |
+| `next_fire_at` `last_fired_at?`      | next occurrence · last fire                                                          |
+| `consecutive_failures` `last_error?` | in-a-row enactment failures · last error (cleared on success)                        |
 
 **`Run`** — one per firing decision, newest-first: `srn_…` with `outcome` (`enacted` · `skipped` · `failed`), `scheduled_for?` (`null` for a manual fire), `fired_at`, `session_id?` (when enacted), `error?`. Chain `session_id` into `GET /sessions/:id`.
 
@@ -749,23 +829,23 @@ context, not a redirect URL. Status responses never contain credentials.
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.agents.authorizeManagedSlack(id, { returnDeploymentId? })` | Start managed-app OAuth. |
-| `oc.agents.getManagedSlack(id)` | Read workspace, app identity, state, and `openUrl`. |
-| `oc.agents.listManagedSlackConnections()` | List this owner's current workspace claims and owning agents before OAuth. |
-| `oc.agents.disconnectManagedSlack(id)` | Stop routing this agent without uninstalling the workspace app. |
+| Call                                                           | Purpose                                                                    |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `oc.agents.authorizeManagedSlack(id, { returnDeploymentId? })` | Start managed-app OAuth.                                                   |
+| `oc.agents.getManagedSlack(id)`                                | Read workspace, app identity, state, and `openUrl`.                        |
+| `oc.agents.listManagedSlackConnections()`                      | List this owner's current workspace claims and owning agents before OAuth. |
+| `oc.agents.disconnectManagedSlack(id)`                         | Stop routing this agent without uninstalling the workspace app.            |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /agents/:id/slack/managed/authorize` | Start managed-app OAuth; accepts `return_deployment_id?`. |
-| `GET /agents/:id/slack/managed` | Read the managed connection. |
-| `DELETE /agents/:id/slack/managed` | Disconnect the agent from the shared app. |
-| `GET /slack/managed/connections` | List current owner-scoped workspace claims with safe agent id/name projections. |
+| Method · Path                              | Purpose                                                                         |
+| ------------------------------------------ | ------------------------------------------------------------------------------- |
+| `POST /agents/:id/slack/managed/authorize` | Start managed-app OAuth; accepts `return_deployment_id?`.                       |
+| `GET /agents/:id/slack/managed`            | Read the managed connection.                                                    |
+| `DELETE /agents/:id/slack/managed`         | Disconnect the agent from the shared app.                                       |
+| `GET /slack/managed/connections`           | List current owner-scoped workspace claims with safe agent id/name projections. |
 
 </Tab>
 
@@ -782,41 +862,41 @@ enforces the one-workspace-to-one-agent claim transactionally.
 Builder-owned Slack apps remain a separate resource and can overlap during an
 explicit handoff:
 
-| TypeScript SDK | REST API |
-| --- | --- |
-| `oc.agents.slackManifest(id)` | `POST /agents/:id/slack/manifest` |
-| `oc.agents.connectSlack(id, values)` | `POST /agents/:id/slack` |
-| `oc.agents.getSlack(id)` | `GET /agents/:id/slack` |
-| `oc.agents.disconnectSlack(id)` | `DELETE /agents/:id/slack` |
+| TypeScript SDK                       | REST API                          |
+| ------------------------------------ | --------------------------------- |
+| `oc.agents.slackManifest(id)`        | `POST /agents/:id/slack/manifest` |
+| `oc.agents.connectSlack(id, values)` | `POST /agents/:id/slack`          |
+| `oc.agents.getSlack(id)`             | `GET /agents/:id/slack`           |
+| `oc.agents.disconnectSlack(id)`      | `DELETE /agents/:id/slack`        |
 
 See [Slack](/agent-sessions/slack) for installation, trust boundaries, and
 conversation behavior.
 
 ## Destinations
 
-*Webhooks are configured via SDK/REST (no `oc` command).*
+_Webhooks are configured via SDK/REST (no `oc` command)._
 
 <Tabs>
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `session.destinations.create(params)` | Register a webhook destination. |
-| `session.destinations.list()` · `.get(did)` | List / fetch. |
-| `session.destinations.update(did, params)` | Pause/resume (`enabled`), retune `level`/`types`, rotate `secret`. |
-| `session.destinations.delete(did)` | Remove. |
+| Call                                        | Purpose                                                            |
+| ------------------------------------------- | ------------------------------------------------------------------ |
+| `session.destinations.create(params)`       | Register a webhook destination.                                    |
+| `session.destinations.list()` · `.get(did)` | List / fetch.                                                      |
+| `session.destinations.update(did, params)`  | Pause/resume (`enabled`), retune `level`/`types`, rotate `secret`. |
+| `session.destinations.delete(did)`          | Remove.                                                            |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /sessions/:id/destinations` | Register a webhook destination. |
-| `GET /sessions/:id/destinations` · `…/:did` | List / fetch. |
-| `PATCH /sessions/:id/destinations/:did` | Pause/resume, retune, rotate. |
-| `DELETE /sessions/:id/destinations/:did` | Remove. |
+| Method · Path                               | Purpose                         |
+| ------------------------------------------- | ------------------------------- |
+| `POST /sessions/:id/destinations`           | Register a webhook destination. |
+| `GET /sessions/:id/destinations` · `…/:did` | List / fetch.                   |
+| `PATCH /sessions/:id/destinations/:did`     | Pause/resume, retune, rotate.   |
+| `DELETE /sessions/:id/destinations/:did`    | Remove.                         |
 
 </Tab>
 
@@ -826,27 +906,27 @@ Destination body: `url`, `secret?`, `level?` (`user`), `types?[]`, `include_raw?
 
 ## Deliveries
 
-*Delivery records are read via SDK/REST (no `oc` command).*
+_Delivery records are read via SDK/REST (no `oc` command)._
 
 <Tabs>
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `session.deliveries.list(opts)` | List deliveries — status, attempts, last response/error. |
-| `session.deliveries.get(id)` | One delivery, in detail. |
-| `session.deliveries.redeliver(id)` | Re-send any delivery. |
+| Call                               | Purpose                                                  |
+| ---------------------------------- | -------------------------------------------------------- |
+| `session.deliveries.list(opts)`    | List deliveries — status, attempts, last response/error. |
+| `session.deliveries.get(id)`       | One delivery, in detail.                                 |
+| `session.deliveries.redeliver(id)` | Re-send any delivery.                                    |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `GET /sessions/:id/deliveries?destination=&status=&after=&limit=` | List deliveries. |
-| `GET /sessions/:id/deliveries/:id` | One delivery. |
-| `POST /sessions/:id/deliveries/:id/redeliver` | Re-send any delivery. |
+| Method · Path                                                     | Purpose               |
+| ----------------------------------------------------------------- | --------------------- |
+| `GET /sessions/:id/deliveries?destination=&status=&after=&limit=` | List deliveries.      |
+| `GET /sessions/:id/deliveries/:id`                                | One delivery.         |
+| `POST /sessions/:id/deliveries/:id/redeliver`                     | Re-send any delivery. |
 
 </Tab>
 
@@ -856,61 +936,61 @@ See [Webhooks](/agent-sessions/webhooks#signing-retries-and-dedupe) for signing,
 
 **`Destination`**
 
-| Field | Notes |
-|---|---|
-| `id` `session` `kind` `created_at` `updated_at` | |
-| `url` | webhook target |
-| `level` `types` | visibility threshold · event-type filter |
-| `include_raw` `enabled` `has_secret` | include raw bodies · paused/active · whether a signing secret is set |
-| `created_after_seq` | only events after this seq are delivered |
+| Field                                           | Notes                                                                |
+| ----------------------------------------------- | -------------------------------------------------------------------- |
+| `id` `session` `kind` `created_at` `updated_at` |                                                                      |
+| `url`                                           | webhook target                                                       |
+| `level` `types`                                 | visibility threshold · event-type filter                             |
+| `include_raw` `enabled` `has_secret`            | include raw bodies · paused/active · whether a signing secret is set |
+| `created_after_seq`                             | only events after this seq are delivered                             |
 
 **`Delivery`**
 
-| Field | Notes |
-|---|---|
-| `id` `session` `destination` `created_at` `updated_at` | |
-| `event_id` `event_seq` | the event delivered |
-| `status` `attempts` `last_attempt_at` | delivery state, retry count, last try |
-| `response_code?` `error?` | last response · failure detail |
+| Field                                                  | Notes                                 |
+| ------------------------------------------------------ | ------------------------------------- |
+| `id` `session` `destination` `created_at` `updated_at` |                                       |
+| `event_id` `event_seq`                                 | the event delivered                   |
+| `status` `attempts` `last_attempt_at`                  | delivery state, retry count, last try |
+| `response_code?` `error?`                              | last response · failure detail        |
 
 ## GitHub Apps and Repos
 
-A GitHub App lets OpenComputer mint short-lived, repo-scoped tokens; a **Repo** is a stable handle resolving to your configured App (the OpenComputer App by default). Used for session [sources](#sessions) (work repos) and [deploy-from-a-repo](#deploy-from-a-repo) (the agent's definition repo). Install the [OpenComputer App](https://github.com/apps/opencomputerdev/installations/new). **Bring-your-own** Apps apply to **session sources / PR publishing** (your users acting on their own repos) — **deployment sources always use the OpenComputer App**.
+A GitHub App lets OpenComputer mint short-lived, repo-scoped tokens; a **Repo** is a stable handle resolving to your configured App (the OpenComputer App by default). Used for session [sources](#sessions) (work repos) and [deploy-from-a-repo](#deploy-from-a-repo) (the agent's definition repo). Install the [OpenComputer App](https://github.com/apps/opencomputerdev/installations/new). **Bring-your-own** Apps may back built-in-runtime session sources and PR publishing. Hosted Flue repository tools and deployment sources always use the owner-bound OpenComputer App.
 
 <Tabs>
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.repos.create(params)` · `.get(id)` · `.list()` · `.update(id, params)` | Register / fetch / list / rename a repo. |
-| `oc.github.apps.list()` | List GitHub Apps available to your org. |
-| `oc.github.apps.register(params)` | Register your own App (`byo_stored_key` / `byo_broker`). |
-| `oc.github.apps.createManifestUrl(params)` | One-click: a link to open; OpenComputer hosts the flow + key capture. |
-| `oc.github.apps.createManifest/completeManifest(params)` | Developer-driven manifest flow. |
-| `oc.github.apps.update(id, params)` · `delete(id)` | Update / rotate / remove an App. |
-| `oc.github.installations.list()` | List installations visible to OpenComputer. |
+| Call                                                                       | Purpose                                                               |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `oc.repos.create(params)` · `.get(id)` · `.list()` · `.update(id, params)` | Register / fetch / list / rename a repo.                              |
+| `oc.github.apps.list()`                                                    | List GitHub Apps available to your org.                               |
+| `oc.github.apps.register(params)`                                          | Register your own App (`byo_stored_key` / `byo_broker`).              |
+| `oc.github.apps.createManifestUrl(params)`                                 | One-click: a link to open; OpenComputer hosts the flow + key capture. |
+| `oc.github.apps.createManifest/completeManifest(params)`                   | Developer-driven manifest flow.                                       |
+| `oc.github.apps.update(id, params)` · `delete(id)`                         | Update / rotate / remove an App.                                      |
+| `oc.github.installations.list()`                                           | List installations visible to OpenComputer.                           |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /repos` · `GET /repos/:id` · `GET /repos` · `PATCH /repos/:id` | Register / fetch / list / rename a repo. |
-| `GET /github/apps` · `POST /github/apps` | List · register your own App. |
-| `PATCH /github/apps/:id` · `DELETE /github/apps/:id` | Update / rotate / remove. |
+| Method · Path                                                                      | Purpose                                     |
+| ---------------------------------------------------------------------------------- | ------------------------------------------- |
+| `POST /repos` · `GET /repos/:id` · `GET /repos` · `PATCH /repos/:id`               | Register / fetch / list / rename a repo.    |
+| `GET /github/apps` · `POST /github/apps`                                           | List · register your own App.               |
+| `PATCH /github/apps/:id` · `DELETE /github/apps/:id`                               | Update / rotate / remove.                   |
 | `POST /github/apps/manifest` · `…/manifest/start` · `…/callback` · `…/conversions` | Manifest flow (hosted or developer-driven). |
-| `GET /github/installations` | List installations visible to OpenComputer. |
+| `GET /github/installations`                                                        | List installations visible to OpenComputer. |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
-| `oc repo add <owner/repo>` · `oc repo list` · `oc repo get <id>` | Register / list / fetch a repo. |
-| *(App install + manifest — browser flow; manage in the dashboard or via SDK/REST)* | |
+| Command                                                                            | Purpose                         |
+| ---------------------------------------------------------------------------------- | ------------------------------- |
+| `oc repo add <owner/repo>` · `oc repo list` · `oc repo get <id>`                   | Register / list / fetch a repo. |
+| _(App install + manifest — browser flow; manage in the dashboard or via SDK/REST)_ |                                 |
 
 </Tab>
 
@@ -928,31 +1008,31 @@ Repo = { id, provider, owner, repo, name?, created_at, updated_at }
 
 <Tab title="TypeScript SDK">
 
-| Call | Purpose |
-| --- | --- |
-| `oc.credentials.create(params)` | Add a provider key. |
-| `oc.credentials.list()` · `oc.credentials.delete(id)` | List / remove. |
-| `oc.credentials.setDefault(params)` | Set the org default. |
+| Call                                                  | Purpose              |
+| ----------------------------------------------------- | -------------------- |
+| `oc.credentials.create(params)`                       | Add a provider key.  |
+| `oc.credentials.list()` · `oc.credentials.delete(id)` | List / remove.       |
+| `oc.credentials.setDefault(params)`                   | Set the org default. |
 
 </Tab>
 
 <Tab title="REST API">
 
-| Method · Path | Purpose |
-| --- | --- |
-| `POST /credentials` | Add a provider key. |
-| `GET /credentials` · `DELETE /credentials/:id` | List / remove. |
-| `PUT /credentials/default` | Set the org default (provider derived). |
+| Method · Path                                  | Purpose                                 |
+| ---------------------------------------------- | --------------------------------------- |
+| `POST /credentials`                            | Add a provider key.                     |
+| `GET /credentials` · `DELETE /credentials/:id` | List / remove.                          |
+| `PUT /credentials/default`                     | Set the org default (provider derived). |
 
 </Tab>
 
 <Tab title="oc CLI">
 
-| Command | Purpose |
-| --- | --- |
-| `oc credential add --provider <p> --key <k> [--default]` | Add a provider key. |
-| `oc credential list` · `oc credential remove <id>` | List / remove. |
-| `oc credential set-default <id>` | Set the org default. |
+| Command                                                  | Purpose              |
+| -------------------------------------------------------- | -------------------- |
+| `oc credential add --provider <p> --key <k> [--default]` | Add a provider key.  |
+| `oc credential list` · `oc credential remove <id>`       | List / remove.       |
+| `oc credential set-default <id>`                         | Set the org default. |
 
 </Tab>
 

--- a/docs/agent-sessions/flue.mdx
+++ b/docs/agent-sessions/flue.mdx
@@ -287,7 +287,7 @@ Custom tools in the Worker can currently reach only platform-managed outbound ho
 external `fetch` destinations are not part of the supported profile. Commands run through an
 optional OpenComputer sandbox follow the sandbox's separate network policy.
 
-## Optional sandbox
+## Optional sandbox and working repositories
 
 Add `ocSandbox` only when the agent needs a Linux shell or durable files:
 
@@ -295,6 +295,7 @@ Add `ocSandbox` only when the agent needs a Linux shell or durable files:
 import { defineAgent, defineAgentProfile } from "@flue/runtime";
 import {
   DEFAULT_MODEL,
+  ocRepoTools,
   ocSandbox,
   route,
   useOcGateway,
@@ -312,6 +313,7 @@ export default defineAgent((ctx) => {
     }),
     model: DEFAULT_MODEL,
     sandbox: ocSandbox(ctx.env),
+    tools: [...ocRepoTools(ctx)],
   };
 });
 ```
@@ -320,8 +322,16 @@ Declaring `ocSandbox` performs no provisioning during Worker startup or Flue run
 The first real shell or file operation resolves one sandbox for the session; later operations and
 turns reuse it.
 
-The workspace starts empty. Repository sources and workspace skill discovery are not implemented for
-Flue sessions, so passing `sources` at session creation is rejected.
+The workspace starts empty. Add a [working repository](/agent-sessions/repos#choose-working-repositories-for-a-flue-agent)
+at session creation or with `add_source`. Flue pins the requested ref immediately but creates the
+session sandbox and materializes files only when the app first uses a repository tool. The agent may
+edit those files and call `github_publish_pull_request`; OpenComputer performs authenticated Git
+operations outside the tenant Worker and session sandbox.
+
+`ocRepoTools` adds `list_working_repos`, `add_source`, and
+`github_publish_pull_request`. Tell the agent to list first, state the exact
+`owner/repo` it resolved, and ask when the user's target is ambiguous. Repository
+names do not need to be embedded in the prompt.
 
 ## Variables and secrets
 
@@ -408,8 +418,8 @@ and dashboard as the other runtimes. The important differences are:
 
 - Dashboard sessions and the OpenComputer-managed Slack app deliver direct text through the hosted
   session wire. Native Flue channel bindings and workflows are not exposed by this hosting path.
-- Repository sources, checkout, pull-request publishing, watches, and repo-backed workspaces are not
-  supported for Flue sessions.
+- Working-repository checkout and pull-request publishing are available through the owner-bound
+  OpenComputer GitHub App. Pull-request watches are not part of the current Flue profile.
 - Repository deployment accepts one self-contained npm root with a committed npm lockfile. Pushes
   to its linked production branch deploy automatically; preview branches and staged Flue Workers are
   not supported.

--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -7,8 +7,8 @@ Use Repos when a session needs private code. Giving an agent a GitHub token,
 authenticated remote, or `gh` session gives it whatever that token can do; hiding the
 token behind a proxy does not narrow that authority.
 
-Repos make GitHub access operation-scoped. A **Repo** is a stable repository handle
-(owner/repo) that resolves to your configured GitHub App (the OpenComputer App by default);
+Repos make GitHub access operation-scoped. A **Repo** is a stable `repo_…` handle
+with a current `owner/repo` display name that resolves to your configured GitHub App;
 a **Source** pins `ref` and `sha`.
 OpenComputer checks out the exact commit in a short-lived **Git operations sandbox**,
 copies only files into `/workspace/sources/<name>`, and destroys the token. For writes, the
@@ -41,6 +41,38 @@ sandbox, and deploys the resulting artifact. Repository credentials reach neithe
   their own auth surface while sessions continue to reference repos and sources
   the same way.
 </Note>
+
+## Choose working repositories for a Flue agent
+
+A Flue agent's **repository access policy** limits which repositories it may
+check out and publish to. It is independent of the [deployment source](#use-a-repo-to-deploy-a-flue-agent):
+the deployment source supplies the app, while working repositories supply code
+for a session task.
+
+In guided setup or **Agent → Settings → Repository access**, choose:
+
+- **All granted repositories** — every repository currently granted to the
+  owner-bound OpenComputer GitHub App, including repositories added later.
+- **Only selected repositories** — an explicit set stored by stable `repo_…`
+  id. An empty set disables repository work without disabling chat.
+
+The effective set is the intersection of that policy and the App installation's
+current grant. Removing a repository from GitHub takes effect on the next
+checkout or publish. OpenComputer preserves selected ids that are hidden by a
+truncated GitHub listing and shows unavailable selections separately instead of
+calling them revoked.
+
+Choose a working repository when starting a dashboard session, pass it in
+`sources`, or let the Flue app call `add_source`. A ref is pinned to one commit;
+reusing the source name in that session returns the same pin. OpenComputer
+checks files out lazily into the session sandbox and keeps the GitHub token in a
+separate, short-lived Git operations sandbox.
+
+To publish, the agent calls `github_publish_pull_request`. OpenComputer pushes a
+new `oc/…` branch and opens a PR; it never writes directly to the default branch.
+The managed Flue capability uses the OpenComputer App selected for the agent's
+owner. A bring-your-own App is not used as an alternative authority for this
+policy.
 
 ## How it works
 

--- a/docs/agent-sessions/runtime-tools.mdx
+++ b/docs/agent-sessions/runtime-tools.mdx
@@ -55,13 +55,17 @@ commits as usual; calling the tool hands the requested outcome to the platform, 
 commits the agent's edits to an `oc/<session>/<source>-<id>` branch and opens the PR with a
 just-in-time, write-scoped token — outside the agent sandbox. It returns the PR URL.
 
-| Argument | Required | What it is                                                                      |
-| -------- | -------- | ------------------------------------------------------------------------------- |
-| `source` | yes      | The checked-out source's local name (its directory under `/workspace/sources`). |
-| `title`  | yes      | PR title.                                                                       |
-| `body`   | no       | PR description.                                                                 |
-| `base`   | no       | PR base branch. Defaults to the source's checked-out ref.                       |
-| `draft`  | no       | Open the PR as a draft.                                                         |
+| Argument | Required                 | What it is                                                                                                      |
+| -------- | ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `source` | yes                      | The checked-out source's local name (its directory under `/workspace/sources`).                                 |
+| `title`  | yes                      | PR title.                                                                                                       |
+| `body`   | no                       | PR description.                                                                                                 |
+| `base`   | built-in: no · Flue: yes | PR base branch. Built-in runtimes default to the checked-out ref; hosted Flue requires the exact target branch. |
+| `draft`  | no                       | Open the PR as a draft.                                                                                         |
+
+Hosted Flue uses an object input:
+`github_publish_pull_request({ source, title, body?, base, draft? })`. `base` is
+required. Built-in runtimes keep their existing tool input and may omit `base`.
 
 <Note>
   `github_publish_pull_request` requires a **configured GitHub App** (the
@@ -74,13 +78,16 @@ just-in-time, write-scoped token — outside the agent sandbox. It returns the P
   App; they never fall back to a bring-your-own App.
 </Note>
 
-`add_source(repo, ref, name?)` checks out an **additional** repo into
-`/workspace/sources/<name>` mid-session. `repo` is `"owner/repo"` (or a `repo_…` id), `ref` a
-branch or `refs/pull/N/head`, `name` defaults to the repo name. Same zero-credential model as
-the initial checkout — a Git operations sandbox mints a just-in-time, read-only token; the
-agent never sees it. **Connected-App (`oc_app`) repos only.**
+`add_source` checks out an **additional** repo into
+`/workspace/sources/<name>` mid-session. Built-in runtimes use
+`add_source(repo, ref, name?)`. Hosted Flue uses the object input
+`add_source({ repository, ref, name? })`. `repo`/`repository` is exact
+`"owner/repo"` coordinates (or a `repo_…` id), `ref` is a branch, tag, commit,
+or `refs/pull/N/head`, and `name` defaults to the repo name. The Git operations
+sandbox mints a just-in-time read token; the agent never sees it.
+**Connected-App (`oc_app`) repos only.**
 
-For Flue, `repo` must be within the agent's current
+For Flue, `repository` must be within the agent's current
 [repository access policy](/agent-sessions/repos#choose-working-repositories-for-a-flue-agent).
 Checkout is lazy and uses the session's shared hands sandbox. Publishing always
 creates an `oc/…` branch and pull request; it never pushes directly to the

--- a/docs/agent-sessions/runtime-tools.mdx
+++ b/docs/agent-sessions/runtime-tools.mdx
@@ -4,40 +4,50 @@ title: "Runtime tools"
 description: "The tools a runtime can use — what to rely on when you write prompts"
 ---
 
-When you write a prompt for a [runtime](/agent-sessions/runtimes) (`claude` or `codex`), it's useful to know exactly what the agent can do. Both runtimes act through the same fixed set of tools against the session's **sandbox** — the agent has no direct filesystem, shell, or network of its own. The runtime's built-in local tools are disabled; only these remote tools are available.
+When you write a prompt for a built-in [runtime](/agent-sessions/runtimes) (`claude` or `codex`), it's useful to know exactly what the agent can do. Both runtimes act through the same fixed set of tools against the session's **sandbox** — the agent has no direct filesystem, shell, or network of its own. A hosted [Flue](/agent-sessions/flue) app defines its own tool surface; OpenComputer adds exactly `list_working_repos`, `add_source`, and `github_publish_pull_request` for repository work.
 
 ## Sandbox tools
 
-| Tool | What it does |
-| --- | --- |
-| `bash` | Run a shell command in the sandbox. |
-| `read` | Read a file from the sandbox. |
-| `write` | Write a file to the sandbox. |
-| `ls` | List a directory in the sandbox. |
+| Tool    | What it does                        |
+| ------- | ----------------------------------- |
+| `bash`  | Run a shell command in the sandbox. |
+| `read`  | Read a file from the sandbox.       |
+| `write` | Write a file to the sandbox.        |
+| `ls`    | List a directory in the sandbox.    |
 
 `bash` is the only place commands run. Each call is a fresh shell, so use absolute paths or `cd /workspace && ...`. A run surfaces as an [`exec.completed`](/agent-sessions/events#event-shape) event (`{ command, exit_code, summary }`), with large output available via `content_ref`.
 
 To work on a **public** repo, the agent `git clone`s it via `bash` — the sandbox has open outbound internet (below). For **private** repos, register a [Repo](/agent-sessions/repos) and reference it in the session's `sources`: it's checked out before the first turn and the GitHub credential never enters the sandbox.
 
-<Note>**Network:** the sandbox has **open outbound internet** by default (so `git clone`, package installs, and API calls just work), with private, loopback, link-local, and cloud-metadata addresses blocked.</Note>
+<Note>
+  **Network:** the sandbox has **open outbound internet** by default (so `git
+  clone`, package installs, and API calls just work), with private, loopback,
+  link-local, and cloud-metadata addresses blocked.
+</Note>
 
 ## User-facing tools
 
-| Tool | What it does |
-| --- | --- |
-| `say` | Emit a `user`-level message. |
+| Tool  | What it does                       |
+| ----- | ---------------------------------- |
+| `say` | Emit a `user`-level message.       |
 | `ask` | Ask a question and pause the turn. |
 
 The agent's final `say` is the session result. `ask` ends the turn with `yield_reason: "needs_input"`; answer by [steering](/agent-sessions/messaging) a reply, which wakes the session.
 
 ## GitHub tools
 
-| Tool | What it does |
-| --- | --- |
-| `github_publish_pull_request` | Open a pull request from a checked-out [Repo](/agent-sessions/repos) source. |
-| `add_source` | Check out an additional repo into `/workspace/sources/<name>` mid-session. |
-| `watch_pull_request` | Subscribe to events on a PR the session opened — the session is woken when checks finish, a review or comment lands, or it merges. |
-| `unwatch_pull_request` | Stop watching a PR. |
+| Tool                          | Availability           | What it does                                                                                                                       |
+| ----------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `list_working_repos`          | Hosted Flue            | List the repositories currently effective under the agent's policy and GitHub grant.                                               |
+| `github_publish_pull_request` | Built-in + hosted Flue | Open a pull request from a checked-out [Repo](/agent-sessions/repos) source.                                                       |
+| `add_source`                  | Built-in + hosted Flue | Check out an additional repo into `/workspace/sources/<name>` mid-session.                                                         |
+| `watch_pull_request`          | Built-in               | Subscribe to events on a PR the session opened — the session is woken when checks finish, a review or comment lands, or it merges. |
+| `unwatch_pull_request`        | Built-in               | Stop watching a PR.                                                                                                                |
+
+`list_working_repos()` is the hosted Flue discovery surface. It returns exact
+stable ids, current `owner/repo` names, and default branches; the model chooses
+from that structured result instead of relying on repository names embedded in
+a prompt.
 
 `github_publish_pull_request` lets the agent open a PR **without ever holding a GitHub
 credential**. The agent edits files in `/workspace/sources/<source>` and makes local
@@ -45,19 +55,23 @@ commits as usual; calling the tool hands the requested outcome to the platform, 
 commits the agent's edits to an `oc/<session>/<source>-<id>` branch and opens the PR with a
 just-in-time, write-scoped token — outside the agent sandbox. It returns the PR URL.
 
-| Argument | Required | What it is |
-| --- | --- | --- |
-| `source` | yes | The checked-out source's local name (its directory under `/workspace/sources`). |
-| `title` | yes | PR title. |
-| `body` | no | PR description. |
-| `base` | no | PR base branch. Defaults to the source's checked-out ref. |
-| `draft` | no | Open the PR as a draft. |
+| Argument | Required | What it is                                                                      |
+| -------- | -------- | ------------------------------------------------------------------------------- |
+| `source` | yes      | The checked-out source's local name (its directory under `/workspace/sources`). |
+| `title`  | yes      | PR title.                                                                       |
+| `body`   | no       | PR description.                                                                 |
+| `base`   | no       | PR base branch. Defaults to the source's checked-out ref.                       |
+| `draft`  | no       | Open the PR as a draft.                                                         |
 
 <Note>
-`github_publish_pull_request` requires a **configured GitHub App** (the OpenComputer App or
-a [bring-your-own App](/agent-sessions/repos#bring-your-own-app)). It does **not** work with
-inline (`risky_short_lived_token`) auth, which is **checkout-only** — see
-[Repos & GitHub](/agent-sessions/repos#inline-short-lived-token).
+  `github_publish_pull_request` requires a **configured GitHub App** (the
+  OpenComputer App or a [bring-your-own
+  App](/agent-sessions/repos#bring-your-own-app)). It does **not** work with
+  inline (`risky_short_lived_token`) auth, which is **checkout-only** — see
+  [Repos & GitHub](/agent-sessions/repos#inline-short-lived-token). Built-in
+  sessions may resolve through the configured OpenComputer or bring-your-own
+  App. Hosted Flue repository tools always use the agent owner's OpenComputer
+  App; they never fall back to a bring-your-own App.
 </Note>
 
 `add_source(repo, ref, name?)` checks out an **additional** repo into
@@ -66,16 +80,22 @@ branch or `refs/pull/N/head`, `name` defaults to the repo name. Same zero-creden
 the initial checkout — a Git operations sandbox mints a just-in-time, read-only token; the
 agent never sees it. **Connected-App (`oc_app`) repos only.**
 
+For Flue, `repo` must be within the agent's current
+[repository access policy](/agent-sessions/repos#choose-working-repositories-for-a-flue-agent).
+Checkout is lazy and uses the session's shared hands sandbox. Publishing always
+creates an `oc/…` branch and pull request; it never pushes directly to the
+default branch.
+
 `watch_pull_request(wake_on?, repo?, pr?, intent?)` subscribes the session to a PR it opened;
 OpenComputer wakes the session when the wake condition is met. It does **not** block — call it,
 then finish the turn.
 
-| Argument | Required | What it is |
-| --- | --- | --- |
-| `wake_on` | no | The wake condition: `checks` (default), `review` (a review decision), `comment` (a new comment), `merge` (merged/closed). |
-| `repo` | no | The watched repo. Defaults to the most recent PR the session opened. |
-| `pr` | no | The PR number. Defaults with `repo`. |
-| `intent` | no | Freeform note (the *why*), replayed on wake. |
+| Argument  | Required | What it is                                                                                                                |
+| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `wake_on` | no       | The wake condition: `checks` (default), `review` (a review decision), `comment` (a new comment), `merge` (merged/closed). |
+| `repo`    | no       | The watched repo. Defaults to the most recent PR the session opened.                                                      |
+| `pr`      | no       | The PR number. Defaults with `repo`.                                                                                      |
+| `intent`  | no       | Freeform note (the _why_), replayed on wake.                                                                              |
 
 Watches cover PRs the **same session** opened, on **Connected-App (`oc_app`) repos only**.
 `unwatch_pull_request(repo?, pr?)` stops watching; both args default to the session's only

--- a/docs/agent-sessions/sessions.mdx
+++ b/docs/agent-sessions/sessions.mdx
@@ -6,7 +6,11 @@ description: "Durable, resumable agent execution"
 
 A **session** is an [agent](/agent-sessions/agents) run with an append-only [event log](/agent-sessions/events), a pinned configuration snapshot, and a lifecycle status. The execution substrate depends on the [runtime](/agent-sessions/runtimes): built-in runtimes use managed sandboxes, while [Flue](/agent-sessions/flue) uses a deployed Worker and one Durable Object per session.
 
-<Note>The [dashboard](https://app.opencomputer.dev) lists your sessions and opens each with a live event stream you can watch and steer — handy for following or debugging a run without building UI.</Note>
+<Note>
+  The [dashboard](https://app.opencomputer.dev) lists your sessions and opens
+  each with a live event stream you can watch and steer — handy for following or
+  debugging a run without building UI.
+</Note>
 
 ## Session flow
 
@@ -15,20 +19,25 @@ A **session** is an [agent](/agent-sessions/agents) run with an append-only [eve
 3. The runtime appends [events](/agent-sessions/events) as it works. Built-in runtimes execute in managed sandboxes. Flue executes in its Worker and Durable Object, with no sandbox unless the app explicitly uses `ocSandbox`.
 4. With nothing left to do, the session becomes **idle**. A [steer](/agent-sessions/messaging) message starts the next ordered turn with the same conversation context.
 
-Pass [`sources`](/agent-sessions/repos) to prepare `/workspace/sources/` for a built-in runtime. Flue does not yet support repository sources and rejects that parameter.
+Pass [`sources`](/agent-sessions/repos) to give a session working repositories. Built-in runtimes prepare them before turn one. Flue keeps the same pinned source contract but materializes a repository lazily, when its app first uses the repository tools.
 
-<Note>The built-in runtimes restart from checkpointed state, enforce a turn deadline, and survive sandbox reclaim. Flue relies on Durable Object recovery and event projection instead; its current limit and recovery differences are listed on the [Flue page](/agent-sessions/flue#session-behavior).</Note>
+<Note>
+  The built-in runtimes restart from checkpointed state, enforce a turn
+  deadline, and survive sandbox reclaim. Flue relies on Durable Object recovery
+  and event projection instead; its current limit and recovery differences are
+  listed on the [Flue page](/agent-sessions/flue#session-behavior).
+</Note>
 
 ## Lifecycle
 
-| Status | Meaning |
-| --- | --- |
-| `queued` | Scheduled; no turn is running. |
-| `running` | A turn is executing. |
+| Status           | Meaning                                                            |
+| ---------------- | ------------------------------------------------------------------ |
+| `queued`         | Scheduled; no turn is running.                                     |
+| `running`        | A turn is executing.                                               |
 | `awaiting_input` | A turn ended asking you a question — steerable; reply to continue. |
-| `idle` | No turn running; steerable; runtime state is retained. |
-| `failed` | The session errored out. |
-| `archived` | Closed; read-only. |
+| `idle`           | No turn running; steerable; runtime state is retained.             |
+| `failed`         | The session errored out.                                           |
+| `archived`       | Closed; read-only.                                                 |
 
 A session also carries `last_turn = { id, state, yield_reason?, result_event_id? }`; the fuller turn record (`started_at`, `completed_at`, `error`) comes from [`GET …/result`](/agent-sessions/api-reference) and `…/turns`. The **`yield_reason`** tells you why the last turn ended: `completed`, `needs_input` (the agent asked a question and the session is now `awaiting_input`), `budget_exceeded`, `deadline_exceeded`, `max_turns`, or `canceled`. Limit outcomes require runtime enforcement; the current Flue path does not enforce the generic session limits below.
 
@@ -71,21 +80,31 @@ Response:
 }
 ```
 
-<Tip>**For background jobs, register a [destination](/agent-sessions/webhooks).** Polling `GET /…/result` ties up a request and doesn't survive your process restarting. Create the session with `metadata` and a `destination`; handle `turn.completed` in your webhook, then fetch the result. Reserve `result()` polling for synchronous or interactive flows.</Tip>
+<Tip>
+  **For background jobs, register a [destination](/agent-sessions/webhooks).**
+  Polling `GET /…/result` ties up a request and doesn't survive your process
+  restarting. Create the session with `metadata` and a `destination`; handle
+  `turn.completed` in your webhook, then fetch the result. Reserve `result()`
+  polling for synchronous or interactive flows.
+</Tip>
 
 ## Idempotency & routing
 
 Three independent knobs — don't overload one for another:
 
-- **`key`** — *get-or-create*. One session per natural key (e.g. one per PR). A second create with the same `key` returns the same session; reusing a `key` with a **different** request body is rejected (`create key already used with a different request`).
-- **`Idempotency-Key`** (header) — *retry-safe create*. Makes a keyless create safe to retry (e.g. on a webhook redelivery) without spawning duplicates.
-- **`metadata`** — *routing / app state*. Opaque JSON (≤ 16 KB) echoed back on get/list and **verbatim in webhooks**, so your callback can route to the right record. Never use `key` for routing — that's what `metadata` is for.
+- **`key`** — _get-or-create_. One session per natural key (e.g. one per PR). A second create with the same `key` returns the same session; reusing a `key` with a **different** request body is rejected (`create key already used with a different request`).
+- **`Idempotency-Key`** (header) — _retry-safe create_. Makes a keyless create safe to retry (e.g. on a webhook redelivery) without spawning duplicates.
+- **`metadata`** — _routing / app state_. Opaque JSON (≤ 16 KB) echoed back on get/list and **verbatim in webhooks**, so your callback can route to the right record. Never use `key` for routing — that's what `metadata` is for.
 
 ## Limits
 
 Cap a session at create (or default it on the [agent](/agent-sessions/agents)) with `limits: { tokens, turn_seconds, turns }` — a token budget, per-turn wall-clock, and auto-run count. These are runtime limits, not spend controls; model usage is billed to your provider key (BYO) or to your OpenComputer credits (Managed). Hitting one ends the turn with the matching `yield_reason`.
 
-<Warning>These limits are not yet enforced for [Flue](/agent-sessions/flue) sessions. Do not use them as a deadline, turn-count, or token safety boundary for that runtime.</Warning>
+<Warning>
+  These limits are not yet enforced for [Flue](/agent-sessions/flue) sessions.
+  Do not use them as a deadline, turn-count, or token safety boundary for that
+  runtime.
+</Warning>
 
 ## Model
 
@@ -126,6 +145,14 @@ Content-Type: application/json
 For Flue, archive also retains the conversation in the session's Durable Object storage. See
 [Flue session behavior](/agent-sessions/flue#session-behavior).
 
-<Note>When the agent needs input, the turn ends with `yield_reason: "needs_input"` and the session status becomes `awaiting_input`; reply by [steering](/agent-sessions/messaging).</Note>
+<Note>
+  When the agent needs input, the turn ends with `yield_reason: "needs_input"`
+  and the session status becomes `awaiting_input`; reply by
+  [steering](/agent-sessions/messaging).
+</Note>
 
-<Note>**No cross-session memory.** Each session starts from the agent's prompt + that session's `input` — a durable log is *session history*, not memory the agent carries between sessions.</Note>
+<Note>
+  **No cross-session memory.** Each session starts from the agent's prompt +
+  that session's `input` — a durable log is *session history*, not memory the
+  agent carries between sessions.
+</Note>

--- a/docs/agent-sessions/slack.mdx
+++ b/docs/agent-sessions/slack.mdx
@@ -35,6 +35,10 @@ session, setup changes automatically from “waiting for a message” to a compa
 conversation preview with links to the full session and the agent's session
 history.
 
+For Flue agents, setup may also offer working-repository access and a concrete
+first task such as opening a pull request. GitHub access is optional: Slack chat
+continues to work when repository access is empty or disconnected.
+
 <Warning>
   Anyone in the connected Slack workspace who can message the app can use this
   agent. Use the shared app for evaluation with an agent whose tools and spend

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -40,6 +40,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.7.0",
+        "happy-dom": "^20.11.0",
         "prettier": "^3.8.5",
         "prettier-plugin-tailwindcss": "^0.8.0",
         "shadcn": "^4.12.0",
@@ -3964,6 +3965,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -3997,6 +4008,23 @@
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.62.0",
@@ -4851,6 +4879,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -5655,6 +5696,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -7009,6 +7063,25 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.0.tgz",
+      "integrity": "sha512-XogN4asPd1a56di9prVG6bZxteNcXsZxxKmAvcEfc5Px5Ca2hMyMgk8wvqK2K1V8zXg40j9VANXsDaJYh9DeNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -10878,6 +10951,13 @@
         "node": ">=20.18.1"
       }
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -11196,6 +11276,16 @@
       "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
       "license": "Apache-2.0"
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
@@ -11334,6 +11424,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.3.1",

--- a/web/package.json
+++ b/web/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.7.0",
+    "happy-dom": "^20.11.0",
     "prettier": "^3.8.5",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "shadcn": "^4.12.0",

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -35,12 +35,16 @@ export type {
   AgentDeployment,
   AgentDeploymentLog,
   DeployApp,
+  RepositoryAccess,
+  RepositoryAccessPolicy,
+  RepositoryAccessRepository,
   RepositorySourceInspection,
   ManagedSlackAuthorizeResponse,
   ManagedSlackConnection,
   ManagedSlackWorkspaceConnection,
   ManagedSlackDisconnectResponse,
   Session,
+  SessionSource,
   AgentSnapshot,
   SessionEvent,
   Turn,
@@ -666,6 +670,23 @@ export const deleteAgentSkills = (agentId: string) =>
 export const getDeployApp = () =>
   apiFetch('/v3/github/deploy-app', {}, S.DeployAppSchema)
 
+export const getRepositoryAccess = (agentId: string) =>
+  apiFetch(
+    `/v3/agents/${encodeURIComponent(agentId)}/repository-access`,
+    {},
+    S.RepositoryAccessSchema,
+  )
+
+export const updateRepositoryAccess = (
+  agentId: string,
+  policy: S.RepositoryAccessPolicy,
+) =>
+  apiFetch(
+    `/v3/agents/${encodeURIComponent(agentId)}/repository-access`,
+    { method: 'PUT', body: JSON.stringify(policy) },
+    S.RepositoryAccessSchema,
+  )
+
 export const reviewRepositoryAgent = (body: {
   repo: string
   path: string
@@ -850,7 +871,12 @@ export async function getManagedSlackConnection(agentId: string) {
       S.ManagedSlackConnectionSchema,
     )
   } catch (error) {
-    if (error instanceof ApiError && error.status === 404) return null
+    if (
+      (error instanceof ApiError ||
+        (error instanceof Error && 'status' in error)) &&
+      (error as { status: unknown }).status === 404
+    )
+      return null
     throw error
   }
 }
@@ -933,6 +959,13 @@ export const getSessions = (
 
 export const getSession = (id: string) =>
   apiFetch(`/v3/sessions/${id}`, {}, S.SessionSchema)
+
+export const getSessionSources = (id: string) =>
+  apiFetch(
+    `/v3/sessions/${encodeURIComponent(id)}/sources`,
+    {},
+    S.SessionSourceListSchema,
+  )
 
 // The API wants { agent: <id>, input } (input required). An optional `sources[]` attaches
 // a WORKING repo the agent checks out + opens PRs from — the control plane pins the ref's

--- a/web/src/api/mock-contracts.test.ts
+++ b/web/src/api/mock-contracts.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { mockFetch } from './mock'
-import { RepositorySourceInspectionSchema } from './schemas'
+import {
+  RepositoryAccessSchema,
+  RepositorySourceInspectionSchema,
+  SessionSourceListSchema,
+} from './schemas'
 
 describe('preview API contracts', () => {
   it('keeps the repository review fixture valid against the live schema', () => {
@@ -9,5 +13,18 @@ describe('preview API contracts', () => {
     })
 
     expect(() => RepositorySourceInspectionSchema.parse(response)).not.toThrow()
+  })
+
+  it('keeps repository access and source-detail fixtures valid', () => {
+    expect(() =>
+      RepositoryAccessSchema.parse(
+        mockFetch('/v3/agents/agt_flue_import/repository-access'),
+      ),
+    ).not.toThrow()
+    expect(() =>
+      SessionSourceListSchema.parse(
+        mockFetch('/v3/sessions/ses_a1b2c3/sources'),
+      ),
+    ).not.toThrow()
   })
 })

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -512,7 +512,7 @@ const deployAppInstalled = {
     },
     {
       id: 'repo_01k0supportbot00000000',
-      full_name: 'acme/support-bot',
+      full_name: 'acme/customer-support-automation-and-triage',
       default_branch: 'main',
       private: false,
     },
@@ -536,6 +536,34 @@ const deployApp =
   DEPLOY_PREVIEW === 'not_installed'
     ? deployAppNotInstalled
     : deployAppInstalled
+
+const repositoryAccess = {
+  policy: {
+    mode: 'selected' as const,
+    repository_ids: [
+      'repo_01k0acmeagents000000000',
+      'repo_01k0supportbot00000000',
+    ],
+  },
+  grant: {
+    status: 'active' as const,
+    account: 'acme',
+    repository_selection: 'selected' as const,
+    install_url: 'https://github.com/apps/opencomputerdev/installations/new',
+    configure_url:
+      'https://github.com/apps/opencomputerdev/installations/select_target',
+    truncated: false,
+  },
+  effective_repositories: deployAppInstalled.repositories
+    .slice(0, 2)
+    .map((repo) => ({
+      id: repo.id,
+      full_name: repo.full_name,
+      default_branch: repo.default_branch,
+      private: repo.private,
+    })),
+  unavailable_selected_repositories: [],
+}
 
 // The linked source for the 'connected' preview (echoed for any agent id).
 const deploymentSource = {
@@ -944,6 +972,19 @@ const sessions = [
   },
 ]
 
+const sessionSources = [
+  {
+    name: 'app',
+    repo_id: 'repo_01k0acmeagents000000000',
+    full_name: 'acme/agents',
+    requested_ref: 'main',
+    status: 'ready',
+    path: '/workspace/sources/app',
+    sha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+    resolved_sha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+  },
+]
+
 const sessionEvents = [
   {
     id: 'evt_1',
@@ -1157,8 +1198,11 @@ const ROUTES: Array<[RegExp, Handler]> = [
   [/^\/org$/, () => org],
   [/^\/agents$/, () => []],
   // Durable Agent Sessions — lists return the { data: [...] } envelope.
+  [/^\/v3\/slack\/managed\/connections$/, () => ({ data: [] })],
+  [/^\/v3\/agents\/[^/]+\/slack\/managed$/, () => NOT_FOUND],
   [/^\/v3\/agents\/[^/]+\/slack$/, () => slackConnection],
   [/^\/v3\/github\/deploy-app$/, () => deployApp],
+  [/^\/v3\/agents\/[^/]+\/repository-access$/, () => repositoryAccess],
   [
     /^\/v3\/agents\/[^/]+\/deployments\/[^/]+\/logs(?:\?.*)?$/,
     () => ({
@@ -1199,6 +1243,7 @@ const ROUTES: Array<[RegExp, Handler]> = [
   [/^\/v3\/agents\/[^/]+$/, () => agents[0]],
   [/^\/v3\/agents$/, () => ({ data: [...agents, importedAgent] })],
   [/^\/v3\/credentials$/, () => ({ data: credentials })],
+  [/^\/v3\/sessions\/[^/]+\/sources$/, () => sessionSources],
   [/^\/v3\/sessions\/[^/]+\/events/, () => ({ data: sessionEvents })],
   [/^\/v3\/sessions\/[^/]+\/turns$/, () => ({ data: sessionTurns })],
   [
@@ -1223,6 +1268,7 @@ const ROUTES: Array<[RegExp, Handler]> = [
 // Mutations the preview needs to echo something parseable (e.g. the Slack
 // wizard's POST …/slack/manifest → manifest+steps). Everything else 204-ish.
 const POST_ROUTES: [RegExp, () => unknown][] = [
+  [/^\/v3\/agents\/[^/]+\/repository-access$/, () => repositoryAccess],
   [/^\/v3\/github\/deploy-app\/inspect$/, () => flueInspection],
   [
     /^\/v3\/agents\/import$/,
@@ -1262,7 +1308,11 @@ export function mockFetch<T>(path: string, options: RequestInit = {}): T {
   for (const [re, handler] of ROUTES) {
     if (re.test(path)) {
       const out = handler()
-      if (out === NOT_FOUND) throw new Error('Not found') // mimic a 404
+      if (out === NOT_FOUND) {
+        const error = new Error('Not found') as Error & { status: number }
+        error.status = 404
+        throw error
+      }
       return out as T
     }
   }

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -978,7 +978,7 @@ const sessionSources = [
     repo_id: 'repo_01k0acmeagents000000000',
     full_name: 'acme/agents',
     requested_ref: 'main',
-    status: 'ready',
+    status: 'resolved',
     path: '/workspace/sources/app',
     sha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
     resolved_sha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',

--- a/web/src/api/repository-access-client.test.ts
+++ b/web/src/api/repository-access-client.test.ts
@@ -69,7 +69,7 @@ describe('repository access client', () => {
         repo_id: 'repo_1',
         full_name: 'acme/app',
         requested_ref: 'main',
-        status: 'ready',
+        status: 'resolved',
         path: '/workspace/sources/app',
         sha: 'a'.repeat(40),
         resolved_sha: 'b'.repeat(40),

--- a/web/src/api/repository-access-client.test.ts
+++ b/web/src/api/repository-access-client.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  getRepositoryAccess,
+  getSessionSources,
+  updateRepositoryAccess,
+} from './client'
+
+const access = {
+  policy: { mode: 'selected' as const, repository_ids: ['repo_1'] },
+  grant: {
+    status: 'active' as const,
+    account: 'acme',
+    repository_selection: 'selected' as const,
+    install_url: 'https://github.test/install',
+    configure_url: 'https://github.test/configure',
+    truncated: false,
+  },
+  effective_repositories: [
+    {
+      id: 'repo_1',
+      full_name: 'acme/app',
+      default_branch: 'main',
+      private: true,
+    },
+  ],
+  unavailable_selected_repositories: [],
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('repository access client', () => {
+  it('reads and atomically replaces an agent policy', async () => {
+    const calls: Array<{ input: string; init?: RequestInit }> = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url
+        calls.push({ input: url, init })
+        return Promise.resolve(Response.json(access))
+      }),
+    )
+
+    await expect(getRepositoryAccess('agt_/unsafe')).resolves.toEqual(access)
+    await expect(
+      updateRepositoryAccess('agt_/unsafe', {
+        mode: 'selected',
+        repository_ids: ['repo_1'],
+      }),
+    ).resolves.toEqual(access)
+
+    expect(calls[0]?.input).toBe(
+      '/api/dashboard/v3/agents/agt_%2Funsafe/repository-access',
+    )
+    expect(calls[1]?.init?.method).toBe('PUT')
+    expect(calls[1]?.init?.body).toBe(
+      JSON.stringify({ mode: 'selected', repository_ids: ['repo_1'] }),
+    )
+  })
+
+  it('reads source identity and the pinned ref from session detail', async () => {
+    const sources = [
+      {
+        name: 'app',
+        repo_id: 'repo_1',
+        full_name: 'acme/app',
+        requested_ref: 'main',
+        status: 'ready',
+        path: '/workspace/sources/app',
+        sha: 'a'.repeat(40),
+        resolved_sha: 'b'.repeat(40),
+      },
+    ]
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(Response.json(sources))),
+    )
+
+    await expect(getSessionSources('ses_1')).resolves.toEqual(sources)
+  })
+})

--- a/web/src/api/repository-access-schemas.test.ts
+++ b/web/src/api/repository-access-schemas.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { RepositoryAccessSchema, SessionSourceListSchema } from './schemas'
+
+describe('repository access schemas', () => {
+  it('accepts an intentionally empty selected policy and a truncated grant', () => {
+    expect(
+      RepositoryAccessSchema.parse({
+        policy: { mode: 'selected', repository_ids: [] },
+        grant: {
+          status: 'active',
+          account: 'acme',
+          repository_selection: 'selected',
+          install_url: 'https://github.test/install',
+          configure_url: null,
+          truncated: true,
+        },
+        effective_repositories: [],
+        unavailable_selected_repositories: [
+          { id: 'repo_hidden', full_name: 'acme/hidden' },
+        ],
+      }).grant.truncated,
+    ).toBe(true)
+  })
+
+  it('requires null effective repositories when the server reports no list', () => {
+    const result = RepositoryAccessSchema.safeParse({
+      policy: { mode: 'all' },
+      grant: {
+        status: 'unavailable',
+        account: null,
+        repository_selection: null,
+        install_url: 'https://github.test/install',
+        configure_url: null,
+        truncated: false,
+      },
+      effective_repositories: null,
+      unavailable_selected_repositories: [],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('keeps new source identity fields optional for older responses', () => {
+    expect(
+      SessionSourceListSchema.parse([
+        {
+          name: 'app',
+          status: 'ready',
+          path: '/workspace/sources/app',
+          sha: 'a'.repeat(40),
+        },
+      ]),
+    ).toHaveLength(1)
+  })
+})

--- a/web/src/api/repository-access-schemas.test.ts
+++ b/web/src/api/repository-access-schemas.test.ts
@@ -44,7 +44,7 @@ describe('repository access schemas', () => {
       SessionSourceListSchema.parse([
         {
           name: 'app',
-          status: 'ready',
+          status: 'pending',
           path: '/workspace/sources/app',
           sha: 'a'.repeat(40),
         },

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -650,6 +650,39 @@ export const DeployAppSchema = z.object({
   repository_selection: z.enum(['all', 'selected']).nullish(),
   repositories: z.array(DeployAppRepoSchema).default([]),
 })
+
+// GitHub repositories a Flue agent may use as working sources. This is
+// intentionally separate from DeploymentSourceSchema: a deployment source
+// provides the agent's code, while this policy bounds repositories the running
+// agent may check out and publish to.
+export const RepositoryAccessPolicySchema = z.union([
+  z.object({ mode: z.literal('all') }),
+  z.object({
+    mode: z.literal('selected'),
+    repository_ids: z.array(z.string()),
+  }),
+])
+export const RepositoryAccessRepositorySchema = z.object({
+  id: z.string(),
+  full_name: z.string(),
+  default_branch: z.string(),
+  private: z.boolean(),
+})
+export const RepositoryAccessSchema = z.object({
+  policy: RepositoryAccessPolicySchema,
+  grant: z.object({
+    status: z.enum(['active', 'not_installed', 'unavailable']),
+    account: z.string().nullable(),
+    repository_selection: z.enum(['all', 'selected']).nullable(),
+    install_url: z.string(),
+    configure_url: z.string().nullable(),
+    truncated: z.boolean(),
+  }),
+  effective_repositories: z.array(RepositoryAccessRepositorySchema).nullable(),
+  unavailable_selected_repositories: z
+    .array(z.object({ id: z.string(), full_name: z.string() }))
+    .default([]),
+})
 export const LinkResultSchema = z.object({
   source: DeploymentSourceSchema,
   deployment_id: z.string().nullish(),
@@ -896,6 +929,21 @@ export const SessionListSchema = z.object({
   next_cursor: z.string().nullish(),
 })
 
+export const SessionSourceSchema = z.object({
+  name: z.string(),
+  status: z.string(),
+  path: z.string(),
+  sha: z.string(),
+  resolved_sha: z.string().optional(),
+  repo_id: z.string().optional(),
+  full_name: z.string().optional(),
+  requested_ref: z.string().optional(),
+  error_code: z.string().optional(),
+  error_message: z.string().optional(),
+  retryable: z.boolean().optional(),
+})
+export const SessionSourceListSchema = z.array(SessionSourceSchema)
+
 export const ActorSchema = z.object({
   id: z.string().optional(),
   display: z.string().optional(),
@@ -985,6 +1033,13 @@ export type AgentDeployment = z.infer<typeof AgentDeploymentSchema>
 export type AgentDeploymentLog = z.infer<typeof AgentDeploymentLogSchema>
 export type DeploymentSource = z.infer<typeof DeploymentSourceSchema>
 export type DeployApp = z.infer<typeof DeployAppSchema>
+export type RepositoryAccessPolicy = z.infer<
+  typeof RepositoryAccessPolicySchema
+>
+export type RepositoryAccessRepository = z.infer<
+  typeof RepositoryAccessRepositorySchema
+>
+export type RepositoryAccess = z.infer<typeof RepositoryAccessSchema>
 export type RepositorySourceInspection = z.infer<
   typeof RepositorySourceInspectionSchema
 >
@@ -1004,6 +1059,7 @@ export type ManagedSlackDisconnectResponse = z.infer<
   typeof ManagedSlackDisconnectResponseSchema
 >
 export type Session = z.infer<typeof SessionSchema>
+export type SessionSource = z.infer<typeof SessionSourceSchema>
 export type AgentSnapshot = z.infer<typeof AgentSnapshotSchema>
 export type SessionEvent = z.infer<typeof SessionEventSchema>
 export type Turn = z.infer<typeof TurnSchema>

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -931,7 +931,14 @@ export const SessionListSchema = z.object({
 
 export const SessionSourceSchema = z.object({
   name: z.string(),
-  status: z.string(),
+  status: z.enum([
+    'pending',
+    'materializing',
+    'resolved',
+    'failed',
+    'unavailable',
+    'auth_required',
+  ]),
   path: z.string(),
   sha: z.string(),
   resolved_sha: z.string().optional(),

--- a/web/src/components/repository-access-agent-switch.test.tsx
+++ b/web/src/components/repository-access-agent-switch.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { RepositoryAccess } from '@/api/client'
+import { repositoryAccessQueryKey } from '@/lib/repository-access'
+import { RepositoryAccessPanel } from './repository-access'
+
+const agentA = 'agt_aaaaaaaaaaaaaaaaaaaaaaaa'
+const agentB = 'agt_bbbbbbbbbbbbbbbbbbbbbbbb'
+
+const repository = {
+  id: 'repo_1',
+  full_name: 'acme/support-agent',
+  default_branch: 'main',
+  private: true,
+}
+
+function access(policy: RepositoryAccess['policy']): RepositoryAccess {
+  return {
+    policy,
+    grant: {
+      status: 'active',
+      account: 'acme',
+      repository_selection: 'all',
+      install_url: 'https://github.test/install',
+      configure_url: 'https://github.test/configure',
+      truncated: false,
+    },
+    effective_repositories: policy.mode === 'all' ? [repository] : [],
+    unavailable_selected_repositories: [],
+  }
+}
+
+function button(container: ParentNode, label: string): HTMLButtonElement {
+  const match = [...container.querySelectorAll('button')].find((element) =>
+    element.textContent?.includes(label),
+  )
+  if (!(match instanceof HTMLButtonElement))
+    throw new Error(`Button not found: ${label}`)
+  return match
+}
+
+function radio(container: ParentNode, label: string): HTMLInputElement {
+  const match = [
+    ...container.querySelectorAll<HTMLInputElement>('input[type="radio"]'),
+  ].find((element) => element.closest('label')?.textContent?.includes(label))
+  if (!match) throw new Error(`Radio not found: ${label}`)
+  return match
+}
+
+describe('RepositoryAccessPanel agent scoping', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let client: QueryClient
+
+  beforeEach(() => {
+    ;(
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    })
+    client.setQueryData(
+      repositoryAccessQueryKey(agentA),
+      access({ mode: 'all' }),
+    )
+    client.setQueryData(
+      repositoryAccessQueryKey(agentB),
+      access({ mode: 'selected', repository_ids: [] }),
+    )
+    client.setQueryData(['deploy-app'], {
+      installed: true,
+      install_url: 'https://github.test/install',
+      configure_url: 'https://github.test/configure',
+      account: 'acme',
+      repository_selection: 'all',
+      repositories: [repository],
+    })
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    client.clear()
+    container.remove()
+    document.body.replaceChildren()
+  })
+
+  function renderAgent(agentId: string) {
+    act(() => {
+      root.render(
+        <QueryClientProvider client={client}>
+          <RepositoryAccessPanel agentId={agentId} />
+        </QueryClientProvider>,
+      )
+    })
+  }
+
+  it('discards Agent A draft, search, and confirmation when rerendered for Agent B', () => {
+    renderAgent(agentA)
+
+    const allPolicy = radio(container, 'All granted repositories')
+    const selectedPolicyA = radio(container, 'Only selected repositories')
+    expect(allPolicy.name).toBe(selectedPolicyA.name)
+    expect(allPolicy.checked).toBe(true)
+    act(() => selectedPolicyA.click())
+    expect(selectedPolicyA.checked).toBe(true)
+    const search = container.querySelector<HTMLInputElement>(
+      'input[aria-label="Find a repository"]',
+    )
+    expect(search).not.toBeNull()
+    act(() => {
+      search!.value = 'support'
+      search!.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    expect(search!.value).toBe('support')
+
+    act(() => button(container, 'Save access').click())
+    expect(document.body.textContent).toContain('Narrow repository access?')
+
+    renderAgent(agentB)
+
+    const selectedPolicy = radio(container, 'Only selected repositories')
+    expect(selectedPolicy.checked).toBe(true)
+    expect(button(container, 'Save access').disabled).toBe(true)
+    expect(
+      container.querySelector<HTMLInputElement>(
+        'input[aria-label="Find a repository"]',
+      )?.value,
+    ).toBe('')
+    expect(document.body.textContent).not.toContain('Narrow repository access?')
+  })
+})

--- a/web/src/components/repository-access.test.tsx
+++ b/web/src/components/repository-access.test.tsx
@@ -1,0 +1,150 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type { RepositoryAccess } from '@/api/client'
+import { repositoryAccessQueryKey } from '@/lib/repository-access'
+import {
+  RepositoryAccessPanel,
+  RepositoryAccessSummary,
+} from './repository-access'
+
+const agentId = 'agt_aaaaaaaaaaaaaaaaaaaaaaaa'
+
+function renderAccess(access: RepositoryAccess, summary = false) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  })
+  client.setQueryData(repositoryAccessQueryKey(agentId), access)
+  client.setQueryData(['deploy-app'], {
+    installed: true,
+    install_url: access.grant.install_url,
+    configure_url: access.grant.configure_url,
+    account: access.grant.account,
+    repository_selection: access.grant.repository_selection,
+    repositories: access.effective_repositories ?? [],
+  })
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      {summary ? (
+        <RepositoryAccessSummary agentId={agentId} onOpenSettings={() => {}} />
+      ) : (
+        <RepositoryAccessPanel agentId={agentId} />
+      )}
+    </QueryClientProvider>,
+  )
+}
+
+const selected: RepositoryAccess = {
+  policy: { mode: 'selected', repository_ids: ['repo_1'] },
+  grant: {
+    status: 'active',
+    account: 'acme',
+    repository_selection: 'selected',
+    install_url: 'https://github.test/install',
+    configure_url: 'https://github.test/configure',
+    truncated: false,
+  },
+  effective_repositories: [
+    {
+      id: 'repo_1',
+      full_name: 'acme/a-very-long-repository-name',
+      default_branch: 'main',
+      private: true,
+    },
+  ],
+  unavailable_selected_repositories: [],
+}
+
+describe('repository access UI', () => {
+  it('renders the default all-granted policy without requiring a save', () => {
+    const html = renderAccess({ ...selected, policy: { mode: 'all' } })
+    expect(html).toContain('All granted repositories')
+    expect(html).toContain('Includes repositories added')
+    expect(html).toContain('Save access')
+    expect(html).toContain('disabled=""')
+  })
+
+  it('renders a selected policy, current repository and settings action', () => {
+    const html = renderAccess(selected)
+    expect(html).toContain('Only selected repositories')
+    expect(html).toContain('acme/a-very-long-repository-name')
+    expect(html).toContain('Configure GitHub app')
+    expect(html).toContain('Save access')
+  })
+
+  it('renders selected-empty as disabled repository work', () => {
+    const html = renderAccess({
+      ...selected,
+      policy: { mode: 'selected', repository_ids: [] },
+      effective_repositories: [],
+    })
+    expect(html).toContain('Repository work is disabled')
+    expect(html).toContain('This agent can still chat')
+  })
+
+  it('warns on a partial catalog and keeps unavailable selections visible', () => {
+    const html = renderAccess({
+      ...selected,
+      grant: { ...selected.grant, truncated: true },
+      policy: {
+        mode: 'selected',
+        repository_ids: ['repo_1', 'repo_hidden'],
+      },
+      unavailable_selected_repositories: [
+        { id: 'repo_hidden', full_name: 'acme/removed' },
+      ],
+    })
+    expect(html).toContain('partial repository list')
+    expect(html).toContain('Hidden selections are preserved')
+    expect(html).toContain('acme/removed')
+    expect(html).toContain('Unavailable')
+  })
+
+  it('distinguishes an unavailable grant from a valid empty grant', () => {
+    const html = renderAccess({
+      ...selected,
+      grant: { ...selected.grant, status: 'unavailable' },
+      effective_repositories: null,
+    })
+    expect(html).toContain('GitHub access needs attention')
+    expect(html).toContain('Reconnect GitHub')
+    expect(html).not.toContain('No repositories are available')
+  })
+
+  it('offers GitHub installation without making chat unavailable', () => {
+    const html = renderAccess({
+      ...selected,
+      grant: {
+        ...selected.grant,
+        status: 'not_installed',
+        account: null,
+        repository_selection: null,
+        configure_url: null,
+      },
+      effective_repositories: [],
+    })
+    expect(html).toContain('Connect GitHub to work in repositories')
+    expect(html).toContain('Chat still works without GitHub')
+    expect(html).toContain('>Connect GitHub<')
+  })
+
+  it('summarizes access without duplicating the full editor', () => {
+    const html = renderAccess(selected, true)
+    expect(html).toContain('1 selected repository')
+    expect(html).toContain('Manage access')
+    expect(html).not.toContain('Find a repository')
+  })
+
+  it('distinguishes an unavailable summary from a missing installation', () => {
+    const html = renderAccess(
+      {
+        ...selected,
+        grant: { ...selected.grant, status: 'unavailable' },
+        effective_repositories: null,
+      },
+      true,
+    )
+    expect(html).toContain('GitHub access is unavailable')
+    expect(html).not.toContain('GitHub is not connected')
+  })
+})

--- a/web/src/components/repository-access.test.tsx
+++ b/web/src/components/repository-access.test.tsx
@@ -95,9 +95,21 @@ describe('repository access UI', () => {
       ],
     })
     expect(html).toContain('partial repository list')
-    expect(html).toContain('Hidden selections are preserved')
+    expect(html).toContain('Hidden existing selections are preserved')
     expect(html).toContain('acme/removed')
     expect(html).toContain('Unavailable')
+  })
+
+  it('explains that switching from a truncated all grant is intentionally narrowing', () => {
+    const html = renderAccess({
+      ...selected,
+      grant: { ...selected.grant, truncated: true },
+      policy: { mode: 'all' },
+    })
+    expect(html).toContain(
+      'Switching to selected access limits the agent to repositories you choose from this partial list.',
+    )
+    expect(html).not.toContain('Hidden existing selections are preserved')
   })
 
   it('distinguishes an unavailable grant from a valid empty grant', () => {

--- a/web/src/components/repository-access.tsx
+++ b/web/src/components/repository-access.tsx
@@ -103,13 +103,28 @@ function AccessUnavailable({ access }: { access: RepositoryAccess }) {
   )
 }
 
+interface RepositoryAccessPanelProps {
+  agentId: string
+  context?: 'setup' | 'settings'
+}
+
 export function RepositoryAccessPanel({
   agentId,
   context = 'settings',
-}: {
-  agentId: string
-  context?: 'setup' | 'settings'
-}) {
+}: RepositoryAccessPanelProps) {
+  return (
+    <RepositoryAccessPanelForAgent
+      key={agentId}
+      agentId={agentId}
+      context={context}
+    />
+  )
+}
+
+function RepositoryAccessPanelForAgent({
+  agentId,
+  context = 'settings',
+}: RepositoryAccessPanelProps) {
   const queryClient = useQueryClient()
   const accessQuery = useRepositoryAccess(agentId)
   const deployAppQuery = useQuery({
@@ -248,22 +263,24 @@ export function RepositoryAccessPanel({
           <AccessUnavailable access={access} />
         ) : access && draft ? (
           <div className="space-y-4">
-            <div
-              className="grid gap-2 sm:grid-cols-2"
-              role="radiogroup"
-              aria-label="Repository policy"
-            >
-              <button
-                type="button"
-                role="radio"
-                aria-checked={draft.mode === 'all'}
-                onClick={() => setDraft({ mode: 'all' })}
+            <fieldset className="grid gap-2 sm:grid-cols-2">
+              <legend className="sr-only">Repository policy</legend>
+              <label
                 className={cn(
-                  'hover:border-foreground/20 flex min-h-16 min-w-0 items-start gap-3 rounded-lg border p-3 text-left transition-colors',
+                  'hover:border-foreground/20 focus-within:ring-foreground/20 flex min-h-16 min-w-0 cursor-pointer items-start gap-3 rounded-lg border p-3 text-left transition-colors focus-within:ring-2 focus-within:ring-offset-2',
                   draft.mode === 'all' && 'border-foreground/30 bg-muted/50',
                 )}
               >
+                <input
+                  type="radio"
+                  name={`repository-policy-${agentId}`}
+                  value="all"
+                  checked={draft.mode === 'all'}
+                  onChange={() => setDraft({ mode: 'all' })}
+                  className="sr-only"
+                />
                 <span
+                  aria-hidden
                   className={cn(
                     'mt-0.5 grid size-4 place-items-center rounded-full border',
                     draft.mode === 'all' &&
@@ -280,29 +297,34 @@ export function RepositoryAccessPanel({
                     Includes repositories added to the installation later.
                   </span>
                 </span>
-              </button>
-              <button
-                type="button"
-                role="radio"
-                aria-checked={draft.mode === 'selected'}
-                onClick={() =>
-                  setDraft({
-                    mode: 'selected',
-                    repository_ids:
-                      access.policy.mode === 'selected'
-                        ? selectedRepositoryIds(access.policy)
-                        : (access.effective_repositories ?? []).map(
-                            (repo) => repo.id,
-                          ),
-                  })
-                }
+              </label>
+              <label
                 className={cn(
-                  'hover:border-foreground/20 flex min-h-16 min-w-0 items-start gap-3 rounded-lg border p-3 text-left transition-colors',
+                  'hover:border-foreground/20 focus-within:ring-foreground/20 flex min-h-16 min-w-0 cursor-pointer items-start gap-3 rounded-lg border p-3 text-left transition-colors focus-within:ring-2 focus-within:ring-offset-2',
                   draft.mode === 'selected' &&
                     'border-foreground/30 bg-muted/50',
                 )}
               >
+                <input
+                  type="radio"
+                  name={`repository-policy-${agentId}`}
+                  value="selected"
+                  checked={draft.mode === 'selected'}
+                  onChange={() =>
+                    setDraft({
+                      mode: 'selected',
+                      repository_ids:
+                        access.policy.mode === 'selected'
+                          ? selectedRepositoryIds(access.policy)
+                          : (access.effective_repositories ?? []).map(
+                              (repo) => repo.id,
+                            ),
+                    })
+                  }
+                  className="sr-only"
+                />
                 <span
+                  aria-hidden
                   className={cn(
                     'mt-0.5 grid size-4 place-items-center rounded-full border',
                     draft.mode === 'selected' &&
@@ -321,8 +343,8 @@ export function RepositoryAccessPanel({
                     An empty selection disables repository work.
                   </span>
                 </span>
-              </button>
-            </div>
+              </label>
+            </fieldset>
 
             {access.grant.truncated ? (
               <div className="border-border bg-muted/40 rounded-md border px-3 py-2 text-xs">
@@ -330,8 +352,10 @@ export function RepositoryAccessPanel({
                   GitHub returned a partial repository list
                 </p>
                 <p className="text-muted-foreground mt-0.5">
-                  Hidden selections are preserved when you save. Configure the
-                  GitHub app to see the full grant.
+                  {access.policy.mode === 'selected'
+                    ? 'Hidden existing selections are preserved when you save.'
+                    : 'Switching to selected access limits the agent to repositories you choose from this partial list.'}{' '}
+                  Configure the GitHub app to see the full grant.
                 </p>
               </div>
             ) : null}

--- a/web/src/components/repository-access.tsx
+++ b/web/src/components/repository-access.tsx
@@ -1,0 +1,585 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  ArrowUpRight,
+  Check,
+  ChevronRight,
+  GitPullRequest,
+  LoaderCircle,
+  Search,
+  ShieldCheck,
+} from 'lucide-react'
+import {
+  getDeployApp,
+  updateRepositoryAccess,
+  type RepositoryAccess,
+  type RepositoryAccessPolicy,
+} from '@/api/client'
+import { GithubMark } from '@/components/github-mark'
+import {
+  Panel,
+  PanelContent,
+  PanelDescription,
+  PanelFooter,
+  PanelHeader,
+  PanelTitle,
+} from '@/components/panel'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/skeleton'
+import { notifyError, notifySuccess } from '@/lib/errors'
+import { useRepositoryAccess } from '@/hooks/use-repository-access'
+import {
+  isNarrowingRepositoryAccess,
+  repositoryAccessCandidates,
+  repositoryAccessQueryKey,
+  sameRepositoryAccessPolicy,
+  selectedRepositoryIds,
+  toggleSelectedRepository,
+} from '@/lib/repository-access'
+import { cn } from '@/lib/utils'
+
+function ExternalAction({
+  href,
+  children,
+}: {
+  href: string
+  children: string
+}) {
+  return (
+    <Button asChild size="sm" variant="outline">
+      <a href={href} target="_blank" rel="noreferrer">
+        {children}
+        <ArrowUpRight />
+      </a>
+    </Button>
+  )
+}
+
+function AccessUnavailable({ access }: { access: RepositoryAccess }) {
+  if (access.grant.status === 'not_installed') {
+    return (
+      <div className="flex flex-col items-start gap-3 py-1">
+        <div>
+          <p className="text-sm font-medium">
+            Connect GitHub to work in repositories
+          </p>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Chat still works without GitHub. Connect the OpenComputer app when
+            this agent needs to read code or open pull requests.
+          </p>
+        </div>
+        <ExternalAction href={access.grant.install_url}>
+          Connect GitHub
+        </ExternalAction>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-3 py-1">
+      <div>
+        <p className="text-sm font-medium">GitHub access needs attention</p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          The installation is unavailable. Reconnect it before this agent works
+          in a repository.
+        </p>
+      </div>
+      <ExternalAction href={access.grant.install_url}>
+        Reconnect GitHub
+      </ExternalAction>
+    </div>
+  )
+}
+
+export function RepositoryAccessPanel({
+  agentId,
+  context = 'settings',
+}: {
+  agentId: string
+  context?: 'setup' | 'settings'
+}) {
+  const queryClient = useQueryClient()
+  const accessQuery = useRepositoryAccess(agentId)
+  const deployAppQuery = useQuery({
+    queryKey: ['deploy-app'],
+    queryFn: getDeployApp,
+    enabled:
+      accessQuery.data?.grant.status === 'active' &&
+      accessQuery.data.policy.mode === 'selected',
+    staleTime: 30_000,
+    refetchOnWindowFocus: 'always',
+  })
+  const [draft, setDraft] = useState<RepositoryAccessPolicy | null>(
+    () => accessQuery.data?.policy ?? null,
+  )
+  const baselinePolicy = useRef<RepositoryAccessPolicy | null>(null)
+  const [search, setSearch] = useState('')
+  const [confirming, setConfirming] = useState(false)
+
+  const access = accessQuery.data
+  useEffect(() => {
+    if (!access) return
+    setDraft((current) => {
+      const clean =
+        current === null ||
+        baselinePolicy.current === null ||
+        sameRepositoryAccessPolicy(current, baselinePolicy.current)
+      baselinePolicy.current = access.policy
+      return clean ? access.policy : current
+    })
+  }, [access])
+
+  const candidates = useMemo(
+    () =>
+      access ? repositoryAccessCandidates(access, deployAppQuery.data) : [],
+    [access, deployAppQuery.data],
+  )
+  const visibleCandidates = useMemo(() => {
+    const term = search.trim().toLocaleLowerCase()
+    return term
+      ? candidates.filter((repo) =>
+          repo.full_name.toLocaleLowerCase().includes(term),
+        )
+      : candidates
+  }, [candidates, search])
+
+  const saveMutation = useMutation({
+    mutationFn: (policy: RepositoryAccessPolicy) =>
+      updateRepositoryAccess(agentId, policy),
+    onMutate: async (policy) => {
+      const key = repositoryAccessQueryKey(agentId)
+      await queryClient.cancelQueries({ queryKey: key })
+      const previous = queryClient.getQueryData<RepositoryAccess>(key)
+      if (previous) queryClient.setQueryData(key, { ...previous, policy })
+      return { previous }
+    },
+    onError: (error, _policy, contextValue) => {
+      if (contextValue?.previous) {
+        queryClient.setQueryData(
+          repositoryAccessQueryKey(agentId),
+          contextValue.previous,
+        )
+        setDraft(contextValue.previous.policy)
+        baselinePolicy.current = contextValue.previous.policy
+      }
+      notifyError("Couldn't save repository access.", error)
+    },
+    onSuccess: (next) => {
+      queryClient.setQueryData(repositoryAccessQueryKey(agentId), next)
+      setDraft(next.policy)
+      baselinePolicy.current = next.policy
+      notifySuccess('Repository access saved.')
+    },
+    onSettled: () =>
+      queryClient.invalidateQueries({
+        queryKey: repositoryAccessQueryKey(agentId),
+      }),
+  })
+
+  const save = () => {
+    if (!access || !draft) return
+    if (isNarrowingRepositoryAccess(access.policy, draft)) {
+      setConfirming(true)
+      return
+    }
+    saveMutation.mutate(draft)
+  }
+
+  const title =
+    context === 'setup' ? 'Choose working repositories' : 'Repository access'
+  const description =
+    context === 'setup'
+      ? 'Optional. Let this agent check out code and open pull requests.'
+      : 'Choose where this agent can check out code and open pull requests.'
+
+  return (
+    <Panel className="min-w-0 overflow-hidden">
+      <PanelHeader className="flex-wrap">
+        <div className="min-w-0">
+          <PanelTitle className="flex items-center gap-2">
+            <GithubMark className="size-4" />
+            {title}
+          </PanelTitle>
+          <PanelDescription className="mt-1">{description}</PanelDescription>
+        </div>
+        {access?.grant.status === 'active' && access.grant.account ? (
+          <span className="text-muted-foreground max-w-40 truncate text-xs">
+            {access.grant.account}
+          </span>
+        ) : null}
+      </PanelHeader>
+      <PanelContent>
+        {accessQuery.isLoading ? (
+          <div className="space-y-3" aria-label="Loading repository access">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-24 w-full" />
+          </div>
+        ) : accessQuery.isError ? (
+          <div className="flex flex-col items-start gap-3 py-1">
+            <div>
+              <p className="text-sm font-medium">
+                Couldn’t load repository access
+              </p>
+              <p className="text-muted-foreground mt-1 text-sm">
+                Nothing changed. Try loading it again.
+              </p>
+            </div>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => void accessQuery.refetch()}
+            >
+              Retry
+            </Button>
+          </div>
+        ) : access && access.grant.status !== 'active' ? (
+          <AccessUnavailable access={access} />
+        ) : access && draft ? (
+          <div className="space-y-4">
+            <div
+              className="grid gap-2 sm:grid-cols-2"
+              role="radiogroup"
+              aria-label="Repository policy"
+            >
+              <button
+                type="button"
+                role="radio"
+                aria-checked={draft.mode === 'all'}
+                onClick={() => setDraft({ mode: 'all' })}
+                className={cn(
+                  'hover:border-foreground/20 flex min-h-16 min-w-0 items-start gap-3 rounded-lg border p-3 text-left transition-colors',
+                  draft.mode === 'all' && 'border-foreground/30 bg-muted/50',
+                )}
+              >
+                <span
+                  className={cn(
+                    'mt-0.5 grid size-4 place-items-center rounded-full border',
+                    draft.mode === 'all' &&
+                      'border-foreground bg-foreground text-background',
+                  )}
+                >
+                  {draft.mode === 'all' ? <Check className="size-3" /> : null}
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-sm font-medium">
+                    All granted repositories
+                  </span>
+                  <span className="text-muted-foreground mt-0.5 block text-xs">
+                    Includes repositories added to the installation later.
+                  </span>
+                </span>
+              </button>
+              <button
+                type="button"
+                role="radio"
+                aria-checked={draft.mode === 'selected'}
+                onClick={() =>
+                  setDraft({
+                    mode: 'selected',
+                    repository_ids:
+                      access.policy.mode === 'selected'
+                        ? selectedRepositoryIds(access.policy)
+                        : (access.effective_repositories ?? []).map(
+                            (repo) => repo.id,
+                          ),
+                  })
+                }
+                className={cn(
+                  'hover:border-foreground/20 flex min-h-16 min-w-0 items-start gap-3 rounded-lg border p-3 text-left transition-colors',
+                  draft.mode === 'selected' &&
+                    'border-foreground/30 bg-muted/50',
+                )}
+              >
+                <span
+                  className={cn(
+                    'mt-0.5 grid size-4 place-items-center rounded-full border',
+                    draft.mode === 'selected' &&
+                      'border-foreground bg-foreground text-background',
+                  )}
+                >
+                  {draft.mode === 'selected' ? (
+                    <Check className="size-3" />
+                  ) : null}
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-sm font-medium">
+                    Only selected repositories
+                  </span>
+                  <span className="text-muted-foreground mt-0.5 block text-xs">
+                    An empty selection disables repository work.
+                  </span>
+                </span>
+              </button>
+            </div>
+
+            {access.grant.truncated ? (
+              <div className="border-border bg-muted/40 rounded-md border px-3 py-2 text-xs">
+                <p className="font-medium">
+                  GitHub returned a partial repository list
+                </p>
+                <p className="text-muted-foreground mt-0.5">
+                  Hidden selections are preserved when you save. Configure the
+                  GitHub app to see the full grant.
+                </p>
+              </div>
+            ) : null}
+
+            {draft.mode === 'selected' ? (
+              <div className="space-y-2">
+                <div className="relative">
+                  <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+                  <Input
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                    placeholder="Find a repository"
+                    aria-label="Find a repository"
+                    className="h-8 pl-8"
+                  />
+                </div>
+                {deployAppQuery.isLoading ? (
+                  <div
+                    className="space-y-2"
+                    aria-label="Loading repository catalog"
+                  >
+                    <Skeleton className="h-10 w-full" />
+                    <Skeleton className="h-10 w-full" />
+                  </div>
+                ) : null}
+                {deployAppQuery.isError ? (
+                  <div className="flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-xs">
+                    <span className="text-muted-foreground">
+                      Couldn’t load the full repository list.
+                    </span>
+                    <Button
+                      size="xs"
+                      variant="ghost"
+                      onClick={() => void deployAppQuery.refetch()}
+                    >
+                      Retry
+                    </Button>
+                  </div>
+                ) : null}
+                {!deployAppQuery.isLoading ? (
+                  <div className="max-h-64 overflow-y-auto rounded-lg border">
+                    {visibleCandidates.length ? (
+                      visibleCandidates.map((repo) => {
+                        const checked = draft.repository_ids.includes(repo.id)
+                        const unavailable =
+                          access.unavailable_selected_repositories.some(
+                            (item) => item.id === repo.id,
+                          )
+                        return (
+                          <label
+                            key={repo.id}
+                            className="hover:bg-muted/40 flex min-w-0 cursor-pointer items-center gap-3 overflow-hidden border-b px-3 py-2.5 last:border-b-0"
+                          >
+                            <Checkbox
+                              checked={checked}
+                              onCheckedChange={(next) =>
+                                setDraft(
+                                  toggleSelectedRepository(
+                                    draft,
+                                    repo.id,
+                                    next === true,
+                                  ),
+                                )
+                              }
+                            />
+                            <GithubMark className="text-muted-foreground size-3.5 shrink-0" />
+                            <span
+                              className="min-w-0 flex-1 truncate text-sm"
+                              title={repo.full_name}
+                            >
+                              {repo.full_name}
+                            </span>
+                            {unavailable ? (
+                              <span className="text-muted-foreground shrink-0 text-xs">
+                                Unavailable
+                              </span>
+                            ) : repo.private ? (
+                              <span className="text-muted-foreground shrink-0 text-xs">
+                                Private
+                              </span>
+                            ) : null}
+                          </label>
+                        )
+                      })
+                    ) : (
+                      <p className="text-muted-foreground px-3 py-5 text-center text-sm">
+                        {candidates.length
+                          ? 'No repositories match.'
+                          : deployAppQuery.isError
+                            ? 'Current selections are unavailable until the repository list reloads.'
+                            : 'No repositories are available.'}
+                      </p>
+                    )}
+                  </div>
+                ) : null}
+                {draft.repository_ids.length === 0 ? (
+                  <p className="text-muted-foreground text-xs">
+                    Repository work is disabled. This agent can still chat.
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </PanelContent>
+      {access?.grant.status === 'active' && draft ? (
+        <PanelFooter className="flex-wrap justify-between">
+          <div className="min-w-0">
+            {access.grant.configure_url ? (
+              <a
+                href={access.grant.configure_url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs underline underline-offset-4"
+              >
+                Configure GitHub app <ArrowUpRight className="size-3" />
+              </a>
+            ) : null}
+          </div>
+          <Button
+            size="sm"
+            className="ml-auto"
+            onClick={save}
+            disabled={
+              saveMutation.isPending ||
+              sameRepositoryAccessPolicy(access.policy, draft)
+            }
+          >
+            {saveMutation.isPending ? (
+              <LoaderCircle className="animate-spin" />
+            ) : null}
+            Save access
+          </Button>
+        </PanelFooter>
+      ) : null}
+
+      <AlertDialog open={confirming} onOpenChange={setConfirming}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Narrow repository access?</AlertDialogTitle>
+            <AlertDialogDescription>
+              New checkouts and publishes to removed repositories will be
+              blocked. Files already copied into an active session remain in its
+              sandbox until that session is archived.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep current access</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setConfirming(false)
+                if (draft) saveMutation.mutate(draft)
+              }}
+            >
+              Save narrower access
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Panel>
+  )
+}
+
+export function RepositoryAccessSummary({
+  agentId,
+  onOpenSettings,
+}: {
+  agentId: string
+  onOpenSettings: () => void
+}) {
+  const accessQuery = useRepositoryAccess(agentId)
+  const access = accessQuery.data
+  const effective = access?.effective_repositories ?? []
+  const selected =
+    access?.policy.mode === 'selected'
+      ? access.policy.repository_ids.length
+      : null
+
+  return (
+    <Panel>
+      <PanelHeader className="border-b-0 pb-2">
+        <PanelTitle className="flex items-center gap-2">
+          <GithubMark className="size-4" /> Repository access
+        </PanelTitle>
+      </PanelHeader>
+      <PanelContent className="pt-1">
+        {accessQuery.isLoading ? (
+          <Skeleton className="h-10 w-full" />
+        ) : accessQuery.isError ? (
+          <button
+            className="text-muted-foreground hover:text-foreground text-sm underline"
+            onClick={() => void accessQuery.refetch()}
+          >
+            Couldn’t load access — retry
+          </button>
+        ) : access?.grant.status !== 'active' ? (
+          <p className="text-sm">
+            {access?.grant.status === 'unavailable'
+              ? 'GitHub access is unavailable.'
+              : 'GitHub is not connected.'}
+          </p>
+        ) : (
+          <div className="flex items-start gap-2.5">
+            <ShieldCheck className="text-status-running mt-0.5 size-4 shrink-0" />
+            <div className="min-w-0">
+              <p className="text-sm font-medium">
+                {access.policy.mode === 'all'
+                  ? 'All granted repositories'
+                  : selected === 0
+                    ? 'Repository work disabled'
+                    : `${selected} selected ${selected === 1 ? 'repository' : 'repositories'}`}
+              </p>
+              {effective[0] ? (
+                <p className="text-muted-foreground mt-0.5 truncate text-xs">
+                  {effective[0].full_name}
+                  {effective.length > 1 ? ` +${effective.length - 1}` : ''}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={onOpenSettings}
+          className="text-muted-foreground hover:text-foreground mt-3 inline-flex items-center gap-1 text-xs font-medium"
+        >
+          Manage access <ChevronRight className="size-3" />
+        </button>
+      </PanelContent>
+    </Panel>
+  )
+}
+
+export function RepositoryTaskSuggestion({ agentId }: { agentId: string }) {
+  const { data } = useRepositoryAccess(agentId)
+  const repo = data?.effective_repositories?.[0]
+  if (!repo) return null
+  return (
+    <div className="border-border bg-muted/30 flex items-start gap-3 rounded-lg border px-3 py-2.5">
+      <GitPullRequest className="text-muted-foreground mt-0.5 size-4 shrink-0" />
+      <div>
+        <p className="text-xs font-medium">Try a repository task</p>
+        <p className="text-muted-foreground mt-0.5 text-xs">
+          In{' '}
+          <span className="text-foreground font-mono">{repo.full_name},</span>{' '}
+          add a setup note and open a pull request.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/status-badge.tsx
+++ b/web/src/components/status-badge.tsx
@@ -28,6 +28,7 @@ const STATUS: Record<string, Meta> = {
   ready: { tone: 'running', label: 'Ready', icon: CircleCheck },
   active: { tone: 'running', label: 'Active', icon: CircleCheck },
   success: { tone: 'running', label: 'Success', icon: CircleCheck },
+  resolved: { tone: 'running', label: 'Resolved', icon: CircleCheck },
   stopped: { tone: 'stopped', label: 'Stopped', icon: CircleSlash },
   not_deployed: {
     tone: 'stopped',
@@ -45,6 +46,12 @@ const STATUS: Record<string, Meta> = {
   queued: { tone: 'pending', label: 'Queued', icon: Clock },
   accepted: { tone: 'pending', label: 'Queued', icon: Clock },
   fetching: { tone: 'pending', label: 'Fetching', icon: Loader2, spin: true },
+  materializing: {
+    tone: 'pending',
+    label: 'Materializing',
+    icon: Loader2,
+    spin: true,
+  },
   validating: {
     tone: 'pending',
     label: 'Validating',
@@ -93,6 +100,8 @@ const STATUS: Record<string, Meta> = {
   deleting: { tone: 'pending', label: 'Deleting', icon: Loader2, spin: true },
   error: { tone: 'error', label: 'Error', icon: CircleAlert },
   failed: { tone: 'error', label: 'Failed', icon: CircleAlert },
+  unavailable: { tone: 'error', label: 'Unavailable', icon: CircleAlert },
+  auth_required: { tone: 'error', label: 'Auth required', icon: CircleAlert },
   unverified: { tone: 'error', label: 'Unverified', icon: CircleAlert },
   verified: { tone: 'running', label: 'Verified', icon: CircleCheck },
   superseded: { tone: 'stopped', label: 'Superseded', icon: CircleSlash },

--- a/web/src/components/working-repo-field-state.test.tsx
+++ b/web/src/components/working-repo-field-state.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RepositoryAccess } from '@/api/client'
+import { repositoryAccessQueryKey } from '@/lib/repository-access'
+import { WorkingRepoField, type WorkingRepo } from './working-repo-field'
+
+const agentA = 'agt_aaaaaaaaaaaaaaaaaaaaaaaa'
+const agentB = 'agt_bbbbbbbbbbbbbbbbbbbbbbbb'
+const value: WorkingRepo = {
+  repo: 'repo_1',
+  fullName: 'acme/app',
+  ref: 'main',
+}
+
+function access(
+  repositories: RepositoryAccess['effective_repositories'],
+  truncated = false,
+): RepositoryAccess {
+  return {
+    policy: { mode: 'all' },
+    grant: {
+      status: repositories === null ? 'unavailable' : 'active',
+      account: 'acme',
+      repository_selection: 'all',
+      install_url: 'https://github.test/install',
+      configure_url: 'https://github.test/configure',
+      truncated,
+    },
+    effective_repositories: repositories,
+    unavailable_selected_repositories: [],
+  }
+}
+
+const repository = {
+  id: 'repo_1',
+  full_name: 'acme/app',
+  default_branch: 'main',
+  private: true,
+}
+
+describe('WorkingRepoField selection validity', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let client: QueryClient
+
+  beforeEach(() => {
+    ;(
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    })
+    client.setQueryData(repositoryAccessQueryKey(agentA), access([repository]))
+    client.setQueryData(repositoryAccessQueryKey(agentB), access([repository]))
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    client.clear()
+    container.remove()
+  })
+
+  function renderField(
+    agentId: string,
+    onChange: (next: WorkingRepo | null) => void,
+  ) {
+    act(() => {
+      root.render(
+        <QueryClientProvider client={client}>
+          <WorkingRepoField
+            agentId={agentId}
+            runtime="flue"
+            value={value}
+            onChange={onChange}
+          />
+        </QueryClientProvider>,
+      )
+    })
+  }
+
+  it('clears a selection immediately when the agent scope changes', () => {
+    const onChange = vi.fn()
+    renderField(agentA, onChange)
+    expect(onChange).not.toHaveBeenCalled()
+
+    renderField(agentB, onChange)
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it('clears a selection removed from the loaded effective policy', () => {
+    const onChange = vi.fn()
+    renderField(agentA, onChange)
+
+    act(() => {
+      client.setQueryData(repositoryAccessQueryKey(agentA), access([]))
+    })
+    renderField(agentA, onChange)
+
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it('keeps the selection when an unavailable grant makes the set unknown', () => {
+    const onChange = vi.fn()
+    renderField(agentA, onChange)
+
+    act(() => {
+      client.setQueryData(repositoryAccessQueryKey(agentA), access(null))
+    })
+    renderField(agentA, onChange)
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('keeps the selection when a truncated grant makes absence ambiguous', () => {
+    const onChange = vi.fn()
+    renderField(agentA, onChange)
+
+    act(() => {
+      client.setQueryData(repositoryAccessQueryKey(agentA), access([], true))
+    })
+    renderField(agentA, onChange)
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/working-repo-field.test.ts
+++ b/web/src/components/working-repo-field.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { selectedWorkingRepo } from '@/lib/working-repo'
+
+describe('working repository selection', () => {
+  const repo = {
+    id: 'repo_123',
+    full_name: 'acme/renamed-app',
+    default_branch: 'trunk',
+  }
+
+  it('submits stable repository identity for Flue and keeps the slug for display', () => {
+    expect(selectedWorkingRepo(repo, true, null)).toEqual({
+      repo: 'repo_123',
+      fullName: 'acme/renamed-app',
+      ref: 'trunk',
+    })
+  })
+
+  it('preserves legacy slug behavior for non-Flue agents', () => {
+    expect(selectedWorkingRepo(repo, false, null)).toEqual({
+      repo: 'acme/renamed-app',
+      ref: 'trunk',
+    })
+  })
+
+  it('keeps an explicitly edited branch when the same repository is reselected', () => {
+    expect(
+      selectedWorkingRepo(repo, true, {
+        repo: 'repo_123',
+        fullName: 'acme/renamed-app',
+        ref: 'feature/test',
+      }),
+    ).toMatchObject({ ref: 'feature/test' })
+  })
+})

--- a/web/src/components/working-repo-field.tsx
+++ b/web/src/components/working-repo-field.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Select as SelectPrimitive } from 'radix-ui'
 import { Check, ChevronDown, GitBranch, X } from 'lucide-react'
@@ -53,6 +53,7 @@ export function WorkingRepoField({
     data: app,
     isLoading: appLoading,
     isError: appError,
+    isSuccess: appSuccess,
     refetch: refetchApp,
   } = useQuery({
     queryKey: ['deploy-app'],
@@ -64,6 +65,7 @@ export function WorkingRepoField({
     data: access,
     isLoading: accessLoading,
     isError: accessError,
+    isSuccess: accessSuccess,
     refetch: refetchAccess,
   } = useQuery({
     queryKey: repositoryAccessQueryKey(agentId ?? ''),
@@ -93,6 +95,27 @@ export function WorkingRepoField({
     access?.policy.mode === 'selected' &&
     access.policy.repository_ids.length === 0
   const disabled = !installed || repoOptions.length === 0
+  const scope = `${runtime ?? ''}:${agentId ?? ''}`
+  const previousScope = useRef(scope)
+
+  useEffect(() => {
+    if (previousScope.current === scope) return
+    previousScope.current = scope
+    if (value) onChange(null)
+  }, [onChange, scope, value])
+
+  const optionsAreAuthoritative = useFluePolicy
+    ? accessSuccess &&
+      access?.effective_repositories !== null &&
+      !access?.grant.truncated
+    : appSuccess
+  useEffect(() => {
+    if (!value || !optionsAreAuthoritative) return
+    const stillAvailable = repoOptions.some(
+      (repo) => workingRepoValue(repo, useFluePolicy) === value.repo,
+    )
+    if (!stillAvailable) onChange(null)
+  }, [onChange, optionsAreAuthoritative, repoOptions, useFluePolicy, value])
 
   const pickRepo = (repoValue: string) => {
     const r = repoOptions.find((x) =>

--- a/web/src/components/working-repo-field.tsx
+++ b/web/src/components/working-repo-field.tsx
@@ -2,18 +2,25 @@ import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Select as SelectPrimitive } from 'radix-ui'
 import { Check, ChevronDown, GitBranch, X } from 'lucide-react'
-import { getDeployApp } from '@/api/client'
+import { getDeployApp, getRepositoryAccess } from '@/api/client'
 import { GithubMark } from '@/components/github-mark'
 import { markFloatingLayerPointerDismiss } from '@/components/ui/floating-layer'
 import { cn } from '@/lib/utils'
+import { repositoryAccessQueryKey } from '@/lib/repository-access'
+import {
+  selectedWorkingRepo,
+  workingRepoValue,
+  type WorkingRepoValue,
+} from '@/lib/working-repo'
 
 // The WORKING repo a session checks out and opens PRs from (design 010 §2). Deliberately SEPARATE
 // from the agent's config/"connected" repo (prompt + skills) — an agent is typically configured
 // from one repo and works across others, so this never defaults to the connected repo. Optional:
-// a session starts fine with none; when set, the agent can publish (and later watch) PRs.
+// a session starts fine with none; when set, the agent can publish PRs.
 
-export interface WorkingRepo {
-  repo: string // "owner/repo"
+export interface WorkingRepo extends WorkingRepoValue {
+  repo: string // stable repo_ id for Flue; "owner/repo" for legacy runtimes
+  fullName?: string // display coordinate when repo is a stable id
   ref: string // branch
 }
 
@@ -26,35 +33,74 @@ function splitRepo(full: string): [owner: string, name: string] {
  * Inline, secondary working-repo control for the session composer. A compact, GitHub-marked
  * dropdown — unselected by default (short "Working repo" placeholder); starting a session works
  * empty. Selecting a repo reveals a branch pill (prefilled with the repo's default branch) and a
- * clear (✕). Repos come from what the OpenComputer App can reach (getDeployApp). Custom-styled
- * on the Radix primitive (no new dependency) so it reads as a deliberate control, not stock.
+ * clear (✕). Flue reads the agent's effective repository policy; legacy runtimes retain the
+ * installation-wide getDeployApp list. Custom-styled on the Radix primitive (no new dependency)
+ * so it reads as a deliberate control, not stock.
  */
 export function WorkingRepoField({
+  agentId,
+  runtime,
   value,
   onChange,
 }: {
+  agentId?: string
+  runtime?: string | null
   value: WorkingRepo | null
   onChange: (v: WorkingRepo | null) => void
 }) {
+  const useFluePolicy = runtime === 'flue' && Boolean(agentId)
   const {
     data: app,
-    isLoading,
-    isError,
-    refetch,
+    isLoading: appLoading,
+    isError: appError,
+    refetch: refetchApp,
   } = useQuery({
     queryKey: ['deploy-app'],
     queryFn: getDeployApp,
+    enabled: !useFluePolicy,
     staleTime: 30_000,
   })
-  const repoOptions = useMemo(() => app?.repositories ?? [], [app])
-  const installed = app?.installed !== false // treat "still loading" as installed
+  const {
+    data: access,
+    isLoading: accessLoading,
+    isError: accessError,
+    refetch: refetchAccess,
+  } = useQuery({
+    queryKey: repositoryAccessQueryKey(agentId ?? ''),
+    queryFn: () => getRepositoryAccess(agentId!),
+    enabled: useFluePolicy,
+    staleTime: 15_000,
+    refetchOnWindowFocus: 'always',
+  })
+  const repoOptions = useMemo(
+    () =>
+      useFluePolicy
+        ? (access?.effective_repositories ?? [])
+        : (app?.repositories ?? []),
+    [access, app, useFluePolicy],
+  )
+  const isLoading = useFluePolicy ? accessLoading : appLoading
+  const isError = useFluePolicy ? accessError : appError
+  const refetch = useFluePolicy ? refetchAccess : refetchApp
+  const installed = useFluePolicy
+    ? access?.grant.status === 'active'
+    : app?.installed !== false // treat "still loading" as installed
+  const installUrl = useFluePolicy
+    ? access?.grant.install_url
+    : app?.install_url
+  const policyDisabled =
+    useFluePolicy &&
+    access?.policy.mode === 'selected' &&
+    access.policy.repository_ids.length === 0
   const disabled = !installed || repoOptions.length === 0
 
-  const pickRepo = (fullName: string) => {
-    const r = repoOptions.find((x) => x.full_name === fullName)
+  const pickRepo = (repoValue: string) => {
+    const r = repoOptions.find((x) =>
+      useFluePolicy ? x.id === repoValue : x.full_name === repoValue,
+    )
+    if (!r) return
     // Keep the current branch when re-picking the same repo; else the repo's default.
-    const ref = value?.repo === fullName ? value.ref : r?.default_branch || 'main'
-    onChange({ repo: fullName, ref })
+    onChange(selectedWorkingRepo(r, useFluePolicy, value))
   }
 
   // Load failed → an explicit retry, not a silent "No repos available" dead-end.
@@ -73,31 +119,41 @@ export function WorkingRepoField({
   }
 
   // Not installed → a quiet connect affordance instead of a dead control.
-  if (installed === false && app?.install_url) {
+  if (installed === false && installUrl) {
+    const unavailable = useFluePolicy && access?.grant.status === 'unavailable'
     return (
       <a
-        href={app.install_url}
+        href={installUrl}
         target="_blank"
         rel="noreferrer"
         className="border-border text-muted-foreground hover:text-foreground hover:border-foreground/25 inline-flex h-8 items-center gap-2 rounded-md border border-dashed px-2.5 text-sm transition-colors"
-        title="Connect the OpenComputer GitHub App to work in a repo"
+        title={
+          unavailable
+            ? 'The GitHub installation is unavailable — reconnect it to work in a repo'
+            : 'Connect the OpenComputer GitHub App to work in a repo'
+        }
       >
         <GithubMark className="size-3.5" />
-        Connect GitHub
+        {unavailable ? 'GitHub unavailable' : 'Connect GitHub'}
       </a>
     )
   }
 
-  const [owner, name] = value ? splitRepo(value.repo) : ['', '']
+  const displayRepo = value?.fullName ?? value?.repo ?? ''
+  const [owner, name] = value ? splitRepo(displayRepo) : ['', '']
 
   return (
     <div className="flex flex-wrap items-center gap-1.5">
-      <SelectPrimitive.Root value={value?.repo ?? ''} onValueChange={pickRepo} disabled={disabled}>
+      <SelectPrimitive.Root
+        value={value?.repo ?? ''}
+        onValueChange={pickRepo}
+        disabled={disabled}
+      >
         <SelectPrimitive.Trigger
           aria-label="Working repo"
           title="Optional — the repo the agent works in and opens PRs from"
           className={cn(
-            'border-border bg-panel-2 hover:border-foreground/25 focus-visible:border-foreground/40 data-[state=open]:border-foreground/35 group inline-flex h-8 max-w-64 min-w-40 items-center gap-2 rounded-md border px-2.5 text-sm outline-none transition-colors disabled:cursor-not-allowed disabled:opacity-60',
+            'border-border bg-panel-2 hover:border-foreground/25 focus-visible:border-foreground/40 data-[state=open]:border-foreground/35 group inline-flex h-8 max-w-64 min-w-40 items-center gap-2 rounded-md border px-2.5 text-sm transition-colors outline-none disabled:cursor-not-allowed disabled:opacity-60',
           )}
         >
           <GithubMark className="text-muted-foreground group-hover:text-foreground/70 size-3.5 shrink-0 transition-colors" />
@@ -109,7 +165,13 @@ export function WorkingRepoField({
               </span>
             ) : (
               <span className="text-muted-foreground">
-                {disabled ? (isLoading ? 'Loading repos…' : 'No repos available') : 'Working repo'}
+                {disabled
+                  ? isLoading
+                    ? 'Loading repos…'
+                    : policyDisabled
+                      ? 'Repository access disabled'
+                      : 'No repos available'
+                  : 'Working repo'}
               </span>
             )}
           </span>
@@ -125,10 +187,11 @@ export function WorkingRepoField({
             <SelectPrimitive.Viewport>
               {repoOptions.map((r) => {
                 const [o, n] = splitRepo(r.full_name)
+                const repoValue = workingRepoValue(r, useFluePolicy)
                 return (
                   <SelectPrimitive.Item
-                    key={r.full_name}
-                    value={r.full_name}
+                    key={repoValue}
+                    value={repoValue}
                     className="focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2 text-sm outline-hidden select-none"
                   >
                     <GithubMark className="text-muted-foreground size-3.5 shrink-0" />

--- a/web/src/hooks/use-repository-access.ts
+++ b/web/src/hooks/use-repository-access.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query'
+import { getRepositoryAccess } from '@/api/client'
+import { repositoryAccessQueryKey } from '@/lib/repository-access'
+
+export function useRepositoryAccess(agentId: string, enabled = true) {
+  return useQuery({
+    queryKey: repositoryAccessQueryKey(agentId),
+    queryFn: () => getRepositoryAccess(agentId),
+    enabled: enabled && Boolean(agentId),
+    staleTime: 15_000,
+    refetchOnWindowFocus: 'always',
+  })
+}

--- a/web/src/lib/repository-access.test.ts
+++ b/web/src/lib/repository-access.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isNarrowingRepositoryAccess,
+  repositoryAccessCandidates,
+  repositoryAccessQueryKey,
+  toggleSelectedRepository,
+} from './repository-access'
+
+describe('repository access helpers', () => {
+  it('uses the documented agent-scoped query key', () => {
+    expect(repositoryAccessQueryKey('agt_1')).toEqual([
+      'agent-repository-access',
+      'agt_1',
+    ])
+  })
+
+  it('detects narrowing without treating expansion as narrowing', () => {
+    expect(
+      isNarrowingRepositoryAccess(
+        { mode: 'all' },
+        { mode: 'selected', repository_ids: ['repo_1'] },
+      ),
+    ).toBe(true)
+    expect(
+      isNarrowingRepositoryAccess(
+        { mode: 'selected', repository_ids: ['repo_1'] },
+        { mode: 'all' },
+      ),
+    ).toBe(false)
+    expect(
+      isNarrowingRepositoryAccess(
+        { mode: 'selected', repository_ids: ['repo_1', 'repo_hidden'] },
+        { mode: 'selected', repository_ids: ['repo_1'] },
+      ),
+    ).toBe(true)
+  })
+
+  it('preserves a hidden selection when toggling a visible repository', () => {
+    expect(
+      toggleSelectedRepository(
+        {
+          mode: 'selected',
+          repository_ids: ['repo_hidden', 'repo_visible'],
+        },
+        'repo_new',
+        true,
+      ),
+    ).toEqual({
+      mode: 'selected',
+      repository_ids: ['repo_hidden', 'repo_new', 'repo_visible'],
+    })
+  })
+
+  it('merges candidates by stable id and ignores unregistered rows', () => {
+    const candidates = repositoryAccessCandidates(
+      {
+        policy: { mode: 'selected', repository_ids: ['repo_1'] },
+        grant: {
+          status: 'active',
+          account: 'acme',
+          repository_selection: 'selected',
+          install_url: 'https://github.test/install',
+          configure_url: null,
+          truncated: false,
+        },
+        effective_repositories: [
+          {
+            id: 'repo_1',
+            full_name: 'acme/renamed',
+            default_branch: 'main',
+            private: true,
+          },
+        ],
+        unavailable_selected_repositories: [],
+      },
+      {
+        installed: true,
+        install_url: null,
+        configure_url: null,
+        account: 'acme',
+        repository_selection: 'selected',
+        repositories: [
+          {
+            id: 'repo_1',
+            full_name: 'acme/old-name',
+            default_branch: 'trunk',
+            private: true,
+            linked_sources: [],
+          },
+          {
+            id: null,
+            full_name: 'acme/unregistered',
+            default_branch: 'main',
+            private: false,
+            linked_sources: [],
+          },
+        ],
+      },
+    )
+    expect(candidates).toEqual([
+      {
+        id: 'repo_1',
+        full_name: 'acme/renamed',
+        default_branch: 'main',
+        private: true,
+      },
+    ])
+  })
+})

--- a/web/src/lib/repository-access.ts
+++ b/web/src/lib/repository-access.ts
@@ -1,0 +1,82 @@
+import type {
+  DeployApp,
+  RepositoryAccess,
+  RepositoryAccessPolicy,
+  RepositoryAccessRepository,
+} from '@/api/client'
+
+export const repositoryAccessQueryKey = (agentId: string) =>
+  ['agent-repository-access', agentId] as const
+
+export function selectedRepositoryIds(
+  policy: RepositoryAccessPolicy,
+): string[] {
+  return policy.mode === 'selected' ? policy.repository_ids : []
+}
+
+export function isNarrowingRepositoryAccess(
+  previous: RepositoryAccessPolicy,
+  next: RepositoryAccessPolicy,
+): boolean {
+  if (previous.mode === 'all') return next.mode === 'selected'
+  if (next.mode === 'all') return false
+  const nextIds = new Set(next.repository_ids)
+  return previous.repository_ids.some((id) => !nextIds.has(id))
+}
+
+export function sameRepositoryAccessPolicy(
+  left: RepositoryAccessPolicy,
+  right: RepositoryAccessPolicy,
+): boolean {
+  if (left.mode !== right.mode) return false
+  if (left.mode === 'all' || right.mode === 'all') return true
+  if (left.repository_ids.length !== right.repository_ids.length) return false
+  const rightIds = new Set(right.repository_ids)
+  return left.repository_ids.every((id) => rightIds.has(id))
+}
+
+/**
+ * Repository-access is authoritative for policy and effective access. The
+ * org-scoped deploy-app response only fills the editor's candidate catalog so
+ * selected mode can be expanded. Identity is always the stable repo id.
+ */
+export function repositoryAccessCandidates(
+  access: RepositoryAccess,
+  deployApp?: DeployApp,
+): RepositoryAccessRepository[] {
+  const byId = new Map<string, RepositoryAccessRepository>()
+  for (const repo of deployApp?.repositories ?? []) {
+    if (!repo.id) continue
+    byId.set(repo.id, {
+      id: repo.id,
+      full_name: repo.full_name,
+      default_branch: repo.default_branch ?? 'main',
+      private: repo.private ?? true,
+    })
+  }
+  for (const repo of access.effective_repositories ?? [])
+    byId.set(repo.id, repo)
+  for (const repo of access.unavailable_selected_repositories) {
+    if (!byId.has(repo.id)) {
+      byId.set(repo.id, {
+        ...repo,
+        default_branch: 'main',
+        private: true,
+      })
+    }
+  }
+  return [...byId.values()].sort((a, b) =>
+    a.full_name.localeCompare(b.full_name),
+  )
+}
+
+export function toggleSelectedRepository(
+  policy: RepositoryAccessPolicy,
+  repositoryId: string,
+  checked: boolean,
+): RepositoryAccessPolicy {
+  const ids = new Set(selectedRepositoryIds(policy))
+  if (checked) ids.add(repositoryId)
+  else ids.delete(repositoryId)
+  return { mode: 'selected', repository_ids: [...ids].sort() }
+}

--- a/web/src/lib/session-source-polling.ts
+++ b/web/src/lib/session-source-polling.ts
@@ -1,0 +1,17 @@
+import type { SessionSource } from '@/api/client'
+
+const ACTIVE_SOURCE_STATUSES = new Set(['pending', 'materializing'])
+
+/**
+ * Empty sessions keep a slow watch for the first lazy Flue checkout. Active
+ * materialization polls quickly. Terminal sources return to the slow watch so
+ * a later turn adding another source still appears. React Query pauses these
+ * intervals while the page is backgrounded.
+ */
+export function sessionSourcesRefetchInterval(
+  sources: SessionSource[] | undefined,
+): number {
+  if (sources?.some((source) => ACTIVE_SOURCE_STATUSES.has(source.status)))
+    return 1_500
+  return 5_000
+}

--- a/web/src/lib/working-repo.ts
+++ b/web/src/lib/working-repo.ts
@@ -1,0 +1,34 @@
+export interface WorkingRepoValue {
+  repo: string
+  fullName?: string
+  ref: string
+}
+
+export interface WorkingRepoOption {
+  id?: string | null
+  full_name: string
+  default_branch?: string | null
+}
+
+export function workingRepoValue(
+  repo: WorkingRepoOption,
+  flue: boolean,
+): string {
+  return flue ? (repo.id ?? repo.full_name) : repo.full_name
+}
+
+export function selectedWorkingRepo(
+  repo: WorkingRepoOption,
+  flue: boolean,
+  current: WorkingRepoValue | null,
+): WorkingRepoValue {
+  const repoValue = workingRepoValue(repo, flue)
+  return {
+    repo: repoValue,
+    ...(flue ? { fullName: repo.full_name } : {}),
+    ref:
+      current?.repo === repoValue
+        ? current.ref
+        : (repo.default_branch ?? 'main'),
+  }
+}

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -41,6 +41,10 @@ import { AgentSchedulesTab } from '@/components/agent-schedules'
 import { AgentRevisions } from '@/components/agent-revisions'
 import { AgentDeployments } from '@/components/agent-deployments'
 import {
+  RepositoryAccessPanel,
+  RepositoryAccessSummary,
+} from '@/components/repository-access'
+import {
   WorkingRepoField,
   type WorkingRepo,
 } from '@/components/working-repo-field'
@@ -597,12 +601,20 @@ export default function AgentDetail() {
               </Panel>
               <AgentSkills agentId={agent.id} />
             </div>
-            {/* Right rail: connect-or-status for the agent's source + Slack. */}
+            {/* Right rail: deployment source, working-repo scope, and Slack. */}
             <div className="space-y-4">
               <AgentDeploySource
                 agentId={agent.id}
                 profilePinned={agent.runtime === 'flue'}
               />
+              {agent.runtime === 'flue' ? (
+                <RepositoryAccessSummary
+                  agentId={agent.id}
+                  onOpenSettings={() => {
+                    void navigate(`${base}/settings`)
+                  }}
+                />
+              ) : null}
               <SlackConnect
                 agentId={agent.id}
                 agentName={agent.name}
@@ -652,6 +664,8 @@ export default function AgentDetail() {
                   />
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <WorkingRepoField
+                      agentId={agent.id}
+                      runtime={agent.runtime}
                       value={workingRepo}
                       onChange={setWorkingRepo}
                     />
@@ -704,6 +718,9 @@ export default function AgentDetail() {
 
         {active === 'settings' && (
           <div className="space-y-6">
+            {agent.runtime === 'flue' ? (
+              <RepositoryAccessPanel agentId={agent.id} />
+            ) : null}
             {/* Credential — which key the agent runs on. */}
             <Panel>
               <PanelHeader>

--- a/web/src/pages/AgentSetup.tsx
+++ b/web/src/pages/AgentSetup.tsx
@@ -44,6 +44,10 @@ import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useAgentDeploymentLogs } from '@/hooks/use-agent-deployment-logs'
 import {
+  RepositoryAccessPanel,
+  RepositoryTaskSuggestion,
+} from '@/components/repository-access'
+import {
   agentSetupStage,
   agentSetupPresentation,
 } from '@/lib/agent-setup-presentation'
@@ -647,6 +651,15 @@ export default function AgentSetup() {
           </div>
         ) : null}
       </Panel>
+
+      {agent.runtime === 'flue' && managedSlackStatus === 'active' ? (
+        <div className="space-y-3">
+          <RepositoryAccessPanel agentId={agentId} context="setup" />
+          {stage === 'ready' ? (
+            <RepositoryTaskSuggestion agentId={agentId} />
+          ) : null}
+        </div>
+      ) : null}
 
       {deployment ? (
         <Panel>

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -16,12 +16,14 @@ import { notifyError } from '@/lib/errors'
 import { useHalted } from '@/hooks/useHalted'
 import {
   getSession,
+  getSessionSources,
   getSessionEvents,
   sendMessage,
   cancelSession,
   archiveSession,
   ApiError,
   type SessionEvent,
+  type SessionSource,
 } from '@/api/client'
 import { SessionEventSchema } from '@/api/schemas'
 import { Panel } from '@/components/panel'
@@ -38,6 +40,7 @@ import { SessionWebhooks } from '@/components/session-webhooks'
 import { ApiHint } from '@/components/api-hint'
 import { MessagesSquare } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { GithubMark } from '@/components/github-mark'
 import { formatSpend, usageTokens } from '@/lib/usage'
 import {
   MessageBubble,
@@ -243,6 +246,12 @@ for await (const event of session.events()) {
     queryKey: ['session-events', sessionId],
     queryFn: () => getSessionEvents(sessionId),
     refetchInterval: streamOk ? false : 5000,
+  })
+  const sourcesQuery = useQuery({
+    queryKey: ['session-sources', sessionId],
+    queryFn: () => getSessionSources(sessionId),
+    staleTime: 15_000,
+    refetchOnWindowFocus: 'always',
   })
 
   // Live events over SSE through the dashboard proxy (the proxy injects auth;
@@ -502,6 +511,13 @@ for await (const event of session.events()) {
         </div>
       </Panel>
 
+      <SessionSourcesPanel
+        sources={sourcesQuery.data}
+        loading={sourcesQuery.isLoading}
+        error={sourcesQuery.isError}
+        onRetry={() => void sourcesQuery.refetch()}
+      />
+
       {/* Spend / usage — derived from the session's opaque usage object (no dedicated
           spend endpoint). Tokens shown only when the runtime reports them (flue meters
           at the gateway and reports none here). */}
@@ -667,6 +683,96 @@ for await (const event of session.events()) {
         }
       />
     </div>
+  )
+}
+
+export function SessionSourcesPanel({
+  sources,
+  loading,
+  error,
+  onRetry,
+}: {
+  sources?: SessionSource[]
+  loading: boolean
+  error: boolean
+  onRetry: () => void
+}) {
+  if (!loading && !error && !sources?.length) return null
+  return (
+    <Panel className="mb-4 min-w-0 overflow-hidden">
+      <div className="flex min-w-0 flex-wrap items-center justify-between gap-2 border-b px-4 py-2.5">
+        <h2 className="flex items-center gap-2 text-sm font-semibold">
+          <GithubMark className="size-3.5" /> Working sources
+        </h2>
+        <span className="text-muted-foreground text-xs">
+          {sources?.length ?? 0}{' '}
+          {sources?.length === 1 ? 'repository' : 'repositories'}
+        </span>
+      </div>
+      {loading ? (
+        <div className="space-y-2 p-4">
+          <Skeleton className="h-10 w-full" />
+        </div>
+      ) : error ? (
+        <div className="flex items-center justify-between gap-3 px-4 py-3 text-sm">
+          <span className="text-muted-foreground">
+            Couldn’t load working sources.
+          </span>
+          <Button size="sm" variant="outline" onClick={onRetry}>
+            Retry
+          </Button>
+        </div>
+      ) : (
+        <ul className="divide-y">
+          {sources?.map((source) => {
+            const observedDiffers =
+              source.resolved_sha && source.resolved_sha !== source.sha
+            return (
+              <li
+                key={source.name}
+                className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 gap-y-1 px-4 py-3 text-xs sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,auto)]"
+              >
+                <div className="min-w-48 flex-1">
+                  <p
+                    className="truncate text-sm font-medium"
+                    title={source.full_name ?? source.repo_id ?? source.name}
+                  >
+                    {source.full_name ?? source.repo_id ?? source.name}
+                  </p>
+                  <p
+                    className="text-muted-foreground mt-0.5 truncate font-mono"
+                    title={`Pinned commit ${source.sha}`}
+                  >
+                    {source.requested_ref ? `${source.requested_ref} · ` : ''}
+                    {source.sha.slice(0, 8)}
+                  </p>
+                  {observedDiffers ? (
+                    <p
+                      className="text-status-error mt-0.5 font-mono text-[11px]"
+                      title={`Observed commit ${source.resolved_sha}`}
+                    >
+                      observed {source.resolved_sha?.slice(0, 8)}
+                    </p>
+                  ) : null}
+                </div>
+                <StatusBadge status={source.status} />
+                <code
+                  className="text-muted-foreground col-span-2 min-w-0 truncate sm:col-span-1 sm:max-w-52"
+                  title={source.path}
+                >
+                  {source.path}
+                </code>
+                {source.error_message ? (
+                  <p className="text-status-error col-span-2 w-full sm:col-span-3">
+                    {source.error_message}
+                  </p>
+                ) : null}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </Panel>
   )
 }
 

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -52,6 +52,7 @@ import {
   isOutOfCredits,
   isTurnInput,
 } from '@/lib/session-turns'
+import { sessionSourcesRefetchInterval } from '@/lib/session-source-polling'
 
 function toolSummary(ev: SessionEvent): string {
   const b = (ev.body ?? {}) as Record<string, unknown>
@@ -251,6 +252,8 @@ for await (const event of session.events()) {
     queryKey: ['session-sources', sessionId],
     queryFn: () => getSessionSources(sessionId),
     staleTime: 15_000,
+    refetchInterval: (query) => sessionSourcesRefetchInterval(query.state.data),
+    refetchIntervalInBackground: false,
     refetchOnWindowFocus: 'always',
   })
 

--- a/web/src/pages/Sessions.tsx
+++ b/web/src/pages/Sessions.tsx
@@ -198,7 +198,9 @@ export default function Sessions() {
                   size="sm"
                   onClick={openStart}
                   disabled={halted}
-                  title={halted ? 'Out of credits — top up to resume' : undefined}
+                  title={
+                    halted ? 'Out of credits — top up to resume' : undefined
+                  }
                 >
                   <Plus className="size-4" />
                   Start session
@@ -294,6 +296,8 @@ export default function Sessions() {
               ) : null}
               {agentId ? (
                 <WorkingRepoField
+                  agentId={agentId}
+                  runtime={selectedAgent?.runtime}
                   value={workingRepo}
                   onChange={setWorkingRepo}
                 />

--- a/web/src/pages/agent-setup.test.tsx
+++ b/web/src/pages/agent-setup.test.tsx
@@ -9,6 +9,7 @@ import type {
   SessionEvent,
 } from '@/api/client'
 import { managedSlackConnectionsQueryKey } from '@/lib/managed-slack-connections'
+import { repositoryAccessQueryKey } from '@/lib/repository-access'
 import AgentSetup from './AgentSetup'
 
 const agentId = 'agt_aaaaaaaaaaaaaaaaaaaaaaaa'
@@ -97,6 +98,44 @@ function renderSetup(input: {
       active_revision_id: 'rev_aaaaaaaaaaaaaaaaaaaaaaaa',
     },
   )
+  if (input.agent?.runtime === 'flue') {
+    queryClient.setQueryData(repositoryAccessQueryKey(agentId), {
+      policy: { mode: 'selected', repository_ids: ['repo_1'] },
+      grant: {
+        status: 'active',
+        account: 'acme',
+        repository_selection: 'selected',
+        install_url: 'https://github.test/install',
+        configure_url: 'https://github.test/configure',
+        truncated: false,
+      },
+      effective_repositories: [
+        {
+          id: 'repo_1',
+          full_name: 'acme/support-agent',
+          default_branch: 'main',
+          private: true,
+        },
+      ],
+      unavailable_selected_repositories: [],
+    })
+    queryClient.setQueryData(['deploy-app'], {
+      installed: true,
+      install_url: 'https://github.test/install',
+      configure_url: 'https://github.test/configure',
+      account: 'acme',
+      repository_selection: 'selected',
+      repositories: [
+        {
+          id: 'repo_1',
+          full_name: 'acme/support-agent',
+          default_branch: 'main',
+          private: true,
+          linked_sources: [],
+        },
+      ],
+    })
+  }
   if (input.deployment) {
     queryClient.setQueryData(
       ['agent-deployment', agentId, deploymentId],
@@ -154,6 +193,53 @@ describe('agent setup', () => {
     expect(markup).toContain('Preparing your agent')
     expect(markup).toContain('<details')
     expect(markup).not.toContain('<details open=""')
+  })
+
+  it('does not let optional Flue repository setup compete with Connect Slack', () => {
+    const html = renderSetup({
+      agent: {
+        id: agentId,
+        name: 'Support triage',
+        runtime: 'flue',
+        revision: 1,
+        active_revision_id: 'rev_aaaaaaaaaaaaaaaaaaaaaaaa',
+      },
+      deployment: buildingDeployment,
+      managed: null,
+      search: `?deployment=${deploymentId}`,
+    })
+
+    expect(html).toContain('Connect Slack while we prepare Support triage')
+    expect(html).not.toContain('Choose working repositories')
+  })
+
+  it('keeps Slack first and offers an exact Flue repository task when ready', () => {
+    const html = renderSetup({
+      agent: {
+        id: agentId,
+        name: 'Support triage',
+        runtime: 'flue',
+        revision: 1,
+        active_revision_id: 'rev_aaaaaaaaaaaaaaaaaaaaaaaa',
+      },
+      deployment: {
+        ...buildingDeployment,
+        state: 'ready',
+        phase: 'verify',
+        terminal: true,
+        active: true,
+        allowed_actions: ['open_agent', 'start_session'],
+      },
+      managed: activeSlack,
+      search: `?deployment=${deploymentId}`,
+    })
+
+    expect(html.indexOf('Send your first message')).toBeLessThan(
+      html.indexOf('Choose working repositories'),
+    )
+    expect(html).toContain(
+      'In <span class="text-foreground font-mono">acme/support-agent,</span> add a setup note and open a pull request.',
+    )
   })
 
   it('waits visibly after Slack connects and promotes chat when ready', () => {

--- a/web/src/pages/session-sources.test.tsx
+++ b/web/src/pages/session-sources.test.tsx
@@ -1,0 +1,46 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { SessionSourcesPanel } from './SessionDetail'
+
+describe('session working sources', () => {
+  it('shows stable identity, requested ref, pinned SHA, status, and path', () => {
+    const html = renderToStaticMarkup(
+      <SessionSourcesPanel
+        sources={[
+          {
+            name: 'app',
+            repo_id: 'repo_1',
+            full_name: 'acme/app',
+            requested_ref: 'main',
+            status: 'ready',
+            path: '/workspace/sources/app',
+            sha: 'a'.repeat(40),
+            resolved_sha: 'b'.repeat(40),
+          },
+        ]}
+        loading={false}
+        error={false}
+        onRetry={() => {}}
+      />,
+    )
+    expect(html).toContain('acme/app')
+    expect(html).toContain('main · aaaaaaaa')
+    expect(html).toContain('observed bbbbbbbb')
+    expect(html).toContain(`title="Pinned commit ${'a'.repeat(40)}"`)
+    expect(html).toContain('Ready')
+    expect(html).toContain('/workspace/sources/app')
+  })
+
+  it('stays absent when the session has no sources', () => {
+    expect(
+      renderToStaticMarkup(
+        <SessionSourcesPanel
+          sources={[]}
+          loading={false}
+          error={false}
+          onRetry={() => {}}
+        />,
+      ),
+    ).toBe('')
+  })
+})

--- a/web/src/pages/session-sources.test.tsx
+++ b/web/src/pages/session-sources.test.tsx
@@ -1,5 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
+import { sessionSourcesRefetchInterval } from '@/lib/session-source-polling'
 import { SessionSourcesPanel } from './SessionDetail'
 
 describe('session working sources', () => {
@@ -12,10 +13,43 @@ describe('session working sources', () => {
             repo_id: 'repo_1',
             full_name: 'acme/app',
             requested_ref: 'main',
-            status: 'ready',
+            status: 'resolved',
             path: '/workspace/sources/app',
             sha: 'a'.repeat(40),
             resolved_sha: 'b'.repeat(40),
+          },
+          {
+            name: 'docs',
+            repo_id: 'repo_2',
+            full_name: 'acme/docs',
+            requested_ref: 'main',
+            status: 'materializing',
+            path: '/workspace/sources/docs',
+            sha: 'c'.repeat(40),
+          },
+          {
+            name: 'pending',
+            status: 'pending',
+            path: '/workspace/sources/pending',
+            sha: 'd'.repeat(40),
+          },
+          {
+            name: 'failed',
+            status: 'failed',
+            path: '/workspace/sources/failed',
+            sha: 'e'.repeat(40),
+          },
+          {
+            name: 'unavailable',
+            status: 'unavailable',
+            path: '/workspace/sources/unavailable',
+            sha: 'f'.repeat(40),
+          },
+          {
+            name: 'auth',
+            status: 'auth_required',
+            path: '/workspace/sources/auth',
+            sha: '0'.repeat(40),
           },
         ]}
         loading={false}
@@ -27,7 +61,12 @@ describe('session working sources', () => {
     expect(html).toContain('main · aaaaaaaa')
     expect(html).toContain('observed bbbbbbbb')
     expect(html).toContain(`title="Pinned commit ${'a'.repeat(40)}"`)
-    expect(html).toContain('Ready')
+    expect(html).toContain('Resolved')
+    expect(html).toContain('Materializing')
+    expect(html).toContain('Pending')
+    expect(html).toContain('Failed')
+    expect(html).toContain('Unavailable')
+    expect(html).toContain('Auth required')
     expect(html).toContain('/workspace/sources/app')
   })
 
@@ -42,5 +81,40 @@ describe('session working sources', () => {
         />,
       ),
     ).toBe('')
+  })
+
+  it('watches for new sources and accelerates while materialization is active', () => {
+    expect(sessionSourcesRefetchInterval([])).toBe(5_000)
+    expect(
+      sessionSourcesRefetchInterval([
+        {
+          name: 'app',
+          status: 'pending',
+          path: '/workspace/sources/app',
+          sha: 'a'.repeat(40),
+        },
+      ]),
+    ).toBe(1_500)
+    expect(
+      sessionSourcesRefetchInterval([
+        {
+          name: 'app',
+          status: 'materializing',
+          path: '/workspace/sources/app',
+          sha: 'a'.repeat(40),
+        },
+      ]),
+    ).toBe(1_500)
+    expect(
+      sessionSourcesRefetchInterval([
+        {
+          name: 'app',
+          status: 'resolved',
+          path: '/workspace/sources/app',
+          sha: 'a'.repeat(40),
+          resolved_sha: 'a'.repeat(40),
+        },
+      ]),
+    ).toBe(5_000)
   })
 })


### PR DESCRIPTION
## Summary

- add the Flue repository-access API contract to the dashboard and keep the authoritative per-agent policy separate from the supplementary GitHub catalog
- add a reusable repository-access editor for guided setup and Agent Settings, plus a compact Agent Overview summary
- keep Slack unmistakably primary during first-time setup; after Slack connects, offer optional repository access and promote an exact pull-request task when the deployment is ready
- make Flue session composers display current `owner/repo` names while submitting stable `repo_…` identifiers; preserve the existing slug behavior for built-in runtimes
- show working sources on Session Detail with requested refs, pinned commits, separately labelled observed commits, status, path, and safe failure states
- document the deployment-source/working-repository distinction, policy API and SDK, lazy Flue materialization, exact hosted tools, and owner-bound GitHub authority

## UI

### Guided setup

- while Slack is disconnected, the setup page remains focused on the Connect Slack action
- after Slack becomes active, a repository-access card appears without blocking chat or deployment
- when the agent is ready and at least one repository is effective, setup suggests: `In owner/repo, add a setup note and open a pull request.`

### Agent pages

- Agent Overview gets a compact access summary with a direct Settings affordance
- Agent Settings gets the complete editor: all granted vs selected, search, selected-empty, unavailable selections, truncated-list disclosure, install/configure actions, retry, optimistic save/rollback, and a confirmation before narrowing access
- hidden selected IDs survive refreshes and truncated repository catalogs

### Sessions

- the Flue working-repository picker reads the agent's effective policy and sends the stable repository ID
- built-in runtimes retain the existing installation-wide repository picker and `owner/repo` payload
- Session Detail displays sanitized source identity and pinning state; `sha` is always the pinned commit, while a differing `resolved_sha` is explicitly shown as observed

The UI was reviewed in preview at desktop and narrow widths on `/agents/:id/setup`, `/agents/:id/settings`, and `/sessions/:id`. The repository editor and source rows stay within the document viewport; the only intentional narrow-screen horizontal scroller remains the existing agent tab strip.

## Correctness notes

- query identity is exactly `['agent-repository-access', agentId]`
- `not_installed` is treated as known-empty; only `unavailable` is unknown
- repository-access data is authoritative; `/github/deploy-app` only expands the selected-mode editor catalog
- switching all → selected starts from the current effective set instead of accidentally disabling repository work
- dirty local policy drafts survive focus refetches
- repository access never blocks Slack chat

## Public docs

Updated the agents, API reference, Flue, repos, runtime tools, sessions, and Slack guides. The docs now state that hosted Flue exposes exactly `list_working_repos`, `add_source`, and `github_publish_pull_request`; uses only the owner's OpenComputer GitHub App for this capability; and publishes through an `oc/…` branch and pull request rather than writing to the default branch.

## Verification

- `web: npm run typecheck`
- `web: npm test -- --run` — 30 files, 127 tests
- `web: npm run build`
- targeted ESLint across every changed TS/TSX file
- Prettier check across every changed web/docs file
- `git diff --check`
- combined TypeScript SDK lane already present in the base commit: 8 files / 38 tests, build, and typecheck all green

Full-repo web lint still reports seven unrelated pre-existing errors in Terminal, guided-tour, Browsers, and SandboxDetail; every file changed by this PR is clean.
