### PR TITLE
Harden Flue GitHub review edge cases

### DIFF
--- a/sdks/flue/package-lock.json
+++ b/sdks/flue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/flue",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/flue",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "valibot": "^1.4.2"

--- a/sdks/flue/package.json
+++ b/sdks/flue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/flue",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Run a Flue app as an OpenComputer agent with managed models, repository tools, and demand-driven sandboxes.",
   "keywords": [
     "agents",

--- a/sdks/flue/src/cf-env.test.ts
+++ b/sdks/flue/src/cf-env.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { layerOcEnv } from "./cf-env.js";
+
+describe("Cloudflare env layering", () => {
+  it("prefers ambient values and reads request secrets without enumerating the fallback proxy", () => {
+    const fallback = new Proxy<Record<string, unknown>>(
+      {},
+      {
+        get(_target, property) {
+          if (property === "OC_REPO_API") return "https://fallback.invalid";
+          if (property === "OC_SESSION_TOKEN") return "request-token";
+          return undefined;
+        },
+        ownKeys() {
+          throw new Error("runtime env must not be enumerated");
+        },
+      },
+    );
+    const ambient = {
+      OC_REPO_API: "https://repositories.test",
+      OC_SESSION_TOKEN: undefined,
+    };
+
+    const resolved = layerOcEnv(ambient, fallback);
+
+    expect(resolved.OC_REPO_API).toBe("https://repositories.test");
+    expect(resolved.OC_SESSION_TOKEN).toBe("request-token");
+    expect(layerOcEnv(ambient, undefined)).toBe(ambient);
+  });
+});

--- a/sdks/flue/src/cf-env.ts
+++ b/sdks/flue/src/cf-env.ts
@@ -1,8 +1,9 @@
 // Ambient Cloudflare-Workers env access (design 013 §4). On the `flue build --target cloudflare`
-// build the real Worker bindings (`OC_GATEWAY`, `OC_SESSION_TOKEN`, `OC_SANDBOX_*`, `OC_INGEST`, …)
-// live on the AMBIENT env exported by `cloudflare:workers` — the same one Flue's generated entry reads
-// (`import { env } from 'cloudflare:workers'`). The per-agent `ctx.env` Flue threads into the
-// initializer is EMPTY for these bindings, so OC helpers must read the ambient env instead.
+// build, plain Worker bindings (`OC_GATEWAY`, `OC_SANDBOX_*`, `OC_INGEST`, …) are available on the
+// AMBIENT env exported by `cloudflare:workers` — the same one Flue's generated entry reads
+// (`import { env } from 'cloudflare:workers'`). Worker secrets such as `OC_SESSION_TOKEN` can instead
+// arrive through the runtime-owned env reference at request time. Helpers therefore retain that
+// fallback reference and resolve it lazily, layering ambient plain bindings over its current values.
 //
 // `cloudflare:workers` only resolves inside workerd, so importing it statically would break local
 // `flue dev` on the node target and the package's own vitest. Load it lazily + guarded: on CF the
@@ -23,8 +24,8 @@ try {
 
 /**
  * Resolve the effective OC env: the Cloudflare ambient bindings layered over `fallback` (ambient wins).
- * On CF this returns the real Worker bindings even though `ctx.env` is empty; off CF (local dev / node /
- * tests) it returns `fallback` unchanged so an explicitly-passed env still works.
+ * On CF this adds ambient plain Worker bindings without discarding request-time values from `fallback`;
+ * off CF (local dev / node / tests) it returns `fallback` unchanged.
  */
 export function ocResolveEnv<T extends Record<string, unknown>>(fallback: T | undefined): T {
   const base = (fallback ?? {}) as T;

--- a/sdks/flue/src/cf-env.ts
+++ b/sdks/flue/src/cf-env.ts
@@ -2,8 +2,8 @@
 // build, plain Worker bindings (`OC_GATEWAY`, `OC_SANDBOX_*`, `OC_INGEST`, …) are available on the
 // AMBIENT env exported by `cloudflare:workers` — the same one Flue's generated entry reads
 // (`import { env } from 'cloudflare:workers'`). Worker secrets such as `OC_SESSION_TOKEN` can instead
-// arrive through the runtime-owned env reference at request time. Helpers therefore retain that
-// fallback reference and resolve it lazily, layering ambient plain bindings over its current values.
+// arrive through the runtime-owned env reference at request time. That reference can be a proxy that
+// supports direct property reads but not enumeration, so helpers retain it and never spread it.
 //
 // `cloudflare:workers` only resolves inside workerd, so importing it statically would break local
 // `flue dev` on the node target and the package's own vitest. Load it lazily + guarded: on CF the
@@ -23,12 +23,33 @@ try {
 }
 
 /**
- * Resolve the effective OC env: the Cloudflare ambient bindings layered over `fallback` (ambient wins).
- * On CF this adds ambient plain Worker bindings without discarding request-time values from `fallback`;
- * off CF (local dev / node / tests) it returns `fallback` unchanged.
+ * Layer ambient plain bindings over a runtime-owned fallback without enumerating
+ * the fallback. Defined ambient values win; missing ambient values are read
+ * directly from the fallback at access time.
  */
-export function ocResolveEnv<T extends Record<string, unknown>>(fallback: T | undefined): T {
-  const base = (fallback ?? {}) as T;
-  if (!ambientEnv) return base;
-  return { ...base, ...ambientEnv } as T;
+export function layerOcEnv<T extends Record<string, unknown>>(
+  ambient: Record<string, unknown> | undefined,
+  fallback: T | undefined,
+): T {
+  if (!ambient) return (fallback ?? {}) as T;
+  if (!fallback) return ambient as T;
+  return new Proxy(ambient, {
+    get(target, property) {
+      const value = Reflect.get(target, property, target);
+      return value === undefined
+        ? Reflect.get(fallback, property, fallback)
+        : value;
+    },
+  }) as T;
+}
+
+/**
+ * Resolve the effective OC env. On Cloudflare this layers ambient plain
+ * bindings over the lazily read runtime env; off Cloudflare it returns the
+ * fallback unchanged.
+ */
+export function ocResolveEnv<T extends Record<string, unknown>>(
+  fallback: T | undefined,
+): T {
+  return layerOcEnv(ambientEnv, fallback);
 }

--- a/sdks/flue/src/gateway.ts
+++ b/sdks/flue/src/gateway.ts
@@ -5,7 +5,8 @@
 // SECRET. Secrets are NOT on the CF ambient env (`cloudflare:workers`) at all — only plain vars like
 // OC_GATEWAY are — and `ctx.env` at defineAgent-init is empty for the OC bindings too. So an init-time
 // registerProvider reads the token falsy and every model call throws "No API key for provider: anthropic".
-// The secret DOES live on the per-REQUEST env (`c.env`) — the same source ocSandbox reads at run time.
+// The secret DOES live on the per-REQUEST env (`c.env`); repository and sandbox helpers likewise read
+// their runtime-owned request env references directly rather than enumerating or spreading them.
 // Fix: bind the apiKey at RUN scope from the exported `route` middleware, reading OC_SESSION_TOKEN from
 // `c.env` by DIRECT property access (NEVER spread c.env — the CF env is a proxy and spreading it throws)
 // and OC_GATEWAY from the ambient snapshot, once per isolate. The token is per-DEPLOY (identical for
@@ -52,9 +53,9 @@ function bindOcProvider(env: OcEnv): boolean {
  * initializer** — top-level module code is stripped by the CF build (proven in 1a). This runs at INIT
  * scope, where the per-deploy OC_SESSION_TOKEN (a secret) is typically not yet readable, so it registers
  * the baseUrl (model specifier resolves) and defers the apiKey to `route` (run scope) — see the token-seam
- * note above. Binds the apiKey here too if the token happens to already be present. Reads the CF ambient
- * env (`cloudflare:workers`), not `ctx.env`: on the `--target cloudflare` build the real Worker bindings
- * live on the ambient env and `ctx.env` is empty for them.
+ * note above. Binds the apiKey here too if the token happens to already be present. Plain Worker
+ * bindings come from the CF ambient env; the runtime-owned `ctx.env` is read directly only for values
+ * absent there and may still be tokenless during initialization.
  */
 export function useOcGateway(ctx: AgentInitializerContext<OcEnv>): void {
   bindOcProvider(ocResolveEnv<OcEnv>(ctx.env));

--- a/sdks/flue/src/repo.test.ts
+++ b/sdks/flue/src/repo.test.ts
@@ -135,7 +135,7 @@ describe("ocRepoTools contract", () => {
 });
 
 describe("list_working_repos HTTP fixtures", () => {
-  it("resolves request-time env and encodes the session and query", async () => {
+  it("reads the captured env lazily at tool run and encodes the request", async () => {
     const env: OcRepoEnv = {};
     const list = tool("list_working_repos", env, "ses_/customer space");
     const fetchSpy = vi.fn(async () =>
@@ -146,9 +146,11 @@ describe("list_working_repos HTTP fixtures", () => {
             id: "repo_1",
             full_name: "diggerhq/example app",
             default_branch: "main",
+            visibility: "private",
           },
         ],
         truncated: true,
+        server_revision: 2,
       }),
     );
     vi.stubGlobal("fetch", fetchSpy);
@@ -215,13 +217,80 @@ describe("list_working_repos HTTP fixtures", () => {
             : {}),
         },
       };
-      vi.stubGlobal("fetch", vi.fn(async () => json(body, status)));
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          json(
+            {
+              ...body,
+              server_trace_id: "trace_1",
+              error: { ...body.error, provider_detail: "ignored" },
+            },
+            status,
+          ),
+        ),
+      );
 
       await expect(
         tool("list_working_repos").run({ input: {} }),
       ).resolves.toEqual(body);
     },
   );
+
+  it("accepts additive response growth without freezing list or message size", async () => {
+    const repositories = Array.from({ length: 51 }, (_, index) => ({
+      id: `repo_${index}`,
+      full_name: `owner/repository-${index}`,
+      default_branch: "main",
+      future_field: index,
+    }));
+    const list = tool("list_working_repos");
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          json({
+            ok: true,
+            repositories,
+            truncated: false,
+            next_cursor: null,
+          }),
+        )
+        .mockResolvedValueOnce(
+          json(
+            {
+              ok: false,
+              error: {
+                code: "github_unavailable",
+                message: "x".repeat(501),
+                retryable: true,
+                future_recovery: "retry",
+              },
+            },
+            503,
+          ),
+        ),
+    );
+
+    await expect(list.run({ input: {} })).resolves.toEqual({
+      ok: true,
+      repositories: repositories.map(({ id, full_name, default_branch }) => ({
+        id,
+        full_name,
+        default_branch,
+      })),
+      truncated: false,
+    });
+    await expect(list.run({ input: {} })).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "github_unavailable",
+        message: "x".repeat(501),
+        retryable: true,
+      },
+    });
+  });
 
   it("rejects status, retryability, and retry-after contract drift", async () => {
     const list = tool("list_working_repos");
@@ -330,6 +399,7 @@ describe("add_source HTTP fixture", () => {
         ref: "main",
         sha: "a".repeat(40),
         path: "/workspace/sources/app",
+        materialized_at: "2026-07-21T00:00:00Z",
       }),
     );
     vi.stubGlobal("fetch", fetchSpy);
@@ -418,7 +488,9 @@ describe("github_publish_pull_request HTTP fixtures", () => {
           pull_request: {
             number: 42,
             url: "https://github.com/diggerhq/example-app/pull/42",
+            state: "open",
           },
+          provider_request_id: "request_1",
         });
       }),
     );
@@ -435,9 +507,11 @@ describe("github_publish_pull_request HTTP fixtures", () => {
       signal: controller.signal,
     });
 
-    expect(result).toMatchObject({
+    expect(result).toEqual({
       ok: true,
       no_changes: false,
+      branch: "oc/ses_1/document-setup",
+      commit: "d".repeat(40),
       pull_request: {
         number: 42,
         url: "https://github.com/diggerhq/example-app/pull/42",
@@ -462,7 +536,13 @@ describe("github_publish_pull_request HTTP fixtures", () => {
   it("returns no_changes as a successful terminal result", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => json({ ok: true, no_changes: true })),
+      vi.fn(async () =>
+        json({
+          ok: true,
+          no_changes: true,
+          compared_commit: "a".repeat(40),
+        }),
+      ),
     );
     await expect(
       tool("github_publish_pull_request").run({

--- a/sdks/flue/src/repo.test.ts
+++ b/sdks/flue/src/repo.test.ts
@@ -237,7 +237,7 @@ describe("list_working_repos HTTP fixtures", () => {
     },
   );
 
-  it("accepts additive response growth without freezing list or message size", async () => {
+  it("accepts additive response growth while bounding model-visible list and message size", async () => {
     const repositories = Array.from({ length: 51 }, (_, index) => ({
       id: `repo_${index}`,
       full_name: `owner/repository-${index}`,
@@ -275,18 +275,20 @@ describe("list_working_repos HTTP fixtures", () => {
 
     await expect(list.run({ input: {} })).resolves.toEqual({
       ok: true,
-      repositories: repositories.map(({ id, full_name, default_branch }) => ({
-        id,
-        full_name,
-        default_branch,
-      })),
-      truncated: false,
+      repositories: repositories
+        .slice(0, 50)
+        .map(({ id, full_name, default_branch }) => ({
+          id,
+          full_name,
+          default_branch,
+        })),
+      truncated: true,
     });
     await expect(list.run({ input: {} })).resolves.toEqual({
       ok: false,
       error: {
         code: "github_unavailable",
-        message: "x".repeat(501),
+        message: "x".repeat(500),
         retryable: true,
       },
     });

--- a/sdks/flue/src/repo.ts
+++ b/sdks/flue/src/repo.ts
@@ -33,6 +33,9 @@ const ERROR_CODES = [
   "deployment_unverified",
 ] as const;
 
+const RESPONSE_ERROR_MESSAGE_MAX = 500;
+const RESPONSE_REPOSITORY_MAX = 50;
+
 export type OcRepoErrorCode = (typeof ERROR_CODES)[number];
 
 export interface OcRepoError {
@@ -51,14 +54,20 @@ export type OcRepoFailure = {
 // semantic fields while ignoring additive fields from a newer server. Tool
 // inputs below remain strict and bounded so the model cannot smuggle extra
 // authority or unbounded work.
-const RepoErrorSchema = v.object({
-  code: v.picklist(ERROR_CODES),
-  message: v.pipe(v.string(), v.minLength(1)),
-  retryable: v.boolean(),
-  retry_after_seconds: v.optional(
-    v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(600)),
-  ),
-});
+const RepoErrorSchema = v.pipe(
+  v.object({
+    code: v.picklist(ERROR_CODES),
+    message: v.pipe(v.string(), v.minLength(1)),
+    retryable: v.boolean(),
+    retry_after_seconds: v.optional(
+      v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(600)),
+    ),
+  }),
+  v.transform((error) => ({
+    ...error,
+    message: error.message.slice(0, RESPONSE_ERROR_MESSAGE_MAX),
+  })),
+);
 
 const RepoFailureSchema = v.object({
   ok: v.literal(false),
@@ -77,11 +86,19 @@ export interface WorkingRepository {
   default_branch: string;
 }
 
-const ListWorkingReposSuccessSchema = v.object({
-  ok: v.literal(true),
-  repositories: v.array(WorkingRepositorySchema),
-  truncated: v.boolean(),
-});
+const ListWorkingReposSuccessSchema = v.pipe(
+  v.object({
+    ok: v.literal(true),
+    repositories: v.array(WorkingRepositorySchema),
+    truncated: v.boolean(),
+  }),
+  v.transform((result) => ({
+    ...result,
+    repositories: result.repositories.slice(0, RESPONSE_REPOSITORY_MAX),
+    truncated:
+      result.truncated || result.repositories.length > RESPONSE_REPOSITORY_MAX,
+  })),
+);
 
 const SourceNameSchema = v.pipe(
   v.string(),
@@ -432,8 +449,8 @@ function randomIdempotencyKey(): string {
  *
  * The initializer captures only the session id and the runtime-owned
  * environment reference, not a spread/snapshot. Managed bindings are resolved
- * inside each tool run so request-time secrets on that reference are visible;
- * ambient plain bindings are layered in by `ocResolveEnv`.
+ * inside each tool run so request-time secrets on that reference are visible
+ * through direct property reads; `ocResolveEnv` never enumerates that proxy.
  */
 export function ocRepoTools(
   ctx: AgentInitializerContext<OcRepoEnv>,

--- a/sdks/flue/src/repo.ts
+++ b/sdks/flue/src/repo.ts
@@ -47,21 +47,25 @@ export type OcRepoFailure = {
   error: OcRepoError;
 };
 
-const RepoErrorSchema = v.strictObject({
+// Platform responses are forward-extensible: validate and return the known
+// semantic fields while ignoring additive fields from a newer server. Tool
+// inputs below remain strict and bounded so the model cannot smuggle extra
+// authority or unbounded work.
+const RepoErrorSchema = v.object({
   code: v.picklist(ERROR_CODES),
-  message: v.pipe(v.string(), v.minLength(1), v.maxLength(500)),
+  message: v.pipe(v.string(), v.minLength(1)),
   retryable: v.boolean(),
   retry_after_seconds: v.optional(
     v.pipe(v.number(), v.integer(), v.minValue(1), v.maxValue(600)),
   ),
 });
 
-const RepoFailureSchema = v.strictObject({
+const RepoFailureSchema = v.object({
   ok: v.literal(false),
   error: RepoErrorSchema,
 });
 
-const WorkingRepositorySchema = v.strictObject({
+const WorkingRepositorySchema = v.object({
   id: v.pipe(v.string(), v.minLength(1)),
   full_name: v.pipe(v.string(), v.minLength(3)),
   default_branch: v.pipe(v.string(), v.minLength(1)),
@@ -73,12 +77,9 @@ export interface WorkingRepository {
   default_branch: string;
 }
 
-const ListWorkingReposSuccessSchema = v.strictObject({
+const ListWorkingReposSuccessSchema = v.object({
   ok: v.literal(true),
-  repositories: v.pipe(
-    v.array(WorkingRepositorySchema),
-    v.maxLength(50),
-  ),
+  repositories: v.array(WorkingRepositorySchema),
   truncated: v.boolean(),
 });
 
@@ -108,7 +109,7 @@ const PullRequestBaseSchema = v.pipe(
 );
 
 const AddSourceSuccessSchema = v.pipe(
-  v.strictObject({
+  v.object({
     ok: v.literal(true),
     name: SourceNameSchema,
     repository_id: v.pipe(v.string(), v.startsWith("repo_")),
@@ -123,12 +124,12 @@ const AddSourceSuccessSchema = v.pipe(
   ),
 );
 
-const PublishNoChangesSchema = v.strictObject({
+const PublishNoChangesSchema = v.object({
   ok: v.literal(true),
   no_changes: v.literal(true),
 });
 
-const PublishPullRequestSuccessSchema = v.strictObject({
+const PublishPullRequestSuccessSchema = v.object({
   ok: v.literal(true),
   no_changes: v.literal(false),
   branch: v.pipe(v.string(), v.minLength(1)),
@@ -136,7 +137,7 @@ const PublishPullRequestSuccessSchema = v.strictObject({
     v.string(),
     v.regex(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/i),
   ),
-  pull_request: v.strictObject({
+  pull_request: v.object({
     number: v.pipe(v.number(), v.integer(), v.minValue(1)),
     url: v.pipe(v.string(), v.url()),
   }),
@@ -429,9 +430,10 @@ function randomIdempotencyKey(): string {
 /**
  * Standard hosted-repository tools for an OpenComputer Flue session.
  *
- * The initializer captures only the session id and environment reference.
- * Managed bindings are resolved inside each tool run because Cloudflare
- * secrets are request-scoped.
+ * The initializer captures only the session id and the runtime-owned
+ * environment reference, not a spread/snapshot. Managed bindings are resolved
+ * inside each tool run so request-time secrets on that reference are visible;
+ * ambient plain bindings are layered in by `ocResolveEnv`.
  */
 export function ocRepoTools(
   ctx: AgentInitializerContext<OcRepoEnv>,

--- a/sdks/flue/src/sandbox.ts
+++ b/sdks/flue/src/sandbox.ts
@@ -267,9 +267,9 @@ async function resolveSandboxId(
  * Linux shell or durable files. The default starter intentionally omits it.
  *
  * Resolves the captured runtime env lazily and layers in plain bindings from the CF ambient env
- * (`cloudflare:workers`). The request-time `OC_SESSION_TOKEN` remains on the captured env reference;
- * it is not assumed to exist in the ambient snapshot. `createSessionEnv` validates local configuration
- * and returns a lazy environment without fetching or provisioning anything.
+ * (`cloudflare:workers`). The request-time `OC_SESSION_TOKEN` remains on the captured env proxy and is
+ * read directly; that proxy is never spread or enumerated. `createSessionEnv` validates local
+ * configuration and returns a lazy environment without fetching or provisioning anything.
  */
 export function ocSandbox(
   env: OcSandboxEnv,

--- a/sdks/flue/src/sandbox.ts
+++ b/sdks/flue/src/sandbox.ts
@@ -266,10 +266,10 @@ async function resolveSandboxId(
  * The optional OC-fleet sandbox factory. Add `sandbox: ocSandbox(env)` only when an agent needs a
  * Linux shell or durable files. The default starter intentionally omits it.
  *
- * Reads the CF ambient env (`cloudflare:workers`), not the passed `ctx.env`: on the `--target
- * cloudflare` build the real `OC_SANDBOX_*`/`OC_SESSION_TOKEN` bindings live on the ambient env and
- * `ctx.env` is empty for them (same reason as `useOcGateway`). `createSessionEnv` validates local
- * configuration and returns a lazy environment without fetching or provisioning anything.
+ * Resolves the captured runtime env lazily and layers in plain bindings from the CF ambient env
+ * (`cloudflare:workers`). The request-time `OC_SESSION_TOKEN` remains on the captured env reference;
+ * it is not assumed to exist in the ambient snapshot. `createSessionEnv` validates local configuration
+ * and returns a lazy environment without fetching or provisioning anything.
  */
 export function ocSandbox(
   env: OcSandboxEnv,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,6 +1,9 @@
 import posthog from 'posthog-js'
 import { z } from 'zod'
 import * as S from './schemas'
+import { ApiError } from './errors'
+
+export { ApiError } from './errors'
 
 // Re-export the inferred response types (schemas are the single source of
 // truth) so existing `import { type Sandbox } from '@/api/client'` keeps working.
@@ -117,20 +120,6 @@ function errorDetails(body: unknown): Record<string, unknown> | undefined {
   return error && typeof error === 'object' && !Array.isArray(error)
     ? (error as Record<string, unknown>)
     : undefined
-}
-
-/** An error carrying the HTTP status + the API's typed reason, so callers can branch
- *  (e.g. 404 = not-found; 402 `insufficient_credits` = out of credits → top-up CTA). */
-export class ApiError extends Error {
-  constructor(
-    message: string,
-    readonly status: number,
-    readonly type?: string,
-    readonly details?: Record<string, unknown>,
-  ) {
-    super(message)
-    this.name = 'ApiError'
-  }
 }
 
 export async function apiFetch<T>(
@@ -871,12 +860,7 @@ export async function getManagedSlackConnection(agentId: string) {
       S.ManagedSlackConnectionSchema,
     )
   } catch (error) {
-    if (
-      (error instanceof ApiError ||
-        (error instanceof Error && 'status' in error)) &&
-      (error as { status: unknown }).status === 404
-    )
-      return null
+    if (error instanceof ApiError && error.status === 404) return null
     throw error
   }
 }

--- a/web/src/api/errors.ts
+++ b/web/src/api/errors.ts
@@ -1,0 +1,12 @@
+/** An API failure with the HTTP status and optional typed product reason. */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly type?: string,
+    readonly details?: Record<string, unknown>,
+  ) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}

--- a/web/src/api/managed-slack-client.test.ts
+++ b/web/src/api/managed-slack-client.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ApiError, getManagedSlackConnection } from './client'
+import { mockFetch } from './mock'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('managed Slack missing-resource handling', () => {
+  it('maps a real API 404 to no managed connection', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(Response.json({ error: 'Not found' }, { status: 404 })),
+      ),
+    )
+
+    await expect(
+      getManagedSlackConnection('agt_aaaaaaaaaaaaaaaaaaaaaaaa'),
+    ).resolves.toBeNull()
+  })
+
+  it('does not swallow an unrelated status-bearing Error', async () => {
+    const transportError = Object.assign(new Error('Proxy failed'), {
+      status: 404,
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(transportError)),
+    )
+
+    await expect(
+      getManagedSlackConnection('agt_aaaaaaaaaaaaaaaaaaaaaaaa'),
+    ).rejects.toBe(transportError)
+  })
+
+  it('uses the same ApiError contract in preview mocks', () => {
+    expect(() =>
+      mockFetch('/v3/agents/agt_aaaaaaaaaaaaaaaaaaaaaaaa/slack/managed'),
+    ).toThrow(ApiError)
+  })
+})

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -10,6 +10,8 @@
 // Returns are cast to the caller's T — mock objects only need the fields a
 // screen actually reads, not the full interface.
 
+import { ApiError } from './errors'
+
 // Fixed clock so screenshots are deterministic.
 const BASE = new Date('2026-06-26T17:00:00Z').getTime()
 const at = (daysAgo: number, hoursAgo = 0) =>
@@ -1309,9 +1311,7 @@ export function mockFetch<T>(path: string, options: RequestInit = {}): T {
     if (re.test(path)) {
       const out = handler()
       if (out === NOT_FOUND) {
-        const error = new Error('Not found') as Error & { status: number }
-        error.status = 404
-        throw error
+        throw new ApiError('Not found', 404)
       }
       return out as T
     }

--- a/web/src/components/repository-access.test.tsx
+++ b/web/src/components/repository-access.test.tsx
@@ -118,8 +118,10 @@ describe('repository access UI', () => {
       grant: { ...selected.grant, status: 'unavailable' },
       effective_repositories: null,
     })
-    expect(html).toContain('GitHub access needs attention')
-    expect(html).toContain('Reconnect GitHub')
+    expect(html).toContain('GitHub access is temporarily unavailable')
+    expect(html).toContain('Nothing changed')
+    expect(html).toContain('>Retry<')
+    expect(html).not.toContain('Reconnect GitHub')
     expect(html).not.toContain('No repositories are available')
   })
 

--- a/web/src/components/repository-access.tsx
+++ b/web/src/components/repository-access.tsx
@@ -67,7 +67,13 @@ function ExternalAction({
   )
 }
 
-function AccessUnavailable({ access }: { access: RepositoryAccess }) {
+function AccessUnavailable({
+  access,
+  onRetry,
+}: {
+  access: RepositoryAccess
+  onRetry: () => void
+}) {
   if (access.grant.status === 'not_installed') {
     return (
       <div className="flex flex-col items-start gap-3 py-1">
@@ -90,15 +96,16 @@ function AccessUnavailable({ access }: { access: RepositoryAccess }) {
   return (
     <div className="flex flex-col items-start gap-3 py-1">
       <div>
-        <p className="text-sm font-medium">GitHub access needs attention</p>
+        <p className="text-sm font-medium">
+          GitHub access is temporarily unavailable
+        </p>
         <p className="text-muted-foreground mt-1 text-sm">
-          The installation is unavailable. Reconnect it before this agent works
-          in a repository.
+          Nothing changed. Try loading the installation again.
         </p>
       </div>
-      <ExternalAction href={access.grant.install_url}>
-        Reconnect GitHub
-      </ExternalAction>
+      <Button size="sm" variant="outline" onClick={onRetry}>
+        Retry
+      </Button>
     </div>
   )
 }
@@ -260,7 +267,10 @@ function RepositoryAccessPanelForAgent({
             </Button>
           </div>
         ) : access && access.grant.status !== 'active' ? (
-          <AccessUnavailable access={access} />
+          <AccessUnavailable
+            access={access}
+            onRetry={() => void accessQuery.refetch()}
+          />
         ) : access && draft ? (
           <div className="space-y-4">
             <fieldset className="grid gap-2 sm:grid-cols-2">

--- a/web/src/lib/session-source-polling.ts
+++ b/web/src/lib/session-source-polling.ts
@@ -1,6 +1,25 @@
-import type { SessionSource } from '@/api/client'
+import type { Session, SessionSource } from '@/api/client'
 
 const ACTIVE_SOURCE_STATUSES = new Set(['pending', 'materializing'])
+const LIVE_SESSION_STATUSES = new Set([
+  'queued',
+  'running',
+  'awaiting_input',
+  'idle',
+])
+
+export function isFlueSession(
+  session: Pick<Session, 'agent_snapshot'> | undefined,
+): boolean {
+  return session?.agent_snapshot?.runtime === 'flue'
+}
+
+export function canSessionChangeFlueSources(
+  session: Pick<Session, 'status' | 'agent_snapshot'> | undefined,
+): boolean {
+  if (!session || !isFlueSession(session)) return false
+  return LIVE_SESSION_STATUSES.has(session.status)
+}
 
 /**
  * Empty sessions keep a slow watch for the first lazy Flue checkout. Active

--- a/web/src/pages/SessionDetail.tsx
+++ b/web/src/pages/SessionDetail.tsx
@@ -52,7 +52,11 @@ import {
   isOutOfCredits,
   isTurnInput,
 } from '@/lib/session-turns'
-import { sessionSourcesRefetchInterval } from '@/lib/session-source-polling'
+import {
+  canSessionChangeFlueSources,
+  isFlueSession,
+  sessionSourcesRefetchInterval,
+} from '@/lib/session-source-polling'
 
 function toolSummary(ev: SessionEvent): string {
   const b = (ev.body ?? {}) as Record<string, unknown>
@@ -248,13 +252,18 @@ for await (const event of session.events()) {
     queryFn: () => getSessionEvents(sessionId),
     refetchInterval: streamOk ? false : 5000,
   })
+  const sourcesEnabled = isFlueSession(session)
+  const sourcesCanChange = canSessionChangeFlueSources(session)
   const sourcesQuery = useQuery({
     queryKey: ['session-sources', sessionId],
     queryFn: () => getSessionSources(sessionId),
+    enabled: sourcesEnabled,
     staleTime: 15_000,
-    refetchInterval: (query) => sessionSourcesRefetchInterval(query.state.data),
+    refetchInterval: sourcesCanChange
+      ? (query) => sessionSourcesRefetchInterval(query.state.data)
+      : false,
     refetchIntervalInBackground: false,
-    refetchOnWindowFocus: 'always',
+    refetchOnWindowFocus: sourcesCanChange ? 'always' : false,
   })
 
   // Live events over SSE through the dashboard proxy (the proxy injects auth;

--- a/web/src/pages/session-sources.test.tsx
+++ b/web/src/pages/session-sources.test.tsx
@@ -1,6 +1,10 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { sessionSourcesRefetchInterval } from '@/lib/session-source-polling'
+import {
+  canSessionChangeFlueSources,
+  isFlueSession,
+  sessionSourcesRefetchInterval,
+} from '@/lib/session-source-polling'
 import { SessionSourcesPanel } from './SessionDetail'
 
 describe('session working sources', () => {
@@ -116,5 +120,32 @@ describe('session working sources', () => {
         },
       ]),
     ).toBe(5_000)
+  })
+
+  it('loads only Flue sources and polls only while the session can change', () => {
+    for (const status of ['queued', 'running', 'awaiting_input', 'idle']) {
+      const session = {
+        status,
+        agent_snapshot: { runtime: 'flue' },
+      }
+      expect(isFlueSession(session)).toBe(true)
+      expect(canSessionChangeFlueSources(session)).toBe(true)
+    }
+    expect(isFlueSession(undefined)).toBe(false)
+    expect(canSessionChangeFlueSources(undefined)).toBe(false)
+    const builtIn = {
+      status: 'running',
+      agent_snapshot: { runtime: 'claude' },
+    }
+    expect(isFlueSession(builtIn)).toBe(false)
+    expect(canSessionChangeFlueSources(builtIn)).toBe(false)
+    for (const status of ['failed', 'archived']) {
+      const terminalFlue = {
+        status,
+        agent_snapshot: { runtime: 'flue' },
+      }
+      expect(isFlueSession(terminalFlue)).toBe(true)
+      expect(canSessionChangeFlueSources(terminalFlue)).toBe(false)
+    }
   })
 })


### PR DESCRIPTION
## Summary

- restore `getManagedSlackConnection` to the exact shared `ApiError` boundary and make preview mocks throw the same class
- stop irrelevant Session Detail source traffic: non-Flue sessions never query sources, terminal Flue sessions fetch for read-only display without polling, and only live Flue sessions poll
- make transient repository-access discovery failures retry in place instead of incorrectly asking users to reconnect GitHub
- accept additive Flue repository API response fields while projecting trusted server growth into bounded model-visible output
- preserve the runtime-owned request-env proxy: ambient bindings win when defined, fallback secrets are read directly, and the fallback is never spread or enumerated
- retain strict bounded tool inputs and bump `@opencomputer/flue` to `0.3.1`; this PR does not publish the package

## Request and compatibility contracts

Session-source queries use the authoritative session snapshot and lifecycle:

- non-Flue or not-yet-loaded: disabled
- Flue `failed` / `archived`: one logical query, no interval or focus refetch
- Flue `queued` / `running` / `awaiting_input` / `idle`: 5s polling, accelerated to 1.5s while a source is pending or materializing
- background tab: no interval polling

Repository response validators accept and strip additive fields at every object level. Known semantic fields remain validated. Oversized trusted responses are accepted but projected safely: repository lists are sliced to 50 and force `truncated=true`; product messages are truncated to 500 characters. Model-authored inputs remain exact `strictObject` schemas with the existing shape and length caps.

The env layer never enumerates the runtime-owned fallback proxy. A dedicated fixture combines ambient bindings with a fallback whose `ownKeys` throws while direct `OC_SESSION_TOKEN` access succeeds.

## Package delivery

- package version: `@opencomputer/flue@0.3.1`
- lockfile change: package-root metadata only
- publish status: not published by this PR
- follow-up after publication: pin the stock starter to `0.3.1`, update its lockfile, and regenerate only affected golden output

## Verification

- web focused review tests: 3 files / 16 tests pass
- prior full web suite: 33 files / 138 tests pass
- Flue SDK `prepublishOnly` at `0.3.1`: 38 tests, build, and workerd compatibility check pass
- `git diff --check`: pass

No sessions-api/backend files or behavior are changed.