### PR TITLE
fix(sessions): remove unsupported revision override

### DIFF
--- a/cmd/oc/internal/commands/session.go
+++ b/cmd/oc/internal/commands/session.go
@@ -1,7 +1,7 @@
 package commands
 
 // `oc session` — Durable Agent Sessions runtime verbs (/v3/sessions/*). A session
-// is one run of an agent's active (or pinned) revision. Distinct from `oc agent`
+// is one run of an agent's active revision. Distinct from `oc agent`
 // (which manages the behavior); sessions are addressed by id.
 
 import (
@@ -44,10 +44,9 @@ var sessionCmd = &cobra.Command{
 }
 
 var sessionCreateCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Start a session on an agent",
-	Example: "  oc session create --agent issue-fixer --input \"triage issue #42\"\n" +
-		"  oc session create --agent issue-fixer --input \"...\" --revision 3   # pin a staged revision",
+	Use:     "create",
+	Short:   "Start a session on an agent",
+	Example: "  oc session create --agent issue-fixer --input \"triage issue #42\"",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sc, err := sessionsClient(cmd)
 		if err != nil {
@@ -55,7 +54,6 @@ var sessionCreateCmd = &cobra.Command{
 		}
 		ref, _ := cmd.Flags().GetString("agent")
 		input, _ := cmd.Flags().GetString("input")
-		revision, _ := cmd.Flags().GetString("revision")
 		if ref == "" {
 			id, rerr := targetAgentID(cmd, sc, nil) // fall back to cwd agent.toml
 			if rerr != nil {
@@ -72,9 +70,6 @@ var sessionCreateCmd = &cobra.Command{
 			return fmt.Errorf("--input is required (the first message to the agent)")
 		}
 		body := map[string]interface{}{"agent": ref, "input": input}
-		if revision != "" {
-			body["revision"] = revision
-		}
 		specs, _ := cmd.Flags().GetStringArray("source")
 		sources, err := parseSources(specs)
 		if err != nil {
@@ -285,7 +280,6 @@ func bodyText(body interface{}) (string, bool) {
 func init() {
 	sessionCreateCmd.Flags().String("agent", "", "Agent id or name to run (else the cwd agent.toml)")
 	sessionCreateCmd.Flags().String("input", "", "First message to the agent (required)")
-	sessionCreateCmd.Flags().String("revision", "", "Pin a specific revision (number or rev_ id; default = active)")
 	sessionCreateCmd.Flags().StringArray("source", nil, "Attach a GitHub repo as a working source: owner/repo[@ref] (default ref: HEAD). Repeatable.")
 	sessionListCmd.Flags().String("agent", "", "Filter by agent id or name")
 

--- a/cmd/oc/internal/commands/session_test.go
+++ b/cmd/oc/internal/commands/session_test.go
@@ -2,6 +2,12 @@ package commands
 
 import "testing"
 
+func TestSessionCreateDoesNotExposeRevisionFlag(t *testing.T) {
+	if flag := sessionCreateCmd.Flags().Lookup("revision"); flag != nil {
+		t.Fatal("session create must not expose unsupported revision selection")
+	}
+}
+
 func TestParseSources(t *testing.T) {
 	ok := []struct {
 		in       []string

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -68,15 +68,15 @@ oc agent build --dir . --check-only --json  # validate a Flue app without creden
 
 <Tab title="oc CLI">
 
-| Command                                                                  | Purpose                                                                    |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| `oc session create --agent <id\|name> [--revision <n>] [--input <text>]` | Start a session (`--revision` pins a specific revision; default = active). |
-| `oc session get <id>`                                                    | Fetch a session.                                                           |
-| `oc session list [--agent <id>] [--status <s>]`                          | List sessions.                                                             |
-| `oc session cancel <id>`                                                 | Cooperatively stop the active turn.                                        |
-| `oc session result <id>`                                                 | The resolved final result.                                                 |
-| `oc session steer <id> <text>`                                           | Send input to a running or waiting session.                                |
-| _(archive · turns · sources · client tokens — REST/SDK only)_            |                                                                            |
+| Command                                                   | Purpose                                          |
+| --------------------------------------------------------- | ------------------------------------------------ |
+| `oc session create --agent <id\|name> [--input <text>]`   | Start a session on the agent's active revision. |
+| `oc session get <id>`                                     | Fetch a session.                                 |
+| `oc session list [--agent <id>] [--status <s>]`           | List sessions.                                   |
+| `oc session cancel <id>`                                  | Cooperatively stop the active turn.              |
+| `oc session result <id>`                                  | The resolved final result.                       |
+| `oc session steer <id> <text>`                            | Send input to a running or waiting session.      |
+| _(archive · turns · sources · client tokens — REST/SDK only)_ |                                                  |
 
 </Tab>
 
@@ -85,7 +85,6 @@ oc agent build --dir . --check-only --json  # validate a Flue app without creden
 **Create params** — `agent` is **required**; the model resolves to **Managed** (default) or a [credential](#credentials), else `422 no_credential` / `422 managed_unavailable`.
 
 - `input` — the task (string or [envelope](/agent-sessions/messaging#message-input)). Truncate large inputs; let the agent fetch the rest via [sandbox tools](/agent-sessions/runtime-tools).
-- `revision?`: pin a specific revision (number / `rev_…`); default = the agent's active one. Use to test a [staged](/agent-sessions/revisions#staging-vs-activating) built-in runtime revision. A Flue agent has one live Worker, so an old revision does not isolate older Worker code.
 - `model?` — run this session on a different model than the agent's (same `provider/model` form; its provider must match the agent's [runtime](/agent-sessions/runtimes), e.g. `anthropic/…` for `claude`). Default = the agent's model. Pinned for the session's life like the rest of the snapshot. Rejected (`400 invalid`) for [flue](/agent-sessions/flue) agents — their model is fixed in the deployed artifact.
 - `key?` — get-or-create (one session per key). Keyless: an `Idempotency-Key` header makes create retry-safe.
 - `metadata?` — opaque routing state (≤ 16 KB); on get/list + **verbatim in webhooks**; never sent to the model, not indexed.

--- a/docs/agent-sessions/flue.mdx
+++ b/docs/agent-sessions/flue.mdx
@@ -382,7 +382,7 @@ the `queued`, `fetching`, `validating`, `installing`, `building`, `uploading`, `
 <Warning>
 Flue currently has one live Worker per agent. Uploading a deployment changes the code used by new and
 existing sessions before revision verification finishes. There is no isolated staged Worker, canary
-route, or automatic Worker rollback. `--no-activate`, an old revision pin, and a pointer-only
+route, or automatic Worker rollback. `--no-activate` and a pointer-only
 `oc agent rollback` do not restore older Worker code.
 
 From the live-upload guard until verification finishes, new session creation and new input return the

--- a/docs/agent-sessions/revisions.mdx
+++ b/docs/agent-sessions/revisions.mdx
@@ -85,23 +85,19 @@ Inline deployments finish synchronously (`state: "ready"` with a `revision_id`) 
 
 ### Staging vs activating
 
-<Warning>Isolated staging is not available for Flue. A Flue upload changes the one live Worker even when deployment metadata requests `activate: false`. Do not use `--no-activate` or a pinned revision as a Flue canary. See [Flue deployment behavior](/agent-sessions/flue#deployment-and-revision-behavior).</Warning>
+<Warning>Isolated staging is not available for Flue. A Flue upload changes the one live Worker even when deployment metadata requests `activate: false`. Do not use `--no-activate` as a Flue canary. See [Flue deployment behavior](/agent-sessions/flue#deployment-and-revision-behavior).</Warning>
 
-By default a ready deployment is **activated** — its revision becomes what new sessions use. Pass **`activate: false`** to **stage** instead: the revision is created but not made active, so you can test it before it goes live.
+By default a ready deployment is **activated** — its revision becomes what new sessions use. Pass **`activate: false`** to **stage** instead: the revision is created but not made active.
 
 ```ts
-// 1. stage a revision (not activated)
+// Stage a revision (not activated).
 const { deployment } = await oc.agents.deployments.create("agt_123", { input: { type: "inline", prompt: "…" }, activate: false });
 
-// 2. test it — a session pins the agent's ACTIVE revision by default; pass `revision`
-//    to run the staged one instead
-const session = await oc.sessions.create({ agent: "agt_123", revision: deployment.revision_id, input: "…" });
-
-// 3. happy? promote it
+// After reviewing it, promote it to make it active.
 await oc.agents.revisions.activate("agt_123", deployment.revision_id);
 ```
 
-So `revision` on [session create](/agent-sessions/sessions) is how you exercise any non-active revision (a staged one, or an old one) without touching what's live.
+A session always starts on the agent's active revision. A staged built-in revision cannot be invoked directly today; activate it when you are ready for new sessions to use it.
 
 For built-in [repo deployments](#deploy-from-a-repo), the **branch decides** and `activate` is ignored:
 a push to the production branch activates, while another branch stages. Flue repository deployment
@@ -160,7 +156,7 @@ oc agent link acme/agents --path issue-fixer --branch main
 Linking deploys the current `main` HEAD right away (`deploy_now: false` / `--no-deploy` to skip). Then every push that touches the directory deploys:
 
 - push to **`main`** (production) → a new revision, **activated**.
-- push to **another branch** → a revision **staged** (test, then [promote](#roll-back-and-promote)).
+- push to **another branch** → a revision **staged** (review, then [promote](#roll-back-and-promote)).
 - a push not touching the directory → **no-op**; identical directory content → **skipped** (no churn).
 
 OpenComputer posts a **commit status** (queued → ready / failed) so a deployment's result shows in GitHub.

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/agents/session-create-contract.test.ts
+++ b/sdks/typescript/src/agents/session-create-contract.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import type { CreateSessionParams } from "./sessions.js";
+
+type HasRevisionOverride = "revision" extends keyof CreateSessionParams ? true : false;
+const hasRevisionOverride: HasRevisionOverride = false;
+
+describe("session create contract", () => {
+  it("does not expose unsupported revision selection", () => {
+    expect(hasRevisionOverride).toBe(false);
+  });
+});

--- a/sdks/typescript/src/agents/sessions.ts
+++ b/sdks/typescript/src/agents/sessions.ts
@@ -10,11 +10,6 @@ export interface CreateSessionParams {
   agent: string;
   input: string | Envelope;
   /**
-   * Pin a specific revision (number or `rev_…` id) instead of the agent's active one — e.g. to
-   * test a staged revision before promoting it. Defaults to the active revision.
-   */
-  revision?: number | string;
-  /**
    * Override the agent's model for this session — the session runs this model instead of the
    * one pinned by the agent's revision. Same `provider/model` form as the agent's model, and
    * must resolve to the agent's runtime's provider. Defaults to the agent's model. Not


### PR DESCRIPTION
## TL;DR

Session creation always resolves the agent active revision in Sessions API, but the TypeScript SDK, CLI, and public docs offered a revision override that the backend ignores. This removes that false contract while preserving the response-side revision snapshot.

The SDK moves from 0.13.0 to 0.13.1 so the correction can ship through the version-gated publish workflow after merge.

## Review map

- sdks/typescript/src/agents/sessions.ts and its contract test: remove CreateSessionParams.revision.
- cmd/oc/internal/commands/session.go and its flag test: remove --revision and request wiring.
- docs/agent-sessions/{api-reference,revisions,flue}.mdx: state that creates use the active revision and staged revisions cannot currently be invoked directly.

## Risk and rollout boundary

This removes a documented but ineffective client option. Callers that supplied it were already running the active revision. There is no Sessions API change, migration, config change, deployment, or Agent URL implementation. Explicit preview-revision invocation remains future work.

## Verification

- go test ./cmd/oc/internal/commands
- cd sdks/typescript && npm test — 9 files, 39 tests passed
- cd sdks/typescript && npm run lint
- cd sdks/typescript && npm run build
- go run ./cmd/oc session create --help — no revision flag
- git diff --check

## Remaining gate

Review and merge only; no publish or deployment was performed as part of this PR.