### PR TITLE
Runtime-neutral repository access (evergreen)

### DIFF
--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -157,7 +157,7 @@ Hook creation returns `{ hook, hook_url }` once. `Hook` contains `id`,
 - `key?` — get-or-create (one session per key). Keyless: an `Idempotency-Key` header makes create retry-safe.
 - `metadata?` — opaque routing state (≤ 16 KB); on get/list + **verbatim in webhooks**; never sent to the model, not indexed.
 - `limits?` `{ tokens, turn_seconds, turns }`: non-monetary. On built-in runtimes, `tokens` is checked from committed usage before the next turn and can overshoot by one in-flight turn; `turn_seconds` and `turns` remain separate. These limits are stored but not enforced for Flue sessions.
-- `sources?`: working repositories (the token never enters the agent sandbox; see [GitHub](#github-apps-and-repos)). Built-in runtimes prepare them before turn one; Flue materializes them lazily. Each registered `{ repo, ref, sha?, name? }` or inline `{ url, ref, sha, name?, auth }`. `ref` is required; `sha` is required for inline sources but **optional for a registered repo**. Flue accepts only repositories allowed by the agent's repository-access policy.
+- `sources?`: working repositories (the token never enters the agent sandbox; see [GitHub](#github-apps-and-repos)). Built-in runtimes prepare them before turn one; Flue materializes them lazily. Each registered `{ repo, ref, sha?, name? }` or inline `{ url, ref, sha, name?, auth }`. `ref` is required; `sha` is required for inline sources but **optional for a registered repo**. For every runtime, `selected` repository access admits only registered repositories allowed by the agent policy and reauthorizes checkout and publishing at use time.
 - Client tokens: `scopes?` (`read`/`steer`), `ttl?` 60–86400 s (SDK `ttlSeconds`).
 
 A built-in runtime session pins the agent's active revision for its whole life. A Flue session records its selected deployment but executes on the agent's one live Worker; deploying that Worker can therefore affect an existing session.
@@ -341,7 +341,7 @@ _Managed with the SDK (`session.watches.create/list/delete`), the CLI (`oc sessi
 | `oc.agents.repository.import(params)`          | Import an exact reviewed source and enqueue its first deployment.             |
 | `oc.agents.get(id)` · `oc.agents.list()`       | Fetch / list.                                                                 |
 | `oc.agents.update(id, params)`                 | Update bindings (credential / limits) — `prompt`/`model` deploy a revision.   |
-| `oc.agents.getRepositoryAccess(id)`            | Read a Flue agent's GitHub grant, policy, and effective working repositories. |
+| `oc.agents.getRepositoryAccess(id)`            | Read an agent's GitHub grant, policy, and effective working repositories.     |
 | `oc.agents.updateRepositoryAccess(id, policy)` | Atomically replace that policy.                                               |
 | `oc.agents.delete(id)`                         | Delete an agent.                                                              |
 
@@ -355,7 +355,7 @@ _Managed with the SDK (`session.watches.create/list/delete`), the CLI (`oc sessi
 | `POST /agents/import`               | Atomically create an agent from an exact reviewed GitHub source and enqueue its first deployment. |
 | `GET /agents/:id` · `GET /agents`   | Fetch / list.                                                                                     |
 | `PATCH /agents/:id`                 | Update bindings; `prompt`/`model` deploy a revision.                                              |
-| `GET /agents/:id/repository-access` | Read working-repository access for a Flue agent.                                                  |
+| `GET /agents/:id/repository-access` | Read working-repository access for an agent.                                                       |
 | `PUT /agents/:id/repository-access` | Atomically replace its policy.                                                                    |
 | `DELETE /agents/:id`                | Delete an agent.                                                                                  |
 
@@ -386,10 +386,11 @@ URL semantics. See [Agent URLs and Hooks](#agent-urls-and-hooks).
 an agent with no active revision; revision #1 appears only after the queued build and live deployment
 verify successfully.
 
-### Flue repository access
+### Repository access
 
-Repository access is separate from the repository used to deploy the Flue app.
-It bounds which repositories the running agent may check out and publish to:
+Repository access is available for every runtime and is separate from the
+repository used to deploy an agent. `selected` bounds session sources, checkout,
+and pull-request publishing for all runtimes; `all` preserves the open behavior.
 
 ```ts TypeScript SDK
 const access = await oc.agents.getRepositoryAccess(agent.id);
@@ -438,8 +439,8 @@ Use `{ "mode": "all" }` for every repository in the current and future App
 grant. An empty selected list disables repository work but not chat. When the
 grant is `not_installed`, `effective_repositories` is the known-empty `[]`.
 Only a transient `unavailable` grant uses `null`, because no complete set was
-read. The owner-bound
-OpenComputer App is the only authority for this Flue capability.
+read. In `selected` mode, the owner-bound OpenComputer App is the only
+repository authority.
 
 ## Deployments and revisions
 
@@ -1035,7 +1036,7 @@ See [Webhooks](/agent-sessions/webhooks#signing-retries-and-dedupe) for signing,
 
 ## GitHub Apps and Repos
 
-A GitHub App lets OpenComputer mint short-lived, repo-scoped tokens; a **Repo** is a stable handle resolving to your configured App (the OpenComputer App by default). Used for session [sources](#sessions) (work repos) and [deploy-from-a-repo](#deploy-from-a-repo) (the agent's definition repo). Install the [OpenComputer App](https://github.com/apps/opencomputerdev/installations/new). **Bring-your-own** Apps may back built-in-runtime session sources and PR publishing. Hosted Flue repository tools and deployment sources always use the owner-bound OpenComputer App.
+A GitHub App lets OpenComputer mint short-lived, repo-scoped tokens; a **Repo** is a stable handle resolving to your configured App (the OpenComputer App by default). Used for session [sources](#sessions) (work repos) and [deploy-from-a-repo](#deploy-from-a-repo) (the agent's definition repo). Install the [OpenComputer App](https://github.com/apps/opencomputerdev/installations/new). In `selected` repository-access mode, every runtime uses the owner-bound OpenComputer App. In `all` mode, configured **bring-your-own** Apps may continue to back built-in-runtime session sources and PR publishing. Hosted Flue repository tools and deployment sources always use the owner-bound OpenComputer App.
 
 <Tabs>
 

--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -42,12 +42,13 @@ sandbox, and deploys the resulting artifact. Repository credentials reach neithe
   the same way.
 </Note>
 
-## Choose working repositories for a Flue agent
+## Choose working repositories for an agent
 
-A Flue agent's **repository access policy** limits which repositories it may
-check out and publish to. It is independent of the [deployment source](#use-a-repo-to-deploy-a-flue-agent):
-the deployment source supplies the app, while working repositories supply code
-for a session task.
+An agent's **repository access policy** limits which repositories it may use for
+session sources, checkout, and pull-request publishing. It is independent of a
+[deployment source](#use-a-repo-to-deploy-a-flue-agent): the deployment source
+supplies the agent definition, while working repositories supply code for a
+session task.
 
 In guided setup or **Agent → Settings → Repository access**, choose:
 
@@ -63,16 +64,14 @@ truncated GitHub listing and shows unavailable selections separately instead of
 calling them revoked.
 
 Choose a working repository when starting a dashboard session, pass it in
-`sources`, or let the Flue app call `add_source`. A ref is pinned to one commit;
-reusing the source name in that session returns the same pin. OpenComputer
-checks files out lazily into the session sandbox and keeps the GitHub token in a
-separate, short-lived Git operations sandbox.
+`sources`, or let the running agent call `add_source`. A ref is pinned to one
+commit. OpenComputer checks files out into the session sandbox and keeps the
+GitHub token in a separate, short-lived Git operations sandbox.
 
 To publish, the agent calls `github_publish_pull_request`. OpenComputer pushes a
 new `oc/…` branch and opens a PR; it never writes directly to the default branch.
-The managed Flue capability uses the OpenComputer App selected for the agent's
-owner. A bring-your-own App is not used as an alternative authority for this
-policy.
+With `selected` access, the owner-bound OpenComputer App is the only authority.
+`all` preserves the existing open behavior, including configured App resolution.
 
 ## How it works
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/agents/agents.ts
+++ b/sdks/typescript/src/agents/agents.ts
@@ -84,7 +84,7 @@ export interface ManagedSlackWorkspaceConnection extends ManagedSlackConnection 
   agent: { id: string; name: string };
 }
 
-/** Which repositories a Flue agent may use as working sources. */
+/** Which repositories an agent may use as working sources. */
 export type RepositoryAccessPolicy =
   | { mode: "all" }
   | { mode: "selected"; repositoryIds: string[] };

--- a/web/src/lib/repository-access.test.ts
+++ b/web/src/lib/repository-access.test.ts
@@ -3,6 +3,7 @@ import {
   isNarrowingRepositoryAccess,
   repositoryAccessCandidates,
   repositoryAccessQueryKey,
+  showRepositoryAccessDuringSetup,
   toggleSelectedRepository,
 } from './repository-access'
 
@@ -12,6 +13,14 @@ describe('repository access helpers', () => {
       'agent-repository-access',
       'agt_1',
     ])
+  })
+
+  it('shows built-in repository access before Slack while preserving Flue setup order', () => {
+    expect(showRepositoryAccessDuringSetup('claude', 'disconnected')).toBe(true)
+    expect(showRepositoryAccessDuringSetup('codex', undefined)).toBe(true)
+    expect(showRepositoryAccessDuringSetup('pi', null)).toBe(true)
+    expect(showRepositoryAccessDuringSetup('flue', 'disconnected')).toBe(false)
+    expect(showRepositoryAccessDuringSetup('flue', 'active')).toBe(true)
   })
 
   it('detects narrowing without treating expansion as narrowing', () => {

--- a/web/src/lib/repository-access.ts
+++ b/web/src/lib/repository-access.ts
@@ -8,6 +8,16 @@ import type {
 export const repositoryAccessQueryKey = (agentId: string) =>
   ['agent-repository-access', agentId] as const
 
+/** Built-in runtimes can configure repository scope before Slack. Flue keeps
+ * its established guided order, which reveals repository access after managed
+ * Slack is active. */
+export function showRepositoryAccessDuringSetup(
+  runtime: string | null | undefined,
+  managedSlackStatus: string | null | undefined,
+): boolean {
+  return runtime !== 'flue' || managedSlackStatus === 'active'
+}
+
 export function selectedRepositoryIds(
   policy: RepositoryAccessPolicy,
 ): string[] {

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -733,21 +733,20 @@ export default function AgentDetail() {
               </div>
               {/* Overview keeps integrations compact; Settings owns mutations. */}
               <div className="space-y-4">
-                {agent.runtime === 'flue' ? (
-                  <RepositoryAccessSummary
-                    agentId={agent.id}
-                    onOpenSettings={() => {
-                      void navigate(`${base}/settings?section=github`)
-                    }}
-                  />
-                ) : (
+                {agent.runtime !== 'flue' ? (
                   <DeploymentSourceSummary
                     agentId={agent.id}
                     onOpenSettings={() => {
                       void navigate(`${base}/settings?section=github`)
                     }}
                   />
-                )}
+                ) : null}
+                <RepositoryAccessSummary
+                  agentId={agent.id}
+                  onOpenSettings={() => {
+                    void navigate(`${base}/settings?section=github`)
+                  }}
+                />
                 <SlackConnectionSummary
                   agentId={agent.id}
                   onOpenSettings={() => {
@@ -806,9 +805,7 @@ export default function AgentDetail() {
                 agentId={agent.id}
                 profilePinned={agent.runtime === 'flue'}
               />
-              {agent.runtime === 'flue' ? (
-                <RepositoryAccessPanel agentId={agent.id} />
-              ) : null}
+              <RepositoryAccessPanel agentId={agent.id} />
             </section>
             <section
               id="slack"

--- a/web/src/pages/AgentSetup.tsx
+++ b/web/src/pages/AgentSetup.tsx
@@ -63,6 +63,7 @@ import {
 } from '@/lib/managed-slack-notice'
 import { useManagedSlackConnections } from '@/lib/managed-slack-connections'
 import { latestManagedSlackSession } from '@/lib/managed-slack-session'
+import { showRepositoryAccessDuringSetup } from '@/lib/repository-access'
 import {
   bodyText,
   isTerminalSessionStatus,
@@ -652,10 +653,10 @@ export default function AgentSetup() {
         ) : null}
       </Panel>
 
-      {agent.runtime === 'flue' && managedSlackStatus === 'active' ? (
+      {showRepositoryAccessDuringSetup(agent.runtime, managedSlackStatus) ? (
         <div className="space-y-3">
           <RepositoryAccessPanel agentId={agentId} context="setup" />
-          {stage === 'ready' ? (
+          {stage === 'ready' && managedSlackStatus === 'active' ? (
             <RepositoryTaskSuggestion agentId={agentId} />
           ) : null}
         </div>


### PR DESCRIPTION
## Evergreen scope

Long-lived integration PR for work 030 section 4B. Additional repository-access product work may be folded into this branch before final review and merge.

Companion sessions-api authority and runtime enforcement: https://github.com/diggerhq/sessions-api/pull/101

## Current foundation

- Shows repository access in Overview and Settings for every runtime.
- Makes repository scope available before Slack setup for built-in runtimes while retaining the established Flue setup order.
- Generalizes the TypeScript SDK repository-policy documentation and bumps the package to 0.15.0.
- Documents that selected bounds sources, checkout, and pull-request publishing for every runtime while all preserves open behavior.
- Reuses the existing dashboard components and narrowing confirmation behavior.

## Validation

- Dashboard: 158 tests, TypeScript typecheck, and production build
- Changed dashboard files: ESLint clean
- TypeScript SDK: 43 tests, lint, and build
- git diff --check

Full dashboard lint still reports seven baseline errors in untouched Terminal, guided-tour, Browsers, and SandboxDetail files. Prettier reports an existing class-order difference in an untouched AgentDetail line; the 4B hunks are formatted.

## Merge and deploy order

Sessions-api PR #101 must be merged and deployed before this dashboard PR. Until that backend is live, non-Flue repository-access GET and PUT retain the old 409 behavior and the newly visible settings panel renders an error card.

## Integration notes

- Base: origin/main at 0806f08999bbbdb83c40549793cdadb1b9328aa4
- Parallel 4A currently shares api-reference.mdx, repos.mdx, and the TypeScript SDK package manifests. The documentation hunks are separate, and both branches currently select SDK version 0.15.0.
- If 4A and 4B are folded together, retain one 0.15.0 bump. If they merge separately, rebase and restamp the later PR to the next publishable version.
- Production dashboard testing runs commit 2ff917bb267f68cb439f7c0fea11fd81b5bcfc90; dashboard health passed on 2026-07-23.
- No customer-data live smokes were run.