### PR TITLE
Surface prompt-defined Flue repositories

### DIFF
--- a/cmd/oc/internal/commands/agent_build.go
+++ b/cmd/oc/internal/commands/agent_build.go
@@ -32,11 +32,12 @@ var agentBuildCmd = &cobra.Command{
 		}
 
 		result, err := fluebuild.Build(cmd.Context(), fluebuild.Options{
-			Dir:            dir,
-			Target:         target,
-			OutputDir:      output,
-			BuilderVersion: Version,
-			CheckOnly:      checkOnly,
+			Dir:                      dir,
+			Target:                   target,
+			OutputDir:                output,
+			BuilderVersion:           Version,
+			SynthesisTemplateVersion: os.Getenv("OC_FLUE_SYNTH_TEMPLATE_VERSION"),
+			CheckOnly:                checkOnly,
 		})
 		if err != nil {
 			return err

--- a/cmd/oc/internal/commands/agent_deploy_flue.go
+++ b/cmd/oc/internal/commands/agent_deploy_flue.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/opensandbox/opensandbox/cmd/oc/internal/client"
@@ -38,6 +39,11 @@ type artifactUploadResponse struct {
 }
 
 func deployFlue(cmd *cobra.Command, sc *client.Client, dir string, m *manifest, noActivate bool) error {
+	if isPromptDefinedFlueRoot(dir) {
+		return fmt.Errorf(
+			"prompt-defined Flue agents currently deploy from GitHub: push this directory, then choose Agents → Create agent → Import from GitHub",
+		)
+	}
 	// 1. Run the same credential, manifest, engine, and lockfile projection as
 	//    the managed builder before any authenticated API call. --check-only
 	//    never executes repository code and never needs installed dependencies.
@@ -154,6 +160,28 @@ func deployFlue(cmd *cobra.Command, sc *client.Client, dir string, m *manifest, 
 		})
 	})
 	return nil
+}
+
+func isPromptDefinedFlueRoot(dir string) bool {
+	regular := func(name string) bool {
+		info, err := os.Lstat(name)
+		return err == nil && info.Mode().IsRegular()
+	}
+	if !regular(filepath.Join(dir, "prompt.md")) {
+		return false
+	}
+	for _, marker := range []string{
+		"package.json",
+		"flue.config.ts",
+		"flue.config.js",
+		"flue.config.mjs",
+		"flue.config.cjs",
+	} {
+		if _, err := os.Lstat(filepath.Join(dir, marker)); err == nil {
+			return false
+		}
+	}
+	return true
 }
 
 func presentFlueBuildError(err error) error {

--- a/cmd/oc/internal/commands/agent_deploy_flue.go
+++ b/cmd/oc/internal/commands/agent_deploy_flue.go
@@ -1,27 +1,29 @@
 package commands
 
 // Flue deploy flow (design 013 §6 — the Worker-for-Platforms Durable-Object model).
-// When agent.toml declares `[runtime] family = "flue"`, `oc agent deploy` does NOT
-// read prompt.md/skills/; it runs the app's own `flue build --target cloudflare`, then
-// stages only regular .js/.mjs modules as one tar.gz in R2 via a presigned PUT, and
-// POSTs the deployment referencing only the R2 bundle digest + a small canonical
-// Flue descriptor + the entrypoint agent name — NO module bytes in the JSON, so the
-// API host stays byte-free. The CP records
-// a `verifying` deploy; an off-host runner fetches the bundle, composes, mints the
-// per-deploy token, WfP-uploads, and finalizes. The existing deployment poll absorbs
-// the runner latency (verifying → ready|failed).
+// A prompt-defined root stages only agent.toml, prompt.md, and exact SKILL.md files;
+// the isolated managed builder owns synthesis and the framework build. A complete app
+// runs its own local `flue build --target cloudflare` and stages only the resulting
+// regular .js/.mjs modules. Both paths keep source/module bytes out of API JSON and
+// converge on the same off-host deploy runner and verifying → ready|failed poll.
 
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"time"
+	"unicode/utf8"
 
+	"github.com/opensandbox/opensandbox/cmd/oc/internal/bundle"
 	"github.com/opensandbox/opensandbox/cmd/oc/internal/client"
 	"github.com/opensandbox/opensandbox/cmd/oc/internal/fluebuild"
 	"github.com/spf13/cobra"
@@ -38,11 +40,25 @@ type artifactUploadResponse struct {
 	AlreadyUploaded bool   `json:"already_uploaded"`
 }
 
+type localSourceUploadResponse struct {
+	URL             string `json:"url"`
+	ExpiresAt       string `json:"expires_at"`
+	AlreadyUploaded bool   `json:"already_uploaded"`
+}
+
+const (
+	fluePromptMaxBytes       = 256 * 1024
+	fluePromptMaxSkills      = 32
+	fluePromptMaxSkillBytes  = 256 * 1024
+	fluePromptMaxSkillsBytes = 2 * 1024 * 1024
+	fluePromptMaxArchive     = 4 * 1024 * 1024
+)
+
+var fluePromptSkillName = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,63}$`)
+
 func deployFlue(cmd *cobra.Command, sc *client.Client, dir string, m *manifest, noActivate bool) error {
 	if isPromptDefinedFlueRoot(dir) {
-		return fmt.Errorf(
-			"prompt-defined Flue agents currently deploy from GitHub: push this directory, then choose Agents → Create agent → Import from GitHub",
-		)
+		return deployPromptDefinedFlue(cmd, sc, dir, m, noActivate)
 	}
 	// 1. Run the same credential, manifest, engine, and lockfile projection as
 	//    the managed builder before any authenticated API call. --check-only
@@ -163,11 +179,11 @@ func deployFlue(cmd *cobra.Command, sc *client.Client, dir string, m *manifest, 
 }
 
 func isPromptDefinedFlueRoot(dir string) bool {
-	regular := func(name string) bool {
-		info, err := os.Lstat(name)
-		return err == nil && info.Mode().IsRegular()
+	exists := func(name string) bool {
+		_, err := os.Lstat(name)
+		return err == nil
 	}
-	if !regular(filepath.Join(dir, "prompt.md")) {
+	if !exists(filepath.Join(dir, "prompt.md")) {
 		return false
 	}
 	for _, marker := range []string{
@@ -182,6 +198,250 @@ func isPromptDefinedFlueRoot(dir string) bool {
 		}
 	}
 	return true
+}
+
+// deployPromptDefinedFlue stages the bounded behavior source directly into the
+// transient source bucket, then asks the existing isolated managed-build plane
+// to synthesize and build it. The API sees only the source reference.
+func deployPromptDefinedFlue(
+	cmd *cobra.Command,
+	sc *client.Client,
+	dir string,
+	m *manifest,
+	noActivate bool,
+) error {
+	if m.Name == "" {
+		return fmt.Errorf("prompt-defined Flue deployments require `name` in agent.toml")
+	}
+	if m.Runtime.Type != "" && m.Runtime.Type != "default" {
+		return fmt.Errorf("prompt-defined Flue deployments require runtime.type = \"default\"")
+	}
+	files, err := readPromptDefinedFlueSource(dir)
+	if err != nil {
+		return err
+	}
+	sourceTarGz, err := bundle.Pack(files)
+	if err != nil {
+		return fmt.Errorf("pack prompt-defined Flue source: %w", err)
+	}
+	if len(sourceTarGz) > fluePromptMaxArchive {
+		return fmt.Errorf(
+			"prompt-defined Flue source archive exceeds %d bytes",
+			fluePromptMaxArchive,
+		)
+	}
+	uploadID, err := newLocalSourceUploadID()
+	if err != nil {
+		return fmt.Errorf("create source upload id: %w", err)
+	}
+	digest := bundle.Digest(sourceTarGz)
+
+	id, err := resolveDeployAgent(cmd, sc, m)
+	if err != nil {
+		return err
+	}
+	if err := syncManifestVars(cmd, sc, id, m); err != nil {
+		return err
+	}
+	if !jsonOutput {
+		printDeployProgress("uploading source")
+	}
+	if err := uploadLocalBuildSource(
+		cmd.Context(),
+		sc,
+		id,
+		uploadID,
+		digest,
+		sourceTarGz,
+	); err != nil {
+		return err
+	}
+
+	rt := m.Runtime.Type
+	if rt == "" {
+		rt = "default"
+	}
+	input := map[string]interface{}{
+		"type":       "source",
+		"source":     map[string]interface{}{"upload_id": uploadID, "digest": digest, "size_bytes": len(sourceTarGz)},
+		"entrypoint": m.Name,
+		"model":      m.Model,
+		"runtime":    map[string]string{"type": rt},
+	}
+	body := map[string]interface{}{"input": input, "activate": !noActivate}
+	if idem, _ := cmd.Flags().GetString("idempotency-key"); idem != "" {
+		body["idempotency_key"] = idem
+	}
+	var env DeploymentEnvelope
+	if err := sc.Post(cmd.Context(), "/v3/agents/"+id+"/deployments", body, &env); err != nil {
+		return err
+	}
+	d := env.Deployment
+	if !terminalState(d.State) && d.State != "" {
+		to, _ := cmd.Flags().GetInt("timeout")
+		d, err = pollDeployment(cmd, sc, id, d.ID, time.Duration(to)*time.Second)
+		if err != nil {
+			return err
+		}
+	}
+	if d.State == "failed" {
+		printer.Print(d, func() { fmt.Printf("Deploy failed: %s\n", deployFailMsg(d)) })
+		return &ExitError{Code: 1}
+	}
+	handoff := Agent{}
+	if !jsonOutput && d.State == "ready" {
+		handoff = loadDeployHandoff(cmd, sc, id)
+	}
+	printer.Print(d, func() {
+		n := revisionNumber(cmd, sc, id, d.RevisionID)
+		status := "staged"
+		if d.Active {
+			status = "active"
+		}
+		printDeploySuccess(printer.W, deploySuccess{
+			Agent: handoff, Revision: n, Status: status,
+		})
+	})
+	return nil
+}
+
+func readPromptDefinedFlueSource(dir string) ([]bundle.File, error) {
+	readRegular := func(rel string, maxBytes int) ([]byte, error) {
+		path := filepath.Join(dir, filepath.FromSlash(rel))
+		info, err := os.Lstat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, fmt.Errorf("%s is missing", rel)
+			}
+			return nil, fmt.Errorf("inspect %s: %w", rel, err)
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("%s must be a regular file", rel)
+		}
+		if info.Size() > int64(maxBytes) {
+			return nil, fmt.Errorf("%s exceeds %d bytes", rel, maxBytes)
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", rel, err)
+		}
+		if !utf8.Valid(content) {
+			return nil, fmt.Errorf("%s must be valid UTF-8", rel)
+		}
+		return content, nil
+	}
+
+	manifestBytes, err := readRegular("agent.toml", fluePromptMaxArchive)
+	if err != nil {
+		return nil, err
+	}
+	promptBytes, err := readRegular("prompt.md", fluePromptMaxBytes)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(string(promptBytes)) == "" {
+		return nil, fmt.Errorf("prompt.md must not be empty")
+	}
+	if _, err := os.Lstat(filepath.Join(dir, "mcp.json")); err == nil {
+		return nil, fmt.Errorf("mcp.json is not supported by prompt-defined Flue agents")
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("inspect mcp.json: %w", err)
+	}
+
+	files := []bundle.File{
+		{Path: "agent.toml", Mode: 0o644, Content: manifestBytes},
+		{Path: "prompt.md", Mode: 0o644, Content: promptBytes},
+	}
+	skillsRoot := filepath.Join(dir, "skills")
+	entries, err := os.ReadDir(skillsRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return files, nil
+		}
+		return nil, fmt.Errorf("read skills/: %w", err)
+	}
+	rootInfo, err := os.Lstat(skillsRoot)
+	if err != nil {
+		return nil, fmt.Errorf("inspect skills/: %w", err)
+	}
+	if !rootInfo.IsDir() {
+		return nil, fmt.Errorf("skills must be a directory")
+	}
+
+	totalSkillBytes := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		rel := "skills/" + entry.Name() + "/SKILL.md"
+		if _, err := os.Lstat(filepath.Join(dir, filepath.FromSlash(rel))); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("inspect %s: %w", rel, err)
+		}
+		if !fluePromptSkillName.MatchString(entry.Name()) {
+			return nil, fmt.Errorf("skill directory %q has an invalid name", entry.Name())
+		}
+		content, err := readRegular(rel, fluePromptMaxSkillBytes)
+		if err != nil {
+			return nil, err
+		}
+		totalSkillBytes += len(content)
+		if totalSkillBytes > fluePromptMaxSkillsBytes {
+			return nil, fmt.Errorf(
+				"prompt-defined Flue skill files exceed %d bytes",
+				fluePromptMaxSkillsBytes,
+			)
+		}
+		files = append(files, bundle.File{Path: rel, Mode: 0o644, Content: content})
+		if len(files)-2 > fluePromptMaxSkills {
+			return nil, fmt.Errorf(
+				"prompt-defined Flue agents support at most %d skills",
+				fluePromptMaxSkills,
+			)
+		}
+	}
+	return files, nil
+}
+
+func newLocalSourceUploadID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return "src_" + hex.EncodeToString(raw[:]), nil
+}
+
+func uploadLocalBuildSource(
+	ctx context.Context,
+	sc *client.Client,
+	agentID string,
+	uploadID string,
+	digest string,
+	tarGz []byte,
+) error {
+	body := map[string]interface{}{
+		"upload_id":  uploadID,
+		"digest":     digest,
+		"size_bytes": len(tarGz),
+	}
+	var response localSourceUploadResponse
+	if err := sc.Post(
+		ctx,
+		"/v3/agents/"+agentID+"/source-artifacts",
+		body,
+		&response,
+	); err != nil {
+		return fmt.Errorf("request source upload url: %w", err)
+	}
+	if response.AlreadyUploaded {
+		return nil
+	}
+	if response.URL == "" {
+		return fmt.Errorf("source upload url response was empty")
+	}
+	return putGzip(ctx, response.URL, tarGz, "source")
 }
 
 func presentFlueBuildError(err error) error {
@@ -225,7 +485,11 @@ func uploadArtifact(ctx context.Context, sc *client.Client, agentID, digest stri
 	if resp.URL == "" {
 		return fmt.Errorf("bundle upload url response was empty")
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, resp.URL, bytes.NewReader(tarGz))
+	return putGzip(ctx, resp.URL, tarGz, "bundle")
+}
+
+func putGzip(ctx context.Context, url string, tarGz []byte, label string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(tarGz))
 	if err != nil {
 		return err
 	}
@@ -233,12 +497,12 @@ func uploadArtifact(ctx context.Context, sc *client.Client, agentID, digest stri
 	req.ContentLength = int64(len(tarGz))
 	put, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("upload bundle: %w", err)
+		return fmt.Errorf("upload %s: %w", label, err)
 	}
 	defer put.Body.Close()
 	if put.StatusCode >= 300 {
 		snippet, _ := io.ReadAll(io.LimitReader(put.Body, 512))
-		return fmt.Errorf("bundle upload failed (HTTP %d): %s", put.StatusCode, string(snippet))
+		return fmt.Errorf("%s upload failed (HTTP %d): %s", label, put.StatusCode, string(snippet))
 	}
 	return nil
 }

--- a/cmd/oc/internal/commands/agent_deploy_flue_test.go
+++ b/cmd/oc/internal/commands/agent_deploy_flue_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -50,6 +51,8 @@ type fakeCP struct {
 	artifactDigest string
 	artifactSize   float64
 	uploaded       []byte
+	sourceBody     map[string]any
+	sourceUploaded []byte
 	deployBody     map[string]any
 	getCount       int
 }
@@ -83,6 +86,10 @@ func (f *fakeCP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		f.artifactDigest, _ = body["digest"].(string)
 		f.artifactSize, _ = body["size_bytes"].(float64)
 		writeJSON(map[string]any{"url": f.self + "/upload/" + f.artifactDigest, "expires_at": "2099-01-01T00:00:00Z"})
+	case r.Method == "POST" && r.URL.Path == "/v3/agents/"+fakeAgentID+"/source-artifacts":
+		_ = json.NewDecoder(r.Body).Decode(&f.sourceBody)
+		uploadID, _ := f.sourceBody["upload_id"].(string)
+		writeJSON(map[string]any{"url": f.self + "/source-upload/" + uploadID, "expires_at": "2099-01-01T00:00:00Z"})
 	case r.Method == "PUT" && strings.HasPrefix(r.URL.Path, "/upload/"):
 		if ct := r.Header.Get("Content-Type"); ct != "application/gzip" {
 			http.Error(w, "bad content-type: "+ct, http.StatusBadRequest)
@@ -91,6 +98,15 @@ func (f *fakeCP) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		buf := new(bytes.Buffer)
 		_, _ = buf.ReadFrom(r.Body)
 		f.uploaded = buf.Bytes()
+		w.WriteHeader(http.StatusOK)
+	case r.Method == "PUT" && strings.HasPrefix(r.URL.Path, "/source-upload/"):
+		if ct := r.Header.Get("Content-Type"); ct != "application/gzip" {
+			http.Error(w, "bad content-type: "+ct, http.StatusBadRequest)
+			return
+		}
+		buf := new(bytes.Buffer)
+		_, _ = buf.ReadFrom(r.Body)
+		f.sourceUploaded = buf.Bytes()
 		w.WriteHeader(http.StatusOK)
 	case r.Method == "POST" && r.URL.Path == "/v3/agents/"+fakeAgentID+"/deployments":
 		_ = json.NewDecoder(r.Body).Decode(&f.deployBody)
@@ -441,28 +457,153 @@ func TestDeployFlueBlocksOnLeakedKey(t *testing.T) {
 	}
 }
 
-func TestPromptDefinedFlueRootGetsGithubRecoveryInsteadOfNpmError(t *testing.T) {
+func TestDeployPromptDefinedFlueEndToEnd(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "prompt.md"), "Help the user.\n", 0o644)
+	manifestBytes := []byte(
+		"name = \"e2e-flue\"\nmodel = \"anthropic/claude-sonnet-5\"\n" +
+			"[runtime]\nfamily = \"flue\"\ntype = \"default\"\n",
+	)
+	promptBytes := []byte("Help the user with `quotes`, ${expressions}, and care.\n")
+	skillBytes := []byte("# Review\n\nInspect the diff before publishing.\n")
+	writeFile(t, filepath.Join(dir, "agent.toml"), string(manifestBytes), 0o644)
+	writeFile(t, filepath.Join(dir, "prompt.md"), string(promptBytes), 0o644)
+	writeFile(t, filepath.Join(dir, "skills", "review", "SKILL.md"), string(skillBytes), 0o644)
+	writeFile(t, filepath.Join(dir, "README.md"), "not part of the build source\n", 0o644)
 	if !isPromptDefinedFlueRoot(dir) {
 		t.Fatal("expected prompt-defined root")
 	}
+
+	expected, err := bundle.Pack([]bundle.File{
+		{Path: "agent.toml", Mode: 0o644, Content: manifestBytes},
+		{Path: "prompt.md", Mode: 0o644, Content: promptBytes},
+		{Path: "skills/review/SKILL.md", Mode: 0o644, Content: skillBytes},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedDigest := bundle.Digest(expected)
+
+	f := &fakeCP{}
+	srv := httptest.NewServer(f)
+	defer srv.Close()
+	f.self = srv.URL
+
 	cmd := &cobra.Command{}
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("idempotency-key", "local-e2e", "")
+	cmd.Flags().Int("timeout", 30, "")
 	cmd.SetContext(context.Background())
-	err := deployFlue(
+	m := &manifest{Name: "e2e-flue", Model: "anthropic/claude-sonnet-5"}
+	m.Runtime.Family = "flue"
+	m.Runtime.Type = "default"
+
+	prev := printer
+	printer = output.New(false)
+	var humanOutput bytes.Buffer
+	printer.W = &humanOutput
+	defer func() { printer = prev }()
+
+	err = deployFlue(
 		cmd,
-		client.NewSessionsAPI("http://127.0.0.1:0", "must-not-be-used"),
+		client.NewSessionsAPI(srv.URL, "test-key"),
 		dir,
-		&manifest{},
+		m,
 		false,
 	)
-	if err == nil || !strings.Contains(err.Error(), "deploy from GitHub") {
-		t.Fatalf("expected GitHub recovery, got %v", err)
+	if err != nil {
+		t.Fatalf("deployFlue: %v", err)
 	}
+	if !bytes.Equal(f.sourceUploaded, expected) {
+		t.Fatalf("uploaded source differs from bounded canonical source (got %d bytes, want %d)", len(f.sourceUploaded), len(expected))
+	}
+	if f.sourceBody["digest"] != expectedDigest {
+		t.Errorf("source digest = %v, want %s", f.sourceBody["digest"], expectedDigest)
+	}
+	if f.sourceBody["size_bytes"] != float64(len(expected)) {
+		t.Errorf("source size = %v, want %d", f.sourceBody["size_bytes"], len(expected))
+	}
+	uploadID, _ := f.sourceBody["upload_id"].(string)
+	if !regexp.MustCompile(`^src_[0-9a-f]{32}$`).MatchString(uploadID) {
+		t.Errorf("upload id = %q", uploadID)
+	}
+
+	input, _ := f.deployBody["input"].(map[string]any)
+	if input["type"] != "source" || input["entrypoint"] != "e2e-flue" ||
+		input["model"] != "anthropic/claude-sonnet-5" {
+		t.Errorf("source deployment input = %#v", input)
+	}
+	source, _ := input["source"].(map[string]any)
+	if source["upload_id"] != uploadID || source["digest"] != expectedDigest ||
+		source["size_bytes"] != float64(len(expected)) {
+		t.Errorf("deployment source ref = %#v", source)
+	}
+	if runtimeInput, _ := input["runtime"].(map[string]any); runtimeInput["type"] != "default" {
+		t.Errorf("runtime input = %#v", input["runtime"])
+	}
+	if f.deployBody["activate"] != true || f.deployBody["idempotency_key"] != "local-e2e" {
+		t.Errorf("deployment envelope = %#v", f.deployBody)
+	}
+	encoded, _ := json.Marshal(f.deployBody)
+	for _, forbidden := range []string{
+		string(promptBytes),
+		string(skillBytes),
+		"README.md",
+		"source.tgz",
+	} {
+		if strings.Contains(string(encoded), forbidden) {
+			t.Errorf("byte-free deployment request leaked %q: %s", forbidden, encoded)
+		}
+	}
+	if !strings.Contains(humanOutput.String(), "✓ Deployed e2e-flue") ||
+		!strings.Contains(humanOutput.String(), "Agent URL") {
+		t.Errorf("deploy handoff missing:\n%s", humanOutput.String())
+	}
+
 	writeFile(t, filepath.Join(dir, "package.json"), "{}\n", 0o644)
 	if isPromptDefinedFlueRoot(dir) {
 		t.Fatal("a package marker must select the complete-app path")
 	}
+}
+
+func TestReadPromptDefinedFlueSourceRejectsUnsafeShapes(t *testing.T) {
+	base := func(t *testing.T) string {
+		t.Helper()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "agent.toml"), "name='a'\n", 0o644)
+		writeFile(t, filepath.Join(dir, "prompt.md"), "Help.\n", 0o644)
+		return dir
+	}
+	t.Run("mcp", func(t *testing.T) {
+		dir := base(t)
+		writeFile(t, filepath.Join(dir, "mcp.json"), "{}\n", 0o644)
+		if _, err := readPromptDefinedFlueSource(dir); err == nil || !strings.Contains(err.Error(), "mcp.json") {
+			t.Fatalf("expected mcp rejection, got %v", err)
+		}
+	})
+	t.Run("invalid skill name", func(t *testing.T) {
+		dir := base(t)
+		writeFile(t, filepath.Join(dir, "skills", "Review_Skill", "SKILL.md"), "# Review\n", 0o644)
+		if _, err := readPromptDefinedFlueSource(dir); err == nil || !strings.Contains(err.Error(), "invalid name") {
+			t.Fatalf("expected skill-name rejection, got %v", err)
+		}
+	})
+	t.Run("prompt symlink", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink semantics differ on Windows")
+		}
+		dir := base(t)
+		if err := os.Remove(filepath.Join(dir, "prompt.md")); err != nil {
+			t.Fatal(err)
+		}
+		outside := filepath.Join(t.TempDir(), "prompt.md")
+		writeFile(t, outside, "secret\n", 0o644)
+		if err := os.Symlink(outside, filepath.Join(dir, "prompt.md")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := readPromptDefinedFlueSource(dir); err == nil || !strings.Contains(err.Error(), "regular file") {
+			t.Fatalf("expected symlink rejection, got %v", err)
+		}
+	})
 }
 
 func writeFile(t *testing.T, path, content string, mode os.FileMode) {

--- a/cmd/oc/internal/commands/agent_deploy_flue_test.go
+++ b/cmd/oc/internal/commands/agent_deploy_flue_test.go
@@ -441,6 +441,30 @@ func TestDeployFlueBlocksOnLeakedKey(t *testing.T) {
 	}
 }
 
+func TestPromptDefinedFlueRootGetsGithubRecoveryInsteadOfNpmError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "prompt.md"), "Help the user.\n", 0o644)
+	if !isPromptDefinedFlueRoot(dir) {
+		t.Fatal("expected prompt-defined root")
+	}
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	err := deployFlue(
+		cmd,
+		client.NewSessionsAPI("http://127.0.0.1:0", "must-not-be-used"),
+		dir,
+		&manifest{},
+		false,
+	)
+	if err == nil || !strings.Contains(err.Error(), "deploy from GitHub") {
+		t.Fatalf("expected GitHub recovery, got %v", err)
+	}
+	writeFile(t, filepath.Join(dir, "package.json"), "{}\n", 0o644)
+	if isPromptDefinedFlueRoot(dir) {
+		t.Fatal("a package marker must select the complete-app path")
+	}
+}
+
 func writeFile(t *testing.T, path, content string, mode os.FileMode) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/cmd/oc/internal/commands/agent_init.go
+++ b/cmd/oc/internal/commands/agent_init.go
@@ -82,8 +82,8 @@ var agentInitCmd = &cobra.Command{
 		}
 		if runtime == "flue" {
 			fmt.Printf(
-				"\nScaffolded %d file(s). Edit prompt.md, push this directory to GitHub, then import it from Agents → Create agent.\n",
-				created,
+				"\nScaffolded %d file(s). Edit prompt.md, then:  oc agent deploy %s\n",
+				created, dir,
 			)
 		} else {
 			fmt.Printf("\nScaffolded %d file(s). Edit prompt.md, then:  oc agent deploy %s\n", created, dir)

--- a/cmd/oc/internal/commands/agent_init.go
+++ b/cmd/oc/internal/commands/agent_init.go
@@ -12,7 +12,7 @@ const agentTomlTmpl = `name  = %q
 model = %q
 
 [runtime]
-family = %q   # claude | codex | pi
+family = %q   # claude | codex | pi | flue
 type   = "default"
 
 [limits]
@@ -40,6 +40,7 @@ var agentInitCmd = &cobra.Command{
 	Short: "Scaffold a deployable agent directory (agent.toml + prompt.md + skills/)",
 	Example: "  oc agent init\n" +
 		"  oc agent init ./agents/triage --name triage --model anthropic/claude-sonnet-5\n" +
+		"  oc agent init ./agents/edge --runtime flue\n" +
 		"  oc agent init && $EDITOR prompt.md && oc agent deploy",
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -79,7 +80,14 @@ var agentInitCmd = &cobra.Command{
 			fmt.Printf("  create %s\n", f.path)
 			created++
 		}
-		fmt.Printf("\nScaffolded %d file(s). Edit prompt.md, then:  oc agent deploy %s\n", created, dir)
+		if runtime == "flue" {
+			fmt.Printf(
+				"\nScaffolded %d file(s). Edit prompt.md, push this directory to GitHub, then import it from Agents → Create agent.\n",
+				created,
+			)
+		} else {
+			fmt.Printf("\nScaffolded %d file(s). Edit prompt.md, then:  oc agent deploy %s\n", created, dir)
+		}
 		return nil
 	},
 }
@@ -87,5 +95,5 @@ var agentInitCmd = &cobra.Command{
 func init() {
 	agentInitCmd.Flags().String("name", "", "Agent name (default: the directory name)")
 	agentInitCmd.Flags().String("model", "anthropic/claude-sonnet-5", "Model")
-	agentInitCmd.Flags().String("runtime", "claude", "Runtime family (claude|codex|pi)")
+	agentInitCmd.Flags().String("runtime", "claude", "Runtime family (claude|codex|pi|flue)")
 }

--- a/cmd/oc/internal/fluebuild/fluebuild.go
+++ b/cmd/oc/internal/fluebuild/fluebuild.go
@@ -72,7 +72,8 @@ type Bundle struct {
 }
 
 type Builder struct {
-	Version string `json:"version"`
+	Version           string `json:"version"`
+	SynthesisTemplate string `json:"synthesis_template,omitempty"`
 }
 
 // Vars is named so callers cannot accidentally replace the manifest-derived
@@ -133,9 +134,11 @@ type Options struct {
 	OutputDir      string
 	BuilderVersion string
 	NodeVersion    string
-	CheckOnly      bool
-	BuildStdout    io.Writer
-	BuildStderr    io.Writer
+	// SynthesisTemplateVersion is a trusted managed-builder identity; local builds leave it empty.
+	SynthesisTemplateVersion string
+	CheckOnly                bool
+	BuildStdout              io.Writer
+	BuildStderr              io.Writer
 }
 
 type Result struct {
@@ -181,7 +184,7 @@ func Build(ctx context.Context, opts Options) (Result, error) {
 		opts.BuilderVersion = "oc@" + opts.BuilderVersion
 	}
 
-	projection, err := inspect(ctx, opts.Dir, opts.BuilderVersion, opts.NodeVersion)
+	projection, err := inspect(ctx, opts.Dir, opts.BuilderVersion, opts.NodeVersion, opts.SynthesisTemplateVersion)
 	if err != nil {
 		return Result{}, err
 	}
@@ -276,6 +279,12 @@ func ValidateDeployment(deployment Deployment, requireArtifact bool) error {
 	if !strings.HasPrefix(deployment.Builder.Version, "oc@") || strings.TrimPrefix(deployment.Builder.Version, "oc@") == "" {
 		return fmt.Errorf("deployment builder.version must use oc@<version>")
 	}
+	if deployment.Builder.SynthesisTemplate != "" {
+		valid := regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,127}$`)
+		if !valid.MatchString(deployment.Builder.SynthesisTemplate) {
+			return fmt.Errorf("deployment builder.synthesis_template is invalid")
+		}
+	}
 	if !requireArtifact {
 		if deployment.Flue.Wrangler != nil || deployment.Bundle != nil {
 			return fmt.Errorf("check-only deployment must omit flue.wrangler and bundle")
@@ -298,7 +307,7 @@ func ValidateDeployment(deployment Deployment, requireArtifact bool) error {
 	return nil
 }
 
-func inspect(ctx context.Context, dir, builderVersion, nodeVersion string) (Deployment, error) {
+func inspect(ctx context.Context, dir, builderVersion, nodeVersion, synthesisTemplateVersion string) (Deployment, error) {
 	findings, err := credscan.ScanDir(dir)
 	if err != nil {
 		return Deployment{}, fmt.Errorf("credential scan: %w", err)
@@ -381,7 +390,10 @@ func inspect(ctx context.Context, dir, builderVersion, nodeVersion string) (Depl
 		Model:         m.Model,
 		Vars:          m.Vars,
 		Runtime:       m.Runtime,
-		Builder:       Builder{Version: builderVersion},
+		Builder: Builder{
+			Version:           builderVersion,
+			SynthesisTemplate: synthesisTemplateVersion,
+		},
 	}, nil
 }
 

--- a/cmd/oc/internal/fluebuild/fluebuild_test.go
+++ b/cmd/oc/internal/fluebuild/fluebuild_test.go
@@ -55,6 +55,30 @@ func TestCheckOnlyMatchesFrozenProjectionWithoutExecutingRepositoryCode(t *testi
 	}
 }
 
+func TestCheckOnlyCarriesTrustedSynthesisTemplateIdentity(t *testing.T) {
+	dir := copyFixture(t)
+	result, err := Build(context.Background(), Options{
+		Dir:                      dir,
+		CheckOnly:                true,
+		BuilderVersion:           testBuilderVersion,
+		NodeVersion:              testNodeVersion,
+		SynthesisTemplateVersion: "flue-prompt-template-v1",
+	})
+	if err != nil {
+		t.Fatalf("check-only: %v", err)
+	}
+	if got := result.Deployment.Builder.SynthesisTemplate; got != "flue-prompt-template-v1" {
+		t.Fatalf("synthesis template = %q", got)
+	}
+	raw, err := json.Marshal(result.Deployment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(raw, []byte(`"synthesis_template":"flue-prompt-template-v1"`)) {
+		t.Fatalf("deployment omitted synthesis identity: %s", raw)
+	}
+}
+
 func TestBuildWritesDeterministicArtifactContract(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake Flue binary is a POSIX shell script")

--- a/deploy/flue-builder/README.md
+++ b/deploy/flue-builder/README.md
@@ -13,7 +13,7 @@ changes to lower sandbox-platform layers.
 
 `coordinate.json` is the reviewed logical coordinate. It pins:
 
-- snapshot name `flue-build-node22-19-0-oc-c39b315-r3` (never reuse it for a
+- snapshot name `flue-build-node22-19-0-oc-505b49b-r4` (never reuse it for a
   different recipe or checkpoint);
 - Ubuntu 22.04 / x86-64 platform assertion;
 - Node 22.19.0 and its upstream archive digest;
@@ -80,8 +80,8 @@ export FLUE_BUILD_SNAPSHOT_ALLOW_CREATE=1
 export FLUE_BUILD_SNAPSHOT_ALLOW_PRODUCTION=1
 
 python3 deploy/flue-builder/snapshot.py create \
-  --confirm-name flue-build-node22-19-0-oc-c39b315-r3 \
-  --receipt /secure/operator-state/flue-build-node22-19-0-oc-c39b315-r3.json
+  --confirm-name flue-build-node22-19-0-oc-505b49b-r4 \
+  --receipt /secure/operator-state/flue-build-node22-19-0-oc-505b49b-r4.json
 ```
 
 The command is idempotent only when an existing snapshot has the exact pinned
@@ -93,12 +93,12 @@ Store the receipt in non-secret release metadata. Do not commit environment
 files or API keys. Configure the build worker from the coordinate and receipt:
 
 ```text
-FLUE_BUILD_SANDBOX_SNAPSHOT=flue-build-node22-19-0-oc-c39b315-r3
+FLUE_BUILD_SANDBOX_SNAPSHOT=flue-build-node22-19-0-oc-505b49b-r4
 FLUE_BUILD_SANDBOX_CHECKPOINT_ID=<receipt checkpointId>
 FLUE_BUILD_NODE_VERSION=22.19.0
 FLUE_BUILD_NPM_VERSION=10.9.3
-FLUE_BUILD_OC_VERSION=oc@c39b31560cb78e0d5708a9eda4cfb30ec372eed9
-FLUE_BUILD_OC_BINARY_SHA256=7f7286095aefe78c3027efb79465442070370c6dcf3cda67c9b1315949a42bc1
+FLUE_BUILD_OC_VERSION=oc@505b49b384a24de023726884512686a1448d4ead
+FLUE_BUILD_OC_BINARY_SHA256=aa7fc47efc90ba8048cdca694e51a38de55d78c32c9da8a7e5e54ab4fa46c4f9
 ```
 
 Worker readiness must compare the live snapshot manifest and checkpoint ID to
@@ -126,12 +126,12 @@ and prints only the sandbox ID for operator cleanup.
 ```bash
 export OPENCOMPUTER_API_URL='https://app.opencomputer.dev'
 export OPENCOMPUTER_API_KEY='...'
-export FLUE_BUILD_SANDBOX_SNAPSHOT='flue-build-node22-19-0-oc-c39b315-r3'
+export FLUE_BUILD_SANDBOX_SNAPSHOT='flue-build-node22-19-0-oc-505b49b-r4'
 export FLUE_BUILD_SANDBOX_CHECKPOINT_ID='<receipt checkpointId>'
 export FLUE_BUILD_NODE_VERSION='22.19.0'
 export FLUE_BUILD_NPM_VERSION='10.9.3'
-export FLUE_BUILD_OC_VERSION='oc@c39b31560cb78e0d5708a9eda4cfb30ec372eed9'
-export FLUE_BUILD_OC_BINARY_SHA256='7f7286095aefe78c3027efb79465442070370c6dcf3cda67c9b1315949a42bc1'
+export FLUE_BUILD_OC_VERSION='oc@505b49b384a24de023726884512686a1448d4ead'
+export FLUE_BUILD_OC_BINARY_SHA256='aa7fc47efc90ba8048cdca694e51a38de55d78c32c9da8a7e5e54ab4fa46c4f9'
 export FLUE_BUILD_PROBE_ALLOW_PRODUCTION=1
 
 python3 ci/flue-builder-substrate-probe.py --run

--- a/deploy/flue-builder/coordinate.json
+++ b/deploy/flue-builder/coordinate.json
@@ -1,20 +1,20 @@
 {
   "schemaVersion": 1,
   "snapshot": {
-    "name": "flue-build-node22-19-0-oc-c39b315-r3",
+    "name": "flue-build-node22-19-0-oc-505b49b-r4",
     "builderMemoryMB": 4096,
     "runtimeMemoryMB": 1024
   },
   "recipe": {
     "installer": "install-snapshot.sh",
-    "installerSha256": "9295fa5c9ac50f090c37652eceebe47f966e46c11993a3c97311329e39537e45",
+    "installerSha256": "6cd532408c79e4d13cf8bea6090106a3fe9ce651d9f1908122fe9544d5c7c911",
     "imageTemplate": "image.json",
     "imageTemplateSha256": "d1fc4f3cd27fd1248327f52d9d768a99c9a922d4f0fabf8bf0d6913e2d1e7cd2",
-    "materializedManifestSha256": "364643db99925025513d26674a1ee75e12f621686ff2d15d56aa5dc34020b773"
+    "materializedManifestSha256": "b6b430e26b9f8e240d99b3e17f053392eec2978c2b9b4ad5d504a2388ab0dda5"
   },
   "attestation": {
     "schemaVersion": 1,
-    "snapshotName": "flue-build-node22-19-0-oc-c39b315-r3",
+    "snapshotName": "flue-build-node22-19-0-oc-505b49b-r4",
     "baseImage": "base",
     "platform": {
       "osId": "ubuntu",
@@ -29,10 +29,10 @@
       "version": "10.9.3"
     },
     "oc": {
-      "version": "oc@c39b31560cb78e0d5708a9eda4cfb30ec372eed9",
-      "sourceCommit": "c39b31560cb78e0d5708a9eda4cfb30ec372eed9",
-      "sourceArchiveSha256": "5aaa929e33c54474bfca774c78d6f422168cb0bf24f4ea445b3b0c1bd2a2840e",
-      "binarySha256": "7f7286095aefe78c3027efb79465442070370c6dcf3cda67c9b1315949a42bc1"
+      "version": "oc@505b49b384a24de023726884512686a1448d4ead",
+      "sourceCommit": "505b49b384a24de023726884512686a1448d4ead",
+      "sourceArchiveSha256": "525b70f931ab2a71138350431bfcf23a820831be94f14efbd3e5a186942f6356",
+      "binarySha256": "aa7fc47efc90ba8048cdca694e51a38de55d78c32c9da8a7e5e54ab4fa46c4f9"
     },
     "buildToolchain": {
       "goVersion": "1.25.0",

--- a/deploy/flue-builder/install-snapshot.sh
+++ b/deploy/flue-builder/install-snapshot.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # downloaded input immutable and verified: the resulting checkpoint is trusted
 # to execute arbitrary repository lifecycle code without receiving credentials.
 
-SNAPSHOT_NAME="flue-build-node22-19-0-oc-c39b315-r3"
+SNAPSHOT_NAME="flue-build-node22-19-0-oc-505b49b-r4"
 BASE_IMAGE="base"
 OS_ID="ubuntu"
 OS_VERSION_ID="22.04"
@@ -20,10 +20,10 @@ GO_VERSION="1.25.0"
 GO_ARCHIVE_SHA256="2852af0cb20a13139b3448992e69b868e50ed0f8a1e5940ee1de9e19a123b613"
 GO_URL="https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
 
-OC_SOURCE_COMMIT="c39b31560cb78e0d5708a9eda4cfb30ec372eed9"
-OC_SOURCE_ARCHIVE_SHA256="5aaa929e33c54474bfca774c78d6f422168cb0bf24f4ea445b3b0c1bd2a2840e"
+OC_SOURCE_COMMIT="505b49b384a24de023726884512686a1448d4ead"
+OC_SOURCE_ARCHIVE_SHA256="525b70f931ab2a71138350431bfcf23a820831be94f14efbd3e5a186942f6356"
 OC_SOURCE_URL="https://github.com/diggerhq/opencomputer/archive/${OC_SOURCE_COMMIT}.tar.gz"
-OC_BINARY_SHA256="7f7286095aefe78c3027efb79465442070370c6dcf3cda67c9b1315949a42bc1"
+OC_BINARY_SHA256="aa7fc47efc90ba8048cdca694e51a38de55d78c32c9da8a7e5e54ab4fa46c4f9"
 OC_VERSION="oc@${OC_SOURCE_COMMIT}"
 
 NODE_ROOT="/opt/opencomputer/node-v${NODE_VERSION}"

--- a/docs/agent-sessions/agents.mdx
+++ b/docs/agent-sessions/agents.mdx
@@ -11,8 +11,10 @@ An **agent** is a reusable identity, runtime, model, and deployed behavior. Ever
   GitHub** and keeps **Configure manually** available. Repository import
   recognizes both a complete [Flue](/agent-sessions/flue) app and a
   prompt-defined Flue root containing `agent.toml`, `prompt.md`, and optional
-  `skills/`. You can also deploy a local full-app checkout with `oc agent
-  deploy`. Both paths produce the same deployment and revision history.
+  `skills/`. You can also deploy either local shape with `oc agent deploy`;
+  prompt-defined roots build in the isolated managed builder, while complete
+  apps build locally. Both paths produce the same deployment and revision
+  history.
 </Note>
 
 <CodeGroup>

--- a/docs/agent-sessions/agents.mdx
+++ b/docs/agent-sessions/agents.mdx
@@ -9,10 +9,10 @@ An **agent** is a reusable identity, runtime, model, and deployed behavior. Ever
 <Note>
   The [dashboard](https://app.opencomputer.dev) starts with **Import from
   GitHub** and keeps **Configure manually** available. Repository import
-  recognizes a complete [Flue](/agent-sessions/flue) app; prompt- or skills-only
-  folders are not converted into an agent. You can also deploy a local Flue
-  checkout with `oc agent deploy`. Both Flue paths produce the same deployment
-  and revision history.
+  recognizes both a complete [Flue](/agent-sessions/flue) app and a
+  prompt-defined Flue root containing `agent.toml`, `prompt.md`, and optional
+  `skills/`. You can also deploy a local full-app checkout with `oc agent
+  deploy`. Both paths produce the same deployment and revision history.
 </Note>
 
 <CodeGroup>
@@ -62,7 +62,7 @@ For a built-in runtime, the only behavior an agent needs is a **model** and a **
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | **Default agent**                    | `name` + `model` (+ a prompt)                                                                                                      | a working agent on the default runtime — no setup                                                              |
 | **+ Skills**                         | [`SKILL.md` folders](/agent-sessions/skills) (upload a `.zip`, or include in a repo)                                               | reusable procedures the agent loads when relevant — still the default runtime                                  |
-| **+ Source-controlled deployment**   | link a manually configured built-in agent to `prompt.md` + `skills/`, or import a complete Flue app from a self-contained npm root | versioned [deployments and revisions](/agent-sessions/revisions); Flue imports also include durable build logs |
+| **+ Source-controlled deployment**   | link a built-in agent to `prompt.md` + `skills/`, or import a prompt-defined or complete Flue app from GitHub | versioned [deployments and revisions](/agent-sessions/revisions); Flue imports also include durable build logs |
 | **+ Custom runtime** _(coming soon)_ | bring your own runtime image                                                                                                       | full control of the execution environment                                                                      |
 
 At every built-in rung the agent is a small directory, at most `agent.toml` + `prompt.md` + `skills/`. You can stop at any rung; most agents never go past skills.
@@ -71,7 +71,7 @@ At every built-in rung the agent is a small directory, at most `agent.toml` + `p
 
 Choose **Agents → Create agent → Import from GitHub**, install the OpenComputer GitHub App if needed, and select a repository, production branch, and root. **Review agent** resolves one exact commit without running repository code.
 
-- A complete Flue root shows its entrypoint, model, Managed model access, and an editable OpenComputer agent name.
+- A prompt-defined or complete Flue root shows its entrypoint, model, Managed model access, and an editable OpenComputer agent name.
 - A broken Flue root explains what must be fixed. OpenComputer does not reinterpret it as another agent type.
 - An unrecognized root creates nothing. You can choose another folder, fork the Flue starter, or configure a built-in agent manually.
 - In a monorepo, OpenComputer may suggest bounded candidate folders. You choose one explicitly and review it before deployment.

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -664,7 +664,7 @@ graduate to `flue-app-v1`. Any other profile change sets the link status to
 
 | Command                                                                            | Purpose                                                                                       |
 | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `oc agent deploy [dir] [--agent <id\|name>] [--no-activate] [--verbose]`           | Bundle a local directory → inline deployment; stream framework build output with `--verbose`. |
+| `oc agent deploy [dir] [--agent <id\|name>] [--no-activate] [--verbose]`           | Deploy a local built-in, prompt-defined Flue, or complete Flue directory; `--verbose` streams a local complete-app build. |
 | `oc agent build --dir <dir> [--check-only] [--target cloudflare] [--output <dir>]` | Validate or build a Flue artifact without fetching, installing, authenticating, or deploying. |
 | `oc agent deployments [--agent <id>]` · `oc agent deployments get <id>`            | History · one deployment.                                                                     |
 
@@ -674,7 +674,9 @@ graduate to `flue-app-v1`. Any other profile change sets the link status to
 
 `input`: `{ type:"inline", prompt, model?, skills?, runtime? }` (the **complete** built-in
 behavior — omitted `skills` = none) **or** `{ type:"github", ref?, sha? }` (deploys an already-linked
-repository; `repo`/`path` come from the server-owned link). `activate:false` stages an inline built-in
+repository; `repo`/`path` come from the server-owned link). The CLI's local prompt-defined Flue path
+uses a separately uploaded, digest-bound `source` reference; use `oc agent deploy` rather than constructing
+that transport manually. `activate:false` stages an inline built-in
 deployment. Built-in GitHub links remain branch-driven. A new Flue repository agent instead starts
 with [`POST /agents/import`](#review-and-import-a-repository-agent); import deploys the reviewed production head,
 and subsequent production-branch pushes deploy automatically. Flue has no preview/staged Worker.

--- a/docs/agent-sessions/api-reference.mdx
+++ b/docs/agent-sessions/api-reference.mdx
@@ -451,7 +451,8 @@ the [Deployments & revisions guide](/agent-sessions/revisions).
 ### Review and import a repository agent
 
 Review resolves the moving production branch to one exact commit and interprets bounded metadata
-without executing repository code. Repository-first import currently accepts the exact Flue result.
+without executing repository code. Repository-first import accepts exact `flue-app-v1` and
+`flue-prompt-v1` results.
 
 `GET /github/deploy-app` returns the installed OpenComputer GitHub App and its pickable repositories.
 Each repository includes `linked_sources[]` with the owner-scoped `path`, `production_ref`, `status`,
@@ -536,6 +537,13 @@ unrecognized root can include up to 20 `candidate_roots` and explicitly reports 
 `exact` includes a deployable `profile` and may proceed to import. No response contains a repository
 token or source bytes.
 
+For `flue-prompt-v1`, `profile` keeps the same manifest, source, and builder
+projection and additionally returns `prompt: { bytes }`,
+`skills: { count, bytes, names }`, and
+`builder.synthesis_template`. The profile accepts `agent.toml`, `prompt.md`,
+and optional `skills/*/SKILL.md`; the server synthesizes the complete Flue app
+during the managed build.
+
 The non-exact variants keep the common repository/root/SHA/fingerprint fields shown above and use
 these shapes:
 
@@ -559,7 +567,7 @@ these shapes:
 
 An unrecognized interpretation has `source_profile: null`, `source_profile_version: null`, and
 `reason_code: "unrecognized_source"`. Its optional candidate entries are
-`{ path, source_profile: "flue-app-v1" | null, summary, marker }`; selecting one always performs a
+`{ path, source_profile: "flue-app-v1" | "flue-prompt-v1" | null, summary, marker }`; selecting one always performs a
 new review. `candidate_roots_truncated` means more matches existed than the bounded response could
 return, so ask the user to choose a narrower root rather than selecting one automatically.
 
@@ -623,9 +631,9 @@ or repository-root conflict also returns `409` and identifies the existing agent
 
 The source remains linked after import. Its `source_profile`, `source_profile_version`, and
 `review_fingerprint` describe the reviewed source identity. A later GitHub push that touches the
-selected production root automatically creates the next deployment. If that root no longer matches
-the imported source profile, the link status becomes `source_profile_changed`; no build starts and
-the current active revision remains unchanged.
+selected production root automatically creates the next deployment. A `flue-prompt-v1` source may
+graduate to `flue-app-v1`. Any other profile change sets the link status to
+`source_profile_changed`; no build starts and the current active revision remains unchanged.
 
 ### Deploy
 
@@ -834,7 +842,7 @@ that deploy auto-activates. Repo/path are server-anchored to the link. Deploymen
 | `production_ref`                            | branch that auto-activates on push                                                                                                                                          |
 | `status`                                    | `active`, or a problem: `source_profile_changed`, `path_missing`, `ref_missing` (production branch deleted), `auth_required`, `repo_not_selected`, `app_suspended`, `error` |
 | `latest_seen_sha?` `active_deployed_sha?`   | newest sha observed · sha behind the active revision                                                                                                                        |
-| `source_profile?` `source_profile_version?` | server-selected repository interpretation pinned for this link (`flue-app-v1`, version `1`)                                                                                 |
+| `source_profile?` `source_profile_version?` | server-selected repository interpretation pinned for this link (`flue-app-v1` or `flue-prompt-v1`, version `1`)                                                            |
 | `review_fingerprint?`                       | digest of the latest accepted, exact-SHA reviewed plan; never source bytes or a credential                                                                                  |
 
 ## Schedules

--- a/docs/agent-sessions/flue.mdx
+++ b/docs/agent-sessions/flue.mdx
@@ -97,11 +97,12 @@ model = "anthropic/claude-haiku-4-5"
 family = "flue"
 ```
 
-Import the repository from GitHub. OpenComputer compiles `prompt.md` and up to
-32 packaged skills into a pinned Flue application inside the isolated managed
-builder. The prompt may be at most 256 KiB; each `SKILL.md` may be at most 256
-KiB, with a 2 MiB combined limit. Skill directory names use lowercase letters,
-numbers, and hyphens. `mcp.json` is not supported by this profile.
+Run `oc agent deploy` from the directory, or import it from GitHub.
+OpenComputer compiles `prompt.md` and up to 32 packaged skills into a pinned
+Flue application inside the isolated managed builder. The prompt may be at most
+256 KiB; each `SKILL.md` may be at most 256 KiB, with a 2 MiB combined limit.
+Skill directory names use lowercase letters, numbers, and hyphens. `mcp.json`
+is not supported by this profile.
 
 Add `package.json` and a `flue.config.*` file when you need custom tools or
 application code. Those full-app markers take precedence over `prompt.md`, and
@@ -178,19 +179,29 @@ the existing agent, its active revision, or its sessions.
 
 ## Deploy from your machine
 
-Requirements: Node 22.19 or newer, the `oc` CLI, and an OpenComputer organization with Managed model
-access.
+Requirements: the `oc` CLI and an OpenComputer organization with Managed model
+access. A prompt-defined root needs no local Node installation: the CLI uploads
+its bounded behavior files and the isolated managed builder performs synthesis,
+dependency installation, and the Flue build.
 
-Local deployment currently builds a complete Flue app. Import a prompt-defined
-root from GitHub; `oc agent deploy` points to that path instead of reporting a
-missing npm package.
+```sh
+oc agent init ./support --runtime flue
+cd support
+$EDITOR prompt.md
+
+# Upload source, build in isolation, verify the live Worker, and print its URL.
+oc agent deploy
+```
+
+A complete Flue app builds on your machine and therefore also requires Node
+22.19 or newer and installed dependencies:
 
 ```sh
 git clone https://github.com/diggerhq/oc-flue-starter
 cd oc-flue-starter
 npm install
 
-# Builds the Cloudflare target, deploys it, verifies the live Worker, and activates a revision.
+# Builds the Cloudflare target locally, deploys it, verifies the live Worker, and activates a revision.
 # The agent is created from agent.toml when it does not exist yet.
 oc agent deploy
 

--- a/docs/agent-sessions/flue.mdx
+++ b/docs/agent-sessions/flue.mdx
@@ -73,11 +73,47 @@ consumer view used by the dashboard, API, and webhooks. OpenComputer resumes pro
 cursor after an interruption, so clients do not need to understand Flue submission ids or stream
 offsets.
 
+## Start with a prompt
+
+You do not need to write a Flue application to use its edge runtime. A
+prompt-defined Flue repository has this shape:
+
+```text
+agent.toml
+prompt.md
+skills/
+  triage/
+    SKILL.md
+```
+
+Scaffold it with `oc agent init ./support --runtime flue`, or create the files
+directly:
+
+```toml agent.toml
+name = "support-triage"
+model = "anthropic/claude-haiku-4-5"
+
+[runtime]
+family = "flue"
+```
+
+Import the repository from GitHub. OpenComputer compiles `prompt.md` and up to
+32 packaged skills into a pinned Flue application inside the isolated managed
+builder. The prompt may be at most 256 KiB; each `SKILL.md` may be at most 256
+KiB, with a 2 MiB combined limit. Skill directory names use lowercase letters,
+numbers, and hyphens. `mcp.json` is not supported by this profile.
+
+Add `package.json` and a `flue.config.*` file when you need custom tools or
+application code. Those full-app markers take precedence over `prompt.md`, and
+the next production push graduates the existing agent to the complete Flue app
+without replacing its identity or history. Changing the `name` in `agent.toml`
+still requires a new agent because it changes the Durable Object lineage.
+
 ## Deploy from GitHub
 
-The shortest path for an existing Flue app is the dashboard:
+The shortest path for a prompt-defined or complete Flue app is the dashboard:
 
-1. Fork the [Flue starter](https://github.com/diggerhq/oc-flue-starter/fork), or push your own app to GitHub.
+1. Push a prompt-defined root to GitHub, fork the [Flue starter](https://github.com/diggerhq/oc-flue-starter/fork), or push your own app.
 2. Open **Agents → Create agent → Import from GitHub**.
 3. Install the OpenComputer GitHub App on the repository, then select the repository, production branch, and root directory.
 4. Choose **Review agent**. OpenComputer resolves one exact commit and checks the root without running repository code.
@@ -92,17 +128,20 @@ owning agent, choose another monorepo root, or confirm an inline unlink. The
 unlink stops future push deployments for the old agent; it does not delete the
 agent, active revision, deployment history, or sessions.
 
-The selected root is its own build context and must contain `agent.toml`, `package.json`, and a
-committed `package-lock.json`. The package must declare a Node engine compatible with the exact
-managed builder version and a semver dependency on the Flue CLI. npm workspaces,
-files above the selected root, private registries, submodules, Git LFS, custom install/build
-commands, and build-time secrets are not supported.
+The selected root is its own build context. A prompt-defined root needs
+`agent.toml`, `prompt.md`, and optional `skills/`. A complete app also needs
+`package.json` and a committed `package-lock.json`; its package must declare a
+Node engine compatible with the exact managed builder version and a semver
+dependency on the Flue CLI. npm workspaces, files above the selected root,
+private registries, submodules, Git LFS, custom install/build commands, and
+build-time secrets are not supported.
 
 `agent.toml` is authoritative. If it is malformed, declares an unsupported runtime, or is missing
 from a root that otherwise has strong Flue markers, review returns **This Flue agent needs a fix**.
-OpenComputer does not fall back to generated behavior or another runtime. A prompt- or skills-only
-folder is unrecognized; use a complete Flue root, choose another folder, fork the starter, or create
-a built-in agent manually.
+OpenComputer does not fall back to another runtime. A folder containing
+`prompt.md` or skills but no `agent.toml` is unrecognized; add the explicit
+Flue manifest, choose another folder, fork the starter, or create a built-in
+agent manually.
 
 For a monorepo, reviewing an unrecognized parent can suggest bounded candidate roots. Selecting a
 candidate changes the root and performs a fresh review—it never deploys the suggestion automatically.
@@ -132,14 +171,19 @@ revision **#1**. **Deploy latest** can manually rebuild its current head after a
 failure.
 
 If a later production push removes or replaces the Flue definition, the deployment stops before
-build with `source_profile_changed`; the active revision stays live. Restore the Flue app in the
-linked root, or unlink the source and import the repository as a new agent. Unlinking does not delete
+build with `source_profile_changed`; the active revision stays live. A prompt-defined root may
+graduate to a complete Flue app, but not in the opposite direction. Otherwise restore the previous
+profile, or unlink the source and import the repository as a new agent. Unlinking does not delete
 the existing agent, its active revision, or its sessions.
 
 ## Deploy from your machine
 
 Requirements: Node 22.19 or newer, the `oc` CLI, and an OpenComputer organization with Managed model
 access.
+
+Local deployment currently builds a complete Flue app. Import a prompt-defined
+root from GitHub; `oc agent deploy` points to that path instead of reporting a
+missing npm package.
 
 ```sh
 git clone https://github.com/diggerhq/oc-flue-starter

--- a/docs/agent-sessions/repos.mdx
+++ b/docs/agent-sessions/repos.mdx
@@ -153,7 +153,8 @@ does nothing but Git, and is gone before the next turn.
 ## Use a repo to deploy a Flue agent
 
 Choose **Agents → Create agent → Import from GitHub** when the repository is the agent
-implementation itself. Repository-first creation currently recognizes a complete Flue application.
+implementation itself. Repository-first creation recognizes either a complete Flue application or
+an explicit prompt-defined Flue root (`agent.toml` + `prompt.md` + optional `skills/`).
 The dashboard uses the OpenComputer App to:
 
 1. resolve the selected branch and root at one exact commit without running repository code;
@@ -176,9 +177,11 @@ names and links the owning agent, and offers an inline confirmed unlink. Unlinki
 for the old agent but preserves that agent, its active revision, deployment history, and sessions.
 
 Recognition is deterministic. A root-level `agent.toml` is authoritative: if it is malformed or
-unsupported, the result is a fixable error rather than a guess. Without a manifest, a root-level
-`flue.config.*` file or a Flue package dependency is treated as Flue intent and reports the missing
-manifest. A prompt, `skills/` folder, README, or unrelated package is not converted automatically.
+unsupported, the result is a fixable error rather than a guess. With `runtime.family = "flue"`,
+`prompt.md` selects the prompt-defined profile unless a `package.json` or `flue.config.*` marker
+selects the complete-app profile. Without a manifest, Flue configuration or a Flue package
+dependency reports the missing manifest. A bare prompt, skills folder, README, or unrelated package
+is not converted automatically.
 
 If the selected root is unrecognized, the review can scan the same bounded tree of at most 25,000
 entries and return up to 20 candidate roots no more than six folders deep. Results follow fixed
@@ -193,11 +196,11 @@ build commands as an ordinary disposable OpenComputer sandbox, and emits an arti
 deployment credential belongs to another trusted service and is never present during source or
 build work.
 
-Flue repository deployment supports one self-contained npm root with `agent.toml`,
-`package.json`, and `package-lock.json`. The initial import links that root to its production branch;
-each later push touching the root automatically deploys the branch's new exact head. Other branches
-do not create Flue preview deployments. **Deploy latest** remains available for manually rebuilding
-the current production head after a transient failure. See
+Flue repository deployment supports one selected root: either the prompt-defined shape above or a
+self-contained npm root with `agent.toml`, `package.json`, and `package-lock.json`. The initial import
+links that root to its production branch; each later push touching the root automatically deploys the
+branch's new exact head. Other branches do not create Flue preview deployments. **Deploy latest**
+remains available for manually rebuilding the current production head after a transient failure. See
 [Flue deployment](/agent-sessions/flue#deploy-from-github) for the full build contract and failure
 journey.
 
@@ -206,11 +209,11 @@ relevant files. If any of those change before import, OpenComputer returns a sou
 and creates nothing. Review the current commit again rather than assuming the old confirmation still
 applies.
 
-The source link also remembers that the agent was imported as Flue. Normal Flue changes keep
-deploying on push. If the linked root stops being a Flue app, the deployment fails before build and
-the active revision stays live. Restore the Flue definition, or unlink the source and import it as a
-new agent. Unlinking stops push-to-deploy; it does not delete or convert the existing agent, revision,
-or sessions.
+The source link also remembers the selected Flue profile. Normal changes keep deploying on push, and
+a prompt-defined profile may graduate to a complete Flue app. Other profile changes fail before
+build while the active revision stays live. Restore the previous definition, or unlink the source
+and import it as a new agent. Unlinking stops push-to-deploy; it does not delete or convert the
+existing agent, revision, or sessions.
 
 Manage this link from the agent's **Overview → Repository** panel. **Configure GitHub** changes
 which repositories the OpenComputer App can access. **Unlink repository** releases this root for a

--- a/docs/agent-sessions/revisions.mdx
+++ b/docs/agent-sessions/revisions.mdx
@@ -36,7 +36,7 @@ The agent itself holds only **identity + bindings** (`name`, `runtime`, `credent
 
 ## Deploy
 
-`POST /agents/:id/deployments` is the common post-creation command. `input.type: "inline"` sends behavior directly (API / CLI / dashboard); `input.type: "github"` deploys an already-linked repo — see [Deploy from a repo](#deploy-from-a-repo). Creating a new Flue agent from GitHub uses the atomic [`POST /agents/import`](#import-a-flue-repository) command instead.
+`POST /agents/:id/deployments` is the common post-creation command. `input.type: "inline"` sends behavior directly (API / CLI / dashboard); `input.type: "github"` deploys an already-linked repo — see [Deploy from a repo](#deploy-from-a-repo). The CLI uses a bounded `source` upload for a local prompt-defined Flue root. Creating a new Flue agent from GitHub uses the atomic [`POST /agents/import`](#import-a-flue-repository) command instead.
 
 An inline payload is the **complete** behavior — omitted fields aren't inherited (`prompt` is required; omitted `skills` means *no skills*).
 
@@ -177,13 +177,25 @@ Same as a repo push — handy for CI that isn't GitHub, or trying a change befor
 
 ### Flue framework agents
 
-A [Flue](/agent-sessions/flue) agent (`[runtime] family = "flue"` in `agent.toml`) carries its instructions, tools, and packaged skills in code, so `oc agent deploy` builds and ships the Cloudflare app instead of reading `prompt.md` and the top-level `skills/` directory:
+A prompt-defined [Flue](/agent-sessions/flue) agent contains `agent.toml`,
+`prompt.md`, and optional `skills/`. The CLI uploads those bounded files and
+waits while OpenComputer synthesizes and builds the app in the isolated managed
+builder:
+
+```bash CLI
+oc agent deploy   # upload source, managed build, verify live Worker
+```
+
+A complete Flue app instead carries its behavior in code. The CLI runs its
+locally installed framework build and uploads the generated modules:
 
 ```bash CLI
 oc agent deploy   # flue build --target cloudflare, upload, verify live Worker
 ```
 
-The CLI creates the agent from `agent.toml` when needed, runs the locally installed Flue build, uploads the generated JavaScript modules, and waits for the exact live Worker to become stable. See [Run Flue agents](/agent-sessions/flue) for the required app wiring and current deployment constraints.
+Both paths create the agent from `agent.toml` when needed and wait for the exact
+live Worker to become stable. See [Run Flue agents](/agent-sessions/flue) for
+the two source shapes and current deployment constraints.
 
 ## Roll back and promote
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/sdk",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/agents/repository-agents.test.ts
+++ b/sdks/typescript/src/agents/repository-agents.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { OpenComputer } from "./client.js";
 import type { RepositorySourceInterpretation } from "./repository-agents.js";
 
-// @ts-expect-error invalid profile identity must be flue-app-v1@1 or null/null
+// @ts-expect-error invalid profile identity must be a known profile at v1 or null/null
 const crossedInvalidProfile: RepositorySourceInterpretation = {
   disposition: "invalid",
   sourceProfile: "flue-app-v1",
@@ -62,6 +62,47 @@ afterEach(() => {
 });
 
 describe("agent repository review/import", () => {
+  it("normalizes prompt-profile synthesis metadata", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(Response.json({
+      ...reviewResponse,
+      interpretation: {
+        ...reviewResponse.interpretation,
+        source_profile: "flue-prompt-v1",
+        summary: "Prompt-defined Flue agent detected",
+        reason_code: "flue_prompt_detected",
+      },
+      profile: {
+        ...reviewResponse.profile,
+        source_profile: "flue-prompt-v1",
+        builder: {
+          node: "22.19.0",
+          synthesis_template: "flue-prompt-template-v1",
+        },
+        prompt: { bytes: 256 },
+        skills: { count: 2, bytes: 1024, names: ["review", "triage"] },
+      },
+    }));
+    const oc = new OpenComputer({
+      apiKey: "oc_test",
+      baseUrl: "https://api.example.test/v3",
+      maxRetries: 0,
+    });
+
+    const review = await oc.agents.repository.review({
+      repo: reviewResponse.repository.id,
+      path: reviewResponse.root,
+      productionRef: reviewResponse.production_ref,
+    });
+    expect(review.interpretation.sourceProfile).toBe("flue-prompt-v1");
+    expect(review.profile?.sourceProfile).toBe("flue-prompt-v1");
+    if (review.profile?.sourceProfile === "flue-prompt-v1") {
+      expect(review.profile.builder.synthesisTemplate).toBe(
+        "flue-prompt-template-v1",
+      );
+      expect(review.profile.skills.names).toEqual(["review", "triage"]);
+    }
+  });
+
   it("normalizes a source-profile review and replays its receipt on import", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")

--- a/sdks/typescript/src/agents/repository-agents.ts
+++ b/sdks/typescript/src/agents/repository-agents.ts
@@ -6,7 +6,7 @@ import type { Http } from "./http.js";
 import type { Agent, CredentialRef } from "./types.js";
 import type { Deployment, DeploymentSource } from "./deployments.js";
 
-export type SourceProfileId = "flue-app-v1";
+export type SourceProfileId = "flue-app-v1" | "flue-prompt-v1";
 
 export interface RepositoryAgentSource {
   type: "github";
@@ -42,8 +42,8 @@ export interface RepositoryCandidateRoot {
     | "flue.config.cjs";
 }
 
-export interface FlueSourceProfile {
-  sourceProfile: "flue-app-v1";
+interface FlueSourceProfileBase {
+  sourceProfile: SourceProfileId;
   sourceProfileVersion: 1;
   manifest: {
     schemaVersion: 1;
@@ -59,19 +59,30 @@ export interface FlueSourceProfile {
     flueCli: string;
   };
   lockfile: { version: number };
-  builder: { node: string };
+  builder: { node: string; synthesisTemplate?: string };
   source: { files: number; bytes: number };
   variableNames: string[];
   warnings: RepositoryReviewIssue[];
 }
 
+export type FlueSourceProfile =
+  | (FlueSourceProfileBase & {
+      sourceProfile: "flue-app-v1";
+    })
+  | (FlueSourceProfileBase & {
+      sourceProfile: "flue-prompt-v1";
+      prompt: { bytes: number };
+      skills: { count: number; bytes: number; names: string[] };
+      builder: { node: string; synthesisTemplate: string };
+    });
+
 export type RepositorySourceInterpretation =
   | {
       disposition: "exact";
-      sourceProfile: "flue-app-v1";
+      sourceProfile: SourceProfileId;
       sourceProfileVersion: 1;
       summary: string;
-      reasonCode: "flue_detected";
+      reasonCode: "flue_detected" | "flue_prompt_detected";
       assumptions: string[];
       agent: { runtime: "flue"; model: string };
     }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -742,7 +742,7 @@ export const importAgentFromGithub = (
     }
     review: {
       sha: string
-      source_profile: 'flue-app-v1'
+      source_profile: 'flue-app-v1' | 'flue-prompt-v1'
       fingerprint: string
     }
     credential: 'managed'

--- a/web/src/api/repository-inspection-schemas.test.ts
+++ b/web/src/api/repository-inspection-schemas.test.ts
@@ -18,7 +18,7 @@ const common = {
 }
 
 describe('repository source inspection schema', () => {
-  it('accepts the sole launch profile without losing its Flue review projection', () => {
+  it('accepts a full Flue app without losing its review projection', () => {
     const parsed = RepositorySourceInspectionSchema.parse({
       ...common,
       interpretation: {
@@ -55,6 +55,55 @@ describe('repository source inspection schema', () => {
 
     expect(parsed.profile?.manifest.entrypoint).toBe('support-triage')
     expect(parsed.review_fingerprint).toBe(reviewFingerprint)
+  })
+
+  it('accepts the bounded prompt-defined Flue profile', () => {
+    const parsed = RepositorySourceInspectionSchema.parse({
+      ...common,
+      interpretation: {
+        disposition: 'exact',
+        source_profile: 'flue-prompt-v1',
+        source_profile_version: 1,
+        summary: 'Prompt-defined Flue agent detected',
+        reason_code: 'flue_prompt_detected',
+        assumptions: [],
+        agent: { runtime: 'flue', model: 'anthropic/claude-haiku-4-5' },
+      },
+      profile: {
+        source_profile: 'flue-prompt-v1',
+        source_profile_version: 1,
+        manifest: {
+          schema_version: 1,
+          entrypoint: 'support-triage',
+          model: 'anthropic/claude-haiku-4-5',
+          runtime: { family: 'flue', type: 'default' },
+          vars: {},
+        },
+        package: {
+          name: 'opencomputer-flue-prompt-agent',
+          node_engine: '>=22.19 <23',
+          flue_cli: '1.0.0-beta.9',
+        },
+        lockfile: { version: 3 },
+        builder: {
+          node: '22.19.0',
+          synthesis_template: 'flue-prompt-template-v1',
+        },
+        source: { files: 4, bytes: 2048 },
+        prompt: { bytes: 256 },
+        skills: { count: 2, bytes: 1024, names: ['review', 'triage'] },
+        variable_names: [],
+        warnings: [],
+      },
+    })
+
+    expect(parsed.profile?.source_profile).toBe('flue-prompt-v1')
+    if (parsed.profile?.source_profile === 'flue-prompt-v1') {
+      expect(parsed.profile.skills.names).toEqual(['review', 'triage'])
+      expect(parsed.profile.builder.synthesis_template).toBe(
+        'flue-prompt-template-v1',
+      )
+    }
   })
 
   it('treats broken Flue and unrecognized source as review results', () => {

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -615,7 +615,7 @@ export const DeploymentSourceSchema = z.object({
   latest_seen_sha: z.string().nullish(),
   active_deployed_sha: z.string().nullish(),
   full_name: z.string().nullish(), // "owner/repo" (joined from the repo row)
-  source_profile: z.literal('flue-app-v1').nullish(),
+  source_profile: z.enum(['flue-app-v1', 'flue-prompt-v1']).nullish(),
   source_profile_version: z.literal(1).nullish(),
   review_fingerprint: z.string().nullish(),
 })
@@ -698,7 +698,7 @@ export const RepositoryReviewIssueSchema = z.object({
 
 export const RepositoryCandidateRootSchema = z.object({
   path: z.string(),
-  source_profile: z.literal('flue-app-v1').nullable(),
+  source_profile: z.enum(['flue-app-v1', 'flue-prompt-v1']).nullable(),
   summary: z.string(),
   marker: z.enum([
     'agent.toml',
@@ -709,8 +709,7 @@ export const RepositoryCandidateRootSchema = z.object({
   ]),
 })
 
-export const FlueSourceProfileSchema = z.object({
-  source_profile: z.literal('flue-app-v1'),
+const FlueSourceProfileBaseSchema = z.object({
   source_profile_version: z.literal(1),
   manifest: z.object({
     schema_version: z.literal(1),
@@ -728,15 +727,36 @@ export const FlueSourceProfileSchema = z.object({
     flue_cli: z.string(),
   }),
   lockfile: z.object({ version: z.number() }),
-  builder: z.object({ node: z.string() }),
+  builder: z.object({
+    node: z.string(),
+    synthesis_template: z.string().optional(),
+  }),
   source: z.object({ files: z.number(), bytes: z.number() }),
   variable_names: z.array(z.string()).default([]),
   warnings: z.array(RepositoryReviewIssueSchema).default([]),
 })
 
-const ExactRepositorySourceInterpretationSchema = z.object({
+export const FlueSourceProfileSchema = z.union([
+  FlueSourceProfileBaseSchema.extend({
+    source_profile: z.literal('flue-app-v1'),
+  }),
+  FlueSourceProfileBaseSchema.extend({
+    source_profile: z.literal('flue-prompt-v1'),
+    prompt: z.object({ bytes: z.number() }),
+    skills: z.object({
+      count: z.number(),
+      bytes: z.number(),
+      names: z.array(z.string()),
+    }),
+    builder: z.object({
+      node: z.string(),
+      synthesis_template: z.string(),
+    }),
+  }),
+])
+
+const ExactRepositorySourceInterpretationBase = z.object({
   disposition: z.literal('exact'),
-  source_profile: z.literal('flue-app-v1'),
   source_profile_version: z.literal(1),
   summary: z.string(),
   reason_code: z.string(),
@@ -746,6 +766,15 @@ const ExactRepositorySourceInterpretationSchema = z.object({
     model: z.string(),
   }),
 })
+
+const ExactRepositorySourceInterpretationSchema = z.union([
+  ExactRepositorySourceInterpretationBase.extend({
+    source_profile: z.literal('flue-app-v1'),
+  }),
+  ExactRepositorySourceInterpretationBase.extend({
+    source_profile: z.literal('flue-prompt-v1'),
+  }),
+])
 
 const InvalidRepositorySourceInterpretationBase = z.object({
   disposition: z.literal('invalid'),
@@ -757,6 +786,10 @@ const InvalidRepositorySourceInterpretationBase = z.object({
 const InvalidRepositorySourceInterpretationSchema = z.union([
   InvalidRepositorySourceInterpretationBase.extend({
     source_profile: z.literal('flue-app-v1'),
+    source_profile_version: z.literal(1),
+  }),
+  InvalidRepositorySourceInterpretationBase.extend({
+    source_profile: z.literal('flue-prompt-v1'),
     source_profile_version: z.literal(1),
   }),
   InvalidRepositorySourceInterpretationBase.extend({

--- a/web/src/lib/repository-onboarding.test.ts
+++ b/web/src/lib/repository-onboarding.test.ts
@@ -84,7 +84,7 @@ describe('repository onboarding presentation', () => {
     })
   })
 
-  it('is honest when prompt/skills-only source is unrecognized', () => {
+  it('explains how to make an unrecognized folder deployable', () => {
     const presentation = repositoryReviewPresentation({
       ...common,
       interpretation: {
@@ -96,9 +96,55 @@ describe('repository onboarding presentation', () => {
       },
     })
 
-    expect(presentation.explanation).toContain(
-      'Prompts or skills alone are not converted automatically',
-    )
+    expect(presentation.explanation).toContain('agent.toml')
+  })
+
+  it('presents an exact prompt-defined Flue agent without implying source code', () => {
+    const presentation = repositoryReviewPresentation({
+      ...common,
+      interpretation: {
+        disposition: 'exact',
+        source_profile: 'flue-prompt-v1',
+        source_profile_version: 1,
+        summary: 'Prompt-defined Flue agent detected',
+        reason_code: 'flue_prompt_detected',
+        assumptions: [],
+        agent: { runtime: 'flue', model: 'anthropic/claude-haiku-4-5' },
+      },
+      profile: {
+        source_profile: 'flue-prompt-v1',
+        source_profile_version: 1,
+        manifest: {
+          schema_version: 1,
+          entrypoint: 'support',
+          model: 'anthropic/claude-haiku-4-5',
+          runtime: { family: 'flue', type: 'default' },
+          vars: {},
+        },
+        package: {
+          name: 'opencomputer-flue-prompt-agent',
+          node_engine: '>=22.19 <23',
+          flue_cli: '1.0.0-beta.9',
+        },
+        lockfile: { version: 3 },
+        builder: {
+          node: '22.19.0',
+          synthesis_template: 'flue-prompt-template-v1',
+        },
+        source: { files: 3, bytes: 1024 },
+        prompt: { bytes: 128 },
+        skills: { count: 1, bytes: 512, names: ['triage'] },
+        variable_names: [],
+        warnings: [],
+      },
+    })
+
+    expect(presentation).toEqual({
+      heading: 'Prompt-defined Flue agent',
+      explanation:
+        'OpenComputer will turn this prompt and its skills into a Flue app at build time.',
+      primaryAction: 'deploy',
+    })
   })
 
   it('requires a fresh review for the typed source-change conflict', () => {

--- a/web/src/lib/repository-onboarding.ts
+++ b/web/src/lib/repository-onboarding.ts
@@ -64,11 +64,19 @@ export function repositoryReviewPresentation(
 ): RepositoryReviewPresentation {
   switch (inspection.interpretation.disposition) {
     case 'exact':
-      return {
-        heading: 'Flue agent detected',
-        explanation: 'Review the detected entrypoint, model, and agent name.',
-        primaryAction: 'deploy',
-      }
+      return inspection.interpretation.source_profile === 'flue-prompt-v1'
+        ? {
+            heading: 'Prompt-defined Flue agent',
+            explanation:
+              'OpenComputer will turn this prompt and its skills into a Flue app at build time.',
+            primaryAction: 'deploy',
+          }
+        : {
+            heading: 'Flue app detected',
+            explanation:
+              'Review the detected entrypoint, model, and agent name.',
+            primaryAction: 'deploy',
+          }
     case 'invalid':
       return {
         heading: 'This Flue agent needs a fix',
@@ -87,7 +95,7 @@ export function repositoryReviewPresentation(
         : {
             heading: "We couldn't find an agent definition in this folder",
             explanation:
-              'OpenComputer looked for an agent manifest and strong Flue markers. Prompts or skills alone are not converted automatically.',
+              'Add an agent.toml next to prompt.md, choose another folder, or start from the Flue app template.',
             primaryAction: 'choose_folder',
           }
   }

--- a/web/src/pages/AgentNew.tsx
+++ b/web/src/pages/AgentNew.tsx
@@ -788,6 +788,16 @@ function GithubImport({
                   {inspection.profile.manifest.model}
                 </span>
               </PanelDescription>
+              {inspection.profile.source_profile === 'flue-prompt-v1' ? (
+                <p className="text-muted-foreground mt-2 text-xs">
+                  prompt.md
+                  {' · '}
+                  {inspection.profile.skills.count}{' '}
+                  {inspection.profile.skills.count === 1 ? 'skill' : 'skills'}
+                  {' · '}
+                  built as a Flue app on OpenComputer
+                </p>
+              ) : null}
             </div>
           </PanelHeader>
           <PanelContent className="space-y-4">


### PR DESCRIPTION
## Summary

- extend the dashboard, browser schemas, and TypeScript SDK with the exact `flue-prompt-v1` review profile
- present prompt-defined Flue clearly during repository review, including prompt and skill counts
- scaffold a prompt-shaped agent with `oc agent init --runtime flue`
- make `oc agent deploy` package and deploy prompt-defined roots without a local Node/Flue installation
- stage only bounded `agent.toml`, `prompt.md`, and `skills/*/SKILL.md` inputs, then send a byte-free deployment reference to the control plane
- pin the immutable production builder recipe to the exact CLI commit that emits the synthesis-template contract
- document prompt-defined repositories, local deployment, limits, full-app precedence, deploy-on-push, and prompt-to-app graduation

## UX

A repository with `agent.toml`, `prompt.md`, and optional skills reviews as **Prompt-defined Flue agent**. The review explains that OpenComputer builds it as a Flue app, shows a compact `prompt.md · N skills · built as a Flue app` summary, and continues through the existing guided deployment and Slack setup flow.

From a local prompt-defined root, `oc agent deploy` now creates or resolves the Flue agent, syncs configured variables, uploads a deterministic bounded source archive directly to transient storage, starts the managed deployment, follows it to a terminal state, and prints the Agent URL plus dashboard handoff. A complete Flue app keeps the existing local build path.

## Safety

- local packaging uses an explicit regular-file allowlist and rejects symlinks, `mcp.json`, invalid skill names, invalid UTF-8, and all documented size-limit violations
- the managed builder remains the sole synthesis implementation
- the deployment API and queue receive no prompt or skill bytes
- the new immutable snapshot is pinned by recipe, source archive, reproducible CLI binary, manifest, and checkpoint identity

## Verification

- `go test ./cmd/oc/...`
- end-to-end CLI fake-control-plane test covering deterministic archive contents, direct signed upload, byte-free deployment request, polling, and handoff
- unsafe-shape tests for `mcp.json`, invalid skills, and prompt symlinks
- dashboard: 38 files / 160 tests passed on Node 22.19; production build passed
- snapshot recipe check, substrate contract check, and eight substrate-probe unit tests
- full `go test ./...` was attempted; unrelated platform suites require QEMU/Redis assets unavailable in this workspace, while the affected CLI packages pass

## Scope

This is the OpenComputer evergreen for work 030 4A, including W1-W5 and the W4 CLI path. It is based on current `main` and composes with the already-merged runtime-neutral repository-access work.

## Production proof

- The branch CLI successfully deployed the public `diggerhq/oc-flue-slack-pr-agent` prompt-and-skills repo through the managed pipeline; the resulting agent is verified and responds at its Agent URL.
- Until this evergreen merges into a CLI release, the exact test binary is available in this workspace at `$HOME/.local/bin/oc-flue-prompt`.


## SDK release

- bump `@opencomputer/sdk` to `0.15.1` so the additive `flue-prompt-v1` review contract publishes with the PR
- package lock is synchronized; 44 SDK tests, TypeScript build, and `npm pack --dry-run` pass
