### PR TITLE
fix auth race in CI

### DIFF
--- a/.github/workflows/build-worker-ami.yml
+++ b/.github/workflows/build-worker-ami.yml
@@ -154,11 +154,26 @@ jobs:
           echo "Previous golden version: ${PREV:-<none>}"
 
       - name: Build image
+        env:
+          # packer-plugin-azure authenticates via OIDC directly and fetches a
+          # FRESH GitHub OIDC token per Azure call (ARM_OIDC_REQUEST_*), so it
+          # survives long (>50 min) builds — unlike use_azure_cli_auth, whose
+          # one-shot federated client assertion expires ~5 min in and can't
+          # refresh, which failed the capture step with AADSTS700024.
+          ARM_USE_OIDC: "true"
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         run: |
           # Use run number as patch version for gallery (must be integer)
           PATCH=${{ github.run_number }}
 
+          # GitHub's OIDC token endpoint (present because permissions: id-token: write).
+          export ARM_OIDC_REQUEST_TOKEN="$ACTIONS_ID_TOKEN_REQUEST_TOKEN"
+          export ARM_OIDC_REQUEST_URL="$ACTIONS_ID_TOKEN_REQUEST_URL"
+
           packer build \
+            -var "use_azure_cli_auth=false" \
             -var "worker_version=$VERSION" \
             -var "agent_version=$VERSION" \
             -var "subscription_id=$AZURE_SUBSCRIPTION_ID" \
@@ -177,10 +192,19 @@ jobs:
             -var "tigris_goldens_bucket=${{ secrets.TIGRIS_GOLDENS_BUCKET }}" \
             deploy/packer/worker-ami.pkr.hcl | tee /tmp/packer-output.txt
 
-          # Use the gallery image ID (NVMe-compatible for v7 VMs)
-          GALLERY_IMAGE_ID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}/providers/Microsoft.Compute/galleries/${AZURE_GALLERY_NAME}/images/osb-worker-v7/versions/1.0.${PATCH}"
+      # Fresh az session for the post-build az calls (verify, cleanup) — the
+      # original login's session may be near expiry after a ~55 min packer build.
+      - name: Azure Re-Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-          # Verify it exists
+      - name: Verify image + export id
+        run: |
+          PATCH=${{ github.run_number }}
+          GALLERY_IMAGE_ID="/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}/providers/Microsoft.Compute/galleries/${AZURE_GALLERY_NAME}/images/osb-worker-v7/versions/1.0.${PATCH}"
           if ! az sig image-version show \
             --resource-group "$AZURE_RESOURCE_GROUP" \
             --gallery-name ${AZURE_GALLERY_NAME} \
@@ -190,16 +214,8 @@ jobs:
             cat /tmp/packer-output.txt
             exit 1
           fi
-
           echo "IMAGE_ID=$GALLERY_IMAGE_ID" >> $GITHUB_ENV
           echo "Built gallery image: $GALLERY_IMAGE_ID (version=1.0.${PATCH})"
-
-      - name: Azure Re-Login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Publish image coordinates to Infisical (/shared → all cell KVs)
         env:

--- a/deploy/packer/worker-ami.pkr.hcl
+++ b/deploy/packer/worker-ami.pkr.hcl
@@ -50,6 +50,12 @@ variable "resource_group" {
   description = "Resource group for the managed image."
 }
 
+variable "use_azure_cli_auth" {
+  type        = bool
+  default     = true
+  description = "Auth via the Azure CLI session (local/dev). CI sets false to use ARM_USE_OIDC + ARM_OIDC_REQUEST_TOKEN/URL so packer refreshes its own OIDC token on long builds."
+}
+
 variable "location" {
   type    = string
   default = "westus2"
@@ -167,8 +173,13 @@ source "azure-arm" "worker" {
   subscription_id = var.subscription_id
   location        = var.location
 
-  # Use managed identity or Azure CLI credentials
-  use_azure_cli_auth = true
+  # Auth: local/dev uses the Azure CLI session (use_azure_cli_auth=true, the
+  # default). CI passes -var use_azure_cli_auth=false and provides ARM_USE_OIDC +
+  # ARM_CLIENT_ID/ARM_TENANT_ID + ARM_OIDC_REQUEST_TOKEN/URL so the plugin fetches
+  # a FRESH GitHub OIDC token per Azure auth. The CLI path caches the one-shot
+  # federated client assertion (valid ~5 min) and can't refresh it, so long
+  # (>50 min) image builds died with AADSTS700024 near the capture step.
+  use_azure_cli_auth = var.use_azure_cli_auth
 
   # Base image: Ubuntu 24.04 LTS
   image_publisher = "Canonical"


### PR DESCRIPTION
The last worker image build ran out of time against the credential