### PR TITLE
Fix worker-image build: service-principal auth for packer

### DIFF
--- a/.github/workflows/build-worker-ami.yml
+++ b/.github/workflows/build-worker-ami.yml
@@ -155,16 +155,15 @@ jobs:
 
       - name: Build image
         env:
-          # Service-principal client-secret auth: a long-lived credential the
-          # plugin refreshes for the WHOLE build. The prior CLI-federated session
-          # cached a one-shot OIDC client assertion (~5 min) that couldn't refresh
-          # and died mid-build with AADSTS700024; ARM_USE_OIDC didn't switch the
-          # plugin over (it fell back to MSI → "Identity not found"). Providing
-          # ARM_CLIENT_SECRET completes the SP credential so the plugin uses it.
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          # Service-principal client-secret auth, fed as packer VARIABLES
+          # (PKR_VAR_* → var.client_id/client_secret/tenant_id on the azure-arm
+          # source). packer-plugin-azure v2 ignores ARM_* env for creds (it fell
+          # back to MSI → "Identity not found"), so they must be explicit source
+          # fields. This is a long-lived credential — survives the whole build,
+          # no OIDC assertion to expire (the AADSTS700024 root cause).
+          PKR_VAR_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+          PKR_VAR_client_secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          PKR_VAR_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
         run: |
           # Use run number as patch version for gallery (must be integer)
           PATCH=${{ github.run_number }}

--- a/deploy/packer/worker-ami.pkr.hcl
+++ b/deploy/packer/worker-ami.pkr.hcl
@@ -53,7 +53,24 @@ variable "resource_group" {
 variable "use_azure_cli_auth" {
   type        = bool
   default     = true
-  description = "Auth via the Azure CLI session (local/dev). CI sets false to use ARM_USE_OIDC + ARM_OIDC_REQUEST_TOKEN/URL so packer refreshes its own OIDC token on long builds."
+  description = "Auth via the Azure CLI session (local/dev). CI sets false and passes client_id/client_secret/tenant_id (service-principal) so packer holds a long-lived credential for the whole build."
+}
+
+# Service-principal credentials (CI only — fed via PKR_VAR_* env from secrets).
+# packer-plugin-azure v2 does NOT read ARM_* env for creds, so they must be
+# explicit fields on the source block. Empty in local/dev (uses CLI auth).
+variable "client_id" {
+  type    = string
+  default = ""
+}
+variable "client_secret" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+variable "tenant_id" {
+  type    = string
+  default = ""
 }
 
 variable "location" {
@@ -172,6 +189,12 @@ variable "tigris_region" {
 source "azure-arm" "worker" {
   subscription_id = var.subscription_id
   location        = var.location
+
+  # Service-principal client-secret auth (empty ⇒ ignored, CLI auth used). Set
+  # by CI; must be explicit fields here since the plugin ignores ARM_* env.
+  client_id     = var.client_id
+  client_secret = var.client_secret
+  tenant_id     = var.tenant_id
 
   # Auth: local/dev uses the Azure CLI session (use_azure_cli_auth=true, the
   # default). CI passes -var use_azure_cli_auth=false and provides service-


### PR DESCRIPTION
The Build Worker Image job was failing on auth. Three chained causes: (1) with use_azure_cli_auth the CLI's one-shot federated OIDC assertion (~5min) can't refresh, so ~55min builds died at capture with AADSTS700024; (2) ARM_USE_OIDC didn't switch the plugin to OIDC; (3) packer-plugin-azure v2 ignores ARM_* creds entirely and fell back to Managed Identity ("Identity not found").

Fix: pass service-principal creds as explicit azure-arm source fields (client_id/client_secret/tenant_id) via PKR_VAR_* env from the existing AZURE_CLIENT_SECRET, with use_azure_cli_auth=false in CI. A long-lived credential the plugin refreshes for the whole build — no assertion to expire, no MSI. Local/dev still defaults to CLI auth. Post-build image verify also moved after a fresh azure/login.