### PR TITLE
Harden sandbox pool

### DIFF
--- a/internal/api/admin_workers.go
+++ b/internal/api/admin_workers.go
@@ -2,9 +2,13 @@ package api
 
 import (
 	"context"
+	"log"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
+
+	pb "github.com/opensandbox/opensandbox/proto/worker"
 )
 
 // adminSetWorkerDraining toggles the in-memory `Draining` flag on a worker so
@@ -56,4 +60,78 @@ func (s *Server) adminSetWorkerDraining(c echo.Context) error {
 		"workerID": workerID,
 		"draining": drain,
 	})
+}
+
+// adminForceHibernate force-deep-hibernates a specific sandbox, bypassing the
+// customer-hibernate no-op guard. The manual lever for a box wedging a drain
+// (un-migratable: no golden, split→merged base skew, ghost). It goes to S3 and
+// wakes later (convert-on-fork rebases any base skew).
+//
+// POST /admin/sandboxes/:id/hibernate
+func (s *Server) adminForceHibernate(c echo.Context) error {
+	if s.workerRegistry == nil || s.store == nil {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "not available in this mode"})
+	}
+	sandboxID := c.Param("id")
+	if sandboxID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "sandbox id required"})
+	}
+	ctx := c.Request().Context()
+	session, err := s.store.GetSandboxSession(ctx, sandboxID)
+	if err != nil || session == nil {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": "sandbox not found"})
+	}
+	client, err := s.workerRegistry.GetWorkerClient(session.WorkerID)
+	if err != nil {
+		return c.JSON(http.StatusBadGateway, map[string]string{"error": "worker unreachable: " + err.Error()})
+	}
+	hctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+	if _, err := client.HibernateSandbox(hctx, &pb.HibernateSandboxRequest{SandboxId: sandboxID}); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "hibernate failed: " + err.Error()})
+	}
+	_ = s.store.UpdateSandboxSessionStatus(context.Background(), sandboxID, "hibernated", nil)
+	return c.JSON(http.StatusOK, map[string]any{"sandboxID": sandboxID, "status": "hibernated", "worker": session.WorkerID})
+}
+
+// adminEvictWorker force-drains a worker: mark draining, wipe pooled boxes, and
+// deep-hibernate every remaining running/paused box to S3 — the nuclear lever to
+// empty a wedged worker so the roll can terminate it. Async; watch the logs.
+//
+// POST /admin/workers/:id/evict
+func (s *Server) adminEvictWorker(c echo.Context) error {
+	if s.workerRegistry == nil || s.store == nil {
+		return c.JSON(http.StatusServiceUnavailable, map[string]string{"error": "not available in this mode"})
+	}
+	workerID := c.Param("id")
+	client, err := s.workerRegistry.GetWorkerClient(workerID)
+	if err != nil {
+		return c.JSON(http.StatusBadGateway, map[string]string{"error": "worker unreachable: " + err.Error()})
+	}
+	s.workerRegistry.SetDraining(workerID, true)
+	go func() {
+		bg := context.Background()
+		s.WipeWorkerPool(bg, workerID)
+		list, err := client.ListSandboxes(bg, &pb.ListSandboxesRequest{})
+		if err != nil {
+			log.Printf("admin evict %s: ListSandboxes failed: %v", workerID, err)
+			return
+		}
+		n := 0
+		for _, sb := range list.Sandboxes {
+			if sb.Status != "running" && sb.Status != "paused" {
+				continue
+			}
+			hctx, cancel := context.WithTimeout(bg, 120*time.Second)
+			if _, herr := client.HibernateSandbox(hctx, &pb.HibernateSandboxRequest{SandboxId: sb.SandboxId}); herr != nil {
+				log.Printf("admin evict %s: hibernate %s failed: %v", workerID, sb.SandboxId, herr)
+			} else {
+				_ = s.store.UpdateSandboxSessionStatus(bg, sb.SandboxId, "hibernated", nil)
+				n++
+			}
+			cancel()
+		}
+		log.Printf("admin evict %s: deep-hibernated %d box(es)", workerID, n)
+	}()
+	return c.JSON(http.StatusAccepted, map[string]any{"workerID": workerID, "status": "eviction started (draining + wipe pool + hibernate-all)"})
 }

--- a/internal/api/pool.go
+++ b/internal/api/pool.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/opensandbox/opensandbox/pkg/types"
 	pb "github.com/opensandbox/opensandbox/proto/worker"
 )
 
@@ -35,6 +36,16 @@ func (s *Server) poolTarget() int {
 	return 10
 }
 
+// poolMaxMemPct is the host-memory ceiling for pool refill: once a worker's
+// memory is above this, the reconciler stops manufacturing pool boxes onto it.
+// The pool always yields to real customer load — this matches the scaler's
+// memory scale-up trigger (resourceMemThreshold), so at the point new workers
+// are being added for pressure the pool stops adding to it. Paused pool boxes
+// have their RAM reclaimed, but manufacture briefly restores a full VM and a
+// burst of claims resumes them, so gating on real headroom prevents the pool
+// from tipping a hot worker over.
+const poolMaxMemPct = 70.0
+
 func poolTemplateName() string {
 	if v := os.Getenv("OPENSANDBOX_POOL_TEMPLATE"); v != "" {
 		return v
@@ -47,6 +58,12 @@ func poolTemplateName() string {
 // then CreateSandbox{pooled:true} — the worker golden-restores it and parks it
 // paused. Rolls back the PG row if the worker create fails.
 func (s *Server) manufacturePoolBoxOn(ctx context.Context, workerID, region, template, goldenVersion string) error {
+	// Golden gate: a pool box with no golden_version can't be migrated/rebased
+	// later (the drain fails "no goldenVersion"). Refuse to make one — the worker
+	// hasn't reported its golden yet, so skip it this tick.
+	if goldenVersion == "" {
+		return fmt.Errorf("pool: worker %s reports no golden version yet — skipping", workerID)
+	}
 	grpcClient, err := s.workerRegistry.GetWorkerClient(workerID)
 	if err != nil {
 		return fmt.Errorf("pool: no client for %s: %w", workerID, err)
@@ -57,18 +74,35 @@ func (s *Server) manufacturePoolBoxOn(ctx context.Context, workerID, region, tem
 	}
 	grpcCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
-	if _, err := grpcClient.CreateSandbox(grpcCtx, &pb.CreateSandboxRequest{
+	resp, err := grpcClient.CreateSandbox(grpcCtx, &pb.CreateSandboxRequest{
 		SandboxId: sandboxID,
 		Template:  template,
 		Pooled:    true,
-	}); err != nil {
+	})
+	if err != nil {
 		_ = s.store.WipePooled(ctx, sandboxID) // roll back the reserved row
 		return fmt.Errorf("pool: manufacture %s on %s: %w", sandboxID, workerID, err)
 	}
-	if goldenVersion != "" {
-		_ = s.store.SetSandboxGoldenVersion(ctx, sandboxID, goldenVersion)
+	// Capability gate: a pool-capable worker parks the box and returns
+	// status="pooled". An OLD worker that doesn't understand the flag ignores it,
+	// makes a normal RUNNING box, and returns "running" — a malformed pool box
+	// that can't be claimed and wedges drains. Destroy it and refuse to pool on
+	// this worker (so the pool can never pollute an un-rolled fleet).
+	if resp.GetStatus() != string(types.SandboxStatusPooled) {
+		dctx, dcancel := context.WithTimeout(context.Background(), 30*time.Second)
+		_, _ = grpcClient.DestroySandbox(dctx, &pb.DestroySandboxRequest{SandboxId: sandboxID})
+		dcancel()
+		_ = s.store.WipePooled(ctx, sandboxID)
+		return fmt.Errorf("pool: worker %s not pool-capable (CreateSandbox returned status=%q, want pooled) — skipping until rolled", workerID, resp.GetStatus())
 	}
-	log.Printf("pool: manufactured %s (template=%s) on %s", sandboxID, template, workerID)
+	// Stamp the authoritative golden the worker reported (fall back to the
+	// registry value) so the box is migratable/rebasable later.
+	golden := resp.GetGoldenVersion()
+	if golden == "" {
+		golden = goldenVersion
+	}
+	_ = s.store.SetSandboxGoldenVersion(ctx, sandboxID, golden)
+	log.Printf("pool: manufactured %s (template=%s, golden=%s) on %s", sandboxID, template, golden, workerID)
 	return nil
 }
 
@@ -116,6 +150,14 @@ func (s *Server) StartPoolReconciler(ctx context.Context, isLeader func() bool) 
 func (s *Server) reconcilePool(ctx context.Context, region, template string, perWorkerTarget int) {
 	for _, w := range s.workerRegistry.GetAllWorkers() {
 		if w.Region != region || w.Draining {
+			continue
+		}
+		// Memory-pressure gate: stop filling the pool on a worker whose host
+		// memory is over the ceiling. Real customer load takes priority — the
+		// pool is a latency optimization, not something that should push a hot
+		// worker into pressure. It resumes refilling once the box gets headroom.
+		if w.MemPct > poolMaxMemPct {
+			log.Printf("pool: %s at %.0f%% memory (> %.0f%%) — skipping refill", w.ID, w.MemPct, poolMaxMemPct)
 			continue
 		}
 		have, err := s.store.CountPooledOnWorker(ctx, w.ID, template)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -321,6 +321,8 @@ func NewServer(mgr sandbox.Manager, ptyMgr *sandbox.PTYManager, apiKey string, o
 	admin.GET("/report", s.adminReport)
 	admin.POST("/events/clear", s.adminClearEvents)
 	admin.POST("/workers/:id/drain", s.adminSetWorkerDraining)
+	admin.POST("/workers/:id/evict", s.adminEvictWorker)
+	admin.POST("/sandboxes/:id/hibernate", s.adminForceHibernate)
 	admin.GET("/demo/migration", s.demoPingPongPage)
 	admin.GET("/demo/chaos", s.demoChaosPage)
 

--- a/internal/api/sandbox.go
+++ b/internal/api/sandbox.go
@@ -753,6 +753,9 @@ func (s *Server) tryClaimPooled(c echo.Context, ctx context.Context, cfg types.S
 
 	// Promote pending→running (emits sandbox.created + sandbox.ready).
 	_ = s.store.UpdateSandboxSessionStatus(ctx, box.SandboxID, "running", nil)
+	if g := claimResp.GetGoldenVersion(); g != "" {
+		_ = s.store.SetSandboxGoldenVersion(ctx, box.SandboxID, g)
+	}
 
 	// Grow to requested resources (virtio-mem + cgroup), mirroring the cold path.
 	if cfg.MemoryMB > 0 || cfg.CpuCount > 0 {
@@ -999,6 +1002,17 @@ func (s *Server) createSandboxRemote(c echo.Context, ctx context.Context, cfg ty
 	// Creation succeeded — promote session to running.
 	if s.store != nil {
 		_ = s.store.UpdateSandboxSessionStatus(ctx, sandboxID, "running", nil)
+		// Stamp the authoritative golden the worker actually created this box on,
+		// so a later live-migrate can pick the right rebase base. Falls back to
+		// the registry heartbeat's golden for pre-golden workers. EVERY box must
+		// end up with a golden_version — a blank one is unmigratable.
+		golden := grpcResp.GetGoldenVersion()
+		if golden == "" {
+			golden = worker.GoldenVersion
+		}
+		if golden != "" {
+			_ = s.store.SetSandboxGoldenVersion(ctx, sandboxID, golden)
+		}
 	}
 
 	// Preview-URL auth: validate the payload, hash the token, persist it on

--- a/internal/controlplane/scaler.go
+++ b/internal/controlplane/scaler.go
@@ -1254,6 +1254,8 @@ func (s *Scaler) drainWorker(workerID, machineID, region string) {
 
 	migrationFailures := 0
 	const maxMigrationFailures = 3 // after 3 failed attempts, stop trying migration
+	backoffRounds := 0             // consecutive persistent-failure rounds
+	const maxBackoffRounds = 2     // ~10min of persistent migrate failure → deep-hibernate the stuck boxes
 
 	for {
 		select {
@@ -1289,6 +1291,21 @@ func (s *Scaler) drainWorker(workerID, machineID, region string) {
 		// handle truly session-less VMs.
 		var running []string
 		for _, sb := range listResp.Sandboxes {
+			// Pool boxes are disposable (generic, no customer data). If the drain
+			// finds one — even mislabeled "running" on a pre-pool worker that
+			// ignored the pooled flag — destroy it rather than migrate/hibernate,
+			// so a pool box can never wedge a scaler drain (the admin path already
+			// wipes; this covers the roll + smart-drain).
+			if s.store != nil {
+				if sess, serr := s.store.GetSandboxSession(ctx, sb.SandboxId); serr == nil && sess != nil && sess.Status == "pooled" {
+					dctx, dcancel := context.WithTimeout(ctx, 15*time.Second)
+					_, _ = sourceClient.DestroySandbox(dctx, &pb.DestroySandboxRequest{SandboxId: sb.SandboxId})
+					dcancel()
+					_ = s.store.WipePooled(context.Background(), sb.SandboxId)
+					log.Printf("scaler: drain: wiped pooled box %s off %s (disposable)", sb.SandboxId, workerID)
+					continue
+				}
+			}
 			// Paused boxes are RAM-resident only (no checkpoint) — a drain would
 			// otherwise be lost. MOVE them to another worker without billing:
 			// genuinely resume the box (unbilled), live-migrate it as a normal
@@ -1369,6 +1386,32 @@ func (s *Scaler) drainWorker(workerID, machineID, region string) {
 		// migration genuinely can't complete, drainTimeout terminates the loop
 		// and the next eval tick takes over.
 		if migrationFailures >= maxMigrationFailures {
+			backoffRounds++
+			// After a couple of persistent-failure rounds the cause isn't
+			// transient (no golden_version, split→merged base skew, no viable
+			// target). Rather than retry until drainTimeout and leave the worker
+			// un-drained — wedging the roll — deep-hibernate the stuck running
+			// boxes, the SAME fallback the paused path uses. They go to S3 and
+			// wake later (convert-on-fork rebases any split→merged skew). A live
+			// box gets put to sleep, but that beats stalling the whole fleet roll.
+			if backoffRounds >= maxBackoffRounds {
+				log.Printf("scaler: drain: %d persistent migrate failures on %s — deep-hibernating %d un-migratable running box(es) as fallback", migrationFailures, workerID, len(running))
+				for _, sbID := range running {
+					hibCtx, hibCancel := context.WithTimeout(ctx, 120*time.Second)
+					if _, herr := sourceClient.HibernateSandbox(hibCtx, &pb.HibernateSandboxRequest{SandboxId: sbID}); herr != nil {
+						log.Printf("scaler: drain: fallback deep-hibernate %s on %s failed: %v", sbID, workerID, herr)
+					} else {
+						if s.store != nil {
+							_ = s.store.UpdateSandboxSessionStatus(context.Background(), sbID, "hibernated", nil)
+						}
+						log.Printf("scaler: drain: deep-hibernated running %s on %s (migrate fallback)", sbID, workerID)
+					}
+					hibCancel()
+				}
+				migrationFailures = 0
+				backoffRounds = 0
+				continue
+			}
 			log.Printf("scaler: drain: %d migration failures on %s, backing off 5min before retry (%d sandboxes remaining)",
 				migrationFailures, workerID, len(running))
 			select {

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -1820,14 +1820,15 @@ func (m *Manager) createFromGolden(ctx context.Context, cfg types.SandboxConfig,
 		id, time.Since(t0).Milliseconds(), hostPort, guestPort, netCfg.TAPName, guestCID)
 
 	return &types.Sandbox{
-		ID:        id,
-		Template:  template,
-		Status:    types.SandboxStatusRunning,
-		StartedAt: now,
-		EndAt:     now.Add(timeout),
-		CpuCount:  cpus,
-		MemoryMB:  memMB,
-		HostPort:  hostPort,
+		ID:            id,
+		Template:      template,
+		Status:        types.SandboxStatusRunning,
+		StartedAt:     now,
+		EndAt:         now.Add(timeout),
+		CpuCount:      cpus,
+		MemoryMB:      memMB,
+		HostPort:      hostPort,
+		GoldenVersion: vm.goldenVersion,
 	}, nil
 }
 
@@ -2323,14 +2324,15 @@ func (m *Manager) Create(ctx context.Context, cfg types.SandboxConfig) (sb *type
 		id, template, cpus, memMB, hostPort, guestPort, netCfg.TAPName, guestMAC, guestCID)
 
 	return &types.Sandbox{
-		ID:        id,
-		Template:  template,
-		Status:    types.SandboxStatusRunning,
-		StartedAt: now,
-		EndAt:     now.Add(timeout),
-		CpuCount:  cpus,
-		MemoryMB:  memMB,
-		HostPort:  hostPort,
+		ID:            id,
+		Template:      template,
+		Status:        types.SandboxStatusRunning,
+		StartedAt:     now,
+		EndAt:         now.Add(timeout),
+		CpuCount:      cpus,
+		MemoryMB:      memMB,
+		HostPort:      hostPort,
+		GoldenVersion: vm.goldenVersion,
 	}, nil
 }
 
@@ -4764,12 +4766,13 @@ func (m *Manager) ForkFromCheckpoint(ctx context.Context, checkpointID string, c
 	return &types.Sandbox{
 		ID:        id,
 		Template:  meta.Template,
-		Status:    types.SandboxStatusRunning,
-		StartedAt: now,
-		EndAt:     now.Add(timeout),
-		CpuCount:  cpus,
-		MemoryMB:  memMB + virtioMemAddedMB,
-		HostPort:  hostPort,
+		Status:        types.SandboxStatusRunning,
+		StartedAt:     now,
+		EndAt:         now.Add(timeout),
+		CpuCount:      cpus,
+		MemoryMB:      memMB + virtioMemAddedMB,
+		HostPort:      hostPort,
+		GoldenVersion: vm.goldenVersion,
 	}, nil
 }
 
@@ -4838,14 +4841,15 @@ func (m *Manager) IsBillingSuppressed(sandboxID string) bool {
 
 func vmToSandbox(vm *VMInstance) *types.Sandbox {
 	return &types.Sandbox{
-		ID:        vm.ID,
-		Template:  vm.Template,
-		Status:    vm.Status,
-		StartedAt: vm.StartedAt,
-		EndAt:     vm.EndAt,
-		CpuCount:  vm.CpuCount,
-		MemoryMB:  vm.MemoryMB,
-		HostPort:  vm.HostPort,
+		ID:            vm.ID,
+		Template:      vm.Template,
+		Status:        vm.Status,
+		StartedAt:     vm.StartedAt,
+		EndAt:         vm.EndAt,
+		CpuCount:      vm.CpuCount,
+		MemoryMB:      vm.MemoryMB,
+		HostPort:      vm.HostPort,
+		GoldenVersion: vm.goldenVersion,
 	}
 }
 

--- a/internal/qemu/pool.go
+++ b/internal/qemu/pool.go
@@ -64,12 +64,13 @@ func (m *Manager) ClaimPooled(ctx context.Context, sandboxID string, cfg types.S
 
 	log.Printf("qemu: claim %s: resumed + rebound in %dms (template=%s)", sandboxID, time.Since(t0).Milliseconds(), vm.Template)
 	return &types.Sandbox{
-		ID:        sandboxID,
-		Template:  vm.Template,
-		Status:    types.SandboxStatusRunning,
-		StartedAt: time.Now(),
-		CpuCount:  vm.CpuCount,
-		MemoryMB:  vm.MemoryMB,
-		HostPort:  vm.HostPort,
+		ID:            sandboxID,
+		Template:      vm.Template,
+		Status:        types.SandboxStatusRunning,
+		StartedAt:     time.Now(),
+		CpuCount:      vm.CpuCount,
+		MemoryMB:      vm.MemoryMB,
+		HostPort:      vm.HostPort,
+		GoldenVersion: vm.goldenVersion,
 	}, nil
 }

--- a/internal/worker/grpc_server.go
+++ b/internal/worker/grpc_server.go
@@ -264,10 +264,10 @@ func (s *GRPCServer) CreateSandbox(ctx context.Context, req *pb.CreateSandboxReq
 			s.recordInitialScaleEvent(ctx, sb.ID, cfg)
 			s.configureLogshipForSandbox(ctx, sb.ID)
 			return &pb.CreateSandboxResponse{
-				SandboxId: sb.ID,
-				Status:    string(sb.Status),
-				MemoryMb:  int32(sb.MemoryMB),
-			}, nil
+				SandboxId:     sb.ID,
+				Status:        string(sb.Status),
+				MemoryMb:      int32(sb.MemoryMB),
+				GoldenVersion: sb.GoldenVersion}, nil
 		}
 		// Cache miss path: try to recover by downloading the checkpoint from
 		// S3, then retry the fork. The archive at TemplateRootfsKey holds
@@ -319,10 +319,10 @@ func (s *GRPCServer) CreateSandbox(ctx context.Context, req *pb.CreateSandboxReq
 		s.recordInitialScaleEvent(ctx, sb.ID, cfg)
 		s.configureLogshipForSandbox(ctx, sb.ID)
 		return &pb.CreateSandboxResponse{
-			SandboxId: sb.ID,
-			Status:    string(sb.Status),
-			MemoryMb:  int32(sb.MemoryMB),
-		}, nil
+			SandboxId:     sb.ID,
+			Status:        string(sb.Status),
+			MemoryMb:      int32(sb.MemoryMB),
+			GoldenVersion: sb.GoldenVersion}, nil
 	}
 
 	// Handle sandbox snapshot template: resolve S3 keys to local paths.
@@ -360,10 +360,10 @@ func (s *GRPCServer) CreateSandbox(ctx context.Context, req *pb.CreateSandboxReq
 		}
 		log.Printf("grpc: manufactured pool box %s (template=%s) — parked paused", sb.ID, cfg.Template)
 		return &pb.CreateSandboxResponse{
-			SandboxId: sb.ID,
-			Status:    string(types.SandboxStatusPooled),
-			MemoryMb:  int32(sb.MemoryMB),
-		}, nil
+			SandboxId:     sb.ID,
+			Status:        string(types.SandboxStatusPooled),
+			MemoryMb:      int32(sb.MemoryMB),
+			GoldenVersion: sb.GoldenVersion}, nil
 	}
 
 	// Register with sandbox router for rolling timeout tracking.
@@ -383,10 +383,10 @@ func (s *GRPCServer) CreateSandbox(ctx context.Context, req *pb.CreateSandboxReq
 	s.configureLogshipForSandbox(ctx, sb.ID)
 
 	return &pb.CreateSandboxResponse{
-		SandboxId: sb.ID,
-		Status:    string(sb.Status),
-		MemoryMb:  int32(sb.MemoryMB),
-	}, nil
+		SandboxId:     sb.ID,
+		Status:        string(sb.Status),
+		MemoryMb:      int32(sb.MemoryMB),
+		GoldenVersion: sb.GoldenVersion}, nil
 }
 
 // initSandboxDB opens the per-sandbox SQLite (creating + schema-initing it
@@ -498,10 +498,10 @@ func (s *GRPCServer) ClaimSandbox(ctx context.Context, req *pb.ClaimSandboxReque
 
 	log.Printf("grpc: claimed pool box %s (template=%s)", sb.ID, sb.Template)
 	return &pb.ClaimSandboxResponse{
-		SandboxId: sb.ID,
-		Status:    string(sb.Status),
-		MemoryMb:  int32(sb.MemoryMB),
-	}, nil
+		SandboxId:     sb.ID,
+		Status:        string(sb.Status),
+		MemoryMb:      int32(sb.MemoryMB),
+		GoldenVersion: sb.GoldenVersion}, nil
 }
 
 func (s *GRPCServer) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRequest) (*pb.DestroySandboxResponse, error) {

--- a/pkg/types/sandbox.go
+++ b/pkg/types/sandbox.go
@@ -43,6 +43,12 @@ type Sandbox struct {
 	CpuCount   int               `json:"cpuCount"`
 	MemoryMB   int               `json:"memoryMB"`
 	MachineID  string            `json:"machineID,omitempty"`
+	// GoldenVersion is the golden snapshot this box's rootfs is backed by, as
+	// reported authoritatively by the worker that created it. The control plane
+	// stamps it onto the PG session so a later live-migrate can pick the right
+	// rebase base. Every created box must carry this — a blank one is
+	// unmigratable ("source sandbox has no goldenVersion").
+	GoldenVersion string `json:"goldenVersion,omitempty"`
 	// ConnectURL and Token are currently unused by SDKs. All data-plane traffic
 	// flows through the control plane's SandboxAPIProxy, which proxies to workers
 	// over the internal VPC network. Direct worker access support coming in a future release.

--- a/proto/worker/worker.pb.go
+++ b/proto/worker/worker.pb.go
@@ -259,7 +259,12 @@ type CreateSandboxResponse struct {
 	// snapshot's base memory is the floor (downscale would OOM restored
 	// processes), and the hotplug ceiling caps the upper end. Always reflects
 	// the actual value the sandbox is running at.
-	MemoryMb      int32 `protobuf:"varint,3,opt,name=memory_mb,json=memoryMb,proto3" json:"memory_mb,omitempty"`
+	MemoryMb int32 `protobuf:"varint,3,opt,name=memory_mb,json=memoryMb,proto3" json:"memory_mb,omitempty"`
+	// Golden snapshot this box's rootfs is backed by, reported authoritatively by
+	// the worker. The control plane stamps it on the PG session so a later
+	// live-migrate can pick the right rebase base. Empty only from pre-golden
+	// workers (CP falls back to the registry heartbeat's golden then).
+	GoldenVersion string `protobuf:"bytes,4,opt,name=golden_version,json=goldenVersion,proto3" json:"golden_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -313,6 +318,13 @@ func (x *CreateSandboxResponse) GetMemoryMb() int32 {
 		return x.MemoryMb
 	}
 	return 0
+}
+
+func (x *CreateSandboxResponse) GetGoldenVersion() string {
+	if x != nil {
+		return x.GoldenVersion
+	}
+	return ""
 }
 
 type ClaimSandboxRequest struct {
@@ -420,6 +432,7 @@ type ClaimSandboxResponse struct {
 	SandboxId     string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
 	Status        string                 `protobuf:"bytes,2,opt,name=status,proto3" json:"status,omitempty"`
 	MemoryMb      int32                  `protobuf:"varint,3,opt,name=memory_mb,json=memoryMb,proto3" json:"memory_mb,omitempty"`
+	GoldenVersion string                 `protobuf:"bytes,4,opt,name=golden_version,json=goldenVersion,proto3" json:"golden_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -473,6 +486,13 @@ func (x *ClaimSandboxResponse) GetMemoryMb() int32 {
 		return x.MemoryMb
 	}
 	return 0
+}
+
+func (x *ClaimSandboxResponse) GetGoldenVersion() string {
+	if x != nil {
+		return x.GoldenVersion
+	}
+	return ""
 }
 
 type DestroySandboxRequest struct {
@@ -4469,12 +4489,13 @@ const file_proto_worker_worker_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a=\n" +
 	"\x0fSecretEnvsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"k\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x92\x01\n" +
 	"\x15CreateSandboxResponse\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x1b\n" +
-	"\tmemory_mb\x18\x03 \x01(\x05R\bmemoryMb\"\xe2\x04\n" +
+	"\tmemory_mb\x18\x03 \x01(\x05R\bmemoryMb\x12%\n" +
+	"\x0egolden_version\x18\x04 \x01(\tR\rgoldenVersion\"\xe2\x04\n" +
 	"\x13ClaimSandboxRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x18\n" +
@@ -4494,12 +4515,13 @@ const file_proto_worker_worker_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aE\n" +
 	"\x17SecretAllowedHostsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"j\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x91\x01\n" +
 	"\x14ClaimSandboxResponse\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status\x12\x1b\n" +
-	"\tmemory_mb\x18\x03 \x01(\x05R\bmemoryMb\"6\n" +
+	"\tmemory_mb\x18\x03 \x01(\x05R\bmemoryMb\x12%\n" +
+	"\x0egolden_version\x18\x04 \x01(\tR\rgoldenVersion\"6\n" +
 	"\x15DestroySandboxRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\"\x18\n" +

--- a/proto/worker/worker.proto
+++ b/proto/worker/worker.proto
@@ -131,6 +131,11 @@ message CreateSandboxResponse {
   // processes), and the hotplug ceiling caps the upper end. Always reflects
   // the actual value the sandbox is running at.
   int32 memory_mb = 3;
+  // Golden snapshot this box's rootfs is backed by, reported authoritatively by
+  // the worker. The control plane stamps it on the PG session so a later
+  // live-migrate can pick the right rebase base. Empty only from pre-golden
+  // workers (CP falls back to the registry heartbeat's golden then).
+  string golden_version = 4;
 }
 
 message ClaimSandboxRequest {
@@ -148,6 +153,7 @@ message ClaimSandboxResponse {
   string sandbox_id = 1;
   string status = 2;
   int32 memory_mb = 3;
+  string golden_version = 4;
 }
 
 message DestroySandboxRequest {


### PR DESCRIPTION
Five fixes making the pre-warmed pool safe through a worker roll (default-ON on a pre-pool fleet wedged prod twice):

1. Capability gate: refuse/destroy a non-pooled box from an old worker.
2. Drain-wipe: dispose pooled boxes on the roll path, not just admin.
3. Golden stamp: worker returns golden_version; CP stamps every box.
4. Hibernate fallback + admin evict/hibernate levers for stuck boxes.
5. Mem gate: stop refill above 70% host memory.