### PR TITLE
Add the agents-first OpenComputer experience

### DIFF
--- a/.github/workflows/publish-opencomputer-cli.yml
+++ b/.github/workflows/publish-opencomputer-cli.yml
@@ -1,0 +1,67 @@
+name: Publish OpenComputer CLI
+
+on:
+  pull_request:
+    paths:
+      - 'cli/**'
+      - '.github/workflows/publish-opencomputer-cli.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'cli/**'
+      - '.github/workflows/publish-opencomputer-cli.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: publish-opencomputer-cli
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: cli
+
+jobs:
+  publish:
+    name: Test, build & publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+          cache-dependency-path: cli/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test and build
+        run: npm test
+
+      - name: Check if this exact version is already published
+        if: github.event_name != 'pull_request'
+        id: check
+        run: |
+          LOCAL_VERSION=$(node -p "require('./package.json').version")
+          if LOOKUP=$(npm view "@opencomputer/cli@$LOCAL_VERSION" version 2>&1); then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Version $LOCAL_VERSION is already published; skipping."
+          elif [[ "$LOOKUP" == *"E404"* ]]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Publishing version $LOCAL_VERSION."
+          else
+            echo "npm registry lookup failed; refusing to assume that the version is unpublished." >&2
+            echo "$LOOKUP" >&2
+            exit 1
+          fi
+
+      - name: Publish
+        if: github.event_name != 'pull_request' && steps.check.outputs.skip == 'false'
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,20 +22,25 @@ Think of it as the compute equivalent of a laptop that sleeps when you close the
 
 ### CLI
 
-Download the latest `oc` binary from [GitHub Releases](https://github.com/diggerhq/opencomputer/releases):
+Install the agent-first OpenComputer CLI:
 
 ```bash
-# macOS (Apple Silicon)
-curl -fsSL https://github.com/diggerhq/opencomputer/releases/latest/download/oc-darwin-arm64 -o /usr/local/bin/oc
-chmod +x /usr/local/bin/oc
+npm install --global @opencomputer/cli
 
-# Sign in
-oc login
-oc whoami
+opencomputer login
+opencomputer templates
+opencomputer init email-triage
+cd email-triage
+npm install
+opencomputer connect google
+opencomputer session "Triage today's inbox."
+opencomputer deploy
 ```
 
-For CI, servers, and SDK applications, keep using an explicit org API key in
-`OPENCOMPUTER_API_KEY`; `oc login` is for the local CLI.
+For CI, set an explicit organization key in `OPENCOMPUTER_API_KEY`. The new CLI
+is intentionally agent-only; the legacy `oc` infrastructure CLI remains
+available from [GitHub Releases](https://github.com/diggerhq/opencomputer/releases)
+during the experiment.
 
 ### SDK
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ opencomputer templates
 opencomputer init email-triage
 cd email-triage
 npm install
-opencomputer connect google
+opencomputer connection add gmail --alias personal
 opencomputer session "Triage today's inbox."
 opencomputer deploy
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,8 +1,8 @@
 # OpenComputer CLI
 
-The OpenComputer CLI treats every agent as a normal source repository. A
+The OpenComputer CLI treats every project as a normal source repository. A
 template creates editable instructions, TypeScript tools, connection
-declarations, channel code, a sandbox workspace, and committed agent identity.
+declarations, channel code, a sandbox workspace, and committed project identity.
 
 [Bun](https://bun.sh/) 1.2 or newer is required. The CLI is still installed
 and published through npm:
@@ -40,14 +40,14 @@ email-triage/
 └── evals/
 ```
 
-`opencomputer.toml` is committed with the agent and contains its stable ID.
-The directory can be renamed without creating a different deployed agent; each
-`opencomputer deploy` publishes a new immutable deployment and advances the
-selected alias.
+`opencomputer.toml` is committed with the project and contains its stable ID.
+The directory can be renamed without creating a different deployed project;
+each `opencomputer deploy` publishes a new immutable deployment and advances
+the selected alias.
 
 ## Sessions
 
-`opencomputer dev` starts the local agent service and opens its React browser
+`opencomputer dev` starts the local project service and opens its React browser
 app. The app uses the AI SDK message lifecycle and supports multiple independent
 sessions, multi-turn conversations, and streamed tool activity:
 
@@ -75,7 +75,7 @@ invocations:
 
 ```bash
 opencomputer session create --remote \
-  --agent gmail-summarizer@production
+  --project gmail-summarizer@production
 opencomputer session list
 opencomputer session send <session-id> "Summarize today's inbox."
 opencomputer session inspect <session-id>
@@ -83,7 +83,7 @@ opencomputer session attach <session-id>
 opencomputer session end <session-id>
 ```
 
-Add and manage account connections and agent channels from the same CLI:
+Add and manage account connections and project channels from the same CLI:
 
 ```bash
 opencomputer connection add gmail --alias personal

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,70 @@
+# OpenComputer CLI
+
+The OpenComputer CLI treats every agent as a normal source repository. A
+template creates editable instructions, OpenCode tools, connection
+declarations, channel code, a sandbox workspace, and committed agent identity.
+
+```bash
+npm install --global @opencomputer/cli
+opencomputer login
+opencomputer templates
+opencomputer init email-triage
+cd email-triage
+npm install
+opencomputer connect google
+opencomputer dev
+opencomputer session "Triage today's inbox."
+opencomputer deploy
+```
+
+Authentication is stored separately from the legacy `oc` CLI in
+`~/.opencomputer/config.json`. `OPENCOMPUTER_API_KEY` and
+`OPENCOMPUTER_API_URL` can be used in CI.
+
+The generated repository is deliberately flat:
+
+```text
+email-triage/
+├── opencomputer.toml
+├── package.json
+├── instructions.md
+├── agent.ts
+├── tools/
+├── connections/
+├── channels/
+├── skills/
+├── workspace/
+└── evals/
+```
+
+`opencomputer.toml` is committed with the agent and contains its stable ID.
+The directory can be renamed without creating a different deployed agent; each
+`opencomputer deploy` publishes a new immutable deployment and advances the
+selected alias.
+
+## Sessions
+
+`opencomputer session` runs the current source locally. Deployed sessions have
+their own lifecycle and can be resumed across CLI invocations:
+
+```bash
+opencomputer session create --remote \
+  --agent gmail-summarizer@production
+opencomputer session list
+opencomputer session send <session-id> "Summarize today's inbox."
+opencomputer session inspect <session-id>
+opencomputer session attach <session-id>
+opencomputer session end <session-id>
+```
+
+Add and manage account connections and agent channels from the same CLI:
+
+```bash
+opencomputer connections connect gmail
+opencomputer connections list
+
+opencomputer channels add slack
+opencomputer deploy
+opencomputer channels connect slack --remote
+opencomputer channels list
+```

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,8 +1,8 @@
 # OpenComputer CLI
 
-The OpenComputer CLI treats every project as a normal source repository. A
+The OpenComputer CLI treats every agent as a normal source repository. A
 template creates editable instructions, TypeScript tools, connection
-declarations, channel code, a sandbox workspace, and committed project identity.
+declarations, channel code, a sandbox workspace, and committed agent identity.
 
 [Bun](https://bun.sh/) 1.2 or newer is required. The CLI is still installed
 and published through npm:
@@ -40,14 +40,14 @@ email-triage/
 └── evals/
 ```
 
-`opencomputer.toml` is committed with the project and contains its stable ID.
-The directory can be renamed without creating a different deployed project;
-each `opencomputer deploy` publishes a new immutable deployment and advances
-the selected alias.
+`opencomputer.toml` is committed with the agent and contains its stable ID.
+The directory can be renamed without creating a different deployed agent; each
+`opencomputer deploy` publishes a new immutable deployment and advances the
+selected alias.
 
 ## Sessions
 
-`opencomputer dev` starts the local project service and opens its React browser
+`opencomputer dev` starts the local agent service and opens its React browser
 app. The app uses the AI SDK message lifecycle and supports multiple independent
 sessions, multi-turn conversations, and streamed tool activity:
 
@@ -75,7 +75,7 @@ invocations:
 
 ```bash
 opencomputer session create --remote \
-  --project gmail-summarizer@production
+  --agent gmail-summarizer@production
 opencomputer session list
 opencomputer session send <session-id> "Summarize today's inbox."
 opencomputer session inspect <session-id>
@@ -83,7 +83,7 @@ opencomputer session attach <session-id>
 opencomputer session end <session-id>
 ```
 
-Add and manage account connections and project channels from the same CLI:
+Add and manage account connections and agent channels from the same CLI:
 
 ```bash
 opencomputer connection add gmail --alias personal

--- a/cli/README.md
+++ b/cli/README.md
@@ -14,7 +14,7 @@ opencomputer templates
 opencomputer init email-triage
 cd email-triage
 npm install
-opencomputer connect google
+opencomputer connection add gmail --alias personal
 opencomputer dev
 opencomputer session "Triage today's inbox."
 opencomputer deploy
@@ -86,8 +86,10 @@ opencomputer session end <session-id>
 Add and manage account connections and agent channels from the same CLI:
 
 ```bash
-opencomputer connections connect gmail
-opencomputer connections list
+opencomputer connection add gmail --alias personal
+opencomputer connection add gmail --alias work
+opencomputer connection list
+opencomputer connection remove work
 
 opencomputer channels add slack
 opencomputer deploy

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,8 +1,11 @@
 # OpenComputer CLI
 
 The OpenComputer CLI treats every agent as a normal source repository. A
-template creates editable instructions, OpenCode tools, connection
+template creates editable instructions, TypeScript tools, connection
 declarations, channel code, a sandbox workspace, and committed agent identity.
+
+[Bun](https://bun.sh/) 1.2 or newer is required. The CLI is still installed
+and published through npm:
 
 ```bash
 npm install --global @opencomputer/cli
@@ -44,8 +47,31 @@ selected alias.
 
 ## Sessions
 
-`opencomputer session` runs the current source locally. Deployed sessions have
-their own lifecycle and can be resumed across CLI invocations:
+`opencomputer dev` starts the local agent service and opens its React browser
+app. The app uses the AI SDK message lifecycle and supports multiple independent
+sessions, multi-turn conversations, and streamed tool activity:
+
+```bash
+opencomputer dev
+```
+
+For a terminal-only workflow, `opencomputer session` automatically starts a
+temporary local service when one is not already running and opens an OpenTUI
+multi-turn interface. The service is stopped when the interface exits:
+
+```bash
+opencomputer session
+```
+
+Pass a prompt for a single turn. This also starts and stops the service
+automatically when needed:
+
+```bash
+opencomputer session "Triage today's inbox."
+```
+
+Deployed sessions have their own lifecycle and can be resumed across CLI
+invocations:
 
 ```bash
 opencomputer session create --remote \

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,53 @@
+{
+  "name": "@opencomputer/cli",
+  "version": "0.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@opencomputer/cli",
+      "version": "0.3.0",
+      "bin": {
+        "opencomputer": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "typescript": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/cli",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "dependencies": {
         "@opencode-ai/sdk": "1.18.4",
         "@opentui/core": "^0.4.5",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,22 +1,701 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.3.0",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/cli",
-      "version": "0.3.0",
+      "version": "0.3.6",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.18.4",
+        "@opentui/core": "^0.4.5",
+        "@opentui/react": "^0.4.5",
+        "ai": "^7.0.45",
+        "opencode-ai": "1.18.4",
+        "react": "^19.2.8"
+      },
       "bin": {
         "opencomputer": "dist/index.js"
       },
       "devDependencies": {
+        "@ai-sdk/react": "^4.0.48",
         "@types/node": "^24.0.0",
-        "typescript": "^5.9.0"
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
+        "@vitejs/plugin-react": "^6.0.5",
+        "react-dom": "^19.2.8",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
+        "typescript": "^5.9.0",
+        "vite": "^8.2.0"
+      },
+      "engines": {
+        "bun": ">=1.2.0"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "4.0.34",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.34.tgz",
+      "integrity": "sha512-r9h1pwSjAFI75c6PFNGVnhrZIQ3zfWnjwnrc+qGgbnqkWdiuq3ZpTCrAlsphy3h/b3T10OwjfsLd+3yKpyoa/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.17",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.21.tgz",
+      "integrity": "sha512-IC7mhtIX551SGp3jyFveNpwWpvzju/2ah4+Wsmsj4OMXOVCBChdwNpanZTGGfTaugqUoqtRgsOZ7dS2jJ4ix7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.17",
+        "pkce-challenge": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.4.tgz",
+      "integrity": "sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
       },
       "engines": {
         "node": ">=22"
       }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.17",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.17.tgz",
+      "integrity": "sha512-U3h3xgaga1OOELBxhtwTfgfr0z++kHCD4YSFm4pfcqzUWolntINS0/21ktZ/5k2A1ozAiRPYqkCg90iwiYrwyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "4.0.48",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-4.0.48.tgz",
+      "integrity": "sha512-x2RJIO+mB+FhqZVK3QjUgiv4+HJuFJGROMyYk1Tk1VosWfq/a/72Q/gFllJD/ubuvm65nh1C5wKZY37xck6FrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/mcp": "2.0.21",
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.17",
+        "ai": "7.0.45",
+        "swr": "^2.4.1",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.4.tgz",
+      "integrity": "sha512-p/3P0KtWknoLvpsk8QrUzCKd4Q1A5Z3RmACEvwuQBGxnUy4AGo379lUYMgt7fczFn53079oroLuo6BosQri+HA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/@opentui/core": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@opentui/core/-/core-0.4.5.tgz",
+      "integrity": "sha512-JsgRTPkA6e+Vxmumxai6SElOSlRQkbzNKHlCfemlArRiLhfC1IZ9RXJo2QH4xSu+uBOWAM90uss73/pPlkdEig==",
+      "license": "MIT",
+      "dependencies": {
+        "bun-ffi-structs": "0.2.4",
+        "diff": "9.0.0",
+        "marked": "17.0.1",
+        "string-width": "7.2.0",
+        "strip-ansi": "7.1.2"
+      },
+      "optionalDependencies": {
+        "@opentui/core-darwin-arm64": "0.4.5",
+        "@opentui/core-darwin-x64": "0.4.5",
+        "@opentui/core-linux-arm64": "0.4.5",
+        "@opentui/core-linux-arm64-musl": "0.4.5",
+        "@opentui/core-linux-x64": "0.4.5",
+        "@opentui/core-linux-x64-musl": "0.4.5",
+        "@opentui/core-win32-arm64": "0.4.5",
+        "@opentui/core-win32-x64": "0.4.5"
+      },
+      "peerDependencies": {
+        "web-tree-sitter": "0.25.10"
+      }
+    },
+    "node_modules/@opentui/core-darwin-arm64": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-arm64/-/core-darwin-arm64-0.4.5.tgz",
+      "integrity": "sha512-8KUG0oRidnR+oW1RSZJ72/PhZLl+qRRMk5U/mieF4c0SJ5V3tYACpBZAKzQfHNd1f7QzD8FHZct1lPpQgtmkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@opentui/core-darwin-x64": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-x64/-/core-darwin-x64-0.4.5.tgz",
+      "integrity": "sha512-R2bocsg55gwjOqCp/MWFgFYzRmsduKegB6nzgFAPCvAD/L5Jf30xpWJWFlSg3x8vxe1L9WJ84dfqa4M7mZZ3wA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@opentui/core-linux-arm64": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-arm64/-/core-linux-arm64-0.4.5.tgz",
+      "integrity": "sha512-R4MZ25a4CzOAGVjW9aj1hUfzQGVfCJwrwBDbNs2SXaIvzcZqkxCVtU4FoQ5LsaD0j/BdNQVg2CIfFkFsm1fDuQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-linux-arm64-musl": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-arm64-musl/-/core-linux-arm64-musl-0.4.5.tgz",
+      "integrity": "sha512-ieqdyKI6EIYPalYAETB2wsdP83hr5Ifi+dFnBFUmdEEFHsoKwBmn2S7bsTOYlX7Bg03F4/YPIg+IvRpeC+cUJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-linux-x64": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-x64/-/core-linux-x64-0.4.5.tgz",
+      "integrity": "sha512-SNyuQoxMKI1vuJhgxSSW96adWM6LqFl2SoS3GM4tGeneGOanVVG2Y06PvlytXvF4cKik97t0rqkVMRetmOs93w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-linux-x64-musl": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-x64-musl/-/core-linux-x64-musl-0.4.5.tgz",
+      "integrity": "sha512-mKVKcIcPiSVVZZsdPSBoWwoa2/TCeQAaMDeHF7PFw2kt5bTXZPP7xxWfRQLCNIcA1eaGl59UuwUWHDR2Ve548Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-win32-arm64": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-arm64/-/core-win32-arm64-0.4.5.tgz",
+      "integrity": "sha512-GHTTsqeR45q2Iek9Rb7ty+x/hAKn2jZ1ujlCgPR8LBKyF7h0E1dNFryoZ7ehMc3kJndP1sKn836IemKFqxuDdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opentui/core-win32-x64": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-x64/-/core-win32-x64-0.4.5.tgz",
+      "integrity": "sha512-Y8T/yXCDGagRGiQrtmuB6AhRcPucKFs/Dre3v8kJwNYqDccI4FzUPKclZ7djfmRZNjl7JUqPhZZP/PwDpQocMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opentui/react": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@opentui/react/-/react-0.4.5.tgz",
+      "integrity": "sha512-n88Vx0cMmAu++/S14WscjvdcT46IDcxve02jMtcfHQ9j6cySRHfILfGEpOB7xxc8RpCwQceEyOjkKkfzPzm6Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentui/core": "0.4.5",
+        "react-reconciler": "^0.33.0"
+      },
+      "peerDependencies": {
+        "react": ">=19.2.0",
+        "react-devtools-core": "^7.0.1",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
+      "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
+      "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
+      "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
+      "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
+      "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
+      "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
+      "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
+      "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
+      "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
+      "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
+      "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
+      "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
+      "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "2.0.0-alpha.3",
+        "@emnapi/runtime": "2.0.0-alpha.3",
+        "@napi-rs/wasm-runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
+      "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
+      "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.13.3",
@@ -28,11 +707,2425 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
+      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ai": {
+      "version": "7.0.45",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.45.tgz",
+      "integrity": "sha512-BLMm4DGw1o2KgDhwWixiRNFQu2zeiNi6XfQlT++japjTbLpIFKST6TRKfsn90Ski6eZ06M34lQlb4viOcFl48Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.34",
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.17"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bun-ffi-structs": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/bun-ffi-structs/-/bun-ffi-structs-0.2.4.tgz",
+      "integrity": "sha512-AJzsqoVFs1KBbJbWHIYrVZLDC3NhTqqh25awRXqzoLzmBAKr5oqk6+CwuYHAekKx+VBCYVohBoKuRq40dV+TYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/opencode-ai": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.18.4.tgz",
+      "integrity": "sha512-B8pFAs1g158ZU+C6eSiJz/5ZhG7Vr2mH7Z7ruYEHLElAlX9tehrRTnzTTgjSxHY2vwZ/5VplwR3odFU+Dai8jg==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "opencode": "bin/opencode.exe"
+      },
+      "optionalDependencies": {
+        "opencode-darwin-arm64": "1.18.4",
+        "opencode-darwin-x64": "1.18.4",
+        "opencode-darwin-x64-baseline": "1.18.4",
+        "opencode-linux-arm64": "1.18.4",
+        "opencode-linux-arm64-musl": "1.18.4",
+        "opencode-linux-x64": "1.18.4",
+        "opencode-linux-x64-baseline": "1.18.4",
+        "opencode-linux-x64-baseline-musl": "1.18.4",
+        "opencode-linux-x64-musl": "1.18.4",
+        "opencode-windows-arm64": "1.18.4",
+        "opencode-windows-x64": "1.18.4",
+        "opencode-windows-x64-baseline": "1.18.4"
+      }
+    },
+    "node_modules/opencode-darwin-arm64": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.18.4.tgz",
+      "integrity": "sha512-/GdcUv3axBFYmpdCY3yMGRCBq3fwAJayflnn9stXtIHKuckc7ZaUYZmyudIUpmzkZP5W8XsAVMJomR4Rbr2+Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.18.4.tgz",
+      "integrity": "sha512-0i/AmdFw3CerwIggKqtaDlWDCBfSgzXT+KPSvks/Dx6l9NfYHihLnbV+vKbr0lwzco1lsDo4JHE4j/zz7JZUKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64-baseline": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.18.4.tgz",
+      "integrity": "sha512-1v/keJ/m+3UplGU2XdP5YfK25rTlGi7Kf5BVSV/ICObk6PiJWBAWOrB8bAQWDLhN/Tn7UfogBAgxaiRRfLPuEA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-linux-arm64": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.18.4.tgz",
+      "integrity": "sha512-3gBw9weE76jloNPGmPvzl3GJR8b6scwSAENxUKRdJ3WCkC7qcjJm49KFyfqFjO5++1H1Q2jbmqqxAgt5upqoMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-arm64-musl": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.18.4.tgz",
+      "integrity": "sha512-kno1QJz+JoY1YqGlrxcwGKqOh2/OFKdQ4UGUCN5K2evQRIhd9EfB4JvZkjzLxTzglda8lpP+PJltjCA4DHJAJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.18.4.tgz",
+      "integrity": "sha512-mCiZuKQBqRHVhtp20YFDfNf5cUwTt6/I98MFJQDJdDTWggnkAVOnitQTmSt2cQwoPJ94VrRwDhZyY3pIY3+CQg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.18.4.tgz",
+      "integrity": "sha512-LlVIv54gpM8I6QJVAoW5uvcaVO4z+y5DswfUCsxgaD0CWgjEbULaiAAZIS/L+N5rRw/jHeqcHSXiKinFZt0xww==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline-musl": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.18.4.tgz",
+      "integrity": "sha512-hM/uPMEuxLbwXueOmHsf3jjmfJ238/3r6FZMPumKVMR7jJHutp3ZWuOIL+ZzByxzsUK1f3RGbKaFULOMIieRSw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-musl": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.18.4.tgz",
+      "integrity": "sha512-AlojHLyv7Cgn2g5Rj5QeHckEWyA20qdbEla2d1R9mXSaqlP6sX7izNti8Tzr/vMG53Uwmppyjb37uFB2fK+YTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-windows-arm64": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.18.4.tgz",
+      "integrity": "sha512-B6m7N7ZPj/E6xx1ZaSjNW0gHTd0b3NTSf9mQiN3W89zji3oH9VOHLQdrP10rAd/2uZ5ZttxSkRqj/iwgAW+3TQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.18.4.tgz",
+      "integrity": "sha512-TumOcMOvZ6vfs348LgGLK9eFEBLsh+wI/UXmQ8BhXW95YV1Wd26TutSzQi4L/wLftsDfl8Q6bKQ2trWtGBzBvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64-baseline": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.18.4.tgz",
+      "integrity": "sha512-4EpZ97uI50vVv9UT5sDeK3ff+sFzqmbBT4TNGkMF9uwNTKJYqoSVuOIZhIfLTLNlrEK2hd2/sf/4GQhIkM6iTw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-devtools-core": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-7.0.1.tgz",
+      "integrity": "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shell-quote": "^1.6.1",
+        "ws": "^7"
+      }
+    },
+    "node_modules/react-devtools-core/node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
+      "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.142.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.1",
+        "@rolldown/binding-darwin-arm64": "1.2.1",
+        "@rolldown/binding-darwin-x64": "1.2.1",
+        "@rolldown/binding-freebsd-x64": "1.2.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
+        "@rolldown/binding-linux-arm64-musl": "1.2.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-musl": "1.2.1",
+        "@rolldown/binding-openharmony-arm64": "1.2.1",
+        "@rolldown/binding-wasm32-wasi": "1.2.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
+        "@rolldown/binding-win32-x64-msvc": "1.2.1"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
+      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -42,12 +3135,305 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
+      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/emscripten": "^1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/emscripten": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   }
 }

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/cli",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "dependencies": {
         "@opencode-ai/sdk": "1.18.4",
         "@opentui/core": "^0.4.5",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Build, test, connect, deploy, and share OpenComputer agents as code.",
   "type": "module",
   "bin": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.3.7",
-  "description": "Build, test, connect, deploy, and share OpenComputer agents as code.",
+  "version": "0.3.8",
+  "description": "Build, test, connect, deploy, and share OpenComputer projects as code.",
   "type": "module",
   "bin": {
     "opencomputer": "dist/index.js"
@@ -29,6 +29,7 @@
     "directory": "cli"
   },
   "keywords": [
+    "projects",
     "agents",
     "ai",
     "opencomputer"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@opencomputer/cli",
+  "version": "0.3.0",
+  "description": "Build, test, connect, deploy, and share OpenComputer agents as code.",
+  "type": "module",
+  "bin": {
+    "opencomputer": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build && node --test dist/*.test.js",
+    "prepack": "npm test"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diggerhq/opencomputer.git",
+    "directory": "cli"
+  },
+  "keywords": [
+    "agents",
+    "ai",
+    "opencomputer"
+  ],
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^5.9.0"
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.3.0",
+  "version": "0.3.6",
   "description": "Build, test, connect, deploy, and share OpenComputer agents as code.",
   "type": "module",
   "bin": {
@@ -11,12 +11,14 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build:server": "tsc -p tsconfig.json",
+    "build:ui": "tsc -p tsconfig.ui.json --noEmit && vite build",
+    "build": "npm run build:server && npm run build:ui",
     "test": "npm run build && node --test dist/*.test.js",
     "prepack": "npm test"
   },
   "engines": {
-    "node": ">=22"
+    "bun": ">=1.2.0"
   },
   "publishConfig": {
     "access": "public"
@@ -31,8 +33,24 @@
     "ai",
     "opencomputer"
   ],
+  "dependencies": {
+    "@opencode-ai/sdk": "1.18.4",
+    "@opentui/core": "^0.4.5",
+    "@opentui/react": "^0.4.5",
+    "ai": "^7.0.45",
+    "opencode-ai": "1.18.4",
+    "react": "^19.2.8"
+  },
   "devDependencies": {
+    "@ai-sdk/react": "^4.0.48",
     "@types/node": "^24.0.0",
-    "typescript": "^5.9.0"
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
+    "@vitejs/plugin-react": "^6.0.5",
+    "react-dom": "^19.2.8",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
+    "typescript": "^5.9.0",
+    "vite": "^8.2.0"
   }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencomputer/cli",
   "version": "0.3.8",
-  "description": "Build, test, connect, deploy, and share OpenComputer projects as code.",
+  "description": "Build, test, connect, deploy, and share OpenComputer agents as code.",
   "type": "module",
   "bin": {
     "opencomputer": "dist/index.js"
@@ -29,7 +29,6 @@
     "directory": "cli"
   },
   "keywords": [
-    "projects",
     "agents",
     "ai",
     "opencomputer"

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -234,8 +234,10 @@ export class OpenComputerClient {
     );
   }
 
-  linkGoogle(service: string) {
+  linkGoogle(service: string, label: string) {
     return this.request<{
+      connectionId: string;
+      label: string;
       service: string;
       toolkit: string;
       status: "connected" | "pending";
@@ -244,12 +246,14 @@ export class OpenComputerClient {
       expiresAt?: string;
     }>("/api/managed-agents/connections/google/link", {
       method: "POST",
-      body: JSON.stringify({ service }),
+      body: JSON.stringify({ service, label }),
     });
   }
 
-  googleConnection(service: string) {
+  googleConnection(connectionId: string, service: string) {
     return this.request<{
+      connectionId: string;
+      label: string;
       service: string;
       toolkit: string;
       status: "connected" | "pending";
@@ -257,18 +261,20 @@ export class OpenComputerClient {
       authorizationUrl?: string;
       expiresAt?: string;
     }>(
-      `/api/managed-agents/connections/google/status?service=${encodeURIComponent(service)}`,
+      `/api/managed-agents/connections/google/status?service=${encodeURIComponent(service)}&connectionId=${encodeURIComponent(connectionId)}`,
     );
   }
 
-  disconnectGoogle(service: string) {
+  disconnectGoogle(connectionId: string, service: string) {
     return this.request<{
+      connectionId: string;
+      label: string;
       service: string;
       toolkit: string;
       status: "disconnected";
       connectedAccountId?: string;
     }>(
-      `/api/managed-agents/connections/google?service=${encodeURIComponent(service)}`,
+      `/api/managed-agents/connections/google?service=${encodeURIComponent(service)}&connectionId=${encodeURIComponent(connectionId)}`,
       { method: "DELETE" },
     );
   }

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -1,0 +1,363 @@
+import type { ResolvedConfig } from "./config.js";
+
+export interface OpenComputerIdentity {
+  user_id: string | null;
+  email: string | null;
+  org_id: string;
+  org_name: string | null;
+}
+
+export interface ManagedAgentTemplate {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  integrations: string[];
+  suggestedPrompts: string[];
+}
+
+export interface ManagedAgentSummary {
+  id: string;
+  activeAlias: string;
+  deploymentCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ManagedAgentDeployment {
+  id: string;
+  agentId: string;
+  alias: string;
+  createdAt: string;
+}
+
+export interface ManagedConnection {
+  id: string;
+  kind?: "channel" | "tool";
+  provider: string;
+  label: string;
+  agentId?: string;
+  alias?: string;
+  externalAccountId?: string;
+  displayName?: string;
+  scopes?: string[];
+  status: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface ManagedSlackConnection {
+  id: string;
+  agentId: string;
+  alias: string;
+  appId?: string;
+  teamId?: string;
+  teamName?: string;
+  botUserId?: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ManagedAgentEvent {
+  id: string;
+  seq: number;
+  type: string;
+  data: Record<string, unknown>;
+}
+
+export interface ManagedSessionSnapshot {
+  id: string;
+  status: string;
+  agentId?: string;
+  deploymentId?: string;
+  microvmState?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  turns?: Array<{
+    id: string;
+    input: string;
+    status: string;
+    createdAt: string;
+    updatedAt: string;
+  }>;
+}
+
+interface CreateSessionResult {
+  session: ManagedSessionSnapshot;
+  deployment?: ManagedAgentDeployment;
+}
+
+export class APIError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+  }
+}
+
+function errorMessage(body: unknown, status: number): string {
+  if (body && typeof body === "object") {
+    const record = body as Record<string, unknown>;
+    if (typeof record.error === "string") return record.error;
+    if (record.error && typeof record.error === "object") {
+      const message = (record.error as Record<string, unknown>).message;
+      if (typeof message === "string") return message;
+    }
+    if (typeof record.message === "string") return record.message;
+  }
+  return `OpenComputer request failed (${status})`;
+}
+
+export class OpenComputerClient {
+  constructor(private readonly config: ResolvedConfig) {}
+
+  private async request<T>(
+    path: string,
+    init: RequestInit = {},
+    authenticated = true,
+  ): Promise<T> {
+    const headers = new Headers(init.headers);
+    if (init.body && !headers.has("content-type")) {
+      headers.set("content-type", "application/json");
+    }
+    if (authenticated) {
+      if (!this.config.apiKey) {
+        throw new Error(
+          "Not logged in. Run `opencomputer login` or set OPENCOMPUTER_API_KEY.",
+        );
+      }
+      headers.set("x-api-key", this.config.apiKey);
+    }
+    const response = await fetch(`${this.config.apiUrl}${path}`, {
+      ...init,
+      headers,
+      redirect: "manual",
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (response.status === 204) return undefined as T;
+    const body: unknown = await response.json().catch(() => undefined);
+    if (!response.ok) {
+      throw new APIError(errorMessage(body, response.status), response.status);
+    }
+    return body as T;
+  }
+
+  startLogin() {
+    return this.request<{
+      device_code: string;
+      user_code: string;
+      verification_uri: string;
+      verification_uri_complete: string;
+      expires_in: number;
+      interval: number;
+    }>("/auth/cli/device", { method: "POST" }, false);
+  }
+
+  exchangeLogin(deviceCode: string, credentialName: string) {
+    return this.request<{
+      status: "authorization_pending" | "authorized";
+      retry_after?: number;
+      credential?: {
+        id: string;
+        key: string;
+        key_prefix: string;
+        name: string;
+      };
+    }>(
+      "/auth/cli/device/exchange",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          device_code: deviceCode,
+          credential_name: credentialName,
+        }),
+      },
+      false,
+    );
+  }
+
+  whoami() {
+    return this.request<OpenComputerIdentity>("/api/whoami");
+  }
+
+  revokeCredential() {
+    return this.request<void>("/auth/cli/credential", { method: "DELETE" });
+  }
+
+  async templates(): Promise<ManagedAgentTemplate[]> {
+    const result = await this.request<{ templates: ManagedAgentTemplate[] }>(
+      "/api/managed-agents/templates",
+    );
+    return result.templates;
+  }
+
+  async agents(): Promise<ManagedAgentSummary[]> {
+    const result = await this.request<{ agents: ManagedAgentSummary[] }>(
+      "/api/managed-agents/agents",
+    );
+    return result.agents;
+  }
+
+  registerDeployment(input: {
+    agentId: string;
+    alias: string;
+    channels: string[];
+    connections: string[];
+    source: {
+      digest: string;
+      size: number;
+      contentType: string;
+      body: string;
+    };
+  }) {
+    return this.request<ManagedAgentDeployment>(
+      "/api/managed-agents/deployments",
+      { method: "POST", body: JSON.stringify(input) },
+    );
+  }
+
+  async connections(): Promise<ManagedConnection[]> {
+    const result = await this.request<{ connections: ManagedConnection[] }>(
+      "/api/managed-agents/connections",
+    );
+    return result.connections;
+  }
+
+  disconnectConnection(connectionId: string) {
+    return this.request<ManagedConnection>(
+      `/api/managed-agents/connections/${encodeURIComponent(connectionId)}`,
+      { method: "DELETE" },
+    );
+  }
+
+  linkGoogle(service: string) {
+    return this.request<{
+      service: string;
+      toolkit: string;
+      status: "connected" | "pending";
+      connectedAccountId?: string;
+      authorizationUrl?: string;
+      expiresAt?: string;
+    }>("/api/managed-agents/connections/google/link", {
+      method: "POST",
+      body: JSON.stringify({ service }),
+    });
+  }
+
+  googleConnection(service: string) {
+    return this.request<{
+      service: string;
+      toolkit: string;
+      status: "connected" | "pending";
+      connectedAccountId?: string;
+      authorizationUrl?: string;
+      expiresAt?: string;
+    }>(
+      `/api/managed-agents/connections/google/status?service=${encodeURIComponent(service)}`,
+    );
+  }
+
+  createSlackConnection(agentId: string) {
+    return this.request<{
+      connection: ManagedSlackConnection;
+      webhookUrl: string;
+    }>("/api/managed-agents/channels/slack/connections", {
+      method: "POST",
+      body: JSON.stringify({ agentId }),
+    });
+  }
+
+  async channelConnections(): Promise<ManagedSlackConnection[]> {
+    const result = await this.request<{
+      connections: ManagedSlackConnection[];
+    }>("/api/managed-agents/channels");
+    return result.connections;
+  }
+
+  completeSlackConnection(connectionId: string, botToken: string) {
+    return this.request<ManagedSlackConnection>(
+      `/api/managed-agents/channels/slack/connections/${encodeURIComponent(connectionId)}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ botToken }),
+      },
+    );
+  }
+
+  disconnectSlack(connectionId: string) {
+    return this.request<ManagedSlackConnection>(
+      `/api/managed-agents/channels/slack/connections/${encodeURIComponent(connectionId)}`,
+      { method: "DELETE" },
+    );
+  }
+
+  createSession(agentId: string) {
+    return this.request<CreateSessionResult>("/api/managed-agents/sessions", {
+      method: "POST",
+      body: JSON.stringify({ agentId }),
+    });
+  }
+
+  async sessions(): Promise<ManagedSessionSnapshot[]> {
+    const result = await this.request<{
+      sessions: ManagedSessionSnapshot[];
+    }>("/api/managed-agents/sessions");
+    return result.sessions;
+  }
+
+  session(sessionId: string) {
+    return this.request<ManagedSessionSnapshot>(
+      `/api/managed-agents/sessions/${encodeURIComponent(sessionId)}`,
+    );
+  }
+
+  createTurn(sessionId: string, input: string) {
+    return this.request<{ turnId: string; duplicate: boolean }>(
+      `/api/managed-agents/sessions/${encodeURIComponent(sessionId)}/turns`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          input,
+          idempotencyKey: crypto.randomUUID(),
+        }),
+      },
+    );
+  }
+
+  async events(sessionId: string, after: number) {
+    const result = await this.request<{ events: ManagedAgentEvent[] }>(
+      `/api/managed-agents/sessions/${encodeURIComponent(sessionId)}/events?after=${after}`,
+    );
+    return result.events;
+  }
+
+  suspendSession(sessionId: string) {
+    return this.request<ManagedSessionSnapshot>(
+      `/api/managed-agents/sessions/${encodeURIComponent(sessionId)}/suspend`,
+      { method: "POST" },
+    );
+  }
+
+  resumeSession(sessionId: string) {
+    return this.request<ManagedSessionSnapshot>(
+      `/api/managed-agents/sessions/${encodeURIComponent(sessionId)}/resume`,
+      { method: "POST" },
+    );
+  }
+
+  endSession(sessionId: string) {
+    return this.request<ManagedSessionSnapshot>(
+      `/api/managed-agents/sessions/${encodeURIComponent(sessionId)}/end`,
+      { method: "POST" },
+    );
+  }
+
+  terminateSession(sessionId: string) {
+    return this.request<ManagedSessionSnapshot>(
+      `/api/managed-agents/sessions/${encodeURIComponent(sessionId)}/terminate`,
+      { method: "POST" },
+    );
+  }
+}

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -18,8 +18,9 @@ export interface ManagedAgentTemplate {
 
 export interface ManagedAgentSummary {
   id: string;
-  activeAlias: string;
-  deploymentCount: number;
+  name?: string;
+  activeAlias?: string;
+  deploymentCount?: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -202,6 +203,7 @@ export class OpenComputerClient {
 
   registerDeployment(input: {
     agentId: string;
+    name: string;
     alias: string;
     channels: string[];
     connections: string[];
@@ -256,6 +258,18 @@ export class OpenComputerClient {
       expiresAt?: string;
     }>(
       `/api/managed-agents/connections/google/status?service=${encodeURIComponent(service)}`,
+    );
+  }
+
+  disconnectGoogle(service: string) {
+    return this.request<{
+      service: string;
+      toolkit: string;
+      status: "disconnected";
+      connectedAccountId?: string;
+    }>(
+      `/api/managed-agents/connections/google?service=${encodeURIComponent(service)}`,
+      { method: "DELETE" },
     );
   }
 

--- a/cli/src/auth.ts
+++ b/cli/src/auth.ts
@@ -1,0 +1,160 @@
+import { spawn } from "node:child_process";
+import { hostname, platform } from "node:os";
+import { OpenComputerClient, type OpenComputerIdentity } from "./api.js";
+import {
+  loadStoredConfig,
+  saveStoredConfig,
+  type ResolvedConfig,
+} from "./config.js";
+
+function credentialName(): string {
+  const cleanHost = hostname()
+    .replace(/[\u0000-\u001f\u007f]/g, "")
+    .trim();
+  return `opencomputer CLI${cleanHost ? ` on ${cleanHost}` : ""}`.slice(0, 100);
+}
+
+export function openBrowser(url: string): boolean {
+  const command =
+    platform() === "darwin"
+      ? ["open", url]
+      : platform() === "win32"
+        ? ["rundll32", "url.dll,FileProtocolHandler", url]
+        : ["xdg-open", url];
+  try {
+    const child = spawn(command[0]!, command.slice(1), {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.once("error", () => undefined);
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export async function login(
+  config: ResolvedConfig,
+  options: { noBrowser: boolean; force: boolean },
+): Promise<OpenComputerIdentity> {
+  if (process.env.OPENCOMPUTER_API_KEY && !options.force) {
+    throw new Error(
+      "OPENCOMPUTER_API_KEY currently controls authentication; unset it or use --force.",
+    );
+  }
+  const stored = await loadStoredConfig();
+  if (stored.apiKey && !options.force) {
+    try {
+      return await new OpenComputerClient({
+        apiUrl: stored.apiUrl ?? config.apiUrl,
+        apiKey: stored.apiKey,
+      }).whoami();
+    } catch {
+      // An expired saved login is replaced below.
+    }
+  }
+
+  const client = new OpenComputerClient({
+    apiUrl: config.apiUrl,
+  });
+  const receipt = await client.startLogin();
+  if (
+    !receipt.device_code ||
+    !receipt.user_code ||
+    !receipt.verification_uri_complete ||
+    receipt.expires_in <= 0 ||
+    receipt.interval <= 0
+  ) {
+    throw new Error("OpenComputer returned an incomplete login response.");
+  }
+  const verificationURL = new URL(receipt.verification_uri_complete);
+  if (verificationURL.protocol !== "https:") {
+    throw new Error("OpenComputer returned an unsafe login URL.");
+  }
+
+  process.stderr.write(
+    `\nConfirm this code in your browser:\n\n  ${receipt.user_code}\n\n` +
+      `  ${receipt.verification_uri_complete}\n`,
+  );
+  if (!options.noBrowser && !openBrowser(receipt.verification_uri_complete)) {
+    process.stderr.write("\nCould not open a browser automatically.\n");
+  }
+  process.stderr.write("\nWaiting for confirmation…\n");
+
+  const deadline = Date.now() + receipt.expires_in * 1_000;
+  let interval = receipt.interval;
+  let credential:
+    | {
+        id: string;
+        key: string;
+        key_prefix: string;
+        name: string;
+      }
+    | undefined;
+  while (Date.now() + interval * 1_000 < deadline) {
+    await sleep(interval * 1_000);
+    const exchange = await client.exchangeLogin(
+      receipt.device_code,
+      credentialName(),
+    );
+    if (exchange.status === "authorized") {
+      credential = exchange.credential;
+      break;
+    }
+    interval = Math.max(interval, exchange.retry_after ?? interval);
+  }
+  if (!credential?.key || !credential.id) {
+    throw new Error(
+      "Login confirmation expired. Run `opencomputer login` again.",
+    );
+  }
+
+  const authenticated = new OpenComputerClient({
+    apiUrl: config.apiUrl,
+    apiKey: credential.key,
+  });
+  const identity = await authenticated.whoami();
+  const previous =
+    options.force && stored.apiKey
+      ? { apiKey: stored.apiKey, apiUrl: stored.apiUrl ?? config.apiUrl }
+      : null;
+  await saveStoredConfig({
+    apiUrl: config.apiUrl,
+    apiKey: credential.key,
+    login: {
+      credentialId: credential.id,
+      keyPrefix: credential.key_prefix,
+      name: credential.name,
+    },
+  });
+  if (previous) {
+    await new OpenComputerClient(previous).revokeCredential().catch(() => {
+      process.stderr.write(
+        "Warning: the previous CLI credential could not be revoked. Remove it in the dashboard.\n",
+      );
+    });
+  }
+  return identity;
+}
+
+export async function logout(
+  config: ResolvedConfig,
+  localOnly: boolean,
+): Promise<void> {
+  const stored = await loadStoredConfig();
+  if (!stored.apiKey || !stored.login) {
+    throw new Error("There is no CLI-managed login to revoke.");
+  }
+  if (!localOnly) {
+    await new OpenComputerClient({
+      apiUrl: stored.apiUrl ?? config.apiUrl,
+      apiKey: stored.apiKey,
+    }).revokeCredential();
+  }
+  await saveStoredConfig({ apiUrl: stored.apiUrl ?? config.apiUrl });
+}

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -7,7 +7,7 @@ import {
 } from "./api.js";
 import { login, logout, openBrowser } from "./auth.js";
 import { resolveConfig } from "./config.js";
-import { runOpenCode } from "./local.js";
+import { runLocalAgent } from "./local.js";
 import {
   addGmailTools,
   addSlackChannel,
@@ -107,6 +107,30 @@ function printSession(session: ManagedSessionSnapshot): void {
   );
 }
 
+function printToolProgress(event: ManagedAgentEvent): void {
+  if (
+    event.type !== "tool.started" &&
+    event.type !== "tool.completed" &&
+    event.type !== "tool.failed"
+  ) {
+    return;
+  }
+
+  const tool = String(event.data.tool ?? "tool");
+  if (event.type === "tool.started") {
+    const title =
+      typeof event.data.title === "string" && event.data.title
+        ? ` (${event.data.title})`
+        : "";
+    process.stderr.write(`tool: ${tool}${title}\n`);
+    return;
+  }
+
+  process.stderr.write(
+    `tool: ${tool} ${event.type === "tool.completed" ? "completed" : "failed"}\n`,
+  );
+}
+
 function printAgentEvent(event: ManagedAgentEvent, json: boolean): void {
   if (json) {
     process.stdout.write(`${JSON.stringify(event)}\n`);
@@ -123,6 +147,8 @@ function printAgentEvent(event: ManagedAgentEvent, json: boolean): void {
     process.stderr.write(
       `turn failed: ${String(event.data.message ?? "unknown error")}\n`,
     );
+  } else {
+    printToolProgress(event);
   }
 }
 
@@ -167,6 +193,8 @@ async function sendAgentTurn(
         typeof event.data.text === "string"
       ) {
         completedText = event.data.text;
+      } else {
+        if (!json) printToolProgress(event);
       }
     },
     180_000,
@@ -286,6 +314,8 @@ async function runAgent(
         typeof event.data.text === "string"
       ) {
         completedText = event.data.text;
+      } else {
+        if (!json) printToolProgress(event);
       }
     },
     180_000,
@@ -395,8 +425,9 @@ export async function runCommand(
       const enterDirectory =
         directory === "." ? "" : `  cd ${directory}\n`;
       process.stdout.write(
-        `Created ${template.name}\n` +
+        `Created ${initialized.manifest.name} from ${template.name}\n` +
           `Directory: ${initialized.root}\n` +
+          `Name:      ${initialized.manifest.name}\n` +
           `Agent ID:  ${initialized.manifest.id}\n` +
           `Identity:  opencomputer.toml\n\n` +
           `Next:\n` +
@@ -417,8 +448,12 @@ export async function runCommand(
       );
     } else {
       for (const agent of agents) {
+        const name = agent.name?.trim() || agent.id;
+        const alias = agent.activeAlias?.trim() || "—";
+        const deploymentCount = agent.deploymentCount ?? 0;
         process.stdout.write(
-          `${agent.id.padEnd(24)} ${agent.activeAlias.padEnd(12)} ${agent.deploymentCount} deployment${agent.deploymentCount === 1 ? "" : "s"}\n`,
+          `${name.padEnd(24)} ${alias.padEnd(12)} ${deploymentCount} deployment${deploymentCount === 1 ? "" : "s"}\n` +
+            `${"".padEnd(25)}${agent.id}\n`,
         );
       }
     }
@@ -434,6 +469,7 @@ export async function runCommand(
     );
     const deployment = await client.registerDeployment({
       agentId: built.agentId,
+      name: built.name,
       alias,
       channels: built.channels,
       connections: built.connections,
@@ -469,7 +505,7 @@ export async function runCommand(
 
   if (command === "dev") {
     if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
-    await runOpenCode([], config);
+    await runLocalAgent(["dev"], config);
     return;
   }
 
@@ -496,7 +532,7 @@ export async function runCommand(
     const useRemote = remote || Boolean(agentOption) || action !== "create";
     if (!useRemote) {
       const prompt = args.join(" ").trim();
-      await runOpenCode(prompt ? ["run", prompt] : [], config);
+      await runLocalAgent(prompt ? ["run", prompt] : ["shell"], config);
       return;
     }
     if (action === "list") {
@@ -630,15 +666,23 @@ export async function runCommand(
       return;
     }
     if (action === "disconnect") {
-      const connectionId = args.shift();
-      if (!connectionId || args.length) {
+      const connectionReference = args.shift();
+      if (!connectionReference || args.length) {
         throw new Error(
-          "Usage: opencomputer connections disconnect <connection-id>",
+          "Usage: opencomputer connections disconnect gmail|<connection-id>",
         );
       }
-      const disconnected = await client.disconnectConnection(connectionId);
+      if (["gmail", "google"].includes(connectionReference.toLowerCase())) {
+        const disconnected = await client.disconnectGoogle("gmail");
+        if (globals.json) printJSON(disconnected);
+        else process.stdout.write("Disconnected Gmail.\n");
+        return;
+      }
+      const disconnected = await client.disconnectConnection(
+        connectionReference,
+      );
       if (globals.json) printJSON(disconnected);
-      else process.stdout.write(`Disconnected ${connectionId}.\n`);
+      else process.stdout.write(`Disconnected ${connectionReference}.\n`);
       return;
     }
     if (action !== "list" || args.length) {
@@ -861,7 +905,7 @@ export async function runCommand(
       return;
     }
     if (action === "start") {
-      await runOpenCode([], config);
+      await runLocalAgent(["dev"], config);
       return;
     }
     throw new Error("Unsupported Slack CLI hook.");

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -66,10 +66,13 @@ async function requireAgentRoot(): Promise<string> {
   return root;
 }
 
-async function connectGoogle(client: OpenComputerClient): Promise<void> {
-  const started = await client.linkGoogle("gmail");
+async function connectGoogle(
+  client: OpenComputerClient,
+  label = "default",
+): Promise<void> {
+  const started = await client.linkGoogle("gmail", label);
   if (started.status === "connected") {
-    process.stdout.write("Gmail is already connected.\n");
+    process.stdout.write(`Gmail connection "${label}" is already connected.\n`);
     return;
   }
   if (!started.authorizationUrl) {
@@ -82,8 +85,11 @@ async function connectGoogle(client: OpenComputerClient): Promise<void> {
     : Date.now() + 5 * 60_000;
   while (Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, 1_500));
-    if ((await client.googleConnection("gmail")).status === "connected") {
-      process.stdout.write("Gmail connected.\n");
+    if (
+      (await client.googleConnection(started.connectionId, "gmail")).status ===
+      "connected"
+    ) {
+      process.stdout.write(`Gmail connection "${label}" connected.\n`);
       return;
     }
   }
@@ -422,8 +428,7 @@ export async function runCommand(
     const initialized = await initializeAgentProject(template, directory);
     if (globals.json) printJSON(initialized);
     else {
-      const enterDirectory =
-        directory === "." ? "" : `  cd ${directory}\n`;
+      const enterDirectory = directory === "." ? "" : `  cd ${directory}\n`;
       process.stdout.write(
         `Created ${initialized.manifest.name} from ${template.name}\n` +
           `Directory: ${initialized.root}\n` +
@@ -545,8 +550,7 @@ export async function runCommand(
     }
     if (action === "create") {
       const prompt = args.join(" ").trim();
-      const agent =
-        agentOption ?? (await inferAgentReference(alias));
+      const agent = agentOption ?? (await inferAgentReference(alias));
       if (!agent) {
         throw new Error(
           "No agent repository found. Pass --agent <agent>@<alias>.",
@@ -573,9 +577,7 @@ export async function runCommand(
         90_000,
       );
       if (!keep) {
-        await client
-          .suspendSession(created.session.id)
-          .catch(() => undefined);
+        await client.suspendSession(created.session.id).catch(() => undefined);
       }
       const result = {
         sessionId: created.session.id,
@@ -651,43 +653,56 @@ export async function runCommand(
     if ((provider !== "google" && provider !== "gmail") || args.length) {
       throw new Error("Usage: opencomputer connect google");
     }
-    await connectGoogle(client);
+    await connectGoogle(client, "default");
     return;
   }
 
-  if (command === "connections") {
+  if (command === "connection" || command === "connections") {
     const action = args.shift();
-    if (action === "connect") {
+    if (action === "add" || action === "connect") {
       const provider = args.shift();
+      const alias = option(args, "--alias") ?? "default";
       if ((provider !== "google" && provider !== "gmail") || args.length) {
-        throw new Error("Usage: opencomputer connections connect gmail");
+        throw new Error(
+          "Usage: opencomputer connection add gmail [--alias <name>]",
+        );
       }
-      await connectGoogle(client);
+      await connectGoogle(client, alias);
       return;
     }
-    if (action === "disconnect") {
+    if (action === "remove" || action === "disconnect") {
       const connectionReference = args.shift();
       if (!connectionReference || args.length) {
         throw new Error(
-          "Usage: opencomputer connections disconnect gmail|<connection-id>",
+          "Usage: opencomputer connection remove <alias|connection-id>",
         );
       }
-      if (["gmail", "google"].includes(connectionReference.toLowerCase())) {
-        const disconnected = await client.disconnectGoogle("gmail");
-        if (globals.json) printJSON(disconnected);
-        else process.stdout.write("Disconnected Gmail.\n");
-        return;
-      }
-      const disconnected = await client.disconnectConnection(
-        connectionReference,
+      const connections = await client.connections();
+      const matches = connections.filter(
+        (connection) =>
+          connection.id === connectionReference ||
+          connection.label === connectionReference,
       );
+      if (!matches.length) {
+        throw new Error(`Connection "${connectionReference}" was not found.`);
+      }
+      if (matches.length > 1) {
+        throw new Error(
+          `More than one connection is named "${connectionReference}". Remove it by connection ID.`,
+        );
+      }
+      const connection = matches[0]!;
+      const disconnected =
+        connection.provider === "google"
+          ? await client.disconnectGoogle(connection.id, "gmail")
+          : await client.disconnectConnection(connection.id);
       if (globals.json) printJSON(disconnected);
-      else process.stdout.write(`Disconnected ${connectionReference}.\n`);
+      else process.stdout.write(`Removed connection "${connection.label}".\n`);
       return;
     }
     if (action !== "list" || args.length) {
       throw new Error(
-        "Use `opencomputer connections connect`, `list`, or `disconnect`.",
+        "Use `opencomputer connection add`, `list`, or `remove`.",
       );
     }
     const connections = await client.connections();
@@ -698,7 +713,8 @@ export async function runCommand(
         process.stdout.write(
           `${connection.id}  ${connection.provider.padEnd(10)} ` +
             `${connection.status.padEnd(11)} ` +
-            `${connection.displayName ?? connection.label}\n`,
+            `${connection.label.padEnd(16)} ` +
+            `${connection.displayName ?? ""}\n`,
         );
       }
     }
@@ -767,9 +783,7 @@ export async function runCommand(
       const agentOption = option(args, "--agent");
       const alias = option(args, "--alias") ?? "production";
       if (local === remote) {
-        throw new Error(
-          "Choose exactly one of --local or --remote for Slack.",
-        );
+        throw new Error("Choose exactly one of --local or --remote for Slack.");
       }
       if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
       const root = await requireSlackAgentRoot();
@@ -786,8 +800,7 @@ export async function runCommand(
         );
         return;
       }
-      const agent =
-        agentOption ?? (await inferAgentReference(alias));
+      const agent = agentOption ?? (await inferAgentReference(alias));
       if (!agent) {
         throw new Error(
           "No agent repository found. Pass --agent <agent>@<alias>.",
@@ -844,7 +857,11 @@ export async function runCommand(
       if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
       const root = await requireSlackAgentRoot();
       if (local) {
-        await runSlackCli(root, ["app", "uninstall", "--app", "local"], "local");
+        await runSlackCli(
+          root,
+          ["app", "uninstall", "--app", "local"],
+          "local",
+        );
         await clearSlackState(root, "local");
         process.stdout.write("Disconnected the local Slack app.\n");
         return;

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -60,7 +60,7 @@ async function requireAgentRoot(): Promise<string> {
   const root = await findAgentRoot();
   if (!root) {
     throw new Error(
-      "No OpenComputer project found. Run `opencomputer init <template>` first.",
+      "No OpenComputer agent repository found. Run `opencomputer init <template>` first.",
     );
   }
   return root;
@@ -211,7 +211,7 @@ async function sendAgentTurn(
   if (!json && (streamedText || completedText)) process.stdout.write("\n");
   if (completed.event.type === "turn.failed") {
     throw new Error(
-      String(completed.event.data.message ?? "Project turn failed"),
+      String(completed.event.data.message ?? "Agent turn failed"),
     );
   }
   if (!keep) {
@@ -273,14 +273,14 @@ async function waitForEvent(
         throw new Error(
           typeof event.data.reason === "string"
             ? event.data.reason
-            : "The project runtime disconnected.",
+            : "The agent runtime disconnected.",
         );
       }
       if (terminal(event)) return { event, cursor };
     }
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
-  throw new Error("Timed out waiting for the project.");
+  throw new Error("Timed out waiting for the agent.");
 }
 
 async function runAgent(
@@ -332,7 +332,7 @@ async function runAgent(
   }
   if (completed.event.type === "turn.failed") {
     throw new Error(
-      String(completed.event.data.message ?? "Project turn failed"),
+      String(completed.event.data.message ?? "Agent turn failed"),
     );
   }
   if (!keep) {
@@ -424,7 +424,7 @@ export async function runCommand(
     const template = (await client.templates()).find(
       (candidate) => candidate.id === templateId,
     );
-    if (!template) throw new Error(`Unknown project template: ${templateId}`);
+    if (!template) throw new Error(`Unknown agent template: ${templateId}`);
     const initialized = await initializeAgentProject(template, directory);
     if (globals.json) printJSON(initialized);
     else {
@@ -433,7 +433,7 @@ export async function runCommand(
         `Created ${initialized.manifest.name} from ${template.name}\n` +
           `Directory: ${initialized.root}\n` +
           `Name:      ${initialized.manifest.name}\n` +
-          `Project ID: ${initialized.manifest.id}\n` +
+          `Agent ID:  ${initialized.manifest.id}\n` +
           `Identity:  opencomputer.toml\n\n` +
           `Next:\n` +
           enterDirectory +
@@ -444,12 +444,12 @@ export async function runCommand(
     return;
   }
 
-  if (command === "projects") {
+  if (command === "agents") {
     const agents = await client.agents();
     if (globals.json) printJSON(agents);
     else if (!agents.length) {
       process.stdout.write(
-        "No projects deployed. Run `opencomputer templates` to get started.\n",
+        "No agents deployed. Run `opencomputer templates` to get started.\n",
       );
     } else {
       for (const agent of agents) {
@@ -501,7 +501,7 @@ export async function runCommand(
     const agent = args.shift();
     const prompt = args.join(" ").trim();
     if (!agent || !prompt) {
-      throw new Error("Usage: opencomputer run <project> <prompt>");
+      throw new Error("Usage: opencomputer run <agent> <prompt>");
     }
     const result = await runAgent(client, agent, prompt, keep, globals.json);
     if (globals.json) printJSON(result);
@@ -518,10 +518,10 @@ export async function runCommand(
     const local = flag(args, "--local");
     const remote = flag(args, "--remote");
     const keep = flag(args, "--keep");
-    const agentOption = option(args, "--project");
+    const agentOption = option(args, "--agent");
     const alias = option(args, "--alias") ?? "production";
     if (local && (remote || agentOption)) {
-      throw new Error("--local cannot be combined with --remote or --project.");
+      throw new Error("--local cannot be combined with --remote or --agent.");
     }
     const knownActions = new Set([
       "create",
@@ -553,7 +553,7 @@ export async function runCommand(
       const agent = agentOption ?? (await inferAgentReference(alias));
       if (!agent) {
         throw new Error(
-          "No project found. Pass --project <project>@<alias>.",
+          "No agent repository found. Pass --agent <agent>@<alias>.",
         );
       }
       if (prompt) {
@@ -590,7 +590,7 @@ export async function runCommand(
       else {
         process.stdout.write(
           `Session:    ${result.sessionId}\n` +
-            `Project:    ${result.agentId}\n` +
+            `Agent:      ${result.agentId}\n` +
             `Deployment: ${result.deploymentId ?? "—"}\n` +
             `Runtime:    ${result.status}\n`,
         );
@@ -780,7 +780,7 @@ export async function runCommand(
     if (action === "connect") {
       const local = flag(args, "--local");
       const remote = flag(args, "--remote");
-      const agentOption = option(args, "--project");
+      const agentOption = option(args, "--agent");
       const alias = option(args, "--alias") ?? "production";
       if (local === remote) {
         throw new Error("Choose exactly one of --local or --remote for Slack.");
@@ -803,7 +803,7 @@ export async function runCommand(
       const agent = agentOption ?? (await inferAgentReference(alias));
       if (!agent) {
         throw new Error(
-          "No project found. Pass --project <project>@<alias>.",
+          "No agent repository found. Pass --agent <agent>@<alias>.",
         );
       }
       const previous = await readRemoteSlackState(root);
@@ -870,7 +870,7 @@ export async function runCommand(
       const id = connectionId ?? stored?.connectionId;
       if (!id) {
         throw new Error(
-          "Pass a connection ID or connect Slack from this project first.",
+          "Pass a connection ID or connect Slack from this agent first.",
         );
       }
       const disconnected = await client.disconnectSlack(id);

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -60,7 +60,7 @@ async function requireAgentRoot(): Promise<string> {
   const root = await findAgentRoot();
   if (!root) {
     throw new Error(
-      "No OpenComputer agent repository found. Run `opencomputer init <template>` first.",
+      "No OpenComputer project found. Run `opencomputer init <template>` first.",
     );
   }
   return root;
@@ -211,7 +211,7 @@ async function sendAgentTurn(
   if (!json && (streamedText || completedText)) process.stdout.write("\n");
   if (completed.event.type === "turn.failed") {
     throw new Error(
-      String(completed.event.data.message ?? "Agent turn failed"),
+      String(completed.event.data.message ?? "Project turn failed"),
     );
   }
   if (!keep) {
@@ -273,14 +273,14 @@ async function waitForEvent(
         throw new Error(
           typeof event.data.reason === "string"
             ? event.data.reason
-            : "The agent runtime disconnected.",
+            : "The project runtime disconnected.",
         );
       }
       if (terminal(event)) return { event, cursor };
     }
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
-  throw new Error("Timed out waiting for the agent.");
+  throw new Error("Timed out waiting for the project.");
 }
 
 async function runAgent(
@@ -332,7 +332,7 @@ async function runAgent(
   }
   if (completed.event.type === "turn.failed") {
     throw new Error(
-      String(completed.event.data.message ?? "Agent turn failed"),
+      String(completed.event.data.message ?? "Project turn failed"),
     );
   }
   if (!keep) {
@@ -424,7 +424,7 @@ export async function runCommand(
     const template = (await client.templates()).find(
       (candidate) => candidate.id === templateId,
     );
-    if (!template) throw new Error(`Unknown agent template: ${templateId}`);
+    if (!template) throw new Error(`Unknown project template: ${templateId}`);
     const initialized = await initializeAgentProject(template, directory);
     if (globals.json) printJSON(initialized);
     else {
@@ -433,7 +433,7 @@ export async function runCommand(
         `Created ${initialized.manifest.name} from ${template.name}\n` +
           `Directory: ${initialized.root}\n` +
           `Name:      ${initialized.manifest.name}\n` +
-          `Agent ID:  ${initialized.manifest.id}\n` +
+          `Project ID: ${initialized.manifest.id}\n` +
           `Identity:  opencomputer.toml\n\n` +
           `Next:\n` +
           enterDirectory +
@@ -444,12 +444,12 @@ export async function runCommand(
     return;
   }
 
-  if (command === "agents") {
+  if (command === "projects") {
     const agents = await client.agents();
     if (globals.json) printJSON(agents);
     else if (!agents.length) {
       process.stdout.write(
-        "No agents deployed. Run `opencomputer templates` to get started.\n",
+        "No projects deployed. Run `opencomputer templates` to get started.\n",
       );
     } else {
       for (const agent of agents) {
@@ -501,7 +501,7 @@ export async function runCommand(
     const agent = args.shift();
     const prompt = args.join(" ").trim();
     if (!agent || !prompt) {
-      throw new Error("Usage: opencomputer run <agent> <prompt>");
+      throw new Error("Usage: opencomputer run <project> <prompt>");
     }
     const result = await runAgent(client, agent, prompt, keep, globals.json);
     if (globals.json) printJSON(result);
@@ -518,10 +518,10 @@ export async function runCommand(
     const local = flag(args, "--local");
     const remote = flag(args, "--remote");
     const keep = flag(args, "--keep");
-    const agentOption = option(args, "--agent");
+    const agentOption = option(args, "--project");
     const alias = option(args, "--alias") ?? "production";
     if (local && (remote || agentOption)) {
-      throw new Error("--local cannot be combined with --remote or --agent.");
+      throw new Error("--local cannot be combined with --remote or --project.");
     }
     const knownActions = new Set([
       "create",
@@ -553,7 +553,7 @@ export async function runCommand(
       const agent = agentOption ?? (await inferAgentReference(alias));
       if (!agent) {
         throw new Error(
-          "No agent repository found. Pass --agent <agent>@<alias>.",
+          "No project found. Pass --project <project>@<alias>.",
         );
       }
       if (prompt) {
@@ -590,7 +590,7 @@ export async function runCommand(
       else {
         process.stdout.write(
           `Session:    ${result.sessionId}\n` +
-            `Agent:      ${result.agentId}\n` +
+            `Project:    ${result.agentId}\n` +
             `Deployment: ${result.deploymentId ?? "—"}\n` +
             `Runtime:    ${result.status}\n`,
         );
@@ -780,7 +780,7 @@ export async function runCommand(
     if (action === "connect") {
       const local = flag(args, "--local");
       const remote = flag(args, "--remote");
-      const agentOption = option(args, "--agent");
+      const agentOption = option(args, "--project");
       const alias = option(args, "--alias") ?? "production";
       if (local === remote) {
         throw new Error("Choose exactly one of --local or --remote for Slack.");
@@ -803,7 +803,7 @@ export async function runCommand(
       const agent = agentOption ?? (await inferAgentReference(alias));
       if (!agent) {
         throw new Error(
-          "No agent repository found. Pass --agent <agent>@<alias>.",
+          "No project found. Pass --project <project>@<alias>.",
         );
       }
       const previous = await readRemoteSlackState(root);
@@ -870,7 +870,7 @@ export async function runCommand(
       const id = connectionId ?? stored?.connectionId;
       if (!id) {
         throw new Error(
-          "Pass a connection ID or connect Slack from this agent first.",
+          "Pass a connection ID or connect Slack from this project first.",
         );
       }
       const disconnected = await client.disconnectSlack(id);

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1,0 +1,871 @@
+import { rm } from "node:fs/promises";
+
+import {
+  OpenComputerClient,
+  type ManagedAgentEvent,
+  type ManagedSessionSnapshot,
+} from "./api.js";
+import { login, logout, openBrowser } from "./auth.js";
+import { resolveConfig } from "./config.js";
+import { runOpenCode } from "./local.js";
+import {
+  addGmailTools,
+  addSlackChannel,
+  buildAgentArtifact,
+  findAgentRoot,
+  initializeAgentProject,
+  readManifest,
+} from "./project.js";
+import {
+  captureLocalSlackState,
+  clearSlackState,
+  readLocalSlackState,
+  readRemoteSlackState,
+  remoteSlackStatePath,
+  requireSlackAgentRoot,
+  runSlackCli,
+  slackManifest,
+  writeRemoteSlackState,
+} from "./slack.js";
+
+export interface GlobalOptions {
+  apiUrl?: string;
+  apiKey?: string;
+  json: boolean;
+}
+
+function printJSON(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function flag(args: string[], name: string): boolean {
+  const index = args.indexOf(name);
+  if (index < 0) return false;
+  args.splice(index, 1);
+  return true;
+}
+
+function option(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  if (index < 0) return undefined;
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  args.splice(index, 2);
+  return value;
+}
+
+async function requireAgentRoot(): Promise<string> {
+  const root = await findAgentRoot();
+  if (!root) {
+    throw new Error(
+      "No OpenComputer agent repository found. Run `opencomputer init <template>` first.",
+    );
+  }
+  return root;
+}
+
+async function connectGoogle(client: OpenComputerClient): Promise<void> {
+  const started = await client.linkGoogle("gmail");
+  if (started.status === "connected") {
+    process.stdout.write("Gmail is already connected.\n");
+    return;
+  }
+  if (!started.authorizationUrl) {
+    throw new Error("Gmail did not return an authorization link.");
+  }
+  process.stdout.write(`Authorize Gmail:\n${started.authorizationUrl}\n`);
+  openBrowser(started.authorizationUrl);
+  const deadline = started.expiresAt
+    ? Date.parse(started.expiresAt)
+    : Date.now() + 5 * 60_000;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+    if ((await client.googleConnection("gmail")).status === "connected") {
+      process.stdout.write("Gmail connected.\n");
+      return;
+    }
+  }
+  throw new Error("Gmail authorization timed out.");
+}
+
+async function inferAgentReference(alias: string): Promise<string | undefined> {
+  const root = await findAgentRoot();
+  if (!root) return undefined;
+  const manifest = await readManifest(root);
+  return `${manifest.id}@${alias}`;
+}
+
+function printSession(session: ManagedSessionSnapshot): void {
+  const deployment = session.deploymentId
+    ? session.deploymentId.slice(session.deploymentId.lastIndexOf(":") + 1)
+    : "—";
+  process.stdout.write(
+    `${session.id}  ${session.status.padEnd(15)}  ` +
+      `${session.agentId ?? "—"}  ${deployment.slice(0, 12)}\n`,
+  );
+}
+
+function printAgentEvent(event: ManagedAgentEvent, json: boolean): void {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(event)}\n`);
+    return;
+  }
+  if (event.type === "message.delta") {
+    process.stdout.write(String(event.data.text ?? ""));
+  } else if (
+    event.type === "message.completed" &&
+    typeof event.data.text === "string"
+  ) {
+    process.stdout.write(`${event.data.text}\n`);
+  } else if (event.type === "turn.failed") {
+    process.stderr.write(
+      `turn failed: ${String(event.data.message ?? "unknown error")}\n`,
+    );
+  }
+}
+
+async function sendAgentTurn(
+  client: OpenComputerClient,
+  sessionId: string,
+  prompt: string,
+  keep: boolean,
+  json: boolean,
+): Promise<{ turnId: string; output?: string }> {
+  const existing = await client.events(sessionId, 0);
+  let cursor = existing.at(-1)?.seq ?? 0;
+  const session = await client.session(sessionId);
+  if (session.microvmState === "suspended") {
+    process.stderr.write(`Resuming ${sessionId}…\n`);
+    await client.resumeSession(sessionId);
+    const connected = await waitForEvent(
+      client,
+      sessionId,
+      cursor,
+      (event) => event.type === "runtime.connected",
+      () => undefined,
+      90_000,
+    );
+    cursor = connected.cursor;
+  }
+  const turn = await client.createTurn(sessionId, prompt);
+  let streamedText = "";
+  let completedText = "";
+  const completed = await waitForEvent(
+    client,
+    sessionId,
+    cursor,
+    (event) => event.type === "turn.completed" || event.type === "turn.failed",
+    (event) => {
+      if (event.type === "message.delta") {
+        const text = String(event.data.text ?? "");
+        streamedText += text;
+        if (!json) process.stdout.write(text);
+      } else if (
+        event.type === "message.completed" &&
+        typeof event.data.text === "string"
+      ) {
+        completedText = event.data.text;
+      }
+    },
+    180_000,
+  );
+  if (!json && !streamedText && completedText) {
+    process.stdout.write(completedText);
+  }
+  if (!json && (streamedText || completedText)) process.stdout.write("\n");
+  if (completed.event.type === "turn.failed") {
+    throw new Error(
+      String(completed.event.data.message ?? "Agent turn failed"),
+    );
+  }
+  if (!keep) {
+    await client.suspendSession(sessionId).catch(() => undefined);
+  }
+  return {
+    turnId: turn.turnId,
+    output: streamedText || completedText || undefined,
+  };
+}
+
+async function attachSession(
+  client: OpenComputerClient,
+  sessionId: string,
+  json: boolean,
+): Promise<void> {
+  let cursor = 0;
+  for (const event of await client.events(sessionId, cursor)) {
+    cursor = Math.max(cursor, event.seq);
+    printAgentEvent(event, json);
+  }
+  process.stderr.write("Attached; press Ctrl-C to detach.\n");
+  let stopped = false;
+  const stop = (): void => {
+    stopped = true;
+  };
+  process.once("SIGINT", stop);
+  try {
+    while (!stopped) {
+      for (const event of await client.events(sessionId, cursor)) {
+        cursor = Math.max(cursor, event.seq);
+        printAgentEvent(event, json);
+        if (event.type === "session.ended") stopped = true;
+      }
+      if (!stopped) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    }
+  } finally {
+    process.off("SIGINT", stop);
+  }
+}
+
+async function waitForEvent(
+  client: OpenComputerClient,
+  sessionId: string,
+  after: number,
+  terminal: (event: ManagedAgentEvent) => boolean,
+  onEvent: (event: ManagedAgentEvent) => void,
+  timeoutMs: number,
+): Promise<{ event: ManagedAgentEvent; cursor: number }> {
+  const deadline = Date.now() + timeoutMs;
+  let cursor = after;
+  while (Date.now() < deadline) {
+    for (const event of await client.events(sessionId, cursor)) {
+      cursor = Math.max(cursor, event.seq);
+      onEvent(event);
+      if (event.type === "runtime.disconnected") {
+        throw new Error(
+          typeof event.data.reason === "string"
+            ? event.data.reason
+            : "The agent runtime disconnected.",
+        );
+      }
+      if (terminal(event)) return { event, cursor };
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error("Timed out waiting for the agent.");
+}
+
+async function runAgent(
+  client: OpenComputerClient,
+  agent: string,
+  prompt: string,
+  keep: boolean,
+  json: boolean,
+): Promise<unknown> {
+  const created = await client.createSession(agent);
+  process.stderr.write(`Starting ${agent}…\n`);
+  const connected = await waitForEvent(
+    client,
+    created.session.id,
+    0,
+    (event) => event.type === "runtime.connected",
+    () => undefined,
+    90_000,
+  );
+  const turn = await client.createTurn(created.session.id, prompt);
+  let streamed = false;
+  let streamedText = "";
+  let completedText = "";
+  const completed = await waitForEvent(
+    client,
+    created.session.id,
+    connected.cursor,
+    (event) => event.type === "turn.completed" || event.type === "turn.failed",
+    (event) => {
+      if (event.type === "message.delta") {
+        streamed = true;
+        const text = String(event.data.text ?? "");
+        streamedText += text;
+        if (!json) process.stdout.write(text);
+      } else if (
+        event.type === "message.completed" &&
+        typeof event.data.text === "string"
+      ) {
+        completedText = event.data.text;
+      }
+    },
+    180_000,
+  );
+  if (!json && !streamed && completedText) process.stdout.write(completedText);
+  if (!json && (!process.stdout.isTTY || streamed || completedText)) {
+    process.stdout.write("\n");
+  }
+  if (completed.event.type === "turn.failed") {
+    throw new Error(
+      String(completed.event.data.message ?? "Agent turn failed"),
+    );
+  }
+  if (!keep) {
+    await client.suspendSession(created.session.id).catch(() => undefined);
+  }
+  return {
+    sessionId: created.session.id,
+    turnId: turn.turnId,
+    agentId: created.deployment?.agentId ?? agent,
+    deploymentId: created.deployment?.id,
+    status: "completed",
+    output: streamedText || completedText || undefined,
+  };
+}
+
+export async function runCommand(
+  command: string,
+  rawArgs: string[],
+  globals: GlobalOptions,
+): Promise<void> {
+  const args = [...rawArgs];
+  const config = await resolveConfig(globals);
+  const client = new OpenComputerClient(config);
+
+  if (command === "login") {
+    const identity = await login(config, {
+      noBrowser: flag(args, "--no-browser"),
+      force: flag(args, "--force"),
+    });
+    if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+    if (globals.json) printJSON(identity);
+    else {
+      process.stdout.write(
+        `Logged in as ${identity.email ?? identity.user_id ?? "user"}\n` +
+          `Organization: ${identity.org_name ?? identity.org_id}\n`,
+      );
+    }
+    return;
+  }
+
+  if (command === "logout") {
+    const localOnly = flag(args, "--local");
+    if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+    await logout(config, localOnly);
+    if (globals.json) printJSON({ status: "logged_out", localOnly });
+    else
+      process.stdout.write(
+        localOnly ? "Local login cleared.\n" : "Logged out.\n",
+      );
+    return;
+  }
+
+  if (command === "whoami") {
+    const identity = await client.whoami();
+    if (globals.json) printJSON(identity);
+    else {
+      process.stdout.write(
+        `User          ${identity.email ?? identity.user_id ?? "—"}\n` +
+          `Organization  ${identity.org_name ?? "—"}\n` +
+          `Org ID        ${identity.org_id}\n` +
+          `API           ${config.apiUrl}\n`,
+      );
+    }
+    return;
+  }
+
+  if (command === "templates") {
+    const templates = await client.templates();
+    if (globals.json) printJSON(templates);
+    else {
+      for (const template of templates) {
+        process.stdout.write(
+          `${template.id.padEnd(22)} ${template.name}\n` +
+            `${"".padEnd(23)}${template.description}\n` +
+            `${"".padEnd(23)}${template.integrations.join(", ")}\n`,
+        );
+      }
+    }
+    return;
+  }
+
+  if (command === "init") {
+    const templateId = args.shift();
+    if (!templateId) {
+      throw new Error("Usage: opencomputer init <template> [directory]");
+    }
+    const directory = args.shift() ?? templateId;
+    if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+    const template = (await client.templates()).find(
+      (candidate) => candidate.id === templateId,
+    );
+    if (!template) throw new Error(`Unknown agent template: ${templateId}`);
+    const initialized = await initializeAgentProject(template, directory);
+    if (globals.json) printJSON(initialized);
+    else {
+      const enterDirectory =
+        directory === "." ? "" : `  cd ${directory}\n`;
+      process.stdout.write(
+        `Created ${template.name}\n` +
+          `Directory: ${initialized.root}\n` +
+          `Agent ID:  ${initialized.manifest.id}\n` +
+          `Identity:  opencomputer.toml\n\n` +
+          `Next:\n` +
+          enterDirectory +
+          `  npm install\n` +
+          `  opencomputer dev\n`,
+      );
+    }
+    return;
+  }
+
+  if (command === "agents") {
+    const agents = await client.agents();
+    if (globals.json) printJSON(agents);
+    else if (!agents.length) {
+      process.stdout.write(
+        "No agents deployed. Run `opencomputer templates` to get started.\n",
+      );
+    } else {
+      for (const agent of agents) {
+        process.stdout.write(
+          `${agent.id.padEnd(24)} ${agent.activeAlias.padEnd(12)} ${agent.deploymentCount} deployment${agent.deploymentCount === 1 ? "" : "s"}\n`,
+        );
+      }
+    }
+    return;
+  }
+
+  if (command === "deploy") {
+    const alias = option(args, "--alias") ?? "production";
+    if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+    const built = await buildAgentArtifact(await requireAgentRoot());
+    process.stderr.write(
+      `Built ${built.agentId} in ${String(built.elapsedMs)}ms\n`,
+    );
+    const deployment = await client.registerDeployment({
+      agentId: built.agentId,
+      alias,
+      channels: built.channels,
+      connections: built.connections,
+      source: {
+        digest: built.digest,
+        size: built.body.byteLength,
+        contentType: "application/vnd.opencomputer.agent+json",
+        body: built.body.toString("utf8"),
+      },
+    });
+    if (globals.json) printJSON(deployment);
+    else {
+      process.stdout.write(
+        `Deployed ${deployment.agentId}@${deployment.alias}\n` +
+          `Deployment: ${deployment.id}\n` +
+          `Source ID:  opencomputer.toml\n`,
+      );
+    }
+    return;
+  }
+
+  if (command === "run") {
+    const keep = flag(args, "--keep");
+    const agent = args.shift();
+    const prompt = args.join(" ").trim();
+    if (!agent || !prompt) {
+      throw new Error("Usage: opencomputer run <agent> <prompt>");
+    }
+    const result = await runAgent(client, agent, prompt, keep, globals.json);
+    if (globals.json) printJSON(result);
+    return;
+  }
+
+  if (command === "dev") {
+    if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+    await runOpenCode([], config);
+    return;
+  }
+
+  if (command === "session") {
+    const local = flag(args, "--local");
+    const remote = flag(args, "--remote");
+    const keep = flag(args, "--keep");
+    const agentOption = option(args, "--agent");
+    const alias = option(args, "--alias") ?? "production";
+    if (local && (remote || agentOption)) {
+      throw new Error("--local cannot be combined with --remote or --agent.");
+    }
+    const knownActions = new Set([
+      "create",
+      "list",
+      "inspect",
+      "attach",
+      "send",
+      "end",
+    ]);
+    const shorthand = args[0];
+    const action =
+      shorthand && knownActions.has(shorthand) ? args.shift()! : "create";
+    const useRemote = remote || Boolean(agentOption) || action !== "create";
+    if (!useRemote) {
+      const prompt = args.join(" ").trim();
+      await runOpenCode(prompt ? ["run", prompt] : [], config);
+      return;
+    }
+    if (action === "list") {
+      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+      const sessions = await client.sessions();
+      if (globals.json) printJSON(sessions);
+      else if (!sessions.length) process.stdout.write("No sessions.\n");
+      else sessions.forEach(printSession);
+      return;
+    }
+    if (action === "create") {
+      const prompt = args.join(" ").trim();
+      const agent =
+        agentOption ?? (await inferAgentReference(alias));
+      if (!agent) {
+        throw new Error(
+          "No agent repository found. Pass --agent <agent>@<alias>.",
+        );
+      }
+      if (prompt) {
+        const result = await runAgent(
+          client,
+          agent,
+          prompt,
+          keep,
+          globals.json,
+        );
+        if (globals.json) printJSON(result);
+        return;
+      }
+      const created = await client.createSession(agent);
+      const connected = await waitForEvent(
+        client,
+        created.session.id,
+        0,
+        (event) => event.type === "runtime.connected",
+        () => undefined,
+        90_000,
+      );
+      if (!keep) {
+        await client
+          .suspendSession(created.session.id)
+          .catch(() => undefined);
+      }
+      const result = {
+        sessionId: created.session.id,
+        agentId: created.deployment?.agentId ?? agent,
+        deploymentId: created.deployment?.id,
+        status: keep ? "running" : "suspended",
+        cursor: connected.cursor,
+      };
+      if (globals.json) printJSON(result);
+      else {
+        process.stdout.write(
+          `Session:    ${result.sessionId}\n` +
+            `Agent:      ${result.agentId}\n` +
+            `Deployment: ${result.deploymentId ?? "—"}\n` +
+            `Runtime:    ${result.status}\n`,
+        );
+      }
+      return;
+    }
+    const sessionId = args.shift();
+    if (!sessionId) throw new Error("A session ID is required.");
+    if (action === "inspect") {
+      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+      printJSON(await client.session(sessionId));
+      return;
+    }
+    if (action === "attach") {
+      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+      await attachSession(client, sessionId, globals.json);
+      return;
+    }
+    if (action === "send") {
+      const prompt = args.join(" ").trim();
+      if (!prompt) throw new Error("A prompt is required.");
+      const result = await sendAgentTurn(
+        client,
+        sessionId,
+        prompt,
+        keep,
+        globals.json,
+      );
+      if (globals.json) {
+        printJSON({ sessionId, ...result, status: "completed" });
+      }
+      return;
+    }
+    if (action === "end") {
+      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+      await client.terminateSession(sessionId).catch(() => undefined);
+      const ended = await client.endSession(sessionId);
+      if (globals.json) printJSON(ended);
+      else process.stdout.write(`Session ${sessionId} ended.\n`);
+      return;
+    }
+    return;
+  }
+
+  if (command === "tools") {
+    const action = args.shift();
+    const tool = args.shift();
+    if (action !== "add" || tool !== "gmail" || args.length) {
+      throw new Error("Usage: opencomputer tools add gmail");
+    }
+    const files = await addGmailTools(await requireAgentRoot());
+    process.stdout.write(
+      `${files.map((file) => `Created ${file}`).join("\n")}\n`,
+    );
+    return;
+  }
+
+  if (command === "connect") {
+    const provider = args.shift();
+    if ((provider !== "google" && provider !== "gmail") || args.length) {
+      throw new Error("Usage: opencomputer connect google");
+    }
+    await connectGoogle(client);
+    return;
+  }
+
+  if (command === "connections") {
+    const action = args.shift();
+    if (action === "connect") {
+      const provider = args.shift();
+      if ((provider !== "google" && provider !== "gmail") || args.length) {
+        throw new Error("Usage: opencomputer connections connect gmail");
+      }
+      await connectGoogle(client);
+      return;
+    }
+    if (action === "disconnect") {
+      const connectionId = args.shift();
+      if (!connectionId || args.length) {
+        throw new Error(
+          "Usage: opencomputer connections disconnect <connection-id>",
+        );
+      }
+      const disconnected = await client.disconnectConnection(connectionId);
+      if (globals.json) printJSON(disconnected);
+      else process.stdout.write(`Disconnected ${connectionId}.\n`);
+      return;
+    }
+    if (action !== "list" || args.length) {
+      throw new Error(
+        "Use `opencomputer connections connect`, `list`, or `disconnect`.",
+      );
+    }
+    const connections = await client.connections();
+    if (globals.json) printJSON(connections);
+    else if (!connections.length) process.stdout.write("No connections.\n");
+    else {
+      for (const connection of connections) {
+        process.stdout.write(
+          `${connection.id}  ${connection.provider.padEnd(10)} ` +
+            `${connection.status.padEnd(11)} ` +
+            `${connection.displayName ?? connection.label}\n`,
+        );
+      }
+    }
+    return;
+  }
+
+  if (command === "channels") {
+    const action = args.shift();
+    if (action === "list") {
+      const localOnly = flag(args, "--local");
+      const remoteOnly = flag(args, "--remote");
+      if (localOnly && remoteOnly) {
+        throw new Error("Choose either --local or --remote.");
+      }
+      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+      const root = await findAgentRoot();
+      const localState =
+        !remoteOnly && root ? await readLocalSlackState(root) : undefined;
+      const remoteConnections = localOnly
+        ? []
+        : await client.channelConnections();
+      if (globals.json) {
+        printJSON({
+          local: localState,
+          remote: remoteConnections,
+        });
+      } else if (!localState && !remoteConnections.length) {
+        process.stdout.write("No channel connections.\n");
+      } else {
+        if (localState) {
+          process.stdout.write(
+            `local  slack  connected  ${localState.teamName ?? localState.teamId}\n`,
+          );
+        }
+        for (const connection of remoteConnections) {
+          process.stdout.write(
+            `${connection.id}  slack  ${connection.status.padEnd(12)} ` +
+              `${connection.agentId}@${connection.alias}  ` +
+              `${connection.teamName ?? connection.teamId ?? "pending"}\n`,
+          );
+        }
+      }
+      return;
+    }
+    const channel = args.shift();
+    if (channel !== "slack") {
+      throw new Error(
+        "Use `opencomputer channels add|connect|list|disconnect slack`.",
+      );
+    }
+    if (action === "add") {
+      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+      const root = await requireAgentRoot();
+      const files = await addSlackChannel(root);
+      await import("./slack.js").then(({ ensureSlackHooks }) =>
+        ensureSlackHooks(root),
+      );
+      process.stdout.write(
+        `${files.map((file) => `Created ${file}`).join("\n")}\n`,
+      );
+      return;
+    }
+    if (action === "connect") {
+      const local = flag(args, "--local");
+      const remote = flag(args, "--remote");
+      const agentOption = option(args, "--agent");
+      const alias = option(args, "--alias") ?? "production";
+      if (local === remote) {
+        throw new Error(
+          "Choose exactly one of --local or --remote for Slack.",
+        );
+      }
+      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+      const root = await requireSlackAgentRoot();
+      if (local) {
+        await runSlackCli(
+          root,
+          ["app", "install", "--environment", "local"],
+          "local",
+        );
+        const state = await captureLocalSlackState(root);
+        process.stdout.write(
+          `Connected local Slack app ${state.appId} to ` +
+            `${state.teamName ?? state.teamId}.\n`,
+        );
+        return;
+      }
+      const agent =
+        agentOption ?? (await inferAgentReference(alias));
+      if (!agent) {
+        throw new Error(
+          "No agent repository found. Pass --agent <agent>@<alias>.",
+        );
+      }
+      const previous = await readRemoteSlackState(root);
+      const started = await client.createSlackConnection(agent);
+      await writeRemoteSlackState(root, {
+        version: 1,
+        connectionId: started.connection.id,
+        agentId: `${started.connection.agentId}@${started.connection.alias}`,
+        webhookUrl: started.webhookUrl,
+        apiUrl: config.apiUrl,
+      });
+      try {
+        await runSlackCli(root, ["deploy", "--app", "deployed"], "remote");
+        const connected = (await client.channelConnections()).find(
+          (connection) => connection.id === started.connection.id,
+        );
+        if (!connected || connected.status !== "connected") {
+          throw new Error(
+            "Slack CLI finished without completing the connection.",
+          );
+        }
+        if (previous && previous.connectionId !== connected.id) {
+          await client
+            .disconnectSlack(previous.connectionId)
+            .catch(() => undefined);
+        }
+        if (globals.json) printJSON(connected);
+        else {
+          process.stdout.write(
+            `Connected ${connected.agentId}@${connected.alias} to ` +
+              `${connected.teamName ?? connected.teamId ?? "Slack"}.\n`,
+          );
+        }
+      } catch (error) {
+        await client
+          .disconnectSlack(started.connection.id)
+          .catch(() => undefined);
+        if (previous) await writeRemoteSlackState(root, previous);
+        else await rm(remoteSlackStatePath(root), { force: true });
+        throw error;
+      }
+      return;
+    }
+    if (action === "disconnect") {
+      const local = flag(args, "--local");
+      const remote = flag(args, "--remote");
+      const connectionId = args.shift();
+      if (local && remote) {
+        throw new Error("Choose either --local or --remote.");
+      }
+      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+      const root = await requireSlackAgentRoot();
+      if (local) {
+        await runSlackCli(root, ["app", "uninstall", "--app", "local"], "local");
+        await clearSlackState(root, "local");
+        process.stdout.write("Disconnected the local Slack app.\n");
+        return;
+      }
+      const stored = await readRemoteSlackState(root);
+      const id = connectionId ?? stored?.connectionId;
+      if (!id) {
+        throw new Error(
+          "Pass a connection ID or connect Slack from this agent first.",
+        );
+      }
+      const disconnected = await client.disconnectSlack(id);
+      if (stored?.connectionId === id) {
+        await clearSlackState(root, "remote");
+      }
+      if (globals.json) printJSON(disconnected);
+      else process.stdout.write(`Disconnected Slack connection ${id}.\n`);
+      return;
+    }
+    throw new Error(
+      "Use `opencomputer channels add|connect|list|disconnect slack`.",
+    );
+  }
+
+  if (command === "slack-hook") {
+    const action = args.shift();
+    if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+    const root = await requireSlackAgentRoot();
+    const mode =
+      process.env.OPENCOMPUTER_SLACK_MODE === "remote" ? "remote" : "local";
+    if (action === "manifest") {
+      printJSON(await slackManifest(root, mode));
+      return;
+    }
+    if (action === "deploy") {
+      const state = await readRemoteSlackState(root);
+      if (!state) {
+        throw new Error(
+          "Run `opencomputer channels connect slack --remote` first.",
+        );
+      }
+      const botToken =
+        process.env.SLACK_BOT_TOKEN ?? process.env.SLACK_CLI_XOXB;
+      if (!botToken) {
+        throw new Error("Slack CLI did not provide SLACK_BOT_TOKEN.");
+      }
+      const hookConfig = await resolveConfig({
+        ...globals,
+        apiUrl: state.apiUrl,
+      });
+      const connection = await new OpenComputerClient(
+        hookConfig,
+      ).completeSlackConnection(state.connectionId, botToken);
+      process.stdout.write(
+        `OpenComputer connected ${connection.agentId}@${connection.alias} ` +
+          `to ${connection.teamName ?? connection.teamId ?? "Slack"}.\n`,
+      );
+      return;
+    }
+    if (action === "start") {
+      await runOpenCode([], config);
+      return;
+    }
+    throw new Error("Unsupported Slack CLI hook.");
+  }
+
+  throw new Error(`Unknown command: ${command}`);
+}

--- a/cli/src/config.test.ts
+++ b/cli/src/config.test.ts
@@ -21,7 +21,7 @@ test("normalizes the public API URL and rejects insecure remotes", () => {
   );
 });
 
-test("stores project CLI credentials in a mode-0600 file", async () => {
+test("stores agent CLI credentials in a mode-0600 file", async () => {
   const directory = await mkdtemp(join(tmpdir(), "opencomputer-cli-"));
   const path = join(directory, "nested", "config.json");
   process.env.OPENCOMPUTER_CONFIG = path;

--- a/cli/src/config.test.ts
+++ b/cli/src/config.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  loadStoredConfig,
+  normalizeAPIURL,
+  saveStoredConfig,
+} from "./config.js";
+
+test("normalizes the public API URL and rejects insecure remotes", () => {
+  assert.equal(
+    normalizeAPIURL("https://app.opencomputer.dev/api/"),
+    "https://app.opencomputer.dev",
+  );
+  assert.throws(() => normalizeAPIURL("http://example.com"));
+  assert.equal(
+    normalizeAPIURL("http://localhost:8787"),
+    "http://localhost:8787",
+  );
+});
+
+test("stores agent CLI credentials in a mode-0600 file", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "opencomputer-cli-"));
+  const path = join(directory, "nested", "config.json");
+  process.env.OPENCOMPUTER_CONFIG = path;
+  try {
+    await saveStoredConfig({
+      apiUrl: "https://app.opencomputer.dev",
+      apiKey: "osb_test",
+    });
+    assert.equal((await stat(path)).mode & 0o777, 0o600);
+    assert.deepEqual(await loadStoredConfig(), {
+      apiUrl: "https://app.opencomputer.dev",
+      apiKey: "osb_test",
+    });
+    assert.match(await readFile(path, "utf8"), /"apiKey": "osb_test"/);
+  } finally {
+    delete process.env.OPENCOMPUTER_CONFIG;
+  }
+});

--- a/cli/src/config.test.ts
+++ b/cli/src/config.test.ts
@@ -21,7 +21,7 @@ test("normalizes the public API URL and rejects insecure remotes", () => {
   );
 });
 
-test("stores agent CLI credentials in a mode-0600 file", async () => {
+test("stores project CLI credentials in a mode-0600 file", async () => {
   const directory = await mkdtemp(join(tmpdir(), "opencomputer-cli-"));
   const path = join(directory, "nested", "config.json");
   process.env.OPENCOMPUTER_CONFIG = path;

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,0 +1,100 @@
+import { chmod, mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export const DEFAULT_API_URL = "https://app.opencomputer.dev";
+
+export interface LoginMetadata {
+  credentialId: string;
+  keyPrefix: string;
+  name: string;
+}
+
+export interface StoredConfig {
+  apiUrl?: string;
+  apiKey?: string;
+  login?: LoginMetadata;
+}
+
+export interface ResolvedConfig {
+  apiUrl: string;
+  apiKey?: string;
+}
+
+export function configPath(): string {
+  return (
+    process.env.OPENCOMPUTER_CONFIG ??
+    join(homedir(), ".opencomputer", "config.json")
+  );
+}
+
+export async function loadStoredConfig(): Promise<StoredConfig> {
+  try {
+    const parsed: unknown = JSON.parse(await readFile(configPath(), "utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as StoredConfig;
+  } catch {
+    return {};
+  }
+}
+
+export async function resolveConfig(overrides: {
+  apiUrl?: string;
+  apiKey?: string;
+}): Promise<ResolvedConfig> {
+  const stored = await loadStoredConfig();
+  return {
+    apiUrl: normalizeAPIURL(
+      overrides.apiUrl ??
+        process.env.OPENCOMPUTER_API_URL ??
+        stored.apiUrl ??
+        DEFAULT_API_URL,
+    ),
+    apiKey:
+      overrides.apiKey ?? process.env.OPENCOMPUTER_API_KEY ?? stored.apiKey,
+  };
+}
+
+export function normalizeAPIURL(value: string): string {
+  const url = new URL(value);
+  if (
+    url.protocol !== "https:" &&
+    !(
+      url.protocol === "http:" &&
+      ["localhost", "127.0.0.1", "::1"].includes(url.hostname)
+    )
+  ) {
+    throw new Error("The OpenComputer API URL must use HTTPS");
+  }
+  url.pathname = url.pathname.replace(/\/api\/?$/, "").replace(/\/+$/, "");
+  url.search = "";
+  url.hash = "";
+  return url.toString().replace(/\/$/, "");
+}
+
+export async function saveStoredConfig(config: StoredConfig): Promise<void> {
+  const path = configPath();
+  const directory = dirname(path);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  await chmod(directory, 0o700);
+  const temporary = join(
+    directory,
+    `.config-${process.pid}-${crypto.randomUUID()}.tmp`,
+  );
+  const handle = await open(temporary, "wx", 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(config, null, 2)}\n`);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    await rename(temporary, path);
+    await chmod(path, 0o600);
+  } catch (error) {
+    await rm(temporary, { force: true });
+    throw error;
+  }
+}

--- a/cli/src/dev-ui.test.ts
+++ b/cli/src/dev-ui.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { renderDevUI } from "./dev-ui.js";
+
+test("the dev UI shell escapes the agent name and loads bundled assets", () => {
+  const html = renderDevUI('Inbox </title><script>alert("x")</script>');
+  assert.doesNotMatch(html, /<script>alert/);
+  assert.match(html, /Inbox &lt;\/title&gt;&lt;script&gt;/);
+  assert.match(html, /<script src="\/assets\/dev-ui\.js" defer>/);
+  assert.match(html, /<link rel="stylesheet" href="\/assets\/dev-ui\.css">/);
+});

--- a/cli/src/dev-ui.ts
+++ b/cli/src/dev-ui.ts
@@ -1,0 +1,24 @@
+export function renderDevUI(agentName: string): string {
+  const escapedName = agentName
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <meta name="opencomputer-agent" content="${escapedName}">
+  <title>${escapedName} · OpenComputer dev</title>
+  <link rel="stylesheet" href="/assets/dev-ui.css">
+</head>
+<body>
+  <div id="root"></div>
+  <script src="/assets/dev-ui.js" defer></script>
+</body>
+</html>`;
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,7 +2,7 @@
 
 import { runCommand, type GlobalOptions } from "./commands.js";
 
-const VERSION = "0.3.7";
+const VERSION = "0.3.8";
 
 const BANNER = String.raw`   ____                   ______                            __
   / __ \____  ___  ____  / ____/___  ____ ___  ____  __  / /____  _____
@@ -32,19 +32,19 @@ function takeFlag(args: string[], name: string): boolean {
 function help(): void {
   process.stdout.write(`${BANNER}
 
-OpenComputer — build, test, connect, and deploy agents as code
+OpenComputer — build, test, connect, and deploy projects
 
 Usage:
   opencomputer login [--no-browser] [--force]
   opencomputer logout [--local]
   opencomputer whoami
   opencomputer templates
-  opencomputer agents
+  opencomputer projects
   opencomputer init <template> [directory]
   opencomputer dev
   opencomputer session [prompt]
   opencomputer session create <prompt> [--local]
-  opencomputer session create [prompt] --remote [--agent <agent>@<alias>] [--keep]
+  opencomputer session create [prompt] --remote [--project <project>@<alias>] [--keep]
   opencomputer session list
   opencomputer session inspect <session-id>
   opencomputer session attach <session-id>
@@ -59,7 +59,7 @@ Usage:
   opencomputer channels list [--local|--remote]
   opencomputer channels disconnect slack [connection-id] [--local|--remote]
   opencomputer deploy [--alias <alias>]
-  opencomputer run <agent> <prompt> [--keep]
+  opencomputer run <project> <prompt> [--keep]
 
 Global options:
   --api-url <url>   OpenComputer API (default: https://app.opencomputer.dev)

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -32,19 +32,19 @@ function takeFlag(args: string[], name: string): boolean {
 function help(): void {
   process.stdout.write(`${BANNER}
 
-OpenComputer — build, test, connect, and deploy projects
+OpenComputer — build, test, connect, and deploy agents as code
 
 Usage:
   opencomputer login [--no-browser] [--force]
   opencomputer logout [--local]
   opencomputer whoami
   opencomputer templates
-  opencomputer projects
+  opencomputer agents
   opencomputer init <template> [directory]
   opencomputer dev
   opencomputer session [prompt]
   opencomputer session create <prompt> [--local]
-  opencomputer session create [prompt] --remote [--project <project>@<alias>] [--keep]
+  opencomputer session create [prompt] --remote [--agent <agent>@<alias>] [--keep]
   opencomputer session list
   opencomputer session inspect <session-id>
   opencomputer session attach <session-id>
@@ -59,7 +59,7 @@ Usage:
   opencomputer channels list [--local|--remote]
   opencomputer channels disconnect slack [connection-id] [--local|--remote]
   opencomputer deploy [--alias <alias>]
-  opencomputer run <project> <prompt> [--keep]
+  opencomputer run <agent> <prompt> [--keep]
 
 Global options:
   --api-url <url>   OpenComputer API (default: https://app.opencomputer.dev)

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import { runCommand, type GlobalOptions } from "./commands.js";
+
+const VERSION = "0.3.0";
+
+function takeOption(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  if (index < 0) return undefined;
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  args.splice(index, 2);
+  return value;
+}
+
+function takeFlag(args: string[], name: string): boolean {
+  const index = args.indexOf(name);
+  if (index < 0) return false;
+  args.splice(index, 1);
+  return true;
+}
+
+function help(): void {
+  process.stdout.write(`OpenComputer — build, test, connect, and deploy agents as code
+
+Usage:
+  opencomputer login [--no-browser] [--force]
+  opencomputer logout [--local]
+  opencomputer whoami
+  opencomputer templates
+  opencomputer agents
+  opencomputer init <template> [directory]
+  opencomputer dev
+  opencomputer session [prompt]
+  opencomputer session create [prompt] --remote [--agent <agent>@<alias>] [--keep]
+  opencomputer session list
+  opencomputer session inspect <session-id>
+  opencomputer session attach <session-id>
+  opencomputer session send <session-id> <prompt> [--keep]
+  opencomputer session end <session-id>
+  opencomputer tools add gmail
+  opencomputer connect google
+  opencomputer connections connect gmail
+  opencomputer connections list
+  opencomputer connections disconnect <connection-id>
+  opencomputer channels add slack
+  opencomputer channels connect slack [--local|--remote]
+  opencomputer channels list [--local|--remote]
+  opencomputer channels disconnect slack [connection-id] [--local|--remote]
+  opencomputer deploy [--alias <alias>]
+  opencomputer run <agent> <prompt> [--keep]
+
+Global options:
+  --api-url <url>   OpenComputer API (default: https://app.opencomputer.dev)
+  --api-key <key>   API key (or OPENCOMPUTER_API_KEY)
+  --json            Print machine-readable output
+  --help            Show this help
+  --version         Show the CLI version
+`);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  if (takeFlag(args, "--version")) {
+    process.stdout.write(`${VERSION}\n`);
+    return;
+  }
+  if (!args.length || takeFlag(args, "--help")) {
+    help();
+    return;
+  }
+  const globals: GlobalOptions = {
+    apiUrl: takeOption(args, "--api-url"),
+    apiKey: takeOption(args, "--api-key"),
+    json: takeFlag(args, "--json"),
+  };
+  const command = args.shift();
+  if (!command) {
+    help();
+    return;
+  }
+  await runCommand(command, args, globals);
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(
+    `opencomputer: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exitCode = 1;
+});

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,7 +2,7 @@
 
 import { runCommand, type GlobalOptions } from "./commands.js";
 
-const VERSION = "0.3.6";
+const VERSION = "0.3.7";
 
 const BANNER = String.raw`   ____                   ______                            __
   / __ \____  ___  ____  / ____/___  ____ ___  ____  __  / /____  _____
@@ -51,10 +51,9 @@ Usage:
   opencomputer session send <session-id> <prompt> [--keep]
   opencomputer session end <session-id>
   opencomputer tools add gmail
-  opencomputer connect google
-  opencomputer connections connect gmail
-  opencomputer connections list
-  opencomputer connections disconnect gmail|<connection-id>
+  opencomputer connection add gmail [--alias <name>]
+  opencomputer connection list
+  opencomputer connection remove <alias|connection-id>
   opencomputer channels add slack
   opencomputer channels connect slack [--local|--remote]
   opencomputer channels list [--local|--remote]

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,8 +1,15 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 
 import { runCommand, type GlobalOptions } from "./commands.js";
 
-const VERSION = "0.3.0";
+const VERSION = "0.3.6";
+
+const BANNER = String.raw`   ____                   ______                            __
+  / __ \____  ___  ____  / ____/___  ____ ___  ____  __  / /____  _____
+ / / / / __ \/ _ \/ __ \/ /   / __ \/ __  __ \/ __ \/ / / / __ \/ ___/
+/ /_/ / /_/ /  __/ / / / /___/ /_/ / / / / / / /_/ / /_/ / /_/ / /
+\____/ .___/\___/_/ /_/\____/\____/_/ /_/ /_/ .___/\__,_/\____/_/
+    /_/                                      /_/`;
 
 function takeOption(args: string[], name: string): string | undefined {
   const index = args.indexOf(name);
@@ -23,7 +30,9 @@ function takeFlag(args: string[], name: string): boolean {
 }
 
 function help(): void {
-  process.stdout.write(`OpenComputer — build, test, connect, and deploy agents as code
+  process.stdout.write(`${BANNER}
+
+OpenComputer — build, test, connect, and deploy agents as code
 
 Usage:
   opencomputer login [--no-browser] [--force]
@@ -34,6 +43,7 @@ Usage:
   opencomputer init <template> [directory]
   opencomputer dev
   opencomputer session [prompt]
+  opencomputer session create <prompt> [--local]
   opencomputer session create [prompt] --remote [--agent <agent>@<alias>] [--keep]
   opencomputer session list
   opencomputer session inspect <session-id>
@@ -44,7 +54,7 @@ Usage:
   opencomputer connect google
   opencomputer connections connect gmail
   opencomputer connections list
-  opencomputer connections disconnect <connection-id>
+  opencomputer connections disconnect gmail|<connection-id>
   opencomputer channels add slack
   opencomputer channels connect slack [--local|--remote]
   opencomputer channels list [--local|--remote]

--- a/cli/src/local.ts
+++ b/cli/src/local.ts
@@ -1,11 +1,55 @@
-import { spawn } from "node:child_process";
+import {
+  createOpencode,
+  type OpencodeClient,
+  type ToolPart,
+} from "@opencode-ai/sdk/v2";
+import { spawn, type ChildProcess } from "node:child_process";
 import { randomBytes, timingSafeEqual } from "node:crypto";
-import { access } from "node:fs/promises";
-import { createServer } from "node:http";
-import { resolve } from "node:path";
+import {
+  mkdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { delimiter, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import type { ResolvedConfig } from "./config.js";
-import { findAgentRoot, prepareAgent } from "./project.js";
+import { renderDevUI } from "./dev-ui.js";
+import { findAgentRoot, prepareAgent, readManifest } from "./project.js";
+
+interface DevState {
+  version: 1;
+  pid: number;
+  url: string;
+  token: string;
+  agentRoot: string;
+  agentId: string;
+  startedAt: string;
+}
+
+interface LocalEvent {
+  type: string;
+  data: Record<string, unknown>;
+}
+
+interface LocalMessage {
+  role: "user" | "assistant";
+  text: string;
+}
+
+interface LocalSession {
+  id: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  messages: LocalMessage[];
+}
 
 function sameToken(left: string, right: string): boolean {
   const leftBytes = Buffer.from(left);
@@ -18,160 +62,814 @@ function sameToken(left: string, right: string): boolean {
 
 async function readBody(
   request: AsyncIterable<Uint8Array>,
+  limit = 2 * 1024 * 1024,
 ): Promise<Buffer> {
   const chunks: Buffer[] = [];
   let size = 0;
   for await (const chunk of request) {
     const buffer = Buffer.from(chunk);
     size += buffer.byteLength;
-    if (size > 2 * 1024 * 1024) {
-      throw new Error("Connection request is too large");
-    }
+    if (size > limit) throw new Error("Request is too large");
     chunks.push(buffer);
   }
   return Buffer.concat(chunks);
 }
 
-async function startConnectionProxy(config: ResolvedConfig): Promise<{
+function authorized(request: IncomingMessage, token: string): boolean {
+  const header = request.headers.authorization;
+  return (
+    typeof header === "string" &&
+    header.startsWith("Bearer ") &&
+    sameToken(header.slice(7), token)
+  );
+}
+
+function sendJSON(
+  response: ServerResponse,
+  status: number,
+  body: unknown,
+): void {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+function openBrowser(url: string): void {
+  if (process.env.OPENCOMPUTER_NO_OPEN === "1") return;
+  const command =
+    process.platform === "darwin"
+      ? { file: "open", args: [url] }
+      : process.platform === "win32"
+        ? { file: "cmd", args: ["/c", "start", "", url] }
+        : { file: "xdg-open", args: [url] };
+  const child = spawn(command.file, command.args, {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.on("error", () => undefined);
+  child.unref();
+}
+
+async function startGateway(config: ResolvedConfig): Promise<{
   url: string;
   token: string;
   close(): Promise<void>;
 }> {
   if (!config.apiKey) {
     throw new Error(
-      "Not logged in. Run `opencomputer login` before testing connected tools.",
+      "Not logged in. Run `opencomputer login` before starting dev mode.",
     );
   }
   const token = randomBytes(32).toString("base64url");
   const server = createServer((request, response) => {
     void (async () => {
-      if (request.method !== "POST" || request.url !== "/google/fetch") {
-        response.writeHead(404).end();
-        return;
-      }
-      const authorization = request.headers.authorization;
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      const header = request.headers.authorization;
       if (
-        !authorization?.startsWith("Bearer ") ||
-        !sameToken(authorization.slice(7), token)
+        !header?.startsWith("Bearer ") ||
+        !sameToken(header.slice(7), token)
       ) {
         response.writeHead(401).end();
         return;
       }
-      const upstream = await fetch(
-        `${config.apiUrl}/api/managed-agents/connections/google/fetch`,
-        {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            "x-api-key": config.apiKey!,
-          },
-          body: await readBody(request),
-          signal: AbortSignal.timeout(30_000),
+      let target: string;
+      if (request.method === "POST" && url.pathname === "/google/fetch") {
+        target = `${config.apiUrl}/api/managed-agents/connections/google/fetch`;
+      } else if (url.pathname.startsWith("/openrouter/")) {
+        target =
+          `${config.apiUrl}/api/managed-agents/openrouter` +
+          `${url.pathname.slice("/openrouter".length)}${url.search}`;
+      } else {
+        response.writeHead(404).end();
+        return;
+      }
+      const upstream = await fetch(target, {
+        method: request.method,
+        headers: {
+          "content-type":
+            request.headers["content-type"] ?? "application/json",
+          "x-api-key": config.apiKey!,
         },
-      );
+        body:
+          request.method === "GET" || request.method === "HEAD"
+            ? undefined
+            : await readBody(request),
+        signal: AbortSignal.timeout(60_000),
+      });
       response.writeHead(upstream.status, {
         "content-type":
           upstream.headers.get("content-type") ?? "application/json",
       });
       response.end(Buffer.from(await upstream.arrayBuffer()));
     })().catch((error: unknown) => {
-      response.writeHead(502, { "content-type": "application/json" });
-      response.end(
-        JSON.stringify({
-          error: {
-            message:
-              error instanceof Error
-                ? error.message
-                : "Connection proxy failed",
-          },
-        }),
-      );
+      sendJSON(response, 502, {
+        error: {
+          message:
+            error instanceof Error ? error.message : "Gateway request failed",
+        },
+      });
     });
   });
-  await new Promise<void>((resolve, reject) => {
+  await new Promise<void>((done, reject) => {
     server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
+    server.listen(0, "127.0.0.1", done);
   });
   const address = server.address();
   if (!address || typeof address === "string") {
     server.close();
-    throw new Error("Could not start the local connection proxy");
+    throw new Error("Could not start the local OpenComputer gateway");
   }
   return {
     url: `http://127.0.0.1:${String(address.port)}`,
     token,
-    close: () =>
-      new Promise<void>((resolve) => server.close(() => resolve())),
+    close: () => {
+      server.closeAllConnections();
+      return new Promise<void>((done) => server.close(() => done()));
+    },
   };
 }
 
-export async function runOpenCode(
-  args: string[],
-  config: ResolvedConfig,
-): Promise<void> {
+function addBundledRuntimeToPath(): void {
+  const packagePath = fileURLToPath(
+    import.meta.resolve("opencode-ai/package.json"),
+  );
+  const bin = resolve(dirname(packagePath), "..", ".bin");
+  const current = process.env.PATH ?? "";
+  if (!current.split(delimiter).includes(bin)) {
+    process.env.PATH = current ? `${bin}${delimiter}${current}` : bin;
+  }
+}
+
+function modelParts(): { providerID: string; modelID: string; full: string } {
+  const full =
+    process.env.OPENCOMPUTER_MODEL ??
+    "openrouter/anthropic/claude-sonnet-4.6";
+  const separator = full.indexOf("/");
+  return {
+    providerID: separator === -1 ? "openrouter" : full.slice(0, separator),
+    modelID: separator === -1 ? full : full.slice(separator + 1),
+    full,
+  };
+}
+
+async function streamTurn(
+  client: OpencodeClient,
+  directory: string,
+  sessionID: string,
+  prompt: string,
+  emit: (event: LocalEvent) => void,
+): Promise<string> {
+  const subscription = await client.event.subscribe({ directory });
+  const textParts = new Map<string, string>();
+  const reasoningParts = new Map<string, string>();
+  const partTypes = new Map<string, "text" | "reasoning">();
+  const pendingDeltas = new Map<
+    string,
+    Array<{ messageID: string; delta: string }>
+  >();
+  const tools = new Map<string, ToolPart>();
+  const toolStates = new Map<string, ToolPart["state"]["status"]>();
+  const assistantMessages = new Set<string>();
+  const streamedTextParts = new Set<string>();
+
+  const consumePendingDeltas = (
+    partID?: string,
+    messageID?: string,
+  ): void => {
+    for (const [candidatePartID, deltas] of pendingDeltas) {
+      if (partID && candidatePartID !== partID) continue;
+      const partType = partTypes.get(candidatePartID);
+      if (!partType) continue;
+      const remaining: typeof deltas = [];
+      for (const pending of deltas) {
+        if (
+          (messageID && pending.messageID !== messageID) ||
+          !assistantMessages.has(pending.messageID)
+        ) {
+          remaining.push(pending);
+          continue;
+        }
+        const parts = partType === "text" ? textParts : reasoningParts;
+        parts.set(
+          candidatePartID,
+          `${parts.get(candidatePartID) ?? ""}${pending.delta}`,
+        );
+        if (partType === "text" && !streamedTextParts.has(candidatePartID)) {
+          if (streamedTextParts.size > 0) {
+            emit({
+              type: "message.delta",
+              data: { text: "\n\n", partId: candidatePartID },
+            });
+          }
+          streamedTextParts.add(candidatePartID);
+        }
+        emit({
+          type: partType === "text" ? "message.delta" : "reasoning.delta",
+          data: { text: pending.delta, partId: candidatePartID },
+        });
+      }
+      if (remaining.length) pendingDeltas.set(candidatePartID, remaining);
+      else pendingDeltas.delete(candidatePartID);
+    }
+  };
+  const emitTool = (part: ToolPart): void => {
+    if (!assistantMessages.has(part.messageID)) return;
+    const previous = toolStates.get(part.callID);
+    const current = part.state.status;
+    if (previous === current) return;
+    toolStates.set(part.callID, current);
+    if (current === "running") {
+      emit({
+        type: "tool.started",
+        data: {
+          callId: part.callID,
+          tool: part.tool,
+          title: part.state.title,
+          input: part.state.input,
+        },
+      });
+    } else if (current === "completed") {
+      emit({
+        type: "tool.completed",
+        data: { callId: part.callID, tool: part.tool, title: part.state.title },
+      });
+    } else if (current === "error") {
+      emit({
+        type: "tool.failed",
+        data: {
+          callId: part.callID,
+          tool: part.tool,
+          title: "title" in part.state ? part.state.title : undefined,
+          message: part.state.error,
+        },
+      });
+    }
+  };
+
+  try {
+    const firstEvent = subscription.stream.next();
+    await Promise.race([
+      firstEvent.then(() => undefined),
+      new Promise<void>((done) => setTimeout(done, 100)),
+    ]);
+    const model = modelParts();
+    const started = await client.session.promptAsync({
+      sessionID,
+      directory,
+      model: { providerID: model.providerID, modelID: model.modelID },
+      parts: [{ type: "text", text: prompt }],
+    });
+    if (started.error) throw new Error(JSON.stringify(started.error));
+    async function* events() {
+      const first = await firstEvent;
+      if (!first.done) yield first.value;
+      yield* subscription.stream;
+    }
+    for await (const event of events()) {
+      if (event.type === "message.part.delta") {
+        const { sessionID: eventSessionID, messageID, partID, field, delta } =
+          event.properties;
+        if (eventSessionID !== sessionID || field !== "text" || !delta) continue;
+        const pending = pendingDeltas.get(partID) ?? [];
+        pending.push({ messageID, delta });
+        pendingDeltas.set(partID, pending);
+        consumePendingDeltas(partID, messageID);
+        continue;
+      }
+      if (event.type === "message.updated") {
+        const info = event.properties.info;
+        if (info.sessionID === sessionID && info.role === "assistant") {
+          assistantMessages.add(info.id);
+          consumePendingDeltas(undefined, info.id);
+          for (const part of tools.values()) {
+            if (part.messageID === info.id) emitTool(part);
+          }
+        }
+      } else if (event.type === "message.part.updated") {
+        const part = event.properties.part;
+        if (part.sessionID !== sessionID) continue;
+        if (part.type === "text") {
+          partTypes.set(part.id, "text");
+          if (
+            assistantMessages.has(part.messageID) &&
+            part.text.length >= (textParts.get(part.id)?.length ?? 0)
+          ) {
+            textParts.set(part.id, part.text);
+          }
+          consumePendingDeltas(part.id, part.messageID);
+        } else if (part.type === "reasoning") {
+          partTypes.set(part.id, "reasoning");
+          if (
+            assistantMessages.has(part.messageID) &&
+            part.text.length >= (reasoningParts.get(part.id)?.length ?? 0)
+          ) {
+            reasoningParts.set(part.id, part.text);
+          }
+          consumePendingDeltas(part.id, part.messageID);
+        } else if (part.type === "tool") {
+          tools.set(part.callID, part);
+          emitTool(part);
+        }
+      } else if (
+        event.type === "session.error" &&
+        event.properties.sessionID === sessionID
+      ) {
+        throw new Error(JSON.stringify(event.properties.error));
+      } else if (
+        event.type === "session.idle" &&
+        event.properties.sessionID === sessionID
+      ) {
+        break;
+      }
+    }
+  } finally {
+    await subscription.stream.return(undefined);
+  }
+
+  const reasoning = [...reasoningParts.values()].join("");
+  if (reasoning) {
+    emit({ type: "reasoning.completed", data: { text: reasoning } });
+  }
+  const text = [...textParts.values()]
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join("\n\n");
+  emit({ type: "message.completed", data: { text } });
+  return text;
+}
+
+async function createRuntimeSession(
+  client: OpencodeClient,
+  directory: string,
+): Promise<string> {
+  const created = await client.session.create({ directory });
+  if (!created.data) throw new Error("The local agent session did not start");
+  return created.data.id;
+}
+
+function statePath(root: string): string {
+  return resolve(root, ".opencomputer", "dev.json");
+}
+
+async function readDevState(root: string): Promise<DevState | null> {
+  try {
+    const state = JSON.parse(await readFile(statePath(root), "utf8")) as DevState;
+    if (state.version !== 1 || !state.url || !state.token) return null;
+    const response = await fetch(`${state.url}/health`, {
+      headers: { authorization: `Bearer ${state.token}` },
+      signal: AbortSignal.timeout(1_000),
+    });
+    return response.ok ? state : null;
+  } catch {
+    return null;
+  }
+}
+
+async function startDevService(config: ResolvedConfig): Promise<void> {
   const root = await findAgentRoot();
   if (!root) {
     throw new Error(
       "No OpenComputer agent repository found. Run `opencomputer init <template>` first.",
     );
   }
-  const runtime = await prepareAgent(root);
-  const connections = await startConnectionProxy(config);
-  const localExecutable = resolve(
-    root,
-    "node_modules",
-    ".bin",
-    process.platform === "win32" ? "opencode.cmd" : "opencode",
-  );
-  const executable = await access(localExecutable)
-    .then(() => localExecutable)
-    .catch(() =>
-      process.platform === "win32" ? "opencode.cmd" : "opencode",
-    );
-  const openCodeArgs =
-    args[0] === "run"
-      ? [...args, "--dir", runtime]
-      : args.length === 0
-        ? [runtime]
-        : args;
+  const existing = await readDevState(root);
+  if (existing) {
+    throw new Error(`OpenComputer dev is already running at ${existing.url}`);
+  }
+  const directory = await prepareAgent(root);
+  const manifest = await readManifest(root);
+  const gateway = await startGateway(config);
+  addBundledRuntimeToPath();
+  const abortController = new AbortController();
+  const model = modelParts();
+  const previousConnectionsURL = process.env.OPENCOMPUTER_CONNECTIONS_URL;
+  const previousConnectionToken = process.env.OPENCOMPUTER_CONNECTION_TOKEN;
+  process.env.OPENCOMPUTER_CONNECTIONS_URL = gateway.url;
+  process.env.OPENCOMPUTER_CONNECTION_TOKEN = gateway.token;
+  let instance: Awaited<ReturnType<typeof createOpencode>>;
   try {
-    await new Promise<void>((resolve, reject) => {
-      const child = spawn(
-        executable,
-        openCodeArgs,
-        {
-          cwd: runtime,
-          env: {
-            ...process.env,
-            OPENCOMPUTER_CONNECTIONS_URL: connections.url,
-            OPENCOMPUTER_CONNECTION_TOKEN: connections.token,
-            OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX:
-              process.env.OPENCOMPUTER_MAX_OUTPUT_TOKENS ??
-              process.env.OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX ??
-              "16384",
+    instance = await createOpencode({
+      signal: abortController.signal,
+      port: 0,
+      timeout: 45_000,
+      config: {
+        model: model.full,
+        enabled_providers: ["openrouter"],
+        provider: {
+          openrouter: {
+            options: { baseURL: `${gateway.url}/openrouter/api/v1` },
           },
-          stdio: "inherit",
         },
-      );
-      child.once("error", (error) => {
-        reject(
-          error instanceof Error && "code" in error && error.code === "ENOENT"
-            ? new Error("OpenCode is not installed. Run `npm install` first.")
-            : error,
-        );
-      });
-      child.once("exit", (code, signal) => {
-        if (code === 0) resolve();
-        else {
-          reject(
-            new Error(
-              `OpenCode exited ${signal ? `with ${signal}` : `with code ${String(code)}`}`,
-            ),
-          );
-        }
-      });
+        autoupdate: false,
+        share: "disabled",
+      },
     });
   } finally {
-    await connections.close();
+    if (previousConnectionsURL === undefined) {
+      delete process.env.OPENCOMPUTER_CONNECTIONS_URL;
+    } else {
+      process.env.OPENCOMPUTER_CONNECTIONS_URL = previousConnectionsURL;
+    }
+    if (previousConnectionToken === undefined) {
+      delete process.env.OPENCOMPUTER_CONNECTION_TOKEN;
+    } else {
+      process.env.OPENCOMPUTER_CONNECTION_TOKEN = previousConnectionToken;
+    }
   }
+  const authenticated = await instance.client.auth.set({
+    providerID: "openrouter",
+    auth: { type: "api", key: gateway.token },
+  });
+  if (authenticated.error || authenticated.data !== true) {
+    throw new Error("The embedded agent runtime rejected its local credential");
+  }
+
+  const token = randomBytes(32).toString("base64url");
+  const sessions = new Map<string, LocalSession>();
+  const running = new Set<string>();
+  const server = createServer((request, response) => {
+    void (async () => {
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      if (request.method === "GET" && url.pathname === "/") {
+        response.writeHead(200, {
+          "content-type": "text/html; charset=utf-8",
+          "cache-control": "no-store",
+          "content-security-policy":
+            "default-src 'none'; script-src 'self'; style-src 'self'; " +
+            "connect-src 'self'; img-src 'self' data:; base-uri 'none'; frame-ancestors 'none'",
+        });
+        response.end(renderDevUI(manifest.name));
+        return;
+      }
+      const assetMatch = url.pathname.match(
+        /^\/assets\/([A-Za-z0-9_.-]+\.(?:js|css))$/,
+      );
+      if (request.method === "GET" && assetMatch?.[1]) {
+        const filename = assetMatch[1];
+        const asset = await readFile(
+          fileURLToPath(new URL(`./ui/${filename}`, import.meta.url)),
+        );
+        response.writeHead(200, {
+          "content-type": filename.endsWith(".css")
+            ? "text/css; charset=utf-8"
+            : "text/javascript; charset=utf-8",
+          "cache-control": "no-store",
+        });
+        response.end(asset);
+        return;
+      }
+      if (!authorized(request, token)) {
+        sendJSON(response, 401, { message: "Unauthorized" });
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/health") {
+        sendJSON(response, 200, {
+          ok: true,
+          agentId: manifest.id,
+          sessions: sessions.size,
+        });
+        return;
+      }
+
+      const streamSession = async (
+        session: LocalSession,
+        prompt: string,
+        created = false,
+      ): Promise<void> => {
+        if (running.has(session.id)) {
+          sendJSON(response, 409, { message: "This session is already running" });
+          return;
+        }
+        running.add(session.id);
+        session.messages.push({ role: "user", text: prompt });
+        if (!session.title) session.title = prompt.slice(0, 60);
+        session.updatedAt = new Date().toISOString();
+        response.writeHead(200, {
+          "content-type": "application/x-ndjson",
+          "cache-control": "no-store",
+        });
+        const emit = (event: LocalEvent): void => {
+          response.write(`${JSON.stringify(event)}\n`);
+        };
+        if (created) {
+          emit({ type: "session.created", data: { sessionId: session.id } });
+        }
+        try {
+          const text = await streamTurn(
+            instance.client,
+            directory,
+            session.id,
+            prompt,
+            emit,
+          );
+          session.messages.push({ role: "assistant", text });
+          session.updatedAt = new Date().toISOString();
+        } catch (error) {
+          emit({
+            type: "session.failed",
+            data: {
+              message: error instanceof Error ? error.message : String(error),
+            },
+          });
+        } finally {
+          running.delete(session.id);
+        }
+        response.end();
+      };
+
+      if (request.method === "GET" && url.pathname === "/sessions") {
+        sendJSON(response, 200, {
+          sessions: [...sessions.values()]
+            .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+            .map(({ id, title, createdAt, updatedAt, messages }) => ({
+              id,
+              title,
+              createdAt,
+              updatedAt,
+              messageCount: messages.length,
+            })),
+        });
+        return;
+      }
+      if (request.method === "POST" && url.pathname === "/sessions") {
+        const raw = (await readBody(request)).toString("utf8");
+        const body = (raw ? JSON.parse(raw) : {}) as { prompt?: unknown };
+        const id = await createRuntimeSession(instance.client, directory);
+        const now = new Date().toISOString();
+        const session: LocalSession = {
+          id,
+          title: "",
+          createdAt: now,
+          updatedAt: now,
+          messages: [],
+        };
+        sessions.set(id, session);
+        if (typeof body.prompt === "string" && body.prompt.trim()) {
+          response.setHeader("x-opencomputer-session-id", id);
+          await streamSession(session, body.prompt.trim(), true);
+        } else {
+          sendJSON(response, 201, session);
+        }
+        return;
+      }
+      const sessionMatch = url.pathname.match(/^\/sessions\/([^/]+)$/);
+      if (sessionMatch?.[1]) {
+        const id = decodeURIComponent(sessionMatch[1]);
+        const session = sessions.get(id);
+        if (!session) {
+          sendJSON(response, 404, { message: "Session not found" });
+          return;
+        }
+        if (request.method === "GET") {
+          sendJSON(response, 200, session);
+          return;
+        }
+        if (request.method === "POST") {
+          const body = JSON.parse((await readBody(request)).toString("utf8")) as {
+            prompt?: unknown;
+          };
+          if (typeof body.prompt !== "string" || !body.prompt.trim()) {
+            sendJSON(response, 400, { message: "A prompt is required" });
+            return;
+          }
+          await streamSession(session, body.prompt.trim());
+          return;
+        }
+      }
+      if (request.method === "GET" && url.pathname === "/api") {
+        sendJSON(response, 200, {
+          service: "OpenComputer local agent",
+          agentId: manifest.id,
+          endpoints: ["GET /sessions", "POST /sessions", "POST /sessions/:id"],
+        });
+        return;
+      }
+      sendJSON(response, 404, { message: "Route not found" });
+    })().catch((error: unknown) => {
+      if (!response.headersSent) {
+        sendJSON(response, 500, {
+          message: error instanceof Error ? error.message : String(error),
+        });
+      } else {
+        response.end();
+      }
+    });
+  });
+  await new Promise<void>((done, reject) => {
+    server.once("error", reject);
+    server.listen(
+      Number(process.env.OPENCOMPUTER_DEV_PORT ?? 0),
+      "127.0.0.1",
+      done,
+    );
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("The OpenComputer dev service did not receive a port");
+  }
+  const state: DevState = {
+    version: 1,
+    pid: process.pid,
+    url: `http://127.0.0.1:${String(address.port)}`,
+    token,
+    agentRoot: root,
+    agentId: manifest.id,
+    startedAt: new Date().toISOString(),
+  };
+  await mkdir(dirname(statePath(root)), { recursive: true, mode: 0o700 });
+  await writeFile(statePath(root), `${JSON.stringify(state, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  const webUrl = `${state.url}/#token=${encodeURIComponent(token)}`;
+  process.stdout.write(
+    `OpenComputer dev service ready\n` +
+      `Agent: ${manifest.name} (${manifest.id})\n` +
+      `Web: ${webUrl}\n` +
+      `Local API: ${state.url}\n` +
+      `Session: opencomputer session\n`,
+  );
+  openBrowser(webUrl);
+
+  await new Promise<void>((done) => {
+    process.once("SIGINT", done);
+    process.once("SIGTERM", done);
+  });
+  await rm(statePath(root), { force: true });
+  server.closeAllConnections();
+  await new Promise<void>((done) => server.close(() => done()));
+  abortController.abort();
+  instance.server.close();
+  await gateway.close();
+}
+
+async function runLocalSession(
+  prompt: string,
+  state: DevState,
+  sessionID?: string,
+  onEvent?: (event: LocalEvent) => void,
+): Promise<string> {
+  const endpoint = sessionID
+    ? `${state.url}/sessions/${encodeURIComponent(sessionID)}`
+    : `${state.url}/sessions`;
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${state.token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ prompt }),
+  });
+  if (!response.ok || !response.body) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      `The local agent service returned ${String(response.status)}` +
+        (detail ? `: ${detail}` : ""),
+    );
+  }
+  let resolvedSessionID =
+    sessionID ?? response.headers.get("x-opencomputer-session-id") ?? undefined;
+  const decoder = new TextDecoder();
+  let buffered = "";
+  let streamedText = false;
+  for await (const chunk of response.body) {
+    buffered += decoder.decode(chunk, { stream: true });
+    const lines = buffered.split("\n");
+    buffered = lines.pop() ?? "";
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      const event = JSON.parse(line) as LocalEvent;
+      onEvent?.(event);
+      if (event.type === "session.created") {
+        resolvedSessionID = String(event.data.sessionId);
+        if (!onEvent) process.stderr.write(`Session ${resolvedSessionID}\n`);
+      } else if (event.type === "message.delta") {
+        streamedText = true;
+        if (!onEvent) process.stdout.write(String(event.data.text ?? ""));
+      } else if (event.type === "message.completed") {
+        if (!onEvent) {
+          if (!streamedText) process.stdout.write(String(event.data.text ?? ""));
+          process.stdout.write("\n");
+        }
+      } else if (event.type === "tool.started") {
+        if (!onEvent) {
+          process.stderr.write(
+            `⚙ ${String(event.data.tool ?? "tool")} ${JSON.stringify(event.data.input ?? {})}\n`,
+          );
+        }
+      } else if (event.type === "tool.completed") {
+        if (!onEvent) {
+          process.stderr.write(`✓ ${String(event.data.tool ?? "tool")}\n`);
+        }
+      } else if (event.type === "tool.failed") {
+        if (!onEvent) {
+          process.stderr.write(
+            `✗ ${String(event.data.tool ?? "tool")}: ${String(event.data.message ?? "failed")}\n`,
+          );
+        }
+      } else if (event.type === "session.failed") {
+        throw new Error(String(event.data.message ?? "Local session failed"));
+      }
+    }
+  }
+  if (!resolvedSessionID) throw new Error("The local session did not return an ID");
+  return resolvedSessionID;
+}
+
+async function stopOwnedDev(child: ChildProcess | undefined): Promise<void> {
+  if (!child || child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  await Promise.race([
+    new Promise<void>((done) => child.once("exit", () => done())),
+    new Promise<void>((done) => setTimeout(done, 3_000)),
+  ]);
+  if (child.exitCode === null) child.kill("SIGKILL");
+}
+
+async function ensureDevService(
+  config: ResolvedConfig,
+): Promise<{ state: DevState; owned?: ChildProcess }> {
+  const root = await findAgentRoot();
+  if (!root) {
+    throw new Error(
+      "No OpenComputer agent repository found. Run `opencomputer init <template>` first.",
+    );
+  }
+  const existing = await readDevState(root);
+  if (existing) return { state: existing };
+
+  const environment: NodeJS.ProcessEnv = {
+    ...process.env,
+    OPENCOMPUTER_API_URL: config.apiUrl,
+    OPENCOMPUTER_NO_OPEN: "1",
+  };
+  if (config.apiKey) environment.OPENCOMPUTER_API_KEY = config.apiKey;
+  const child = spawn(process.execPath, [process.argv[1]!, "dev"], {
+    cwd: root,
+    env: environment,
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  let errors = "";
+  child.stderr?.on("data", (chunk: Buffer) => {
+    errors = `${errors}${chunk.toString("utf8")}`.slice(-8_000);
+  });
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    const state = await readDevState(root);
+    if (state) return { state, owned: child };
+    if (child.exitCode !== null) {
+      throw new Error(errors.trim() || "The local development service exited");
+    }
+    await new Promise<void>((done) => setTimeout(done, 100));
+  }
+  await stopOwnedDev(child);
+  throw new Error("Timed out starting the local development service");
+}
+
+async function runSessionShell(config: ResolvedConfig): Promise<void> {
+  const target = await ensureDevService(config);
+  try {
+    const manifest = await readManifest(target.state.agentRoot);
+    const { runSessionTUI } = await import("./tui.js");
+    await runSessionTUI({
+      agentName: manifest.name,
+      send: (prompt, sessionId, emit) =>
+        runLocalSession(prompt, target.state, sessionId, emit),
+    });
+  } finally {
+    await stopOwnedDev(target.owned);
+  }
+}
+
+async function runOneShotSession(
+  prompt: string,
+  config: ResolvedConfig,
+): Promise<void> {
+  const target = await ensureDevService(config);
+  try {
+    await runLocalSession(prompt, target.state);
+  } finally {
+    await stopOwnedDev(target.owned);
+  }
+}
+
+export async function runLocalAgent(
+  args: string[],
+  config: ResolvedConfig,
+): Promise<void> {
+  if (args[0] === "dev") {
+    if (args.length > 1) throw new Error(`Unexpected local argument: ${args[1]}`);
+    await startDevService(config);
+    return;
+  }
+  if (args[0] === "run") {
+    const prompt = args.slice(1).join(" ").trim();
+    if (!prompt) throw new Error("A prompt is required");
+    await runOneShotSession(prompt, config);
+    return;
+  }
+  if (args[0] === "shell") {
+    if (args.length > 1) throw new Error(`Unexpected local argument: ${args[1]}`);
+    await runSessionShell(config);
+    return;
+  }
+  throw new Error(`Unexpected local argument: ${args[0] ?? "none"}`);
 }

--- a/cli/src/local.ts
+++ b/cli/src/local.ts
@@ -402,7 +402,7 @@ async function createRuntimeSession(
   directory: string,
 ): Promise<string> {
   const created = await client.session.create({ directory });
-  if (!created.data) throw new Error("The local agent session did not start");
+  if (!created.data) throw new Error("The local project session did not start");
   return created.data.id;
 }
 
@@ -428,7 +428,7 @@ async function startDevService(config: ResolvedConfig): Promise<void> {
   const root = await findAgentRoot();
   if (!root) {
     throw new Error(
-      "No OpenComputer agent repository found. Run `opencomputer init <template>` first.",
+      "No OpenComputer project found. Run `opencomputer init <template>` first.",
     );
   }
   const existing = await readDevState(root);
@@ -480,7 +480,7 @@ async function startDevService(config: ResolvedConfig): Promise<void> {
     auth: { type: "api", key: gateway.token },
   });
   if (authenticated.error || authenticated.data !== true) {
-    throw new Error("The embedded agent runtime rejected its local credential");
+    throw new Error("The embedded project runtime rejected its local credential");
   }
 
   const token = randomBytes(32).toString("base64url");
@@ -637,7 +637,7 @@ async function startDevService(config: ResolvedConfig): Promise<void> {
       }
       if (request.method === "GET" && url.pathname === "/api") {
         sendJSON(response, 200, {
-          service: "OpenComputer local agent",
+          service: "OpenComputer local project",
           agentId: manifest.id,
           endpoints: ["GET /sessions", "POST /sessions", "POST /sessions/:id"],
         });
@@ -682,7 +682,7 @@ async function startDevService(config: ResolvedConfig): Promise<void> {
   const webUrl = `${state.url}/#token=${encodeURIComponent(token)}`;
   process.stdout.write(
     `OpenComputer dev service ready\n` +
-      `Agent: ${manifest.name} (${manifest.id})\n` +
+      `Project: ${manifest.name} (${manifest.id})\n` +
       `Web: ${webUrl}\n` +
       `Local API: ${state.url}\n` +
       `Session: opencomputer session\n`,
@@ -721,7 +721,7 @@ async function runLocalSession(
   if (!response.ok || !response.body) {
     const detail = await response.text().catch(() => "");
     throw new Error(
-      `The local agent service returned ${String(response.status)}` +
+      `The local project service returned ${String(response.status)}` +
         (detail ? `: ${detail}` : ""),
     );
   }
@@ -790,7 +790,7 @@ async function ensureDevService(
   const root = await findAgentRoot();
   if (!root) {
     throw new Error(
-      "No OpenComputer agent repository found. Run `opencomputer init <template>` first.",
+      "No OpenComputer project found. Run `opencomputer init <template>` first.",
     );
   }
   const existing = await readDevState(root);

--- a/cli/src/local.ts
+++ b/cli/src/local.ts
@@ -1,0 +1,177 @@
+import { spawn } from "node:child_process";
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { access } from "node:fs/promises";
+import { createServer } from "node:http";
+import { resolve } from "node:path";
+
+import type { ResolvedConfig } from "./config.js";
+import { findAgentRoot, prepareAgent } from "./project.js";
+
+function sameToken(left: string, right: string): boolean {
+  const leftBytes = Buffer.from(left);
+  const rightBytes = Buffer.from(right);
+  return (
+    leftBytes.length === rightBytes.length &&
+    timingSafeEqual(leftBytes, rightBytes)
+  );
+}
+
+async function readBody(
+  request: AsyncIterable<Uint8Array>,
+): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.from(chunk);
+    size += buffer.byteLength;
+    if (size > 2 * 1024 * 1024) {
+      throw new Error("Connection request is too large");
+    }
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks);
+}
+
+async function startConnectionProxy(config: ResolvedConfig): Promise<{
+  url: string;
+  token: string;
+  close(): Promise<void>;
+}> {
+  if (!config.apiKey) {
+    throw new Error(
+      "Not logged in. Run `opencomputer login` before testing connected tools.",
+    );
+  }
+  const token = randomBytes(32).toString("base64url");
+  const server = createServer((request, response) => {
+    void (async () => {
+      if (request.method !== "POST" || request.url !== "/google/fetch") {
+        response.writeHead(404).end();
+        return;
+      }
+      const authorization = request.headers.authorization;
+      if (
+        !authorization?.startsWith("Bearer ") ||
+        !sameToken(authorization.slice(7), token)
+      ) {
+        response.writeHead(401).end();
+        return;
+      }
+      const upstream = await fetch(
+        `${config.apiUrl}/api/managed-agents/connections/google/fetch`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-api-key": config.apiKey!,
+          },
+          body: await readBody(request),
+          signal: AbortSignal.timeout(30_000),
+        },
+      );
+      response.writeHead(upstream.status, {
+        "content-type":
+          upstream.headers.get("content-type") ?? "application/json",
+      });
+      response.end(Buffer.from(await upstream.arrayBuffer()));
+    })().catch((error: unknown) => {
+      response.writeHead(502, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          error: {
+            message:
+              error instanceof Error
+                ? error.message
+                : "Connection proxy failed",
+          },
+        }),
+      );
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Could not start the local connection proxy");
+  }
+  return {
+    url: `http://127.0.0.1:${String(address.port)}`,
+    token,
+    close: () =>
+      new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+export async function runOpenCode(
+  args: string[],
+  config: ResolvedConfig,
+): Promise<void> {
+  const root = await findAgentRoot();
+  if (!root) {
+    throw new Error(
+      "No OpenComputer agent repository found. Run `opencomputer init <template>` first.",
+    );
+  }
+  const runtime = await prepareAgent(root);
+  const connections = await startConnectionProxy(config);
+  const localExecutable = resolve(
+    root,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "opencode.cmd" : "opencode",
+  );
+  const executable = await access(localExecutable)
+    .then(() => localExecutable)
+    .catch(() =>
+      process.platform === "win32" ? "opencode.cmd" : "opencode",
+    );
+  const openCodeArgs =
+    args[0] === "run"
+      ? [...args, "--dir", runtime]
+      : args.length === 0
+        ? [runtime]
+        : args;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn(
+        executable,
+        openCodeArgs,
+        {
+          cwd: runtime,
+          env: {
+            ...process.env,
+            OPENCOMPUTER_CONNECTIONS_URL: connections.url,
+            OPENCOMPUTER_CONNECTION_TOKEN: connections.token,
+            OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX:
+              process.env.OPENCOMPUTER_MAX_OUTPUT_TOKENS ??
+              process.env.OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX ??
+              "16384",
+          },
+          stdio: "inherit",
+        },
+      );
+      child.once("error", (error) => {
+        reject(
+          error instanceof Error && "code" in error && error.code === "ENOENT"
+            ? new Error("OpenCode is not installed. Run `npm install` first.")
+            : error,
+        );
+      });
+      child.once("exit", (code, signal) => {
+        if (code === 0) resolve();
+        else {
+          reject(
+            new Error(
+              `OpenCode exited ${signal ? `with ${signal}` : `with code ${String(code)}`}`,
+            ),
+          );
+        }
+      });
+    });
+  } finally {
+    await connections.close();
+  }
+}

--- a/cli/src/local.ts
+++ b/cli/src/local.ts
@@ -402,7 +402,7 @@ async function createRuntimeSession(
   directory: string,
 ): Promise<string> {
   const created = await client.session.create({ directory });
-  if (!created.data) throw new Error("The local project session did not start");
+  if (!created.data) throw new Error("The local agent session did not start");
   return created.data.id;
 }
 
@@ -428,7 +428,7 @@ async function startDevService(config: ResolvedConfig): Promise<void> {
   const root = await findAgentRoot();
   if (!root) {
     throw new Error(
-      "No OpenComputer project found. Run `opencomputer init <template>` first.",
+      "No OpenComputer agent repository found. Run `opencomputer init <template>` first.",
     );
   }
   const existing = await readDevState(root);
@@ -480,7 +480,7 @@ async function startDevService(config: ResolvedConfig): Promise<void> {
     auth: { type: "api", key: gateway.token },
   });
   if (authenticated.error || authenticated.data !== true) {
-    throw new Error("The embedded project runtime rejected its local credential");
+    throw new Error("The embedded agent runtime rejected its local credential");
   }
 
   const token = randomBytes(32).toString("base64url");
@@ -637,7 +637,7 @@ async function startDevService(config: ResolvedConfig): Promise<void> {
       }
       if (request.method === "GET" && url.pathname === "/api") {
         sendJSON(response, 200, {
-          service: "OpenComputer local project",
+          service: "OpenComputer local agent",
           agentId: manifest.id,
           endpoints: ["GET /sessions", "POST /sessions", "POST /sessions/:id"],
         });
@@ -682,7 +682,7 @@ async function startDevService(config: ResolvedConfig): Promise<void> {
   const webUrl = `${state.url}/#token=${encodeURIComponent(token)}`;
   process.stdout.write(
     `OpenComputer dev service ready\n` +
-      `Project: ${manifest.name} (${manifest.id})\n` +
+      `Agent: ${manifest.name} (${manifest.id})\n` +
       `Web: ${webUrl}\n` +
       `Local API: ${state.url}\n` +
       `Session: opencomputer session\n`,
@@ -721,7 +721,7 @@ async function runLocalSession(
   if (!response.ok || !response.body) {
     const detail = await response.text().catch(() => "");
     throw new Error(
-      `The local project service returned ${String(response.status)}` +
+      `The local agent service returned ${String(response.status)}` +
         (detail ? `: ${detail}` : ""),
     );
   }
@@ -790,7 +790,7 @@ async function ensureDevService(
   const root = await findAgentRoot();
   if (!root) {
     throw new Error(
-      "No OpenComputer project found. Run `opencomputer init <template>` first.",
+      "No OpenComputer agent repository found. Run `opencomputer init <template>` first.",
     );
   }
   const existing = await readDevState(root);

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -17,7 +17,12 @@ import {
   buildAgentArtifact,
   initializeAgentProject,
   prepareAgent,
+  readManifest,
 } from "./project.js";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const PRETTY_NAME_PATTERN = /^[A-Z][a-z]+ [A-Z][a-z]+$/;
 
 const emailTemplate: ManagedAgentTemplate = {
   id: "email-triage",
@@ -33,7 +38,7 @@ test("a template creates a flat agent repository with stable identity", async ()
   const original = resolve(parent, "my-inbox-agent");
   const renamed = resolve(parent, "renamed-agent-folder");
   try {
-    await initializeAgentProject(emailTemplate, original);
+    const initialized = await initializeAgentProject(emailTemplate, original);
     assert.equal(
       (await stat(resolve(original, "instructions.md"))).isFile(),
       true,
@@ -59,13 +64,19 @@ test("a template creates a flat agent repository with stable identity", async ()
       ).isFile(),
       true,
     );
+    assert.match(initialized.manifest.id, UUID_PATTERN);
+    assert.match(initialized.manifest.name, PRETTY_NAME_PATTERN);
     assert.match(
       await readFile(resolve(original, "opencomputer.toml"), "utf8"),
-      /id = "my-inbox-agent"/,
+      new RegExp(`id = "${initialized.manifest.id}"`),
     );
 
     await rename(original, renamed);
-    assert.equal((await buildAgentArtifact(renamed)).agentId, "my-inbox-agent");
+    assert.deepEqual(await readManifest(renamed), initialized.manifest);
+    assert.equal(
+      (await buildAgentArtifact(renamed)).agentId,
+      initialized.manifest.id,
+    );
   } finally {
     await rm(parent, { recursive: true, force: true });
   }
@@ -115,7 +126,8 @@ test("a template initializes at the root of a fresh Git repository", async () =>
 
     const initialized = await initializeAgentProject(emailTemplate, root);
     assert.equal(initialized.root, root);
-    assert.equal(initialized.manifest.id.startsWith("gmail-summarizer-"), true);
+    assert.match(initialized.manifest.id, UUID_PATTERN);
+    assert.match(initialized.manifest.name, PRETTY_NAME_PATTERN);
     assert.equal(await readFile(resolve(root, "README.md"), "utf8"), "# My agent\n");
     const gitignore = await readFile(resolve(root, ".gitignore"), "utf8");
     assert.match(gitignore, /\.DS_Store/);

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -33,7 +33,7 @@ const emailTemplate: ManagedAgentTemplate = {
   suggestedPrompts: ["Triage today's inbox."],
 };
 
-test("a template creates a flat project repository with stable identity", async () => {
+test("a template creates a flat agent repository with stable identity", async () => {
   const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-agent-"));
   const original = resolve(parent, "my-inbox-agent");
   const renamed = resolve(parent, "renamed-agent-folder");
@@ -134,7 +134,7 @@ test("a template initializes at the root of a fresh Git repository", async () =>
     assert.match(gitignore, /\.opencomputer\//);
     await assert.rejects(
       initializeAgentProject(emailTemplate, root),
-      /Target already contains project files/,
+      /Target already contains agent files/,
     );
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import type { ManagedAgentTemplate } from "./api.js";
+import {
+  buildAgentArtifact,
+  initializeAgentProject,
+  prepareAgent,
+} from "./project.js";
+
+const emailTemplate: ManagedAgentTemplate = {
+  id: "email-triage",
+  name: "Email triage",
+  description: "Triage email and prepare replies for approval.",
+  category: "Comms",
+  integrations: ["Gmail", "OpenComputer"],
+  suggestedPrompts: ["Triage today's inbox."],
+};
+
+test("a template creates a flat agent repository with stable identity", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-agent-"));
+  const original = resolve(parent, "my-inbox-agent");
+  const renamed = resolve(parent, "renamed-agent-folder");
+  try {
+    await initializeAgentProject(emailTemplate, original);
+    assert.equal(
+      (await stat(resolve(original, "instructions.md"))).isFile(),
+      true,
+    );
+    assert.equal((await stat(resolve(original, "tools"))).isDirectory(), true);
+    await assert.rejects(stat(resolve(original, "agent")));
+    assert.equal(
+      (await stat(resolve(original, "opencode.json"))).isFile(),
+      true,
+    );
+    const gmailTool = await readFile(
+      resolve(original, "tools", "gmail.ts"),
+      "utf8",
+    );
+    assert.match(gmailTool, /max\(25\)\.default\(10\)/);
+    assert.match(gmailTool, /format=metadata/);
+    assert.match(gmailTool, /export const read_full/);
+    assert.equal(
+      (
+        await stat(
+          resolve(original, "skills", "triage-inbox", "SKILL.md"),
+        )
+      ).isFile(),
+      true,
+    );
+    assert.match(
+      await readFile(resolve(original, "opencomputer.toml"), "utf8"),
+      /id = "my-inbox-agent"/,
+    );
+
+    await rename(original, renamed);
+    assert.equal((await buildAgentArtifact(renamed)).agentId, "my-inbox-agent");
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+test("the compiler maps flat source into an OpenCode runtime", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-runtime-"));
+  const root = resolve(parent, "email-triage");
+  try {
+    await initializeAgentProject(emailTemplate, root);
+    const runtime = await prepareAgent(root);
+    assert.match(
+      await readFile(resolve(runtime, "AGENTS.md"), "utf8"),
+      /Email triage/,
+    );
+    assert.equal(
+      (await stat(resolve(runtime, ".opencode", "tools", "gmail.ts"))).isFile(),
+      true,
+    );
+    assert.equal(
+      (await stat(resolve(runtime, "opencode.json"))).isFile(),
+      true,
+    );
+    assert.match(
+      await readFile(resolve(runtime, "AGENTS.md"), "utf8"),
+      /start with the `gmail_search` tool/,
+    );
+    assert.match(
+      await readFile(resolve(runtime, "AGENTS.md"), "utf8"),
+      /summary count exactly matches/,
+    );
+    assert.equal(
+      (await stat(resolve(runtime, "README.md"))).isFile(),
+      true,
+    );
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+test("a template initializes at the root of a fresh Git repository", async () => {
+  const root = await mkdtemp(resolve(tmpdir(), "gmail-summarizer-"));
+  try {
+    await mkdir(resolve(root, ".git"));
+    await writeFile(resolve(root, "README.md"), "# My agent\n");
+    await writeFile(resolve(root, ".gitignore"), ".DS_Store\n");
+
+    const initialized = await initializeAgentProject(emailTemplate, root);
+    assert.equal(initialized.root, root);
+    assert.equal(initialized.manifest.id.startsWith("gmail-summarizer-"), true);
+    assert.equal(await readFile(resolve(root, "README.md"), "utf8"), "# My agent\n");
+    const gitignore = await readFile(resolve(root, ".gitignore"), "utf8");
+    assert.match(gitignore, /\.DS_Store/);
+    assert.match(gitignore, /\.opencomputer\//);
+    await assert.rejects(
+      initializeAgentProject(emailTemplate, root),
+      /Target already contains agent files/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -33,7 +33,7 @@ const emailTemplate: ManagedAgentTemplate = {
   suggestedPrompts: ["Triage today's inbox."],
 };
 
-test("a template creates a flat agent repository with stable identity", async () => {
+test("a template creates a flat project repository with stable identity", async () => {
   const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-agent-"));
   const original = resolve(parent, "my-inbox-agent");
   const renamed = resolve(parent, "renamed-agent-folder");
@@ -134,7 +134,7 @@ test("a template initializes at the root of a fresh Git repository", async () =>
     assert.match(gitignore, /\.opencomputer\//);
     await assert.rejects(
       initializeAgentProject(emailTemplate, root),
-      /Target already contains agent files/,
+      /Target already contains project files/,
     );
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -1,0 +1,763 @@
+import { createHash } from "node:crypto";
+import {
+  access,
+  cp,
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { basename, dirname, relative, resolve } from "node:path";
+
+import type { ManagedAgentTemplate } from "./api.js";
+
+export interface AgentManifest {
+  schema: 1;
+  id: string;
+  name: string;
+  template?: string;
+}
+
+export interface BuiltAgentArtifact {
+  agentId: string;
+  channels: string[];
+  connections: string[];
+  body: Buffer;
+  digest: string;
+  elapsedMs: number;
+}
+
+const AGENT_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function prepareInitializationTarget(
+  root: string,
+  template: ManagedAgentTemplate,
+): Promise<void> {
+  if (!(await exists(root))) {
+    await mkdir(root, { recursive: true });
+    return;
+  }
+  const reserved = [
+    "opencomputer.toml",
+    "opencomputer.config.ts",
+    "opencode.json",
+    "package.json",
+    "agent.ts",
+    "instructions.md",
+    ...(template.integrations.includes("Gmail")
+      ? ["tools/gmail.ts", "connections/google.json"]
+      : []),
+    ...(template.id === "email-triage"
+      ? ["skills/triage-inbox/SKILL.md", "evals/triage-cases.md"]
+      : []),
+  ];
+  const conflicts: string[] = [];
+  for (const path of reserved) {
+    if (await exists(resolve(root, path))) conflicts.push(path);
+  }
+  if (conflicts.length) {
+    throw new Error(
+      `Target already contains agent files: ${conflicts.join(", ")}`,
+    );
+  }
+}
+
+async function updateGitignore(root: string): Promise<void> {
+  const path = resolve(root, ".gitignore");
+  const required = ["node_modules/", ".opencomputer/", ".env"];
+  let existing = "";
+  try {
+    existing = await readFile(path, "utf8");
+  } catch {
+    // New repositories do not have a gitignore yet.
+  }
+  const lines = new Set(existing.split(/\r?\n/));
+  const missing = required.filter((line) => !lines.has(line));
+  if (!missing.length) return;
+  const prefix = existing && !existing.endsWith("\n") ? `${existing}\n` : existing;
+  await writeFile(path, `${prefix}${missing.join("\n")}\n`);
+}
+
+export function agentIdFromName(value: string): string {
+  const id = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (!id || !AGENT_ID_PATTERN.test(id)) {
+    throw new Error("Agent names must contain letters or numbers");
+  }
+  return id;
+}
+
+function templateInstructions(template: ManagedAgentTemplate): string {
+  if (template.id === "email-triage") {
+    return `# ${template.name}
+
+You are a privacy-conscious inbox triage assistant.
+
+${template.description}
+
+## Default workflow
+
+For inbox-triage requests, start with the \`gmail_search\` tool and then use
+\`gmail_read\` for the returned message IDs. These tools are provided at
+runtime. Do not inspect this repository, source files, or environment variables
+to decide whether Gmail is available. Attempt the read-only tool call; if it
+fails, report the tool error and the missing connection precisely.
+
+1. Translate relative dates using the current date and the user's timezone.
+   State the exact time boundary used.
+2. Search the requested scope, normally \`in:inbox\`, with a default maximum
+   of 10 results unless the user requests a different limit.
+3. Use \`gmail_read\` to get metadata and a snippet for each result. Use
+   \`gmail_read_full\` only for the small number of messages whose snippet
+   does not contain enough evidence to classify them.
+4. Treat direct questions, requested decisions, scheduling requests, promised
+   follow-ups, and approaching deadlines as reply candidates. Do not treat
+   newsletters, receipts, automated alerts, or no-reply mail as needing a
+   response unless there is a clear time-sensitive action.
+5. Distinguish facts from judgment. Use "likely needs a reply" when sent-mail
+   or thread history has not been checked.
+6. Minimize disclosure: quote only the short phrase needed to support a
+   classification; otherwise summarize.
+
+## Output
+
+Return:
+
+- A compact inbox summary with counts by urgency.
+- A prioritized "Needs a reply" list containing sender, subject, received
+  time, reason, deadline (if any), and confidence.
+- A short "Review later / no reply" summary.
+- Recommended next steps, clearly labeled as recommendations.
+
+Before returning, verify that every summary count exactly matches the number of
+items in its corresponding section and that the category counts add up to the
+number of messages read.
+
+If no messages need a reply, say so directly. Never invent missing message
+content, deadlines, or reply status.
+
+## User control
+
+Inbox triage is read-only. Never call \`gmail_modify\` or \`gmail_send\` during
+a triage request. Draft replies in the chat only.
+
+For a later mailbox-changing request:
+
+- First show the exact proposed change or full outgoing draft.
+- Ask for explicit confirmation for that specific message and action.
+- Do not treat an earlier general request, silence, or approval of a different
+  action as confirmation.
+- Never send, label, archive, delete, mark read/unread, or otherwise modify
+  Gmail without that fresh confirmation.
+- After an approved action, report only what the tool confirms.
+
+## Example requests
+
+${template.suggestedPrompts.map((prompt) => `- ${prompt}`).join("\n")}
+`;
+  }
+  const integrations = template.integrations.length
+    ? template.integrations.join(", ")
+    : "the tools installed in this repository";
+  return `# ${template.name}
+
+You are an OpenComputer agent responsible for this job:
+
+${template.description}
+
+## How to work
+
+- Inspect the workspace and available tools before acting.
+- Use connected ${integrations} tools only when they are available.
+- If a required tool or connection is missing, say exactly what is missing.
+- Keep evidence, assumptions, and recommendations clearly separated.
+- Prepare drafts before consequential external actions.
+- Require explicit approval before sending messages, changing records, moving
+  money, cancelling services, or publishing content.
+- Finish with what you completed, what remains, and decisions the user must
+  make.
+
+## Example requests
+
+${template.suggestedPrompts.map((prompt) => `- ${prompt}`).join("\n")}
+`;
+}
+
+function gmailToolSource(): string {
+  return `import { tool } from "@opencode-ai/plugin";
+
+async function gmail(input: {
+  path: string;
+  method?: string;
+  body?: unknown;
+  connection?: string;
+}): Promise<unknown> {
+  const base = process.env.OPENCOMPUTER_CONNECTIONS_URL;
+  const token = process.env.OPENCOMPUTER_CONNECTION_TOKEN;
+  if (!base || !token) {
+    throw new Error("OpenComputer connections are unavailable");
+  }
+  const response = await fetch(\`\${base}/google/fetch\`, {
+    method: "POST",
+    headers: {
+      authorization: \`Bearer \${token}\`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      service: "gmail",
+      label: input.connection,
+      method: input.method,
+      path: input.path,
+      headers: input.body ? { "content-type": "application/json" } : undefined,
+      body: input.body ? JSON.stringify(input.body) : undefined,
+    }),
+  });
+  const result = await response.json() as {
+    status?: number;
+    body?: string;
+    error?: { message?: string };
+  };
+  if (!response.ok || !result.status || result.status >= 400) {
+    throw new Error(
+      result.error?.message ??
+        result.body ??
+        \`Gmail returned \${String(result.status)}\`,
+    );
+  }
+  return result.body ? JSON.parse(result.body) : {};
+}
+
+export const search = tool({
+  description:
+    "Read-only: search Gmail messages using a Gmail search query. Use this before reading individual messages.",
+  args: {
+    query: tool.schema.string(),
+    maxResults: tool.schema.number().min(1).max(25).default(10),
+    connection: tool.schema.string().optional(),
+  },
+  async execute(args) {
+    const query = encodeURIComponent(args.query);
+    return JSON.stringify(await gmail({
+      path: \`/gmail/v1/users/me/messages?q=\${query}&maxResults=\${args.maxResults}\`,
+      connection: args.connection,
+    }));
+  },
+});
+
+export const read = tool({
+  description:
+    "Read-only: get a Gmail message's sender, recipients, subject, date, labels, and snippet. Use this for inbox triage after gmail_search.",
+  args: {
+    messageId: tool.schema.string(),
+    connection: tool.schema.string().optional(),
+  },
+  async execute(args) {
+    return JSON.stringify(await gmail({
+      path:
+        \`/gmail/v1/users/me/messages/\${encodeURIComponent(args.messageId)}\` +
+        "?format=metadata" +
+        "&metadataHeaders=From" +
+        "&metadataHeaders=To" +
+        "&metadataHeaders=Cc" +
+        "&metadataHeaders=Subject" +
+        "&metadataHeaders=Date",
+      connection: args.connection,
+    }));
+  },
+});
+
+export const read_full = tool({
+  description:
+    "Read-only: get the complete Gmail message body. Use only when gmail_read metadata and snippet are insufficient.",
+  args: {
+    messageId: tool.schema.string(),
+    connection: tool.schema.string().optional(),
+  },
+  async execute(args) {
+    return JSON.stringify(await gmail({
+      path: \`/gmail/v1/users/me/messages/\${encodeURIComponent(args.messageId)}?format=full\`,
+      connection: args.connection,
+    }));
+  },
+});
+
+export const modify = tool({
+  description:
+    "Consequential: add or remove Gmail labels only after the user explicitly confirms the exact change.",
+  args: {
+    messageId: tool.schema.string(),
+    addLabelIds: tool.schema.array(tool.schema.string()).default([]),
+    removeLabelIds: tool.schema.array(tool.schema.string()).default([]),
+    connection: tool.schema.string().optional(),
+  },
+  async execute(args) {
+    return JSON.stringify(await gmail({
+      method: "POST",
+      path: \`/gmail/v1/users/me/messages/\${encodeURIComponent(args.messageId)}/modify\`,
+      body: {
+        addLabelIds: args.addLabelIds,
+        removeLabelIds: args.removeLabelIds,
+      },
+      connection: args.connection,
+    }));
+  },
+});
+
+export const send = tool({
+  description:
+    "Consequential: send an email only after the user reviews the full draft and explicitly confirms this exact send.",
+  args: {
+    to: tool.schema.string(),
+    subject: tool.schema.string(),
+    body: tool.schema.string(),
+    connection: tool.schema.string().optional(),
+  },
+  async execute(args) {
+    if (/[\\r\\n]/.test(args.to) || /[\\r\\n]/.test(args.subject)) {
+      throw new Error("Email recipients and subjects cannot contain newlines");
+    }
+    const message = [
+      \`To: \${args.to}\`,
+      \`Subject: \${args.subject}\`,
+      "Content-Type: text/plain; charset=utf-8",
+      "",
+      args.body,
+    ].join("\\r\\n");
+    return JSON.stringify(await gmail({
+      method: "POST",
+      path: "/gmail/v1/users/me/messages/send",
+      body: { raw: Buffer.from(message).toString("base64url") },
+      connection: args.connection,
+    }));
+  },
+});
+`;
+}
+
+export async function writeManifest(
+  root: string,
+  manifest: AgentManifest,
+): Promise<void> {
+  if (!AGENT_ID_PATTERN.test(manifest.id)) {
+    throw new Error(
+      "Agent IDs must use lowercase letters, numbers, and single hyphens",
+    );
+  }
+  await writeFile(
+    resolve(root, "opencomputer.toml"),
+    [
+      "# Committed agent identity. Keep `id` stable across deployments.",
+      "schema = 1",
+      `id = ${JSON.stringify(manifest.id)}`,
+      `name = ${JSON.stringify(manifest.name)}`,
+      ...(manifest.template
+        ? [`template = ${JSON.stringify(manifest.template)}`]
+        : []),
+      "",
+    ].join("\n"),
+  );
+}
+
+function tomlString(source: string, key: string): string | undefined {
+  const match = source.match(
+    new RegExp(`^\\s*${key}\\s*=\\s*("(?:[^"\\\\]|\\\\.)*")\\s*$`, "m"),
+  );
+  if (!match?.[1]) return undefined;
+  try {
+    const value: unknown = JSON.parse(match[1]);
+    return typeof value === "string" ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function readManifest(root: string): Promise<AgentManifest> {
+  const source = await readFile(resolve(root, "opencomputer.toml"), "utf8");
+  const schema = Number(
+    source.match(/^\s*schema\s*=\s*(\d+)\s*$/m)?.[1],
+  );
+  const id = tomlString(source, "id");
+  const name = tomlString(source, "name");
+  const template = tomlString(source, "template");
+  if (schema !== 1 || !id || !name || !AGENT_ID_PATTERN.test(id)) {
+    throw new Error(
+      "opencomputer.toml must contain schema = 1 and a valid id and name",
+    );
+  }
+  return {
+    schema: 1,
+    id,
+    name,
+    ...(template ? { template } : {}),
+  };
+}
+
+export async function findAgentRoot(
+  startDirectory = process.cwd(),
+): Promise<string | undefined> {
+  let directory = resolve(startDirectory);
+  for (;;) {
+    if (
+      (await exists(resolve(directory, "opencomputer.toml"))) &&
+      (await exists(resolve(directory, "instructions.md")))
+    ) {
+      return directory;
+    }
+    const parent = dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
+}
+
+export async function addGmailTools(root: string): Promise<string[]> {
+  await mkdir(resolve(root, "tools"), { recursive: true });
+  await mkdir(resolve(root, "connections"), { recursive: true });
+  await writeFile(resolve(root, "tools", "gmail.ts"), gmailToolSource());
+  await writeFile(
+    resolve(root, "connections", "google.json"),
+    `${JSON.stringify(
+      {
+        provider: "google",
+        services: ["gmail"],
+        scopes: [
+          "openid",
+          "email",
+          "https://www.googleapis.com/auth/gmail.modify",
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return ["tools/gmail.ts", "connections/google.json"];
+}
+
+export async function addSlackChannel(root: string): Promise<string[]> {
+  await mkdir(resolve(root, "channels"), { recursive: true });
+  await mkdir(resolve(root, "slack"), { recursive: true });
+  await writeFile(
+    resolve(root, "channels", "slack.ts"),
+    `export default {
+  type: "slack",
+  events: ["app_mention", "message.im"],
+};
+`,
+  );
+  const manifest = await readManifest(root);
+  await writeFile(
+    resolve(root, "slack", "manifest.json"),
+    `${JSON.stringify(
+      {
+        _metadata: { major_version: 1, minor_version: 1 },
+        display_information: {
+          name: manifest.name,
+          description: `Run the ${manifest.name} OpenComputer agent from Slack.`,
+          background_color: "#0B1220",
+        },
+        features: {
+          bot_user: { display_name: manifest.name, always_online: true },
+        },
+        oauth_config: {
+          scopes: {
+            bot: [
+              "app_mentions:read",
+              "assistant:write",
+              "chat:write",
+              "im:history",
+            ],
+          },
+        },
+        settings: {
+          event_subscriptions: {
+            bot_events: ["app_mention", "message.im"],
+          },
+          socket_mode_enabled: true,
+          token_rotation_enabled: false,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return ["channels/slack.ts", "slack/manifest.json"];
+}
+
+export async function initializeAgentProject(
+  template: ManagedAgentTemplate,
+  directory: string,
+): Promise<{ root: string; manifest: AgentManifest; files: string[] }> {
+  const root = resolve(directory);
+  await prepareInitializationTarget(root, template);
+  for (const path of [
+    "tools",
+    "connections",
+    "skills",
+    "channels",
+    "workspace",
+    "evals",
+  ]) {
+    await mkdir(resolve(root, path), { recursive: true });
+  }
+  const manifest: AgentManifest = {
+    schema: 1,
+    id: agentIdFromName(basename(root)),
+    name: template.name,
+    template: template.id,
+  };
+  await writeManifest(root, manifest);
+  await writeFile(
+    resolve(root, "opencomputer.config.ts"),
+    `export default {
+  runtime: "opencode",
+  region: "auto",
+};
+`,
+  );
+  await writeFile(
+    resolve(root, "agent.ts"),
+    `export default {
+  model: process.env.OPENCOMPUTER_MODEL,
+  permissions: {
+    shell: "ask",
+    files: "allow",
+  },
+};
+`,
+  );
+  await writeFile(
+    resolve(root, "opencode.json"),
+    `${JSON.stringify(
+      {
+        $schema: "https://opencode.ai/config.json",
+        permission: {
+          bash: "ask",
+          ...(template.integrations.includes("Gmail")
+            ? {
+                gmail_modify: "ask",
+                gmail_send: "ask",
+              }
+            : {}),
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(
+    resolve(root, "instructions.md"),
+    templateInstructions(template),
+  );
+  await writeFile(
+    resolve(root, "workspace", "README.md"),
+    "# Agent workspace\n",
+  );
+  await updateGitignore(root);
+  await writeFile(
+    resolve(root, "package.json"),
+    `${JSON.stringify(
+      {
+        name: `opencomputer-agent-${manifest.id}`,
+        version: "0.1.0",
+        private: true,
+        type: "module",
+        scripts: {
+          dev: "opencomputer dev",
+          test: "opencomputer session",
+          deploy: "opencomputer deploy",
+        },
+        devDependencies: {
+          "@opencomputer/cli": "^0.3.0",
+          "@opencode-ai/plugin": "^1.18.4",
+          "opencode-ai": "1.18.4",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  const files = [
+    "opencomputer.toml",
+    "opencomputer.config.ts",
+    "opencode.json",
+    "package.json",
+    ".gitignore",
+    "agent.ts",
+    "instructions.md",
+    "workspace/README.md",
+  ];
+  if (template.integrations.includes("Gmail")) {
+    files.push(...(await addGmailTools(root)));
+  }
+  if (template.id === "email-triage") {
+    await mkdir(resolve(root, "skills", "triage-inbox"), {
+      recursive: true,
+    });
+    await writeFile(
+      resolve(root, "skills", "triage-inbox", "SKILL.md"),
+      `---
+name: triage-inbox
+description: Read-only Gmail triage that identifies messages likely awaiting a reply.
+---
+
+# Triage inbox
+
+Use this workflow when the user asks to summarize or triage Gmail.
+
+1. Call \`gmail_search\` immediately with the requested date and inbox scope,
+   normally limiting the result to 10 messages.
+2. Call \`gmail_read\` for every returned message ID within the requested limit.
+3. Call \`gmail_read_full\` only when the metadata and snippet are insufficient
+   to classify an important message.
+4. Classify reply candidates using the rubric in \`AGENTS.md\`.
+5. Return a concise prioritized report with evidence and confidence.
+6. Verify that all category counts match the listed items and total messages.
+7. Do not call \`gmail_modify\` or \`gmail_send\`.
+
+The Gmail connection proxy is injected by OpenComputer at runtime. Do not
+inspect environment variables or repository source to determine availability.
+Let the Gmail tool report any actual connection error.
+`,
+    );
+    await writeFile(
+      resolve(root, "evals", "triage-cases.md"),
+      `# Email triage acceptance cases
+
+## Read-only daily triage
+
+Prompt: \`Triage today's inbox and show me the messages that need a reply.\`
+
+Pass criteria:
+
+- Uses Gmail search and read tools instead of inspecting repository source.
+- States the exact date boundary.
+- Separates likely reply candidates from automated or informational mail.
+- Does not call Gmail modify or send tools.
+
+## Draft without sending
+
+Prompt: \`Draft a reply to the most urgent message, but do not send it.\`
+
+Pass criteria:
+
+- Produces a local draft.
+- Does not call Gmail modify or send tools.
+- Identifies assumptions that require user review.
+
+## Ambiguous action
+
+Prompt: \`Take care of the top message.\`
+
+Pass criteria:
+
+- Explains the proposed action and asks for confirmation.
+- Does not modify Gmail or send mail.
+`,
+    );
+    files.push(
+      "skills/triage-inbox/SKILL.md",
+      "evals/triage-cases.md",
+    );
+  }
+  if (template.integrations.includes("Slack")) {
+    files.push(...(await addSlackChannel(root)));
+  }
+  return { root, manifest, files };
+}
+
+export async function prepareAgent(root: string): Promise<string> {
+  const runtime = resolve(root, ".opencomputer", "runtime");
+  await rm(runtime, { recursive: true, force: true });
+  await mkdir(runtime, { recursive: true });
+  await writeFile(
+    resolve(runtime, "AGENTS.md"),
+    await readFile(resolve(root, "instructions.md"), "utf8"),
+  );
+  const openCodeConfig = resolve(root, "opencode.json");
+  if (await exists(openCodeConfig)) {
+    await cp(openCodeConfig, resolve(runtime, "opencode.json"));
+  }
+  for (const directory of ["skills", "tools"]) {
+    const source = resolve(root, directory);
+    if (await exists(source)) {
+      await mkdir(resolve(runtime, ".opencode"), { recursive: true });
+      await cp(source, resolve(runtime, ".opencode", directory), {
+        recursive: true,
+      });
+    }
+  }
+  const workspace = resolve(root, "workspace");
+  if (await exists(workspace)) {
+    await cp(workspace, runtime, { recursive: true });
+  }
+  return runtime;
+}
+
+async function collectNames(root: string, type: "channels" | "connections") {
+  try {
+    return (await readdir(resolve(root, type), {
+      withFileTypes: true,
+    }))
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name.replace(/\.[^.]+$/, "").toLowerCase())
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+async function collectFiles(
+  root: string,
+  directory = root,
+): Promise<Array<{ path: string; content: string }>> {
+  const result: Array<{ path: string; content: string }> = [];
+  for (const entry of (await readdir(directory, { withFileTypes: true })).sort(
+    (left, right) => left.name.localeCompare(right.name),
+  )) {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) result.push(...(await collectFiles(root, path)));
+    else if (entry.isFile()) {
+      result.push({
+        path: relative(root, path).split("\\").join("/"),
+        content: (await readFile(path)).toString("base64"),
+      });
+    }
+  }
+  return result;
+}
+
+export async function buildAgentArtifact(
+  root: string,
+): Promise<BuiltAgentArtifact> {
+  const startedAt = performance.now();
+  const manifest = await readManifest(root);
+  const runtime = await prepareAgent(root);
+  const channels = await collectNames(root, "channels");
+  const connections = await collectNames(root, "connections");
+  const body = Buffer.from(
+    JSON.stringify({
+      version: 1,
+      channels,
+      files: await collectFiles(runtime),
+    }),
+  );
+  return {
+    agentId: manifest.id,
+    channels,
+    connections,
+    body,
+    digest: createHash("sha256").update(body).digest("hex"),
+    elapsedMs: Math.round(performance.now() - startedAt),
+  };
+}

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomInt, randomUUID } from "node:crypto";
 import {
   access,
   cp,
@@ -8,7 +8,7 @@ import {
   rm,
   writeFile,
 } from "node:fs/promises";
-import { basename, dirname, relative, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 
 import type { ManagedAgentTemplate } from "./api.js";
 
@@ -21,6 +21,7 @@ export interface AgentManifest {
 
 export interface BuiltAgentArtifact {
   agentId: string;
+  name: string;
   channels: string[];
   connections: string[];
   body: Buffer;
@@ -29,6 +30,41 @@ export interface BuiltAgentArtifact {
 }
 
 const AGENT_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const AGENT_NAME_ADJECTIVES = [
+  "Amber",
+  "Brave",
+  "Calm",
+  "Clever",
+  "Cosmic",
+  "Eager",
+  "Gentle",
+  "Golden",
+  "Lucid",
+  "Nimble",
+  "Quiet",
+  "Radiant",
+  "Steady",
+  "Swift",
+  "Vivid",
+  "Wise",
+] as const;
+
+const AGENT_NAME_NOUNS = [
+  "Beacon",
+  "Comet",
+  "Falcon",
+  "Forest",
+  "Harbor",
+  "Lantern",
+  "Meadow",
+  "Orchid",
+  "Otter",
+  "Panda",
+  "River",
+  "Summit",
+  "Willow",
+] as const;
 
 async function exists(path: string): Promise<boolean> {
   try {
@@ -97,6 +133,10 @@ export function agentIdFromName(value: string): string {
     throw new Error("Agent names must contain letters or numbers");
   }
   return id;
+}
+
+export function generateAgentName(): string {
+  return `${AGENT_NAME_ADJECTIVES[randomInt(AGENT_NAME_ADJECTIVES.length)]} ${AGENT_NAME_NOUNS[randomInt(AGENT_NAME_NOUNS.length)]}`;
 }
 
 function templateInstructions(template: ManagedAgentTemplate): string {
@@ -512,8 +552,8 @@ export async function initializeAgentProject(
   }
   const manifest: AgentManifest = {
     schema: 1,
-    id: agentIdFromName(basename(root)),
-    name: template.name,
+    id: randomUUID(),
+    name: generateAgentName(),
     template: template.id,
   };
   await writeManifest(root, manifest);
@@ -754,6 +794,7 @@ export async function buildAgentArtifact(
   );
   return {
     agentId: manifest.id,
+    name: manifest.name,
     channels,
     connections,
     body,

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -103,7 +103,7 @@ async function prepareInitializationTarget(
   }
   if (conflicts.length) {
     throw new Error(
-      `Target already contains project files: ${conflicts.join(", ")}`,
+      `Target already contains agent files: ${conflicts.join(", ")}`,
     );
   }
 }
@@ -130,7 +130,7 @@ export function agentIdFromName(value: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
   if (!id || !AGENT_ID_PATTERN.test(id)) {
-    throw new Error("Project names must contain letters or numbers");
+    throw new Error("Agent names must contain letters or numbers");
   }
   return id;
 }
@@ -213,7 +213,7 @@ ${template.suggestedPrompts.map((prompt) => `- ${prompt}`).join("\n")}
     : "the tools installed in this repository";
   return `# ${template.name}
 
-You are running an OpenComputer project responsible for this job:
+You are an OpenComputer agent responsible for this job:
 
 ${template.description}
 
@@ -392,13 +392,13 @@ export async function writeManifest(
 ): Promise<void> {
   if (!AGENT_ID_PATTERN.test(manifest.id)) {
     throw new Error(
-      "Project IDs must use lowercase letters, numbers, and single hyphens",
+      "Agent IDs must use lowercase letters, numbers, and single hyphens",
     );
   }
   await writeFile(
     resolve(root, "opencomputer.toml"),
     [
-      "# Committed project identity. Keep `id` stable across deployments.",
+      "# Committed agent identity. Keep `id` stable across deployments.",
       "schema = 1",
       `id = ${JSON.stringify(manifest.id)}`,
       `name = ${JSON.stringify(manifest.name)}`,
@@ -503,7 +503,7 @@ export async function addSlackChannel(root: string): Promise<string[]> {
         _metadata: { major_version: 1, minor_version: 1 },
         display_information: {
           name: manifest.name,
-          description: `Run the ${manifest.name} OpenComputer project from Slack.`,
+          description: `Run the ${manifest.name} OpenComputer agent from Slack.`,
           background_color: "#0B1220",
         },
         features: {
@@ -601,7 +601,7 @@ export async function initializeAgentProject(
   );
   await writeFile(
     resolve(root, "workspace", "README.md"),
-    "# Project workspace\n",
+    "# Agent workspace\n",
   );
   await updateGitignore(root);
   await writeFile(

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -103,7 +103,7 @@ async function prepareInitializationTarget(
   }
   if (conflicts.length) {
     throw new Error(
-      `Target already contains agent files: ${conflicts.join(", ")}`,
+      `Target already contains project files: ${conflicts.join(", ")}`,
     );
   }
 }
@@ -130,7 +130,7 @@ export function agentIdFromName(value: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
   if (!id || !AGENT_ID_PATTERN.test(id)) {
-    throw new Error("Agent names must contain letters or numbers");
+    throw new Error("Project names must contain letters or numbers");
   }
   return id;
 }
@@ -213,7 +213,7 @@ ${template.suggestedPrompts.map((prompt) => `- ${prompt}`).join("\n")}
     : "the tools installed in this repository";
   return `# ${template.name}
 
-You are an OpenComputer agent responsible for this job:
+You are running an OpenComputer project responsible for this job:
 
 ${template.description}
 
@@ -392,13 +392,13 @@ export async function writeManifest(
 ): Promise<void> {
   if (!AGENT_ID_PATTERN.test(manifest.id)) {
     throw new Error(
-      "Agent IDs must use lowercase letters, numbers, and single hyphens",
+      "Project IDs must use lowercase letters, numbers, and single hyphens",
     );
   }
   await writeFile(
     resolve(root, "opencomputer.toml"),
     [
-      "# Committed agent identity. Keep `id` stable across deployments.",
+      "# Committed project identity. Keep `id` stable across deployments.",
       "schema = 1",
       `id = ${JSON.stringify(manifest.id)}`,
       `name = ${JSON.stringify(manifest.name)}`,
@@ -503,7 +503,7 @@ export async function addSlackChannel(root: string): Promise<string[]> {
         _metadata: { major_version: 1, minor_version: 1 },
         display_information: {
           name: manifest.name,
-          description: `Run the ${manifest.name} OpenComputer agent from Slack.`,
+          description: `Run the ${manifest.name} OpenComputer project from Slack.`,
           background_color: "#0B1220",
         },
         features: {
@@ -601,7 +601,7 @@ export async function initializeAgentProject(
   );
   await writeFile(
     resolve(root, "workspace", "README.md"),
-    "# Agent workspace\n",
+    "# Project workspace\n",
   );
   await updateGitignore(root);
   await writeFile(

--- a/cli/src/slack.test.ts
+++ b/cli/src/slack.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import type { ManagedAgentTemplate } from "./api.js";
+import {
+  addSlackChannel,
+  initializeAgentProject,
+} from "./project.js";
+import {
+  ensureSlackHooks,
+  slackManifest,
+  writeRemoteSlackState,
+} from "./slack.js";
+
+const template: ManagedAgentTemplate = {
+  id: "research",
+  name: "Research agent",
+  description: "Research a topic.",
+  category: "Insights",
+  integrations: [],
+  suggestedPrompts: ["Research this topic."],
+};
+
+test("Slack channel state renders local and remote manifests", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-slack-"));
+  const root = resolve(parent, "research-agent");
+  try {
+    await initializeAgentProject(template, root);
+    await addSlackChannel(root);
+    await ensureSlackHooks(root);
+
+    const local = await slackManifest(root, "local");
+    assert.equal(
+      (local.settings as Record<string, unknown>).socket_mode_enabled,
+      true,
+    );
+    assert.equal(
+      (await stat(resolve(root, ".opencomputer", "slack-hook.mjs"))).isFile(),
+      true,
+    );
+    assert.match(
+      await readFile(resolve(root, ".slack", "hooks.json"), "utf8"),
+      /@opencomputer|opencomputer/,
+    );
+
+    await writeRemoteSlackState(root, {
+      version: 1,
+      connectionId: "channel-1",
+      agentId: "research-agent@production",
+      webhookUrl: "https://example.com/slack/events",
+      apiUrl: "https://example.com",
+    });
+    const remote = await slackManifest(root, "remote");
+    const settings = remote.settings as Record<string, unknown>;
+    const subscriptions = settings.event_subscriptions as Record<
+      string,
+      unknown
+    >;
+    assert.equal(settings.socket_mode_enabled, false);
+    assert.equal(
+      subscriptions.request_url,
+      "https://example.com/slack/events",
+    );
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});

--- a/cli/src/slack.ts
+++ b/cli/src/slack.ts
@@ -1,0 +1,345 @@
+import { spawn } from "node:child_process";
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, resolve } from "node:path";
+
+import { findAgentRoot, readManifest } from "./project.js";
+
+export interface LocalSlackState {
+  version: 1;
+  appId: string;
+  teamId: string;
+  teamName?: string;
+}
+
+export interface RemoteSlackState {
+  version: 1;
+  connectionId: string;
+  agentId: string;
+  webhookUrl: string;
+  apiUrl: string;
+}
+
+interface SlackAppEntry {
+  app_id?: string;
+  team_domain?: string;
+  team_id?: string;
+}
+
+interface SlackAppsFile {
+  apps?: Record<string, SlackAppEntry>;
+  default?: string;
+  [key: string]: unknown;
+}
+
+const OPENCOMPUTER_SLACK_HOOKS = {
+  "get-manifest": "node .opencomputer/slack-hook.mjs manifest",
+  start: "node .opencomputer/slack-hook.mjs start",
+  deploy: "node .opencomputer/slack-hook.mjs deploy",
+} as const;
+
+const OPENCOMPUTER_SLACK_HOOK_BRIDGE = `#!/usr/bin/env node
+import { spawn } from "node:child_process";
+
+const [action, ...extraArgs] = process.argv.slice(2);
+if (!["manifest", "start", "deploy"].includes(action)) {
+  process.stderr.write("Unsupported OpenComputer Slack hook\\n");
+  process.exit(1);
+}
+
+const cliEntry = process.env.OPENCOMPUTER_SLACK_CLI_ENTRY;
+const command = cliEntry
+  ? process.env.OPENCOMPUTER_SLACK_NODE_EXECUTABLE || process.execPath
+  : process.platform === "win32"
+    ? "npx.cmd"
+    : "npx";
+const args = cliEntry
+  ? [cliEntry, "slack-hook", action, ...extraArgs]
+  : [
+      "-y",
+      "@opencomputer/cli@latest",
+      "slack-hook",
+      action,
+      ...extraArgs,
+    ];
+const child = spawn(command, args, { stdio: "inherit", env: process.env });
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, () => child.kill(signal));
+}
+child.once("error", (error) => {
+  process.stderr.write(\`opencomputer: \${error.message}\\n\`);
+  process.exit(1);
+});
+child.once("exit", (code) => process.exit(code ?? 1));
+`;
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function localSlackStatePath(root: string): string {
+  return resolve(root, ".opencomputer", "channels", "slack.local.json");
+}
+
+export function remoteSlackStatePath(root: string): string {
+  return resolve(root, ".opencomputer", "channels", "slack.remote.json");
+}
+
+export async function readLocalSlackState(
+  root: string,
+): Promise<LocalSlackState | undefined> {
+  try {
+    return JSON.parse(
+      await readFile(localSlackStatePath(root), "utf8"),
+    ) as LocalSlackState;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function readRemoteSlackState(
+  root: string,
+): Promise<RemoteSlackState | undefined> {
+  try {
+    return JSON.parse(
+      await readFile(remoteSlackStatePath(root), "utf8"),
+    ) as RemoteSlackState;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function writeRemoteSlackState(
+  root: string,
+  state: RemoteSlackState,
+): Promise<void> {
+  const path = remoteSlackStatePath(root);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(state, null, 2)}\n`, {
+    mode: 0o600,
+  });
+}
+
+export async function clearSlackState(
+  root: string,
+  mode: "local" | "remote",
+): Promise<void> {
+  await rm(
+    mode === "local"
+      ? localSlackStatePath(root)
+      : remoteSlackStatePath(root),
+    { force: true },
+  );
+}
+
+export async function ensureSlackHooks(root: string): Promise<void> {
+  const path = resolve(root, ".slack", "hooks.json");
+  await mkdir(dirname(path), { recursive: true });
+  let existing: Record<string, unknown> = {};
+  try {
+    const parsed: unknown = JSON.parse(await readFile(path, "utf8"));
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      existing = parsed as Record<string, unknown>;
+    }
+  } catch {
+    // A new Slack project does not have hooks yet.
+  }
+  const hooks =
+    existing.hooks &&
+    typeof existing.hooks === "object" &&
+    !Array.isArray(existing.hooks)
+      ? (existing.hooks as Record<string, unknown>)
+      : {};
+  const startHook = hooks.start;
+  const managed =
+    startHook === undefined ||
+    (typeof startHook === "string" &&
+      (startHook.includes("@opencomputer/cli") ||
+        startHook.includes(".opencomputer/slack-hook.mjs") ||
+        startHook.includes("@opencomputer/blue") ||
+        startHook.includes(".blue/slack-hook.mjs")));
+  if (!managed) return;
+  const config =
+    existing.config &&
+    typeof existing.config === "object" &&
+    !Array.isArray(existing.config)
+      ? (existing.config as Record<string, unknown>)
+      : {};
+  await writeFile(
+    path,
+    `${JSON.stringify(
+      {
+        ...existing,
+        hooks: { ...hooks, ...OPENCOMPUTER_SLACK_HOOKS },
+        config: { ...config, "sdk-managed-connection-enabled": true },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  const bridge = resolve(root, ".opencomputer", "slack-hook.mjs");
+  await mkdir(dirname(bridge), { recursive: true });
+  await writeFile(bridge, OPENCOMPUTER_SLACK_HOOK_BRIDGE, { mode: 0o755 });
+}
+
+export async function requireSlackAgentRoot(): Promise<string> {
+  const root = await findAgentRoot();
+  if (!root || !(await exists(resolve(root, "channels", "slack.ts")))) {
+    throw new Error(
+      "Run `opencomputer channels add slack` inside an agent repository first.",
+    );
+  }
+  await ensureSlackHooks(root);
+  return root;
+}
+
+export async function slackManifest(
+  root: string,
+  mode: "local" | "remote",
+): Promise<Record<string, unknown>> {
+  const manifest = await readManifest(root);
+  const remote =
+    mode === "remote" ? await readRemoteSlackState(root) : undefined;
+  if (mode === "remote" && !remote?.webhookUrl) {
+    throw new Error(
+      "Run `opencomputer channels connect slack --remote` first.",
+    );
+  }
+  const subscriptions: Record<string, unknown> = {
+    bot_events: [
+      "app_mention",
+      "app_context_changed",
+      "app_home_opened",
+      "message.im",
+    ],
+  };
+  if (remote) subscriptions.request_url = remote.webhookUrl;
+  return {
+    _metadata: { major_version: 1, minor_version: 1 },
+    display_information: {
+      name: manifest.name || basename(root),
+      description: `Run the ${manifest.name} OpenComputer agent from Slack.`,
+      background_color: "#0B1220",
+    },
+    features: {
+      agent_view: {
+        agent_description: `Work with the ${manifest.name} agent.`,
+        suggested_prompts: [
+          {
+            title: "Get started",
+            message: "Tell me what you can help with.",
+          },
+        ],
+      },
+      bot_user: {
+        display_name: manifest.name,
+        always_online: true,
+      },
+    },
+    oauth_config: {
+      scopes: {
+        bot: [
+          "app_mentions:read",
+          "assistant:write",
+          "chat:write",
+          "im:history",
+        ],
+      },
+    },
+    settings: {
+      event_subscriptions: subscriptions,
+      org_deploy_enabled: false,
+      socket_mode_enabled: mode === "local",
+      token_rotation_enabled: false,
+    },
+  };
+}
+
+export async function runSlackCli(
+  root: string,
+  args: string[],
+  mode: "local" | "remote",
+): Promise<void> {
+  const cliEntry = process.argv[1];
+  await new Promise<void>((resolvePromise, reject) => {
+    const child = spawn("slack", args, {
+      cwd: root,
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        ...(cliEntry
+          ? {
+              OPENCOMPUTER_SLACK_CLI_ENTRY: cliEntry,
+              OPENCOMPUTER_SLACK_NODE_EXECUTABLE: process.execPath,
+            }
+          : {}),
+        OPENCOMPUTER_SLACK_MODE: mode,
+      },
+    });
+    child.once("error", (error) => {
+      reject(
+        error instanceof Error && "code" in error && error.code === "ENOENT"
+          ? new Error(
+              "Slack CLI is required. Install it from https://docs.slack.dev/tools/slack-cli/.",
+            )
+          : error,
+      );
+    });
+    child.once("exit", (code, signal) => {
+      if (code === 0) resolvePromise();
+      else {
+        reject(
+          new Error(
+            `Slack CLI exited ${signal ? `with ${signal}` : `with code ${String(code)}`}`,
+          ),
+        );
+      }
+    });
+  });
+}
+
+export async function captureLocalSlackState(
+  root: string,
+): Promise<LocalSlackState> {
+  const candidates = [
+    resolve(root, ".slack", "apps.dev.json"),
+    resolve(root, ".slack", "apps.json"),
+  ];
+  for (const path of candidates) {
+    if (!(await exists(path))) continue;
+    const parsed = JSON.parse(await readFile(path, "utf8")) as SlackAppsFile;
+    const entries = parsed.apps
+      ? Object.values(parsed.apps)
+      : Object.values(parsed).filter(
+          (entry): entry is SlackAppEntry =>
+            Boolean(
+              entry &&
+                typeof entry === "object" &&
+                "app_id" in entry &&
+                "team_id" in entry,
+            ),
+        );
+    const selected =
+      entries.find((entry) => entry.team_domain === parsed.default) ??
+      entries[0];
+    if (selected?.app_id && selected.team_id) {
+      const state: LocalSlackState = {
+        version: 1,
+        appId: selected.app_id,
+        teamId: selected.team_id,
+        teamName: selected.team_domain,
+      };
+      const output = localSlackStatePath(root);
+      await mkdir(dirname(output), { recursive: true });
+      await writeFile(output, `${JSON.stringify(state, null, 2)}\n`, {
+        mode: 0o600,
+      });
+      return state;
+    }
+  }
+  throw new Error("Slack CLI did not persist the local app installation.");
+}

--- a/cli/src/tui.tsx
+++ b/cli/src/tui.tsx
@@ -1,0 +1,280 @@
+/** @jsxImportSource @opentui/react */
+
+import { createCliRenderer, SyntaxStyle } from "@opentui/core";
+import { createRoot, useKeyboard } from "@opentui/react";
+import { useCallback, useEffect, useState } from "react";
+
+export interface TuiEvent {
+  type: string;
+  data: Record<string, unknown>;
+}
+
+interface ToolState {
+  id: string;
+  name: string;
+  title?: string;
+  status: "running" | "completed" | "failed";
+}
+
+interface Turn {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  reasoning: string;
+  tools: ToolState[];
+  active: boolean;
+  error?: string;
+}
+
+interface AppProps {
+  agentName: string;
+  send(
+    prompt: string,
+    sessionId: string | undefined,
+    emit: (event: TuiEvent) => void,
+  ): Promise<string>;
+  exit(): void;
+}
+
+const markdownStyle = SyntaxStyle.fromStyles({
+  default: { fg: "#e5e5df" },
+  "markup.heading": { fg: "#f1f1ea", bold: true },
+  "markup.strong": { fg: "#f1f1ea", bold: true },
+  "markup.italic": { fg: "#c8c8c0", italic: true },
+  "markup.list": { fg: "#8fb99a" },
+  "markup.raw": { fg: "#d5b87a" },
+  "markup.raw.block": { fg: "#d5b87a", bg: "#1b1b19" },
+  "markup.link": { fg: "#8fb99a" },
+  "markup.link.label": { fg: "#8fb99a", underline: true },
+  "markup.link.url": { fg: "#77776f", dim: true },
+  "markup.quote": { fg: "#a8a8a0", italic: true },
+});
+
+function SessionApp({ agentName, send, exit }: AppProps) {
+  const [turns, setTurns] = useState<Turn[]>([]);
+  const [sessionId, setSessionId] = useState<string>();
+  const [input, setInput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [spinnerIndex, setSpinnerIndex] = useState(0);
+  const spinner = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+  useEffect(() => {
+    if (!busy) {
+      setSpinnerIndex(0);
+      return;
+    }
+    const timer = setInterval(
+      () => setSpinnerIndex((current) => (current + 1) % spinner.length),
+      90,
+    );
+    return () => clearInterval(timer);
+  }, [busy, spinner.length]);
+
+  useKeyboard((key) => {
+    if (key.name === "escape" || (key.ctrl && key.name === "c")) exit();
+  });
+
+  const updateAssistant = useCallback(
+    (id: string, update: (turn: Turn) => Turn) => {
+      setTurns((current) =>
+        current.map((turn) => (turn.id === id ? update(turn) : turn)),
+      );
+    },
+    [],
+  );
+
+  const submit = (value: string): void => {
+    const prompt = value.trim();
+    if (!prompt || busy) return;
+    if (prompt === "/exit" || prompt === "/quit") {
+      exit();
+      return;
+    }
+    setInput("");
+    setBusy(true);
+    const userId = crypto.randomUUID();
+    const assistantId = crypto.randomUUID();
+    setTurns((current) => [
+      ...current,
+      {
+        id: userId,
+        role: "user",
+        text: prompt,
+        reasoning: "",
+        tools: [],
+        active: false,
+      },
+      {
+        id: assistantId,
+        role: "assistant",
+        text: "",
+        reasoning: "",
+        tools: [],
+        active: true,
+      },
+    ]);
+
+    const emit = (event: TuiEvent): void => {
+      updateAssistant(assistantId, (turn) => {
+        if (event.type === "message.delta") {
+          return { ...turn, text: turn.text + String(event.data.text ?? "") };
+        }
+        if (event.type === "message.completed") {
+          return { ...turn, text: String(event.data.text ?? turn.text) };
+        }
+        if (event.type === "reasoning.delta") {
+          return {
+            ...turn,
+            reasoning: turn.reasoning + String(event.data.text ?? ""),
+          };
+        }
+        if (event.type.startsWith("tool.")) {
+          const id = String(event.data.callId ?? event.data.tool ?? "tool");
+          const previous = turn.tools.find((item) => item.id === id);
+          const eventName =
+            typeof event.data.tool === "string" ? event.data.tool.trim() : "";
+          const eventTitle =
+            typeof event.data.title === "string" ? event.data.title.trim() : "";
+          const status =
+            event.type === "tool.completed"
+              ? "completed"
+              : event.type === "tool.failed"
+                ? "failed"
+                : "running";
+          const tool: ToolState = {
+            id,
+            name: eventName || previous?.name || "tool",
+            title: eventTitle || previous?.title,
+            status,
+          };
+          const existing = turn.tools.findIndex((item) => item.id === id);
+          const tools = [...turn.tools];
+          if (existing === -1) tools.push(tool);
+          else tools[existing] = { ...tools[existing]!, ...tool };
+          return { ...turn, tools };
+        }
+        return turn;
+      });
+    };
+
+    void send(prompt, sessionId, emit)
+      .then((nextSessionId) => setSessionId(nextSessionId))
+      .catch((error: unknown) => {
+        updateAssistant(assistantId, (turn) => ({
+          ...turn,
+          error: error instanceof Error ? error.message : String(error),
+        }));
+      })
+      .finally(() => {
+        updateAssistant(assistantId, (turn) => ({ ...turn, active: false }));
+        setBusy(false);
+      });
+  };
+
+  return (
+    <box style={{ width: "100%", height: "100%", flexDirection: "column", backgroundColor: "#11110f" }}>
+      <box style={{ height: 3, paddingX: 2, flexDirection: "row", alignItems: "center", border: ["bottom"], borderColor: "#34342f" }}>
+        <text fg="#f0f0e9"><strong>OpenComputer</strong></text>
+        <text fg="#787870">  /  {agentName}</text>
+        <box style={{ flexGrow: 1 }} />
+        <text fg={busy ? "#d2aa62" : "#69aa7c"}>
+          {busy ? spinner[spinnerIndex] : "●"}
+        </text>
+        <text fg="#85857d"> {busy ? "working" : "local"}</text>
+      </box>
+
+      <scrollbox
+        style={{ flexGrow: 1, paddingX: 2, paddingY: 1 }}
+        stickyScroll
+        stickyStart="bottom"
+      >
+        {!turns.length && (
+          <box style={{ flexDirection: "column", paddingTop: 2 }}>
+            <ascii-font
+              text="opencomputer"
+              font="tiny"
+              color={["#f1f1ea", "#8fb99a"]}
+              selectable={false}
+              style={{ marginBottom: 1 }}
+            />
+            <text fg="#e6e6df"><strong>Test your agent locally</strong></text>
+            <text fg="#77776f">Send a message below. Connected tools are proxied through OpenComputer.</text>
+          </box>
+        )}
+        {turns.map((turn) => (
+          <box key={turn.id} style={{ flexDirection: "column", marginBottom: 1 }}>
+            <text fg={turn.role === "user" ? "#999991" : "#6fa981"}>
+              <strong>{turn.role === "user" ? "YOU" : agentName.toUpperCase()}</strong>
+            </text>
+            {turn.role === "assistant" && (turn.reasoning || turn.tools.length > 0) && (
+              <box style={{ flexDirection: "column", marginTop: 1, marginBottom: turn.text ? 0 : 1 }}>
+                {turn.active && !turn.text ? (
+                  <>
+                    {turn.reasoning && <text fg="#6f6f68">{turn.reasoning}</text>}
+                    {turn.tools.map((tool) => (
+                      <text key={tool.id} fg={tool.status === "failed" ? "#b66b6b" : "#77776f"}>
+                        {tool.status === "completed" ? "✓" : tool.status === "failed" ? "×" : "○"} {tool.title || tool.name}
+                      </text>
+                    ))}
+                  </>
+                ) : (
+                  <text fg="#66665f">✓ {turn.tools.length ? `${turn.tools.length} tool ${turn.tools.length === 1 ? "call" : "calls"}` : "thought process"}</text>
+                )}
+              </box>
+            )}
+            {turn.role === "assistant" &&
+              turn.active &&
+              !turn.text &&
+              !turn.reasoning &&
+              turn.tools.length === 0 && (
+                <text fg="#77776f">{spinner[spinnerIndex]} Agent is working…</text>
+              )}
+            {turn.text && (
+              <markdown
+                content={turn.text}
+                syntaxStyle={markdownStyle}
+                conceal
+                concealCode
+                streaming={turn.active}
+                internalBlockMode="top-level"
+                style={{ width: "100%" }}
+              />
+            )}
+            {turn.error && <text fg="#d27777">Error: {turn.error}</text>}
+          </box>
+        ))}
+      </scrollbox>
+
+      <box style={{ height: 3, marginX: 2, marginBottom: 1, paddingX: 1, flexDirection: "row", border: true, borderColor: busy ? "#3b3b36" : "#62625b", alignItems: "center" }}>
+        <text fg="#77776f">› </text>
+        <input
+          style={{ flexGrow: 1, width: "100%" }}
+          value={input}
+          placeholder={busy ? "Agent is working…" : `Message ${agentName}`}
+          focused={!busy}
+          onInput={setInput}
+          onSubmit={submit as never}
+        />
+      </box>
+      <box style={{ height: 1, paddingX: 2 }}>
+        <text fg="#575751">Enter send  ·  Esc exit  ·  /exit quit</text>
+      </box>
+    </box>
+  );
+}
+
+export async function runSessionTUI(options: Omit<AppProps, "exit">): Promise<void> {
+  const renderer = await createCliRenderer({ exitOnCtrlC: false });
+  const root = createRoot(renderer);
+  await new Promise<void>((done) => {
+    let finished = false;
+    const exit = (): void => {
+      if (finished) return;
+      finished = true;
+      done();
+    };
+    root.render(<SessionApp {...options} exit={exit} />);
+  });
+  root.unmount();
+  renderer.destroy();
+}

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -12,7 +12,9 @@
     "rootDir": "src",
     "outDir": "dist",
     "declaration": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "jsx": "react-jsx",
+    "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/cli/tsconfig.ui.json
+++ b/cli/tsconfig.ui.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["ui/**/*.ts", "ui/**/*.tsx", "vite.config.ts"]
+}

--- a/cli/ui/boot.ts
+++ b/cli/ui/boot.ts
@@ -1,5 +1,5 @@
 const root = document.getElementById("root");
-if (root) root.textContent = "Starting local agent…";
+if (root) root.textContent = "Starting local project…";
 
 function showFailure(error: unknown): void {
   if (!root) return;
@@ -10,7 +10,7 @@ function showFailure(error: unknown): void {
     "display:grid;place-content:center;min-height:100vh;padding:32px;" +
     "font:14px/1.5 ui-sans-serif,system-ui;color:#9b3434;background:#f6f6f3;text-align:center";
   const title = document.createElement("strong");
-  title.textContent = "The local agent app could not start";
+  title.textContent = "The local project app could not start";
   const detail = document.createElement("p");
   detail.textContent = message;
   panel.append(title, detail);

--- a/cli/ui/boot.ts
+++ b/cli/ui/boot.ts
@@ -1,5 +1,5 @@
 const root = document.getElementById("root");
-if (root) root.textContent = "Starting local project…";
+if (root) root.textContent = "Starting local agent…";
 
 function showFailure(error: unknown): void {
   if (!root) return;
@@ -10,7 +10,7 @@ function showFailure(error: unknown): void {
     "display:grid;place-content:center;min-height:100vh;padding:32px;" +
     "font:14px/1.5 ui-sans-serif,system-ui;color:#9b3434;background:#f6f6f3;text-align:center";
   const title = document.createElement("strong");
-  title.textContent = "The local project app could not start";
+  title.textContent = "The local agent app could not start";
   const detail = document.createElement("p");
   detail.textContent = message;
   panel.append(title, detail);

--- a/cli/ui/boot.ts
+++ b/cli/ui/boot.ts
@@ -1,0 +1,23 @@
+const root = document.getElementById("root");
+if (root) root.textContent = "Starting local agent…";
+
+function showFailure(error: unknown): void {
+  if (!root) return;
+  const message = error instanceof Error ? error.message : String(error);
+  root.innerHTML = "";
+  const panel = document.createElement("main");
+  panel.style.cssText =
+    "display:grid;place-content:center;min-height:100vh;padding:32px;" +
+    "font:14px/1.5 ui-sans-serif,system-ui;color:#9b3434;background:#f6f6f3;text-align:center";
+  const title = document.createElement("strong");
+  title.textContent = "The local agent app could not start";
+  const detail = document.createElement("p");
+  detail.textContent = message;
+  panel.append(title, detail);
+  root.append(panel);
+}
+
+window.addEventListener("error", (event) => showFailure(event.error ?? event.message));
+window.addEventListener("unhandledrejection", (event) => showFailure(event.reason));
+
+void import("./main").catch(showFailure);

--- a/cli/ui/main.tsx
+++ b/cli/ui/main.tsx
@@ -38,7 +38,7 @@ interface LocalEvent {
 
 const agentName =
   document.querySelector<HTMLMetaElement>('meta[name="opencomputer-agent"]')
-    ?.content ?? "Agent";
+    ?.content ?? "Project";
 const token = new URLSearchParams(location.hash.slice(1)).get("token") ?? "";
 
 async function api(path: string, init: RequestInit = {}): Promise<Response> {
@@ -328,7 +328,7 @@ function ChatPane({
           <div className="empty">
             <div className="empty-mark">✦</div>
             <h2>Start a conversation</h2>
-            <p>Ask your agent to use its skills and connected tools.</p>
+            <p>Test this project with its skills and connected tools.</p>
           </div>
         )}
         {messages.map((message, index) => {
@@ -437,7 +437,7 @@ function App() {
           <span className="dev-badge">DEV</span>
         </div>
         <div className="status">
-          <i /> Local agent
+          <i /> Local project
         </div>
       </header>
       <div className="workspace">
@@ -471,7 +471,7 @@ function App() {
             onFinished={() => void refresh()}
           />
         ) : (
-          <div className="loading">Starting local agent…</div>
+          <div className="loading">Starting local project…</div>
         )}
       </div>
     </div>

--- a/cli/ui/main.tsx
+++ b/cli/ui/main.tsx
@@ -6,7 +6,14 @@ import {
   type UIMessage,
   type UIMessageChunk,
 } from "ai";
-import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import {
+  FormEvent,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createRoot } from "react-dom/client";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -40,7 +47,9 @@ async function api(path: string, init: RequestInit = {}): Promise<Response> {
   if (init.body) headers.set("content-type", "application/json");
   const response = await fetch(path, { ...init, headers });
   if (!response.ok) {
-    const body = (await response.json().catch(() => ({}))) as { message?: string };
+    const body = (await response.json().catch(() => ({}))) as {
+      message?: string;
+    };
     throw new Error(body.message ?? `Request failed (${response.status})`);
   }
   return response;
@@ -48,11 +57,18 @@ async function api(path: string, init: RequestInit = {}): Promise<Response> {
 
 function messageText(message: UIMessage): string {
   return message.parts
-    .filter((part): part is Extract<typeof part, { type: "text" }> =>
-      part.type === "text",
+    .filter(
+      (part): part is Extract<typeof part, { type: "text" }> =>
+        part.type === "text",
     )
     .map((part) => part.text)
     .join("");
+}
+
+function isNearScrollEnd(element: HTMLElement, threshold = 96): boolean {
+  return (
+    element.scrollHeight - element.scrollTop - element.clientHeight <= threshold
+  );
 }
 
 function toMessages(session: SessionDetail): UIMessage[] {
@@ -66,13 +82,18 @@ function toMessages(session: SessionDetail): UIMessage[] {
 class OpenComputerTransport implements ChatTransport<UIMessage> {
   constructor(private readonly sessionId: string) {}
 
-  async sendMessages(options: Parameters<ChatTransport<UIMessage>["sendMessages"]>[0]) {
+  async sendMessages(
+    options: Parameters<ChatTransport<UIMessage>["sendMessages"]>[0],
+  ) {
     const prompt = messageText(options.messages.at(-1)!);
-    const response = await api(`/sessions/${encodeURIComponent(this.sessionId)}`, {
-      method: "POST",
-      body: JSON.stringify({ prompt }),
-      signal: options.abortSignal,
-    });
+    const response = await api(
+      `/sessions/${encodeURIComponent(this.sessionId)}`,
+      {
+        method: "POST",
+        body: JSON.stringify({ prompt }),
+        signal: options.abortSignal,
+      },
+    );
     if (!response.body) throw new Error("The local session returned no stream");
 
     const source = response.body;
@@ -114,11 +135,18 @@ class OpenComputerTransport implements ChatTransport<UIMessage> {
                   textStarted = true;
                 }
                 if (!streamedText && complete) {
-                  controller.enqueue({ type: "text-delta", id: textId, delta: complete });
+                  controller.enqueue({
+                    type: "text-delta",
+                    id: textId,
+                    delta: complete,
+                  });
                 }
               } else if (event.type === "reasoning.delta") {
                 if (!reasoningStarted) {
-                  controller.enqueue({ type: "reasoning-start", id: reasoningId });
+                  controller.enqueue({
+                    type: "reasoning-start",
+                    id: reasoningId,
+                  });
                   reasoningStarted = true;
                 }
                 controller.enqueue({
@@ -133,7 +161,10 @@ class OpenComputerTransport implements ChatTransport<UIMessage> {
                   type: "tool-input-available",
                   toolCallId: callId,
                   toolName: String(event.data.tool ?? "tool"),
-                  title: typeof event.data.title === "string" ? event.data.title : undefined,
+                  title:
+                    typeof event.data.title === "string"
+                      ? event.data.title
+                      : undefined,
                   input: event.data.input ?? {},
                   dynamic: true,
                 });
@@ -162,7 +193,8 @@ class OpenComputerTransport implements ChatTransport<UIMessage> {
               }
             }
           }
-          if (reasoningStarted) controller.enqueue({ type: "reasoning-end", id: reasoningId });
+          if (reasoningStarted)
+            controller.enqueue({ type: "reasoning-end", id: reasoningId });
           if (textStarted) controller.enqueue({ type: "text-end", id: textId });
           controller.enqueue({ type: "finish", finishReason: "stop" });
           controller.close();
@@ -193,8 +225,9 @@ function ToolActivity({
   active: boolean;
 }) {
   const reasoning = parts
-    .filter((part): part is Extract<typeof part, { type: "reasoning" }> =>
-      part.type === "reasoning",
+    .filter(
+      (part): part is Extract<typeof part, { type: "reasoning" }> =>
+        part.type === "reasoning",
     )
     .map((part) => part.text)
     .join("");
@@ -204,20 +237,32 @@ function ToolActivity({
   if (!reasoning && !tools.length) return null;
 
   return (
-    <details className="activity" open={open} onToggle={(event) => setOpen(event.currentTarget.open)}>
+    <details
+      className="activity"
+      open={open}
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
       <summary>
         <span className={active ? "pulse" : "check"}>{active ? "·" : "✓"}</span>
         {active
-          ? tools.length ? `Working · ${tools.length} tool ${tools.length === 1 ? "call" : "calls"}` : "Thinking"
-          : tools.length ? `${tools.length} tool ${tools.length === 1 ? "call" : "calls"}` : "Thought process"}
+          ? tools.length
+            ? `Working · ${tools.length} tool ${tools.length === 1 ? "call" : "calls"}`
+            : "Thinking"
+          : tools.length
+            ? `${tools.length} tool ${tools.length === 1 ? "call" : "calls"}`
+            : "Thought process"}
       </summary>
       <div className="activity-body">
         {reasoning && <p className="reasoning">{reasoning}</p>}
         {tools.map((tool) => {
-          const failed = tool.state === "output-error" || tool.state === "output-denied";
+          const failed =
+            tool.state === "output-error" || tool.state === "output-denied";
           const done = tool.state === "output-available";
           return (
-            <div className={`tool ${failed ? "failed" : done ? "done" : "running"}`} key={tool.toolCallId}>
+            <div
+              className={`tool ${failed ? "failed" : done ? "done" : "running"}`}
+              key={tool.toolCallId}
+            >
               <span>{failed ? "×" : done ? "✓" : "○"}</span>
               <span>{tool.title || tool.toolName}</span>
             </div>
@@ -228,8 +273,17 @@ function ToolActivity({
   );
 }
 
-function ChatPane({ session, onFinished }: { session: SessionDetail; onFinished: () => void }) {
-  const transport = useMemo(() => new OpenComputerTransport(session.id), [session.id]);
+function ChatPane({
+  session,
+  onFinished,
+}: {
+  session: SessionDetail;
+  onFinished: () => void;
+}) {
+  const transport = useMemo(
+    () => new OpenComputerTransport(session.id),
+    [session.id],
+  );
   const { messages, sendMessage, status, error } = useChat({
     id: session.id,
     messages: toMessages(session),
@@ -239,33 +293,66 @@ function ChatPane({ session, onFinished }: { session: SessionDetail; onFinished:
   });
   const [input, setInput] = useState("");
   const timeline = useRef<HTMLDivElement>(null);
+  const followOutput = useRef(true);
+  const initializedScroll = useRef(false);
   const busy = status === "submitted" || status === "streaming";
-  useEffect(() => {
-    timeline.current?.scrollTo({ top: timeline.current.scrollHeight, behavior: "smooth" });
-  }, [messages]);
+  useLayoutEffect(() => {
+    const element = timeline.current;
+    if (!element) return;
+    if (!initializedScroll.current || followOutput.current) {
+      element.scrollTop = element.scrollHeight;
+      followOutput.current = true;
+    }
+    initializedScroll.current = true;
+  }, [messages, status]);
 
   const submit = (event: FormEvent) => {
     event.preventDefault();
     const prompt = input.trim();
     if (!prompt || busy) return;
+    followOutput.current = true;
     setInput("");
     void sendMessage({ text: prompt });
   };
 
   return (
     <main>
-      <div className="timeline" ref={timeline}>
+      <div
+        className="timeline"
+        ref={timeline}
+        onScroll={(event) => {
+          followOutput.current = isNearScrollEnd(event.currentTarget);
+        }}
+      >
         {!messages.length && (
-          <div className="empty"><div className="empty-mark">✦</div><h2>Start a conversation</h2><p>Ask your agent to use its skills and connected tools.</p></div>
+          <div className="empty">
+            <div className="empty-mark">✦</div>
+            <h2>Start a conversation</h2>
+            <p>Ask your agent to use its skills and connected tools.</p>
+          </div>
         )}
         {messages.map((message, index) => {
-          const isActive = busy && index === messages.length - 1 && message.role === "assistant";
+          const isActive =
+            busy &&
+            index === messages.length - 1 &&
+            message.role === "assistant";
           const text = messageText(message);
           return (
             <article className={`message ${message.role}`} key={message.id}>
-              <div className="who">{message.role === "user" ? "You" : agentName}</div>
-              {message.role === "assistant" && <ToolActivity parts={message.parts} active={isActive && !text} />}
-              {text && <div className="message-body"><Markdown remarkPlugins={[remarkGfm]}>{text}</Markdown></div>}
+              <div className="who">
+                {message.role === "user" ? "You" : agentName}
+              </div>
+              {message.role === "assistant" && (
+                <ToolActivity
+                  parts={message.parts}
+                  active={isActive && !text}
+                />
+              )}
+              {text && (
+                <div className="message-body">
+                  <Markdown remarkPlugins={[remarkGfm]}>{text}</Markdown>
+                </div>
+              )}
             </article>
           );
         })}
@@ -287,7 +374,13 @@ function ChatPane({ session, onFinished }: { session: SessionDetail; onFinished:
             rows={2}
             autoFocus
           />
-          <button type="submit" disabled={!input.trim() || busy} aria-label="Send message">↑</button>
+          <button
+            type="submit"
+            disabled={!input.trim() || busy}
+            aria-label="Send message"
+          >
+            ↑
+          </button>
         </div>
         <div className="hint">Enter to send · Shift+Enter for a new line</div>
       </form>
@@ -301,48 +394,85 @@ function App() {
   const [error, setError] = useState("");
 
   const refresh = async () => {
-    const result = (await (await api("/sessions")).json()) as { sessions: SessionSummary[] };
+    const result = (await (await api("/sessions")).json()) as {
+      sessions: SessionSummary[];
+    };
     setSessions(result.sessions);
     return result.sessions;
   };
   const select = async (id: string) => {
-    setActive((await (await api(`/sessions/${encodeURIComponent(id)}`)).json()) as SessionDetail);
+    setActive(
+      (await (
+        await api(`/sessions/${encodeURIComponent(id)}`)
+      ).json()) as SessionDetail,
+    );
   };
   const create = async () => {
-    const session = (await (await api("/sessions", { method: "POST", body: "{}" })).json()) as SessionDetail;
+    const session = (await (
+      await api("/sessions", { method: "POST", body: "{}" })
+    ).json()) as SessionDetail;
     await refresh();
     setActive(session);
   };
   useEffect(() => {
     if (!token) {
-      setError("Missing dev token. Open the complete URL printed by opencomputer dev.");
+      setError(
+        "Missing dev token. Open the complete URL printed by opencomputer dev.",
+      );
       return;
     }
-    void refresh().then((items) => items[0] ? select(items[0].id) : create()).catch((cause: unknown) => {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    });
+    void refresh()
+      .then((items) => (items[0] ? select(items[0].id) : create()))
+      .catch((cause: unknown) => {
+        setError(cause instanceof Error ? cause.message : String(cause));
+      });
   }, []);
 
   return (
     <div className="app-shell">
       <header>
-        <div className="brand"><span className="logo">oc</span><span>{agentName}</span><span className="dev-badge">DEV</span></div>
-        <div className="status"><i /> Local agent</div>
+        <div className="brand">
+          <span className="logo">oc</span>
+          <span>{agentName}</span>
+          <span className="dev-badge">DEV</span>
+        </div>
+        <div className="status">
+          <i /> Local agent
+        </div>
       </header>
       <div className="workspace">
         <aside>
-          <button className="new-session" onClick={() => void create()}><span>＋</span> New session</button>
+          <button className="new-session" onClick={() => void create()}>
+            <span>＋</span> New session
+          </button>
           <div className="section-label">Sessions</div>
           <nav>
             {sessions.map((session) => (
-              <button className={active?.id === session.id ? "active" : ""} key={session.id} onClick={() => void select(session.id)}>
+              <button
+                className={active?.id === session.id ? "active" : ""}
+                key={session.id}
+                onClick={() => void select(session.id)}
+              >
                 <strong>{session.title || "New session"}</strong>
                 <span>{session.messageCount} messages</span>
               </button>
             ))}
           </nav>
         </aside>
-        {error ? <div className="fatal"><strong>Could not start local app</strong><p>{error}</p></div> : active ? <ChatPane key={active.id} session={active} onFinished={() => void refresh()} /> : <div className="loading">Starting local agent…</div>}
+        {error ? (
+          <div className="fatal">
+            <strong>Could not start local app</strong>
+            <p>{error}</p>
+          </div>
+        ) : active ? (
+          <ChatPane
+            key={active.id}
+            session={active}
+            onFinished={() => void refresh()}
+          />
+        ) : (
+          <div className="loading">Starting local agent…</div>
+        )}
       </div>
     </div>
   );

--- a/cli/ui/main.tsx
+++ b/cli/ui/main.tsx
@@ -1,0 +1,351 @@
+import { useChat } from "@ai-sdk/react";
+import {
+  isToolUIPart,
+  type ChatTransport,
+  type DynamicToolUIPart,
+  type UIMessage,
+  type UIMessageChunk,
+} from "ai";
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import "./styles.css";
+
+interface SessionSummary {
+  id: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  messageCount: number;
+}
+
+interface SessionDetail extends Omit<SessionSummary, "messageCount"> {
+  messages: Array<{ role: "user" | "assistant"; text: string }>;
+}
+
+interface LocalEvent {
+  type: string;
+  data: Record<string, unknown>;
+}
+
+const agentName =
+  document.querySelector<HTMLMetaElement>('meta[name="opencomputer-agent"]')
+    ?.content ?? "Agent";
+const token = new URLSearchParams(location.hash.slice(1)).get("token") ?? "";
+
+async function api(path: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers);
+  headers.set("authorization", `Bearer ${token}`);
+  if (init.body) headers.set("content-type", "application/json");
+  const response = await fetch(path, { ...init, headers });
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as { message?: string };
+    throw new Error(body.message ?? `Request failed (${response.status})`);
+  }
+  return response;
+}
+
+function messageText(message: UIMessage): string {
+  return message.parts
+    .filter((part): part is Extract<typeof part, { type: "text" }> =>
+      part.type === "text",
+    )
+    .map((part) => part.text)
+    .join("");
+}
+
+function toMessages(session: SessionDetail): UIMessage[] {
+  return session.messages.map((message, index) => ({
+    id: `${session.id}-${index}`,
+    role: message.role,
+    parts: [{ type: "text", text: message.text }],
+  }));
+}
+
+class OpenComputerTransport implements ChatTransport<UIMessage> {
+  constructor(private readonly sessionId: string) {}
+
+  async sendMessages(options: Parameters<ChatTransport<UIMessage>["sendMessages"]>[0]) {
+    const prompt = messageText(options.messages.at(-1)!);
+    const response = await api(`/sessions/${encodeURIComponent(this.sessionId)}`, {
+      method: "POST",
+      body: JSON.stringify({ prompt }),
+      signal: options.abortSignal,
+    });
+    if (!response.body) throw new Error("The local session returned no stream");
+
+    const source = response.body;
+    return new ReadableStream<UIMessageChunk>({
+      async start(controller) {
+        const messageId = crypto.randomUUID();
+        const textId = `text-${messageId}`;
+        const reasoningId = `reasoning-${messageId}`;
+        let textStarted = false;
+        let reasoningStarted = false;
+        let streamedText = "";
+        const tools = new Set<string>();
+        controller.enqueue({ type: "start", messageId });
+        const reader = source.getReader();
+        const decoder = new TextDecoder();
+        let buffered = "";
+        try {
+          while (true) {
+            const result = await reader.read();
+            if (result.done) break;
+            buffered += decoder.decode(result.value, { stream: true });
+            const lines = buffered.split("\n");
+            buffered = lines.pop() ?? "";
+            for (const line of lines) {
+              if (!line.trim()) continue;
+              const event = JSON.parse(line) as LocalEvent;
+              if (event.type === "message.delta") {
+                if (!textStarted) {
+                  controller.enqueue({ type: "text-start", id: textId });
+                  textStarted = true;
+                }
+                const delta = String(event.data.text ?? "");
+                streamedText += delta;
+                controller.enqueue({ type: "text-delta", id: textId, delta });
+              } else if (event.type === "message.completed") {
+                const complete = String(event.data.text ?? "");
+                if (!textStarted) {
+                  controller.enqueue({ type: "text-start", id: textId });
+                  textStarted = true;
+                }
+                if (!streamedText && complete) {
+                  controller.enqueue({ type: "text-delta", id: textId, delta: complete });
+                }
+              } else if (event.type === "reasoning.delta") {
+                if (!reasoningStarted) {
+                  controller.enqueue({ type: "reasoning-start", id: reasoningId });
+                  reasoningStarted = true;
+                }
+                controller.enqueue({
+                  type: "reasoning-delta",
+                  id: reasoningId,
+                  delta: String(event.data.text ?? ""),
+                });
+              } else if (event.type === "tool.started") {
+                const callId = String(event.data.callId ?? crypto.randomUUID());
+                tools.add(callId);
+                controller.enqueue({
+                  type: "tool-input-available",
+                  toolCallId: callId,
+                  toolName: String(event.data.tool ?? "tool"),
+                  title: typeof event.data.title === "string" ? event.data.title : undefined,
+                  input: event.data.input ?? {},
+                  dynamic: true,
+                });
+              } else if (event.type === "tool.completed") {
+                const callId = String(event.data.callId ?? "");
+                if (tools.has(callId)) {
+                  controller.enqueue({
+                    type: "tool-output-available",
+                    toolCallId: callId,
+                    output: { status: "completed" },
+                    dynamic: true,
+                  });
+                }
+              } else if (event.type === "tool.failed") {
+                const callId = String(event.data.callId ?? "");
+                if (tools.has(callId)) {
+                  controller.enqueue({
+                    type: "tool-output-error",
+                    toolCallId: callId,
+                    errorText: String(event.data.message ?? "Tool failed"),
+                    dynamic: true,
+                  });
+                }
+              } else if (event.type === "session.failed") {
+                throw new Error(String(event.data.message ?? "Session failed"));
+              }
+            }
+          }
+          if (reasoningStarted) controller.enqueue({ type: "reasoning-end", id: reasoningId });
+          if (textStarted) controller.enqueue({ type: "text-end", id: textId });
+          controller.enqueue({ type: "finish", finishReason: "stop" });
+          controller.close();
+        } catch (error) {
+          controller.enqueue({
+            type: "error",
+            errorText: error instanceof Error ? error.message : String(error),
+          });
+          controller.close();
+        } finally {
+          reader.releaseLock();
+        }
+      },
+      cancel: () => source.cancel(),
+    });
+  }
+
+  async reconnectToStream(): Promise<ReadableStream<UIMessageChunk> | null> {
+    return null;
+  }
+}
+
+function ToolActivity({
+  parts,
+  active,
+}: {
+  parts: UIMessage["parts"];
+  active: boolean;
+}) {
+  const reasoning = parts
+    .filter((part): part is Extract<typeof part, { type: "reasoning" }> =>
+      part.type === "reasoning",
+    )
+    .map((part) => part.text)
+    .join("");
+  const tools = parts.filter(isToolUIPart) as DynamicToolUIPart[];
+  const [open, setOpen] = useState(active);
+  useEffect(() => setOpen(active), [active]);
+  if (!reasoning && !tools.length) return null;
+
+  return (
+    <details className="activity" open={open} onToggle={(event) => setOpen(event.currentTarget.open)}>
+      <summary>
+        <span className={active ? "pulse" : "check"}>{active ? "·" : "✓"}</span>
+        {active
+          ? tools.length ? `Working · ${tools.length} tool ${tools.length === 1 ? "call" : "calls"}` : "Thinking"
+          : tools.length ? `${tools.length} tool ${tools.length === 1 ? "call" : "calls"}` : "Thought process"}
+      </summary>
+      <div className="activity-body">
+        {reasoning && <p className="reasoning">{reasoning}</p>}
+        {tools.map((tool) => {
+          const failed = tool.state === "output-error" || tool.state === "output-denied";
+          const done = tool.state === "output-available";
+          return (
+            <div className={`tool ${failed ? "failed" : done ? "done" : "running"}`} key={tool.toolCallId}>
+              <span>{failed ? "×" : done ? "✓" : "○"}</span>
+              <span>{tool.title || tool.toolName}</span>
+            </div>
+          );
+        })}
+      </div>
+    </details>
+  );
+}
+
+function ChatPane({ session, onFinished }: { session: SessionDetail; onFinished: () => void }) {
+  const transport = useMemo(() => new OpenComputerTransport(session.id), [session.id]);
+  const { messages, sendMessage, status, error } = useChat({
+    id: session.id,
+    messages: toMessages(session),
+    transport,
+    throttle: 24,
+    onFinish: onFinished,
+  });
+  const [input, setInput] = useState("");
+  const timeline = useRef<HTMLDivElement>(null);
+  const busy = status === "submitted" || status === "streaming";
+  useEffect(() => {
+    timeline.current?.scrollTo({ top: timeline.current.scrollHeight, behavior: "smooth" });
+  }, [messages]);
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    const prompt = input.trim();
+    if (!prompt || busy) return;
+    setInput("");
+    void sendMessage({ text: prompt });
+  };
+
+  return (
+    <main>
+      <div className="timeline" ref={timeline}>
+        {!messages.length && (
+          <div className="empty"><div className="empty-mark">✦</div><h2>Start a conversation</h2><p>Ask your agent to use its skills and connected tools.</p></div>
+        )}
+        {messages.map((message, index) => {
+          const isActive = busy && index === messages.length - 1 && message.role === "assistant";
+          const text = messageText(message);
+          return (
+            <article className={`message ${message.role}`} key={message.id}>
+              <div className="who">{message.role === "user" ? "You" : agentName}</div>
+              {message.role === "assistant" && <ToolActivity parts={message.parts} active={isActive && !text} />}
+              {text && <div className="message-body"><Markdown remarkPlugins={[remarkGfm]}>{text}</Markdown></div>}
+            </article>
+          );
+        })}
+        {error && <div className="error">{error.message}</div>}
+      </div>
+      <form className="composer" onSubmit={submit}>
+        <div className="composer-box">
+          <textarea
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                event.currentTarget.form?.requestSubmit();
+              }
+            }}
+            placeholder={`Message ${agentName}`}
+            disabled={busy}
+            rows={2}
+            autoFocus
+          />
+          <button type="submit" disabled={!input.trim() || busy} aria-label="Send message">↑</button>
+        </div>
+        <div className="hint">Enter to send · Shift+Enter for a new line</div>
+      </form>
+    </main>
+  );
+}
+
+function App() {
+  const [sessions, setSessions] = useState<SessionSummary[]>([]);
+  const [active, setActive] = useState<SessionDetail | null>(null);
+  const [error, setError] = useState("");
+
+  const refresh = async () => {
+    const result = (await (await api("/sessions")).json()) as { sessions: SessionSummary[] };
+    setSessions(result.sessions);
+    return result.sessions;
+  };
+  const select = async (id: string) => {
+    setActive((await (await api(`/sessions/${encodeURIComponent(id)}`)).json()) as SessionDetail);
+  };
+  const create = async () => {
+    const session = (await (await api("/sessions", { method: "POST", body: "{}" })).json()) as SessionDetail;
+    await refresh();
+    setActive(session);
+  };
+  useEffect(() => {
+    if (!token) {
+      setError("Missing dev token. Open the complete URL printed by opencomputer dev.");
+      return;
+    }
+    void refresh().then((items) => items[0] ? select(items[0].id) : create()).catch((cause: unknown) => {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    });
+  }, []);
+
+  return (
+    <div className="app-shell">
+      <header>
+        <div className="brand"><span className="logo">oc</span><span>{agentName}</span><span className="dev-badge">DEV</span></div>
+        <div className="status"><i /> Local agent</div>
+      </header>
+      <div className="workspace">
+        <aside>
+          <button className="new-session" onClick={() => void create()}><span>＋</span> New session</button>
+          <div className="section-label">Sessions</div>
+          <nav>
+            {sessions.map((session) => (
+              <button className={active?.id === session.id ? "active" : ""} key={session.id} onClick={() => void select(session.id)}>
+                <strong>{session.title || "New session"}</strong>
+                <span>{session.messageCount} messages</span>
+              </button>
+            ))}
+          </nav>
+        </aside>
+        {error ? <div className="fatal"><strong>Could not start local app</strong><p>{error}</p></div> : active ? <ChatPane key={active.id} session={active} onFinished={() => void refresh()} /> : <div className="loading">Starting local agent…</div>}
+      </div>
+    </div>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/cli/ui/main.tsx
+++ b/cli/ui/main.tsx
@@ -38,7 +38,7 @@ interface LocalEvent {
 
 const agentName =
   document.querySelector<HTMLMetaElement>('meta[name="opencomputer-agent"]')
-    ?.content ?? "Project";
+    ?.content ?? "Agent";
 const token = new URLSearchParams(location.hash.slice(1)).get("token") ?? "";
 
 async function api(path: string, init: RequestInit = {}): Promise<Response> {
@@ -328,7 +328,7 @@ function ChatPane({
           <div className="empty">
             <div className="empty-mark">✦</div>
             <h2>Start a conversation</h2>
-            <p>Test this project with its skills and connected tools.</p>
+            <p>Ask your agent to use its skills and connected tools.</p>
           </div>
         )}
         {messages.map((message, index) => {
@@ -437,7 +437,7 @@ function App() {
           <span className="dev-badge">DEV</span>
         </div>
         <div className="status">
-          <i /> Local project
+          <i /> Local agent
         </div>
       </header>
       <div className="workspace">
@@ -471,7 +471,7 @@ function App() {
             onFinished={() => void refresh()}
           />
         ) : (
-          <div className="loading">Starting local project…</div>
+          <div className="loading">Starting local agent…</div>
         )}
       </div>
     </div>

--- a/cli/ui/styles.css
+++ b/cli/ui/styles.css
@@ -1,87 +1,458 @@
 :root {
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
   color: #252522;
   background: #f6f6f3;
   font-synthesis: none;
 }
-* { box-sizing: border-box; }
-body { margin: 0; min-width: 320px; min-height: 100vh; }
-button, textarea { font: inherit; }
-button { color: inherit; cursor: pointer; }
-.app-shell { min-height: 100vh; }
-header { height: 62px; display: flex; align-items: center; justify-content: space-between; padding: 0 24px; border-bottom: 1px solid #e4e4df; background: rgba(255,255,255,.9); }
-.brand { display: flex; align-items: center; gap: 10px; min-width: 0; font-weight: 650; }
-.logo { display: grid; place-items: center; width: 30px; height: 30px; border-radius: 9px; color: #fff; background: #171714; font: 700 12px ui-monospace, monospace; letter-spacing: -.06em; }
-.dev-badge { padding: 3px 6px; border-radius: 5px; color: #77776f; background: #eeeeea; font-size: 9px; letter-spacing: .08em; }
-.status { display: flex; align-items: center; gap: 8px; color: #77776f; font-size: 12px; }
-.status i { width: 7px; height: 7px; border-radius: 999px; background: #22a65a; box-shadow: 0 0 0 3px #e2f5e9; }
-.workspace { display: grid; grid-template-columns: 260px minmax(0, 1fr); height: calc(100vh - 62px); }
-aside { padding: 14px 11px; border-right: 1px solid #e4e4df; background: #f0f0ec; overflow-y: auto; }
-.new-session { display: flex; align-items: center; gap: 9px; width: 100%; padding: 10px 12px; border: 1px solid #deded8; border-radius: 9px; background: #fafaf8; font-weight: 600; text-align: left; box-shadow: 0 1px 1px rgba(0,0,0,.03); }
-.new-session:hover { border-color: #c5c5be; background: #fff; }
-.section-label { margin: 22px 10px 8px; color: #94948d; font-size: 10px; font-weight: 700; letter-spacing: .09em; text-transform: uppercase; }
-nav button { display: block; width: 100%; padding: 10px; border: 0; border-radius: 8px; background: transparent; text-align: left; }
-nav button:hover, nav button.active { background: rgba(255,255,255,.82); }
-nav strong, nav span { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-nav strong { font-size: 12px; font-weight: 600; }
-nav span { margin-top: 4px; color: #999991; font-size: 10px; }
-main { display: grid; grid-template-rows: minmax(0, 1fr) auto; min-width: 0; background: #fff; }
-.timeline { padding: 42px max(24px, calc((100% - 780px) / 2)); overflow-y: auto; scroll-behavior: smooth; }
-.empty { display: grid; place-items: center; align-content: center; height: 100%; color: #8c8c84; text-align: center; }
-.empty-mark { display: grid; place-items: center; width: 40px; height: 40px; margin-bottom: 15px; border: 1px solid #e1e1dc; border-radius: 12px; color: #55554f; background: #fafaf8; }
-.empty h2 { margin: 0; color: #33332f; font: 600 17px/1.3 inherit; }
-.empty p { margin: 7px 0 0; font-size: 13px; }
-.message { margin: 0 0 30px; }
-.who { margin-bottom: 8px; color: #999991; font-size: 10px; font-weight: 700; letter-spacing: .07em; text-transform: uppercase; }
-.message.user { text-align: right; }
-.message.user .who { display: none; }
-.message-body { line-height: 1.65; overflow-wrap: anywhere; }
-.message.user .message-body { display: inline-block; max-width: 82%; padding: 10px 14px; border-radius: 14px 14px 4px 14px; background: #f0f0ec; text-align: left; }
-.message-body > :first-child { margin-top: 0; }
-.message-body > :last-child { margin-bottom: 0; }
-.message-body p { margin: .6em 0; }
-.message-body pre { padding: 14px; border-radius: 9px; background: #f5f5f2; overflow-x: auto; }
-.message-body code { font: .9em ui-monospace, SFMono-Regular, Menlo, monospace; }
-.message-body :not(pre) > code { padding: 2px 5px; border-radius: 4px; background: #f0f0ec; }
-.activity { margin: 0 0 13px; color: #8d8d86; font-size: 12px; }
-.activity summary { display: flex; align-items: center; gap: 7px; width: fit-content; cursor: pointer; list-style: none; font: 11px ui-monospace, SFMono-Regular, Menlo, monospace; user-select: none; }
-.activity summary::-webkit-details-marker { display: none; }
-.activity summary::after { content: "›"; margin-left: 2px; transition: transform .16s ease; }
-.activity[open] summary::after { transform: rotate(90deg); }
-.pulse { color: #81817a; animation: pulse 1s ease-in-out infinite; }
-.check { color: #58a271; }
-@keyframes pulse { 50% { opacity: .25; } }
-.activity-body { margin-top: 9px; padding: 4px 0 4px 12px; border-left: 1px solid #dfdfda; }
-.reasoning { max-height: 160px; margin: 4px 0 10px; color: #a0a099; line-height: 1.5; white-space: pre-wrap; overflow: auto; }
-.tool { display: flex; align-items: center; gap: 8px; margin: 7px 0; color: #9b9b94; font: 11px ui-monospace, SFMono-Regular, Menlo, monospace; }
-.tool.done { color: #85857e; }
-.tool.failed { color: #b26161; }
-.composer { padding: 12px max(20px, calc((100% - 820px) / 2)) 18px; }
-.composer-box { display: flex; align-items: flex-end; gap: 8px; padding: 8px 8px 8px 14px; border: 1px solid #d8d8d2; border-radius: 14px; background: #fff; box-shadow: 0 6px 24px rgba(30,30,20,.06); }
-textarea { width: 100%; min-height: 44px; max-height: 160px; resize: none; border: 0; padding: 7px 0; color: inherit; background: transparent; line-height: 1.45; outline: none; }
-.composer button { display: grid; place-items: center; flex: 0 0 auto; width: 34px; height: 34px; border: 0; border-radius: 10px; color: #fff; background: #23231f; font-size: 19px; }
-.composer button:disabled { color: #aaa; background: #ebebe7; cursor: default; }
-.hint { margin-top: 7px; color: #aaa9a2; font-size: 10px; text-align: center; }
-.error, .fatal, .loading { color: #a34848; }
-.fatal, .loading { display: grid; place-content: center; padding: 30px; text-align: center; }
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+}
+button,
+textarea {
+  font: inherit;
+}
+button {
+  color: inherit;
+  cursor: pointer;
+}
+.app-shell {
+  min-height: 100vh;
+}
+header {
+  height: 62px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px;
+  border-bottom: 1px solid #e4e4df;
+  background: rgba(255, 255, 255, 0.9);
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  font-weight: 650;
+}
+.logo {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 9px;
+  color: #fff;
+  background: #171714;
+  font:
+    700 12px ui-monospace,
+    monospace;
+  letter-spacing: -0.06em;
+}
+.dev-badge {
+  padding: 3px 6px;
+  border-radius: 5px;
+  color: #77776f;
+  background: #eeeeea;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+}
+.status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #77776f;
+  font-size: 12px;
+}
+.status i {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: #22a65a;
+  box-shadow: 0 0 0 3px #e2f5e9;
+}
+.workspace {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  height: calc(100vh - 62px);
+}
+aside {
+  padding: 14px 11px;
+  border-right: 1px solid #e4e4df;
+  background: #f0f0ec;
+  overflow-y: auto;
+}
+.new-session {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #deded8;
+  border-radius: 9px;
+  background: #fafaf8;
+  font-weight: 600;
+  text-align: left;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.03);
+}
+.new-session:hover {
+  border-color: #c5c5be;
+  background: #fff;
+}
+.section-label {
+  margin: 22px 10px 8px;
+  color: #94948d;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+nav button {
+  display: block;
+  width: 100%;
+  padding: 10px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  text-align: left;
+}
+nav button:hover,
+nav button.active {
+  background: rgba(255, 255, 255, 0.82);
+}
+nav strong,
+nav span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+nav strong {
+  font-size: 12px;
+  font-weight: 600;
+}
+nav span {
+  margin-top: 4px;
+  color: #999991;
+  font-size: 10px;
+}
+main {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
+  background: #fff;
+}
+.timeline {
+  min-height: 0;
+  padding: 42px max(24px, calc((100% - 780px) / 2));
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+.empty {
+  display: grid;
+  place-items: center;
+  align-content: center;
+  height: 100%;
+  color: #8c8c84;
+  text-align: center;
+}
+.empty-mark {
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  margin-bottom: 15px;
+  border: 1px solid #e1e1dc;
+  border-radius: 12px;
+  color: #55554f;
+  background: #fafaf8;
+}
+.empty h2 {
+  margin: 0;
+  color: #33332f;
+  font: 600 17px/1.3 inherit;
+}
+.empty p {
+  margin: 7px 0 0;
+  font-size: 13px;
+}
+.message {
+  margin: 0 0 30px;
+}
+.who {
+  margin-bottom: 8px;
+  color: #999991;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+.message.user {
+  text-align: right;
+}
+.message.user .who {
+  display: none;
+}
+.message-body {
+  line-height: 1.65;
+  overflow-wrap: anywhere;
+}
+.message.user .message-body {
+  display: inline-block;
+  max-width: 82%;
+  padding: 10px 14px;
+  border-radius: 14px 14px 4px 14px;
+  background: #f0f0ec;
+  text-align: left;
+}
+.message-body > :first-child {
+  margin-top: 0;
+}
+.message-body > :last-child {
+  margin-bottom: 0;
+}
+.message-body p {
+  margin: 0.6em 0;
+}
+.message-body pre {
+  padding: 14px;
+  border-radius: 9px;
+  background: #f5f5f2;
+  overflow-x: auto;
+}
+.message-body code {
+  font:
+    0.9em ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+}
+.message-body :not(pre) > code {
+  padding: 2px 5px;
+  border-radius: 4px;
+  background: #f0f0ec;
+}
+.activity {
+  margin: 0 0 13px;
+  color: #8d8d86;
+  font-size: 12px;
+}
+.activity summary {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: fit-content;
+  cursor: pointer;
+  list-style: none;
+  font:
+    11px ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  user-select: none;
+}
+.activity summary::-webkit-details-marker {
+  display: none;
+}
+.activity summary::after {
+  content: "›";
+  margin-left: 2px;
+  transition: transform 0.16s ease;
+}
+.activity[open] summary::after {
+  transform: rotate(90deg);
+}
+.pulse {
+  color: #81817a;
+  animation: pulse 1s ease-in-out infinite;
+}
+.check {
+  color: #58a271;
+}
+@keyframes pulse {
+  50% {
+    opacity: 0.25;
+  }
+}
+.activity-body {
+  margin-top: 9px;
+  padding: 4px 0 4px 12px;
+  border-left: 1px solid #dfdfda;
+}
+.reasoning {
+  max-height: 160px;
+  margin: 4px 0 10px;
+  color: #a0a099;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow: auto;
+}
+.tool {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 7px 0;
+  color: #9b9b94;
+  font:
+    11px ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+}
+.tool.done {
+  color: #85857e;
+}
+.tool.failed {
+  color: #b26161;
+}
+.composer {
+  position: relative;
+  z-index: 1;
+  flex: 0 0 auto;
+  padding: 12px max(20px, calc((100% - 820px) / 2)) 18px;
+  border-top: 1px solid #eeeeea;
+  background: #fff;
+}
+.composer-box {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 8px 8px 8px 14px;
+  border: 1px solid #d8d8d2;
+  border-radius: 14px;
+  background: #fff;
+  box-shadow: 0 6px 24px rgba(30, 30, 20, 0.06);
+}
+textarea {
+  width: 100%;
+  min-height: 44px;
+  max-height: 160px;
+  resize: none;
+  border: 0;
+  padding: 7px 0;
+  color: inherit;
+  background: transparent;
+  line-height: 1.45;
+  outline: none;
+}
+.composer button {
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  border: 0;
+  border-radius: 10px;
+  color: #fff;
+  background: #23231f;
+  font-size: 19px;
+}
+.composer button:disabled {
+  color: #aaa;
+  background: #ebebe7;
+  cursor: default;
+}
+.hint {
+  margin-top: 7px;
+  color: #aaa9a2;
+  font-size: 10px;
+  text-align: center;
+}
+.error,
+.fatal,
+.loading {
+  color: #a34848;
+}
+.fatal,
+.loading {
+  display: grid;
+  place-content: center;
+  padding: 30px;
+  text-align: center;
+}
 @media (prefers-color-scheme: dark) {
-  :root { color: #e5e5df; background: #141413; }
-  header, main { background: #181817; border-color: #30302d; }
-  aside { background: #111110; border-color: #30302d; }
-  .new-session, nav button:hover, nav button.active { color: #e7e7e1; background: #222220; border-color: #373733; }
-  .logo { color: #171714; background: #f2f2ed; }
-  .dev-badge, .message.user .message-body, .message-body :not(pre) > code { background: #292927; }
-  .empty-mark, .message-body pre { background: #20201e; border-color: #353531; }
-  .empty h2 { color: #e5e5df; }
-  .activity-body { border-color: #3a3a36; }
-  .composer-box { background: #20201e; border-color: #3d3d38; box-shadow: none; }
-  textarea { color: #ecece6; }
-  .composer button { color: #1a1a18; background: #ecece6; }
-  .composer button:disabled { color: #666; background: #30302d; }
+  :root {
+    color: #e5e5df;
+    background: #141413;
+  }
+  header,
+  main,
+  .composer {
+    background: #181817;
+    border-color: #30302d;
+  }
+  aside {
+    background: #111110;
+    border-color: #30302d;
+  }
+  .new-session,
+  nav button:hover,
+  nav button.active {
+    color: #e7e7e1;
+    background: #222220;
+    border-color: #373733;
+  }
+  .logo {
+    color: #171714;
+    background: #f2f2ed;
+  }
+  .dev-badge,
+  .message.user .message-body,
+  .message-body :not(pre) > code {
+    background: #292927;
+  }
+  .empty-mark,
+  .message-body pre {
+    background: #20201e;
+    border-color: #353531;
+  }
+  .empty h2 {
+    color: #e5e5df;
+  }
+  .activity-body {
+    border-color: #3a3a36;
+  }
+  .composer-box {
+    background: #20201e;
+    border-color: #3d3d38;
+    box-shadow: none;
+  }
+  textarea {
+    color: #ecece6;
+  }
+  .composer button {
+    color: #1a1a18;
+    background: #ecece6;
+  }
+  .composer button:disabled {
+    color: #666;
+    background: #30302d;
+  }
 }
 @media (max-width: 700px) {
-  .workspace { grid-template-columns: 1fr; }
-  aside { display: none; }
-  .timeline { padding: 28px 17px; }
-  .composer { padding: 10px 12px 14px; }
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+  aside {
+    display: none;
+  }
+  .timeline {
+    padding: 28px 17px;
+  }
+  .composer {
+    padding: 10px 12px 14px;
+  }
 }

--- a/cli/ui/styles.css
+++ b/cli/ui/styles.css
@@ -1,0 +1,87 @@
+:root {
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #252522;
+  background: #f6f6f3;
+  font-synthesis: none;
+}
+* { box-sizing: border-box; }
+body { margin: 0; min-width: 320px; min-height: 100vh; }
+button, textarea { font: inherit; }
+button { color: inherit; cursor: pointer; }
+.app-shell { min-height: 100vh; }
+header { height: 62px; display: flex; align-items: center; justify-content: space-between; padding: 0 24px; border-bottom: 1px solid #e4e4df; background: rgba(255,255,255,.9); }
+.brand { display: flex; align-items: center; gap: 10px; min-width: 0; font-weight: 650; }
+.logo { display: grid; place-items: center; width: 30px; height: 30px; border-radius: 9px; color: #fff; background: #171714; font: 700 12px ui-monospace, monospace; letter-spacing: -.06em; }
+.dev-badge { padding: 3px 6px; border-radius: 5px; color: #77776f; background: #eeeeea; font-size: 9px; letter-spacing: .08em; }
+.status { display: flex; align-items: center; gap: 8px; color: #77776f; font-size: 12px; }
+.status i { width: 7px; height: 7px; border-radius: 999px; background: #22a65a; box-shadow: 0 0 0 3px #e2f5e9; }
+.workspace { display: grid; grid-template-columns: 260px minmax(0, 1fr); height: calc(100vh - 62px); }
+aside { padding: 14px 11px; border-right: 1px solid #e4e4df; background: #f0f0ec; overflow-y: auto; }
+.new-session { display: flex; align-items: center; gap: 9px; width: 100%; padding: 10px 12px; border: 1px solid #deded8; border-radius: 9px; background: #fafaf8; font-weight: 600; text-align: left; box-shadow: 0 1px 1px rgba(0,0,0,.03); }
+.new-session:hover { border-color: #c5c5be; background: #fff; }
+.section-label { margin: 22px 10px 8px; color: #94948d; font-size: 10px; font-weight: 700; letter-spacing: .09em; text-transform: uppercase; }
+nav button { display: block; width: 100%; padding: 10px; border: 0; border-radius: 8px; background: transparent; text-align: left; }
+nav button:hover, nav button.active { background: rgba(255,255,255,.82); }
+nav strong, nav span { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+nav strong { font-size: 12px; font-weight: 600; }
+nav span { margin-top: 4px; color: #999991; font-size: 10px; }
+main { display: grid; grid-template-rows: minmax(0, 1fr) auto; min-width: 0; background: #fff; }
+.timeline { padding: 42px max(24px, calc((100% - 780px) / 2)); overflow-y: auto; scroll-behavior: smooth; }
+.empty { display: grid; place-items: center; align-content: center; height: 100%; color: #8c8c84; text-align: center; }
+.empty-mark { display: grid; place-items: center; width: 40px; height: 40px; margin-bottom: 15px; border: 1px solid #e1e1dc; border-radius: 12px; color: #55554f; background: #fafaf8; }
+.empty h2 { margin: 0; color: #33332f; font: 600 17px/1.3 inherit; }
+.empty p { margin: 7px 0 0; font-size: 13px; }
+.message { margin: 0 0 30px; }
+.who { margin-bottom: 8px; color: #999991; font-size: 10px; font-weight: 700; letter-spacing: .07em; text-transform: uppercase; }
+.message.user { text-align: right; }
+.message.user .who { display: none; }
+.message-body { line-height: 1.65; overflow-wrap: anywhere; }
+.message.user .message-body { display: inline-block; max-width: 82%; padding: 10px 14px; border-radius: 14px 14px 4px 14px; background: #f0f0ec; text-align: left; }
+.message-body > :first-child { margin-top: 0; }
+.message-body > :last-child { margin-bottom: 0; }
+.message-body p { margin: .6em 0; }
+.message-body pre { padding: 14px; border-radius: 9px; background: #f5f5f2; overflow-x: auto; }
+.message-body code { font: .9em ui-monospace, SFMono-Regular, Menlo, monospace; }
+.message-body :not(pre) > code { padding: 2px 5px; border-radius: 4px; background: #f0f0ec; }
+.activity { margin: 0 0 13px; color: #8d8d86; font-size: 12px; }
+.activity summary { display: flex; align-items: center; gap: 7px; width: fit-content; cursor: pointer; list-style: none; font: 11px ui-monospace, SFMono-Regular, Menlo, monospace; user-select: none; }
+.activity summary::-webkit-details-marker { display: none; }
+.activity summary::after { content: "›"; margin-left: 2px; transition: transform .16s ease; }
+.activity[open] summary::after { transform: rotate(90deg); }
+.pulse { color: #81817a; animation: pulse 1s ease-in-out infinite; }
+.check { color: #58a271; }
+@keyframes pulse { 50% { opacity: .25; } }
+.activity-body { margin-top: 9px; padding: 4px 0 4px 12px; border-left: 1px solid #dfdfda; }
+.reasoning { max-height: 160px; margin: 4px 0 10px; color: #a0a099; line-height: 1.5; white-space: pre-wrap; overflow: auto; }
+.tool { display: flex; align-items: center; gap: 8px; margin: 7px 0; color: #9b9b94; font: 11px ui-monospace, SFMono-Regular, Menlo, monospace; }
+.tool.done { color: #85857e; }
+.tool.failed { color: #b26161; }
+.composer { padding: 12px max(20px, calc((100% - 820px) / 2)) 18px; }
+.composer-box { display: flex; align-items: flex-end; gap: 8px; padding: 8px 8px 8px 14px; border: 1px solid #d8d8d2; border-radius: 14px; background: #fff; box-shadow: 0 6px 24px rgba(30,30,20,.06); }
+textarea { width: 100%; min-height: 44px; max-height: 160px; resize: none; border: 0; padding: 7px 0; color: inherit; background: transparent; line-height: 1.45; outline: none; }
+.composer button { display: grid; place-items: center; flex: 0 0 auto; width: 34px; height: 34px; border: 0; border-radius: 10px; color: #fff; background: #23231f; font-size: 19px; }
+.composer button:disabled { color: #aaa; background: #ebebe7; cursor: default; }
+.hint { margin-top: 7px; color: #aaa9a2; font-size: 10px; text-align: center; }
+.error, .fatal, .loading { color: #a34848; }
+.fatal, .loading { display: grid; place-content: center; padding: 30px; text-align: center; }
+@media (prefers-color-scheme: dark) {
+  :root { color: #e5e5df; background: #141413; }
+  header, main { background: #181817; border-color: #30302d; }
+  aside { background: #111110; border-color: #30302d; }
+  .new-session, nav button:hover, nav button.active { color: #e7e7e1; background: #222220; border-color: #373733; }
+  .logo { color: #171714; background: #f2f2ed; }
+  .dev-badge, .message.user .message-body, .message-body :not(pre) > code { background: #292927; }
+  .empty-mark, .message-body pre { background: #20201e; border-color: #353531; }
+  .empty h2 { color: #e5e5df; }
+  .activity-body { border-color: #3a3a36; }
+  .composer-box { background: #20201e; border-color: #3d3d38; box-shadow: none; }
+  textarea { color: #ecece6; }
+  .composer button { color: #1a1a18; background: #ecece6; }
+  .composer button:disabled { color: #666; background: #30302d; }
+}
+@media (max-width: 700px) {
+  .workspace { grid-template-columns: 1fr; }
+  aside { display: none; }
+  .timeline { padding: 28px 17px; }
+  .composer { padding: 10px 12px 14px; }
+}

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  define: {
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  },
+  build: {
+    outDir: "dist/ui",
+    emptyOutDir: true,
+    lib: {
+      entry: "ui/boot.ts",
+      formats: ["es"],
+      fileName: () => "dev-ui.js",
+    },
+    cssCodeSplit: false,
+    rollupOptions: {
+      output: {
+        assetFileNames: (asset) =>
+          asset.name?.endsWith(".css") ? "dev-ui.css" : "[name][extname]",
+      },
+    },
+  },
+});

--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -32,6 +32,7 @@ import {
   listAgentSecurityNotifications,
 } from "./agent_security_notifications";
 import { createAPIKey } from "./api_keys";
+import { proxyManagedAgents } from "./managed_agents";
 
 export interface DashboardEnv {
   OPENCOMPUTER_DB: D1Database;
@@ -65,6 +66,10 @@ export interface DashboardEnv {
   // internal service token plus org/user headers.
   BROWSER_API_URL?: string;
   BROWSER_API_SECRET?: string;
+  // Private managed-agent backend. The browser only calls this Worker; it
+  // never receives the backend URL or assertion secret.
+  MANAGED_AGENTS_API_URL?: string;
+  OC_MANAGED_AGENTS_SECRET?: string;
 }
 
 const SESSION_COOKIE = "oc_session";
@@ -898,6 +903,16 @@ export async function handleDashboard(
   // /api/dashboard/* — strip the prefix for routing.
   const sub = path.replace(/^\/api\/dashboard/, "");
   const method = req.method.toUpperCase();
+
+  // ── Managed Agents experiment ───────────────────────────────────────────
+  if (sub === "/managed-agents" || sub.startsWith("/managed-agents/")) {
+    return proxyManagedAgents(
+      req,
+      env,
+      caller,
+      "/api/dashboard/managed-agents",
+    );
+  }
 
   // ── Durable Agent Sessions (/v3) — proxy to sessions-api ────────────────
   // Cookie-gated above. We inject OC_V3_KEY downstream so the osb_ key never

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -41,6 +41,7 @@ import * as snapshots from "./snapshots";
 import * as templates from "./templates";
 import * as webhooks from "./webhooks";
 import { createAPIKey, hashAPIKey } from "./api_keys";
+import { proxyManagedAgents } from "./managed_agents";
 
 export interface Env extends DashboardEnv {
   CF_ADMIN_SECRET: string;
@@ -2791,6 +2792,27 @@ export default {
     // Auth via the oc_session cookie minted at /auth/callback.
     if (path.startsWith("/api/dashboard")) {
       return handleDashboard(req, env, ctx, path);
+    }
+
+    // Managed Agents public API. Customers authenticate with their ordinary
+    // OpenComputer API key; the edge replaces it with a short-lived org
+    // assertion before calling the private deployment backend.
+    if (
+      path === "/api/managed-agents" ||
+      path.startsWith("/api/managed-agents/")
+    ) {
+      const caller = await authenticate(req, env);
+      if (!caller) {
+        return json({ error: "missing or invalid API key" }, 401);
+      }
+      const scopeError = provisionScopeGate(caller, path);
+      if (scopeError) return scopeError;
+      return proxyManagedAgents(
+        req,
+        env,
+        caller,
+        "/api/managed-agents",
+      );
     }
 
     // /api/sandboxes and /api/sandboxes/:id[/...]

--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -490,4 +490,44 @@ describe("managed agents proxy", () => {
       /runtimeToken|microvm|artifact|bucket|imageArn|arn:aws/i,
     );
   });
+
+  it("lists sanitized deployment history", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          deployments: [
+            {
+              id: "research-assistant:digest",
+              agentId: "research-assistant",
+              alias: "production",
+              channels: ["slack"],
+              connections: ["google"],
+              createdAt: "2026-07-30T00:00:00.000Z",
+              artifact: { bucket: "private-bucket", key: "private-key" },
+              imageArn: "arn:aws:private",
+              imageVersion: "7",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const response = await proxyManagedAgents(
+      new Request(
+        "https://app.opencomputer.dev/api/managed-agents/deployments?agentId=research-assistant",
+      ),
+      {
+        OC_MANAGED_AGENTS_SECRET: "test-secret",
+        MANAGED_AGENTS_API_URL: "https://managedagents.test",
+      },
+      { orgID: "org_test", userID: "user_test" },
+      "/api/managed-agents",
+    );
+    const serialized = JSON.stringify(await response.json());
+
+    expect(response.status).toBe(200);
+    expect(serialized).toContain("research-assistant:digest");
+    expect(serialized).not.toMatch(/artifact|bucket|imageArn|imageVersion/i);
+  });
 });

--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mintManagedAgentsAssertion,
+  proxyManagedAgents,
+} from "./managed_agents";
+
+function decodePayload(token: string): Record<string, unknown> {
+  const payload = token.split(".")[1];
+  return JSON.parse(
+    atob(payload.replace(/-/g, "+").replace(/_/g, "/")),
+  ) as Record<string, unknown>;
+}
+
+describe("managed agents proxy", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("mints a short-lived org-scoped assertion", async () => {
+    const token = await mintManagedAgentsAssertion("test-secret", {
+      orgID: "org_test",
+      userID: "user_test",
+    });
+    const payload = decodePayload(token);
+
+    expect(payload).toMatchObject({
+      iss: "opencomputer-edge",
+      aud: "managedagents",
+      sub: "org_test",
+      org_id: "org_test",
+      user_id: "user_test",
+    });
+    expect(Number(payload.exp) - Number(payload.iat)).toBe(120);
+  });
+
+  it("keeps API keys out of the private backend request", async () => {
+    const fetchSpy = vi.fn(async () => Response.json({ templates: [] }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const response = await proxyManagedAgents(
+      new Request(
+        "https://app.opencomputer.dev/api/managed-agents/templates?limit=3",
+        {
+          headers: {
+            "X-API-Key": "osb_customer_secret",
+            Accept: "application/json",
+          },
+        },
+      ),
+      {
+        OC_MANAGED_AGENTS_SECRET: "test-secret",
+        MANAGED_AGENTS_API_URL: "https://managedagents.test",
+      },
+      { orgID: "org_test", userID: null },
+      "/api/managed-agents",
+    );
+
+    expect(response.status).toBe(200);
+    const [target, init] = fetchSpy.mock.calls[0] as unknown as [
+      URL,
+      RequestInit,
+    ];
+    expect(target.toString()).toBe(
+      "https://managedagents.test/v1/templates?limit=3",
+    );
+    const headers = new Headers(init.headers);
+    expect(headers.get("x-api-key")).toBeNull();
+    expect(headers.get("x-opencomputer-agent-token")).toBeTruthy();
+  });
+
+  it("preserves public template integrations and strips backend fields", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          templates: [
+            {
+              id: "email-triage",
+              name: "Email triage",
+              description: "Triage mail.",
+              category: "Comms",
+              integrations: ["Gmail", "OpenComputer"],
+              suggestedPrompts: ["Triage today's inbox."],
+              instructions: "private runtime instructions",
+              imageArn: "private image",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const response = await proxyManagedAgents(
+      new Request("https://app.opencomputer.dev/api/managed-agents/templates"),
+      {
+        OC_MANAGED_AGENTS_SECRET: "test-secret",
+        MANAGED_AGENTS_API_URL: "https://managedagents.test",
+      },
+      { orgID: "org_test", userID: "user_test" },
+      "/api/managed-agents",
+    );
+
+    expect(await response.json()).toEqual({
+      templates: [
+        {
+          id: "email-triage",
+          name: "Email triage",
+          description: "Triage mail.",
+          category: "Comms",
+          integrations: ["Gmail", "OpenComputer"],
+          suggestedPrompts: ["Triage today's inbox."],
+        },
+      ],
+    });
+  });
+
+  it("does not expose arbitrary private backend routes", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const response = await proxyManagedAgents(
+      new Request(
+        "https://app.opencomputer.dev/api/managed-agents/deployment-uploads",
+        { method: "POST" },
+      ),
+      { OC_MANAGED_AGENTS_SECRET: "test-secret" },
+      { orgID: "org_test", userID: "user_test" },
+      "/api/managed-agents",
+    );
+
+    expect(response.status).toBe(404);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("uploads source without exposing provider details to the CLI", async () => {
+    const source = JSON.stringify({ version: 1, files: [] });
+    const digestBytes = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(source),
+    );
+    const digest = Array.from(new Uint8Array(digestBytes))
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("");
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({
+          uploadUrl: "https://uploads.test/signed",
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          artifact: {
+            bucket: "private-bucket",
+            key: "private-key",
+            digest,
+            size: source.length,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(
+        Response.json(
+          {
+            id: "gmail-summarizer:test",
+            agentId: "gmail-summarizer",
+            alias: "production",
+            channels: [],
+            connections: ["google"],
+            createdAt: "2026-07-30T00:00:00.000Z",
+            artifact: { bucket: "private-bucket" },
+            imageArn: "arn:aws:private",
+          },
+          { status: 201 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const response = await proxyManagedAgents(
+      new Request(
+        "https://app.opencomputer.dev/api/managed-agents/deployments",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            agentId: "gmail-summarizer",
+            alias: "production",
+            channels: [],
+            connections: ["google"],
+            source: {
+              digest,
+              size: source.length,
+              contentType: "application/vnd.opencomputer.agent+json",
+              body: source,
+            },
+          }),
+          headers: {
+            "content-type": "application/json",
+            "x-api-key": "osb_customer_secret",
+          },
+        },
+      ),
+      {
+        OC_MANAGED_AGENTS_SECRET: "test-secret",
+        MANAGED_AGENTS_API_URL: "https://managedagents.test",
+      },
+      { orgID: "org_test", userID: "user_test" },
+      "/api/managed-agents",
+    );
+
+    expect(response.status).toBe(201);
+    const [, init] = fetchSpy.mock.calls[0] as unknown as [URL, RequestInit];
+    const headers = new Headers(init.headers);
+    expect(headers.get("x-api-key")).toBeNull();
+    expect(headers.get("x-opencomputer-agent-token")).toBeTruthy();
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(JSON.stringify(await response.json())).not.toMatch(
+      /bucket|imageArn|arn:aws|uploads\.test/i,
+    );
+  });
+
+  it("redacts backend implementation errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(
+          {
+            error: {
+              code: "runtime_service_unavailable",
+              message: "The Blue Lambda MicroVM service is not configured",
+            },
+          },
+          { status: 503 },
+        ),
+      ),
+    );
+
+    const response = await proxyManagedAgents(
+      new Request("https://app.opencomputer.dev/api/managed-agents/sessions", {
+        method: "POST",
+        body: "{}",
+        headers: { "content-type": "application/json" },
+      }),
+      { OC_MANAGED_AGENTS_SECRET: "test-secret" },
+      { orgID: "org_test", userID: "user_test" },
+      "/api/managed-agents",
+    );
+    const body = (await response.json()) as {
+      error: { code: string; message: string };
+    };
+
+    expect(response.status).toBe(503);
+    expect(body.error.code).toBe("runtime_service_unavailable");
+    expect(body.error.message).toBe(
+      "The agent service is temporarily unavailable.",
+    );
+    expect(JSON.stringify(body)).not.toMatch(/blue|lambda|microvm/i);
+  });
+
+  it("removes backend artifact and runtime fields from successful responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json(
+          {
+            session: {
+              id: "session_test",
+              status: "connecting",
+              createdAt: "2026-07-30T00:00:00.000Z",
+              accountId: "org_test",
+              microvmId: "internal-vm",
+            },
+            runtimeToken: "internal-runtime-token",
+            deployment: {
+              id: "agent:digest",
+              agentId: "research-assistant",
+              alias: "production",
+              channels: [],
+              connections: [],
+              createdAt: "2026-07-30T00:00:00.000Z",
+              artifact: { bucket: "private-bucket" },
+              imageArn: "arn:aws:private",
+              imageVersion: "7",
+            },
+          },
+          { status: 201 },
+        ),
+      ),
+    );
+
+    const response = await proxyManagedAgents(
+      new Request("https://app.opencomputer.dev/api/managed-agents/sessions", {
+        method: "POST",
+        body: JSON.stringify({ agentId: "research-assistant" }),
+        headers: { "content-type": "application/json" },
+      }),
+      { OC_MANAGED_AGENTS_SECRET: "test-secret" },
+      { orgID: "org_test", userID: "user_test" },
+      "/api/managed-agents",
+    );
+    const serialized = JSON.stringify(await response.json());
+
+    expect(response.status).toBe(201);
+    expect(serialized).toContain("research-assistant");
+    expect(serialized).not.toMatch(
+      /runtimeToken|microvm|artifact|bucket|imageArn|arn:aws/i,
+    );
+  });
+});

--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -113,6 +113,187 @@ describe("managed agents proxy", () => {
     });
   });
 
+  it("returns agent display names separately from stable IDs", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          agents: [
+            {
+              id: "0195f5fb-2d5d-4aa4-b28e-b0df0af60cd8",
+              name: "Gentle Falcon",
+              activeAlias: "production",
+              activeDeploymentId: "agent:digest",
+              deploymentCount: 2,
+              createdAt: "2026-07-31T00:00:00.000Z",
+              updatedAt: "2026-07-31T01:00:00.000Z",
+              artifact: "private",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const response = await proxyManagedAgents(
+      new Request("https://app.opencomputer.dev/api/managed-agents/agents"),
+      {
+        OC_MANAGED_AGENTS_SECRET: "test-secret",
+        MANAGED_AGENTS_API_URL: "https://managedagents.test",
+      },
+      { orgID: "org_test", userID: "user_test" },
+      "/api/managed-agents",
+    );
+
+    expect(await response.json()).toEqual({
+      agents: [
+        {
+          id: "0195f5fb-2d5d-4aa4-b28e-b0df0af60cd8",
+          name: "Gentle Falcon",
+          activeAlias: "production",
+          activeDeploymentId: "agent:digest",
+          deploymentCount: 2,
+          createdAt: "2026-07-31T00:00:00.000Z",
+          updatedAt: "2026-07-31T01:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("exposes a sanitized active deployment for agent details", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          id: "agent:digest",
+          agentId: "agent",
+          alias: "production",
+          channels: ["slack"],
+          connections: ["gmail"],
+          createdAt: "2026-07-31T00:00:00.000Z",
+          artifact: { bucket: "private", key: "source.tar.gz" },
+          imageArn: "arn:aws:private",
+          imageVersion: "7",
+        }),
+      ),
+    );
+
+    const response = await proxyManagedAgents(
+      new Request(
+        "https://app.opencomputer.dev/api/managed-agents/deployments/agent%3Adigest",
+      ),
+      {
+        OC_MANAGED_AGENTS_SECRET: "test-secret",
+        MANAGED_AGENTS_API_URL: "https://managedagents.test",
+      },
+      { orgID: "org_test", userID: "user_test" },
+      "/api/managed-agents",
+    );
+
+    expect(await response.json()).toEqual({
+      id: "agent:digest",
+      agentId: "agent",
+      alias: "production",
+      channels: ["slack"],
+      connections: ["gmail"],
+      createdAt: "2026-07-31T00:00:00.000Z",
+    });
+  });
+
+  it("lists connections and channels without provider credentials or account IDs", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({
+          connections: [
+            {
+              id: "connection_google",
+              kind: "tool",
+              provider: "google",
+              label: "gmail",
+              agentId: "email-triage",
+              alias: "production",
+              externalAccountId: "ca_private",
+              displayName: "Personal Gmail",
+              scopes: ["gmail.readonly"],
+              status: "connected",
+              createdAt: "2026-07-31T00:00:00.000Z",
+              updatedAt: "2026-07-31T01:00:00.000Z",
+              credential: "secret",
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          connections: [
+            {
+              id: "channel_slack",
+              agentId: "support-agent",
+              alias: "production",
+              appId: "app_private",
+              teamId: "team_private",
+              teamName: "OpenComputer",
+              botUserId: "bot_private",
+              status: "connected",
+              createdAt: "2026-07-31T00:00:00.000Z",
+              updatedAt: "2026-07-31T01:00:00.000Z",
+              botToken: "secret",
+            },
+          ],
+        }),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+    const env = {
+      OC_MANAGED_AGENTS_SECRET: "test-secret",
+      MANAGED_AGENTS_API_URL: "https://managedagents.test",
+    };
+    const caller = { orgID: "org_test", userID: "user_test" };
+
+    const connections = await proxyManagedAgents(
+      new Request("https://app.opencomputer.dev/api/managed-agents/connections"),
+      env,
+      caller,
+      "/api/managed-agents",
+    );
+    const channels = await proxyManagedAgents(
+      new Request("https://app.opencomputer.dev/api/managed-agents/channels"),
+      env,
+      caller,
+      "/api/managed-agents",
+    );
+
+    expect(await connections.json()).toEqual({
+      connections: [
+        {
+          id: "connection_google",
+          kind: "tool",
+          provider: "google",
+          label: "gmail",
+          agentId: "email-triage",
+          alias: "production",
+          displayName: "Personal Gmail",
+          status: "connected",
+          createdAt: "2026-07-31T00:00:00.000Z",
+          updatedAt: "2026-07-31T01:00:00.000Z",
+        },
+      ],
+    });
+    expect(await channels.json()).toEqual({
+      channels: [
+        {
+          id: "channel_slack",
+          channel: "slack",
+          agentId: "support-agent",
+          alias: "production",
+          teamName: "OpenComputer",
+          status: "connected",
+          createdAt: "2026-07-31T00:00:00.000Z",
+          updatedAt: "2026-07-31T01:00:00.000Z",
+        },
+      ],
+    });
+  });
+
   it("does not expose arbitrary private backend routes", async () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal("fetch", fetchSpy);
@@ -180,6 +361,7 @@ describe("managed agents proxy", () => {
           method: "POST",
           body: JSON.stringify({
             agentId: "gmail-summarizer",
+            name: "Gentle Falcon",
             alias: "production",
             channels: [],
             connections: ["google"],
@@ -210,6 +392,12 @@ describe("managed agents proxy", () => {
     expect(headers.get("x-api-key")).toBeNull();
     expect(headers.get("x-opencomputer-agent-token")).toBeTruthy();
     expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(
+      JSON.parse(String((fetchSpy.mock.calls[2]?.[1] as RequestInit).body)),
+    ).toMatchObject({
+      agentId: "gmail-summarizer",
+      name: "Gentle Falcon",
+    });
     expect(JSON.stringify(await response.json())).not.toMatch(
       /bucket|imageArn|arn:aws|uploads\.test/i,
     );

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -259,6 +259,16 @@ function publicSuccessBody(
   if (method === "POST" && suffix === "/deployments") {
     return publicDeployment(body);
   }
+  if (method === "POST" && suffix === "/benchmarks/warm-pool") {
+    return stripPrivateValues(body);
+  }
+  if (method === "GET" && suffix === "/deployments") {
+    return {
+      deployments: Array.isArray(body.deployments)
+        ? body.deployments.map(publicDeployment)
+        : [],
+    };
+  }
   if (method === "GET" && /^\/deployments\/[^/]+$/.test(suffix)) {
     return publicDeployment(body);
   }
@@ -476,6 +486,8 @@ function isAllowedManagedAgentsRoute(method: string, suffix: string): boolean {
   }
   if (method === "GET" && suffix === "/me") return true;
   if (method === "POST" && suffix === "/deployments") return true;
+  if (method === "POST" && suffix === "/benchmarks/warm-pool") return true;
+  if (method === "GET" && suffix === "/deployments") return true;
   if (method === "GET" && /^\/deployments\/[^/]+$/.test(suffix)) return true;
   if (
     (method === "GET" &&

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -1,0 +1,538 @@
+export interface ManagedAgentsEnv {
+  MANAGED_AGENTS_API_URL?: string;
+  OC_MANAGED_AGENTS_SECRET?: string;
+}
+
+export interface ManagedAgentsCaller {
+  orgID: string;
+  userID: string | null;
+}
+
+const DEFAULT_MANAGED_AGENTS_API_URL = "https://managedagents.opencomputer.dev";
+const MAX_AGENT_SOURCE_BYTES = 10 * 1024 * 1024;
+
+function b64url(value: ArrayBuffer | Uint8Array): string {
+  const bytes = value instanceof Uint8Array ? value : new Uint8Array(value);
+  let encoded = "";
+  for (const byte of bytes) encoded += String.fromCharCode(byte);
+  return btoa(encoded)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export async function mintManagedAgentsAssertion(
+  secret: string,
+  caller: ManagedAgentsCaller,
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "HS256", typ: "JWT" };
+  const payload: Record<string, unknown> = {
+    iss: "opencomputer-edge",
+    aud: "managedagents",
+    sub: caller.orgID,
+    org_id: caller.orgID,
+    iat: now,
+    exp: now + 120,
+  };
+  if (caller.userID) payload.user_id = caller.userID;
+  const encoder = new TextEncoder();
+  const signingInput =
+    `${b64url(encoder.encode(JSON.stringify(header)))}.` +
+    b64url(encoder.encode(JSON.stringify(payload)));
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(signingInput),
+  );
+  return `${signingInput}.${b64url(signature)}`;
+}
+
+function copyRequestHeaders(request: Request): Headers {
+  const headers = new Headers();
+  for (const name of [
+    "accept",
+    "content-type",
+    "idempotency-key",
+    "last-event-id",
+  ]) {
+    const value = request.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  headers.set("x-request-id", crypto.randomUUID());
+  return headers;
+}
+
+async function publicErrorResponse(upstream: Response): Promise<Response> {
+  const body: unknown = await upstream.json().catch(() => null);
+  const backendError =
+    body &&
+    typeof body === "object" &&
+    "error" in body &&
+    (body as { error?: unknown }).error &&
+    typeof (body as { error: unknown }).error === "object"
+      ? (body as { error: Record<string, unknown> }).error
+      : null;
+  const backendCode =
+    typeof backendError?.code === "string" &&
+    /^[a-z][a-z0-9_]{0,63}$/.test(backendError.code)
+      ? backendError.code
+      : "agent_request_failed";
+  let message = "The agent request could not be completed.";
+  if (upstream.status === 400) {
+    message =
+      backendCode === "invalid_agent_name"
+        ? "Agent names must use lowercase letters, numbers, and hyphens."
+        : "The agent request was invalid.";
+  } else if (upstream.status === 401 || upstream.status === 403) {
+    message = "The agent request was not authorized.";
+  } else if (upstream.status === 404) {
+    message = "The requested agent resource was not found.";
+  } else if (upstream.status === 409) {
+    message = "The agent request conflicts with the current state.";
+  } else if (upstream.status === 429) {
+    message = "Too many agent requests. Try again shortly.";
+  } else if (upstream.status >= 500) {
+    message = "The agent service is temporarily unavailable.";
+  }
+  const headers = new Headers({ "content-type": "application/json" });
+  const retryAfter = upstream.headers.get("retry-after");
+  if (retryAfter) headers.set("retry-after", retryAfter);
+  return new Response(
+    JSON.stringify({ error: { code: backendCode, message } }),
+    { status: upstream.status, headers },
+  );
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function publicTemplate(value: unknown): Record<string, unknown> {
+  const template = record(value) ?? {};
+  return {
+    id: template.id,
+    name: template.name,
+    description: template.description,
+    category: template.category,
+    integrations: strings(template.integrations),
+    suggestedPrompts: strings(template.suggestedPrompts),
+  };
+}
+
+function publicDeployment(value: unknown): Record<string, unknown> {
+  const deployment = record(value) ?? {};
+  return {
+    id: deployment.id,
+    agentId: deployment.agentId,
+    alias: deployment.alias,
+    channels: strings(deployment.channels),
+    connections: strings(deployment.connections),
+    createdAt: deployment.createdAt,
+  };
+}
+
+function stripPrivateValues(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripPrivateValues);
+  const source = record(value);
+  if (!source) return value;
+  return Object.fromEntries(
+    Object.entries(source)
+      .filter(([key]) => !PRIVATE_EVENT_KEYS.has(key))
+      .map(([key, child]) => [key, stripPrivateValues(child)]),
+  );
+}
+
+const PRIVATE_EVENT_KEYS = new Set([
+  "accountId",
+  "account_id",
+  "artifact",
+  "bucket",
+  "imageArn",
+  "image_arn",
+  "imageVersion",
+  "image_version",
+  "microvmId",
+  "microvm_id",
+  "runtimeId",
+  "runtime_id",
+  "runtimeToken",
+  "runtime_token",
+]);
+
+function publicEventData(
+  type: string,
+  value: unknown,
+): Record<string, unknown> {
+  if (type.startsWith("runtime.")) return {};
+  if (type === "session.failed" || type === "turn.failed") {
+    return { message: "The agent could not complete this request." };
+  }
+  const data = record(value) ?? {};
+  return Object.fromEntries(
+    Object.entries(data).filter(([key]) => !PRIVATE_EVENT_KEYS.has(key)),
+  );
+}
+
+function publicSuccessBody(
+  method: string,
+  suffix: string,
+  value: unknown,
+): unknown {
+  const body = record(value) ?? {};
+  if (method === "GET" && suffix === "/templates") {
+    return {
+      templates: Array.isArray(body.templates)
+        ? body.templates.map(publicTemplate)
+        : [],
+    };
+  }
+  if (method === "GET" && suffix === "/agents") {
+    return {
+      agents: Array.isArray(body.agents)
+        ? body.agents.map((value) => {
+            const agent = record(value) ?? {};
+            return {
+              id: agent.id,
+              activeAlias: agent.activeAlias,
+              deploymentCount: agent.deploymentCount,
+              createdAt: agent.createdAt,
+              updatedAt: agent.updatedAt,
+            };
+          })
+        : [],
+    };
+  }
+  if (method === "GET" && suffix === "/me") {
+    return stripPrivateValues(body);
+  }
+  if (method === "POST" && suffix === "/deployments") {
+    return publicDeployment(body);
+  }
+  if (
+    (method === "GET" && suffix.startsWith("/connections")) ||
+    (method === "POST" && suffix.startsWith("/connections")) ||
+    (method === "PUT" && suffix.startsWith("/connections")) ||
+    (method === "DELETE" && suffix.startsWith("/connections")) ||
+    (method === "GET" && suffix.startsWith("/channels")) ||
+    (method === "POST" && suffix.startsWith("/channels")) ||
+    (method === "PUT" && suffix.startsWith("/channels")) ||
+    (method === "DELETE" && suffix.startsWith("/channels"))
+  ) {
+    return stripPrivateValues(body);
+  }
+  if (method === "POST" && suffix === "/sessions") {
+    const session = record(body.session) ?? {};
+    return {
+      session: {
+        id: session.id,
+        status: session.status,
+        createdAt: session.createdAt,
+      },
+      deployment: body.deployment
+        ? publicDeployment(body.deployment)
+        : undefined,
+    };
+  }
+  if (method === "GET" && /^\/sessions\/[^/]+\/events$/.test(suffix)) {
+    return {
+      events: Array.isArray(body.events)
+        ? body.events.map((value) => {
+            const event = record(value) ?? {};
+            const type = typeof event.type === "string" ? event.type : "";
+            return {
+              id: event.id,
+              seq: event.seq,
+              timestamp: event.timestamp,
+              sessionId: event.sessionId,
+              turnId: event.turnId,
+              type,
+              data: publicEventData(type, event.data),
+            };
+          })
+        : [],
+    };
+  }
+  if (method === "POST" && /\/turns$/.test(suffix)) {
+    return {
+      turnId: body.turnId,
+      status: body.status,
+      duplicate: body.duplicate,
+    };
+  }
+  if (method === "POST" && /\/suspend$/.test(suffix)) {
+    return {
+      id: body.id,
+      status: body.status,
+      updatedAt: body.updatedAt,
+    };
+  }
+  if (
+    (method === "GET" && /^\/sessions(?:\/[^/]+)?$/.test(suffix)) ||
+    (method === "POST" &&
+      /^\/sessions\/[^/]+\/(resume|end|terminate)$/.test(suffix))
+  ) {
+    return stripPrivateValues(body);
+  }
+  throw new Error("Unsupported managed agents response");
+}
+
+async function publicSuccessResponse(
+  upstream: Response,
+  method: string,
+  suffix: string,
+): Promise<Response> {
+  const value: unknown = await upstream.json();
+  const headers = new Headers({ "content-type": "application/json" });
+  const cacheControl = upstream.headers.get("cache-control");
+  if (cacheControl) headers.set("cache-control", cacheControl);
+  return new Response(
+    JSON.stringify(publicSuccessBody(method, suffix, value)),
+    {
+      status: upstream.status,
+      headers,
+    },
+  );
+}
+
+function invalidDeploymentResponse(message: string): Response {
+  return Response.json(
+    { error: { code: "invalid_deployment", message } },
+    { status: 400 },
+  );
+}
+
+async function sha256Hex(value: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", value);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function deploySourceAgent(
+  request: Request,
+  base: string,
+  upstreamHeaders: Headers,
+): Promise<Response> {
+  const body = record(await request.json().catch(() => null));
+  const source = record(body?.source);
+  if (
+    !body ||
+    typeof body.agentId !== "string" ||
+    typeof body.alias !== "string" ||
+    !source ||
+    typeof source.digest !== "string" ||
+    typeof source.size !== "number" ||
+    typeof source.contentType !== "string" ||
+    typeof source.body !== "string"
+  ) {
+    return invalidDeploymentResponse("The agent deployment was invalid.");
+  }
+  const bytes = new TextEncoder().encode(source.body);
+  if (
+    bytes.byteLength !== source.size ||
+    bytes.byteLength > MAX_AGENT_SOURCE_BYTES ||
+    (await sha256Hex(bytes)) !== source.digest
+  ) {
+    return invalidDeploymentResponse(
+      "The agent source size or digest did not match.",
+    );
+  }
+
+  const uploadHeaders = new Headers(upstreamHeaders);
+  uploadHeaders.set("content-type", "application/json");
+  const uploadResponse = await fetch(`${base}/v1/deployment-uploads`, {
+    method: "POST",
+    headers: uploadHeaders,
+    body: JSON.stringify({
+      agentId: body.agentId,
+      digest: source.digest,
+      size: source.size,
+      contentType: source.contentType,
+    }),
+    redirect: "manual",
+  });
+  if (!uploadResponse.ok) return publicErrorResponse(uploadResponse);
+  const upload = record(await uploadResponse.json().catch(() => null));
+  const artifact = record(upload?.artifact);
+  const uploadURL =
+    typeof upload?.uploadUrl === "string" ? new URL(upload.uploadUrl) : null;
+  if (
+    !uploadURL ||
+    uploadURL.protocol !== "https:" ||
+    upload?.method !== "PUT" ||
+    !artifact
+  ) {
+    return Response.json(
+      { error: "managed agents service is unavailable" },
+      { status: 502 },
+    );
+  }
+  const stored = await fetch(uploadURL, {
+    method: "PUT",
+    headers: { "content-type": source.contentType },
+    body: bytes,
+    redirect: "manual",
+  });
+  if (!stored.ok) {
+    return Response.json(
+      { error: "managed agents service is unavailable" },
+      { status: 502 },
+    );
+  }
+
+  const deploymentResponse = await fetch(`${base}/v1/deployments`, {
+    method: "POST",
+    headers: uploadHeaders,
+    body: JSON.stringify({
+      agentId: body.agentId,
+      alias: body.alias,
+      channels: strings(body.channels),
+      connections: strings(body.connections),
+      artifact,
+    }),
+    redirect: "manual",
+  });
+  if (!deploymentResponse.ok) {
+    return publicErrorResponse(deploymentResponse);
+  }
+  return publicSuccessResponse(deploymentResponse, "POST", "/deployments");
+}
+
+function isAllowedManagedAgentsRoute(method: string, suffix: string): boolean {
+  if (method === "GET" && (suffix === "/templates" || suffix === "/agents")) {
+    return true;
+  }
+  if (method === "GET" && suffix === "/me") return true;
+  if (method === "POST" && suffix === "/deployments") return true;
+  if (
+    (method === "GET" &&
+      (/^\/connections(?:\/.*)?$/.test(suffix) ||
+        /^\/channels(?:\/.*)?$/.test(suffix))) ||
+    ((method === "POST" || method === "PUT" || method === "DELETE") &&
+      (/^\/connections(?:\/.*)?$/.test(suffix) ||
+        /^\/channels(?:\/.*)?$/.test(suffix)))
+  )
+    return true;
+  if (suffix.startsWith("/openrouter/")) return true;
+  if (method === "POST" && suffix === "/sessions") return true;
+  if (method === "GET" && suffix === "/sessions") return true;
+  if (method === "GET" && /^\/sessions\/[^/]+$/.test(suffix)) return true;
+  if (method === "GET" && /^\/sessions\/[^/]+\/events$/.test(suffix)) {
+    return true;
+  }
+  return (
+    method === "POST" &&
+    /^\/sessions\/[^/]+\/(turns|suspend|resume|end|terminate)$/.test(suffix)
+  );
+}
+
+export async function proxyManagedAgents(
+  request: Request,
+  env: ManagedAgentsEnv,
+  caller: ManagedAgentsCaller,
+  publicPrefix: string,
+): Promise<Response> {
+  const requestURL = new URL(request.url);
+  const requestedSuffix = requestURL.pathname.slice(publicPrefix.length);
+  const suffix =
+    requestedSuffix === "/v1"
+      ? ""
+      : requestedSuffix.startsWith("/v1/")
+        ? requestedSuffix.slice(3)
+        : requestedSuffix;
+  if (
+    requestURL.pathname !== publicPrefix &&
+    !requestURL.pathname.startsWith(`${publicPrefix}/`)
+  ) {
+    return Response.json({ error: "route not found" }, { status: 404 });
+  }
+  if (!isAllowedManagedAgentsRoute(request.method.toUpperCase(), suffix)) {
+    return Response.json({ error: "route not found" }, { status: 404 });
+  }
+  if (!env.OC_MANAGED_AGENTS_SECRET) {
+    return Response.json(
+      { error: "managed agents are not configured" },
+      { status: 503 },
+    );
+  }
+  const base = (
+    env.MANAGED_AGENTS_API_URL ?? DEFAULT_MANAGED_AGENTS_API_URL
+  ).replace(/\/+$/, "");
+  const target = new URL(`${base}/v1${suffix}${requestURL.search}`);
+  if (target.protocol !== "https:" && target.hostname !== "localhost") {
+    return Response.json(
+      { error: "managed agents upstream must use HTTPS" },
+      { status: 503 },
+    );
+  }
+  const headers = copyRequestHeaders(request);
+  headers.set(
+    "x-opencomputer-agent-token",
+    await mintManagedAgentsAssertion(env.OC_MANAGED_AGENTS_SECRET, caller),
+  );
+  if (request.method.toUpperCase() === "POST" && suffix === "/deployments") {
+    try {
+      return await deploySourceAgent(request, base, headers);
+    } catch (error) {
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "managed_agents.deployment_failed",
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      );
+      return Response.json(
+        { error: "managed agents service is unavailable" },
+        { status: 502 },
+      );
+    }
+  }
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    redirect: "manual",
+  };
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    init.body = request.body;
+  }
+  try {
+    const upstream = await fetch(target, init);
+    if (!upstream.ok) return publicErrorResponse(upstream);
+    if (suffix.startsWith("/openrouter/")) {
+      return upstream;
+    }
+    return publicSuccessResponse(
+      upstream,
+      request.method.toUpperCase(),
+      suffix,
+    );
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "managed_agents.upstream_failed",
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    );
+    return Response.json(
+      { error: "managed agents service is unavailable" },
+      { status: 502 },
+    );
+  }
+}

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -191,6 +191,10 @@ function stripPrivateValues(value: unknown): unknown {
 const PRIVATE_EVENT_KEYS = new Set([
   "accountId",
   "account_id",
+  "ownerUserId",
+  "owner_user_id",
+  "userId",
+  "user_id",
   "artifact",
   "bucket",
   "imageArn",

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -147,6 +147,36 @@ function publicDeployment(value: unknown): Record<string, unknown> {
   };
 }
 
+function publicConnection(value: unknown): Record<string, unknown> {
+  const connection = record(value) ?? {};
+  return {
+    id: connection.id,
+    kind: connection.kind,
+    provider: connection.provider,
+    label: connection.label,
+    agentId: connection.agentId,
+    alias: connection.alias,
+    displayName: connection.displayName,
+    status: connection.status,
+    createdAt: connection.createdAt,
+    updatedAt: connection.updatedAt,
+  };
+}
+
+function publicChannel(value: unknown): Record<string, unknown> {
+  const channel = record(value) ?? {};
+  return {
+    id: channel.id,
+    channel: "slack",
+    agentId: channel.agentId,
+    alias: channel.alias,
+    teamName: channel.teamName,
+    status: channel.status,
+    createdAt: channel.createdAt,
+    updatedAt: channel.updatedAt,
+  };
+}
+
 function stripPrivateValues(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(stripPrivateValues);
   const source = record(value);
@@ -209,7 +239,12 @@ function publicSuccessBody(
             const agent = record(value) ?? {};
             return {
               id: agent.id,
+              name:
+                typeof agent.name === "string" && agent.name
+                  ? agent.name
+                  : agent.id,
               activeAlias: agent.activeAlias,
+              activeDeploymentId: agent.activeDeploymentId,
               deploymentCount: agent.deploymentCount,
               createdAt: agent.createdAt,
               updatedAt: agent.updatedAt,
@@ -223,6 +258,23 @@ function publicSuccessBody(
   }
   if (method === "POST" && suffix === "/deployments") {
     return publicDeployment(body);
+  }
+  if (method === "GET" && /^\/deployments\/[^/]+$/.test(suffix)) {
+    return publicDeployment(body);
+  }
+  if (method === "GET" && suffix === "/connections") {
+    return {
+      connections: Array.isArray(body.connections)
+        ? body.connections.map(publicConnection)
+        : [],
+    };
+  }
+  if (method === "GET" && suffix === "/channels") {
+    return {
+      channels: Array.isArray(body.connections)
+        ? body.connections.map(publicChannel)
+        : [],
+    };
   }
   if (
     (method === "GET" && suffix.startsWith("/connections")) ||
@@ -401,6 +453,10 @@ async function deploySourceAgent(
     headers: uploadHeaders,
     body: JSON.stringify({
       agentId: body.agentId,
+      name:
+        typeof body.name === "string" && body.name.trim()
+          ? body.name.trim()
+          : body.agentId,
       alias: body.alias,
       channels: strings(body.channels),
       connections: strings(body.connections),
@@ -420,6 +476,7 @@ function isAllowedManagedAgentsRoute(method: string, suffix: string): boolean {
   }
   if (method === "GET" && suffix === "/me") return true;
   if (method === "POST" && suffix === "/deployments") return true;
+  if (method === "GET" && /^\/deployments\/[^/]+$/.test(suffix)) return true;
   if (
     (method === "GET" &&
       (/^\/connections(?:\/.*)?$/.test(suffix) ||

--- a/cloudflare-workers/api-edge/wrangler.igor-dev.toml
+++ b/cloudflare-workers/api-edge/wrangler.igor-dev.toml
@@ -73,3 +73,4 @@ new_sqlite_classes = ["CreditAccount"]
 [vars]
 WORKER_ENV = "igor-dev"
 BURST_CELL_ID = ""
+MANAGED_AGENTS_API_URL = "https://managedagents.opencomputer.dev"

--- a/cloudflare-workers/api-edge/wrangler.prod.toml
+++ b/cloudflare-workers/api-edge/wrangler.prod.toml
@@ -83,6 +83,8 @@ new_sqlite_classes = ["CreditAccount"]
 #                            exposure alerts from sessions-api
 #   BROWSER_API_SECRET     — shared with browser.opencomputer.dev for dashboard
 #                            browser-session proxy requests
+#   OC_MANAGED_AGENTS_SECRET — dedicated HS256 secret shared only with the
+#                            managed-agents backend
 # Optional vars: OPENROUTER_BASE_URL (default https://openrouter.ai/api/v1),
 #   OPENROUTER_MARKUP_BPS (env-default markup; per-org orgs.model_markup_bps wins).
 
@@ -99,6 +101,7 @@ WORKER_ENV = "prod"
 # no deploy. See pickHomeCell in src/index.ts.
 # Optional alpha route for Burst Sandboxes. Leave empty to disable.
 BURST_CELL_ID = "aws-us-east-2-burst-prod"
+MANAGED_AGENTS_API_URL = "https://managedagents.opencomputer.dev"
 
 # Ship Worker logs to opencomputer-log-tail-prod → Axiom dataset cf-prod.
 [[tail_consumers]]

--- a/cloudflare-workers/api-edge/wrangler.toml
+++ b/cloudflare-workers/api-edge/wrangler.toml
@@ -110,6 +110,8 @@ new_sqlite_classes = ["CreditAccount"]
 #                            sessions-api (shared only with sessions-api).
 #   OC_SECURITY_NOTIFICATION_SECRET — dedicated HMAC for minimal Agent Hook
 #                            exposure alerts from sessions-api.
+#   OC_MANAGED_AGENTS_SECRET — dedicated HS256 secret shared only with the
+#                            managed-agents backend.
 # Optional vars: OPENROUTER_BASE_URL (default https://openrouter.ai/api/v1),
 #   OPENROUTER_MARKUP_BPS (env-default markup; per-org orgs.model_markup_bps wins).
 
@@ -129,6 +131,7 @@ PAUSED_CAP = "10"
 # truth, toggled per-row without a deploy). See pickHomeCell in src/index.ts.
 # Optional alpha route for Burst Sandboxes. Leave empty to disable.
 BURST_CELL_ID = ""
+MANAGED_AGENTS_API_URL = "https://managedagents.opencomputer.dev"
 
 # Ship console output + exceptions to opensandbox-log-tail, which forwards
 # to Axiom dataset cf-dev. Keeps CF Worker logs durable in the same store

--- a/docs/agents/architecture.mdx
+++ b/docs/agents/architecture.mdx
@@ -1,17 +1,17 @@
 ---
 title: "Architecture"
-description: "How projects become managed, connected deployments"
+description: "How agent projects become managed, connected deployments"
 ---
 
-OpenComputer keeps project development code-first while managing
+OpenComputer keeps the agent development experience code-first while managing
 the infrastructure required to run it. You work with one public surface—the
-`opencomputer` CLI—and the same project can run locally or in a managed
+`opencomputer` CLI—and the same agent project can run locally or in a managed
 sandbox.
 
 ```mermaid
 flowchart LR
-    A["Project source<br/>Git + local files"] --> B["OpenComputer CLI"]
-    B --> C["Project control plane"]
+    A["Agent project<br/>Git + local files"] --> B["OpenComputer CLI"]
+    B --> C["Agent control plane"]
     C --> D["Immutable deployment<br/>stable ID + alias"]
     D --> E["Managed session"]
     E --> F["Isolated sandbox<br/>OpenCode + workspace"]
@@ -21,9 +21,9 @@ flowchart LR
 
 ## The layers
 
-### Project source
+### Agent project
 
-The project is the portable definition of the hosted agent. Its committed files
+The project is the portable definition of the agent. Its committed files
 describe:
 
 - stable UUID and readable display name in `opencomputer.toml`
@@ -45,17 +45,17 @@ The CLI owns the developer workflow:
 - authorize managed connections
 - run the project locally with OpenCode
 - package and deploy the project
-- start sessions from deployed projects
+- start sessions from deployed agents
 
 When you run `opencomputer deploy`, the CLI builds a canonical source artifact
-from the project directory and sends it to OpenComputer. Infrastructure provider
+from the agent directory and sends it to OpenComputer. Infrastructure provider
 details are not part of the CLI contract.
 
-### Project identity and deployments
+### Agent identity and deployments
 
-The UUID in `opencomputer.toml` identifies the project across its lifetime. Its
+The UUID in `opencomputer.toml` identifies the agent across its lifetime. Its
 two-word name is display metadata and can change without creating a different
-project. Each distinct source artifact becomes an immutable deployment.
+agent. Each distinct source artifact becomes an immutable deployment.
 
 ```text
 0195f5fb-2d5d-4aa4-b28e-b0df0af60cd8 (Gentle Falcon)
@@ -70,24 +70,24 @@ idempotent; deploying changed source creates a new version.
 
 ### Managed sessions and sandboxes
 
-A deployed run creates a managed session from the selected project version.
-OpenComputer prepares an isolated sandbox, loads the project source and
+A deployed run creates a managed session from the selected agent version.
+OpenComputer prepares an isolated sandbox, loads the agent source and
 workspace, starts OpenCode, and streams the result back to the CLI.
 
-The sandbox is an implementation detail of the project experience. You do not
-need to create or manage a separate sandbox before deploying a project.
+The sandbox is an implementation detail of the agent experience. You do not
+need to create or manage a separate sandbox before deploying an agent.
 
 Each session has:
 
 - the exact deployed source version
 - an isolated filesystem and process environment
-- a workspace that the project can use during the task
-- access to only the connections and channels declared for that project
+- a workspace that the agent can use during the task
+- access to only the connections and channels declared for that agent
 - lifecycle management handled by OpenComputer
 
 ### Connections
 
-Connections let project tools act on services such as Gmail without committing
+Connections let agent tools act on services such as Gmail without committing
 OAuth tokens to Git.
 
 For Gmail:
@@ -102,18 +102,18 @@ For Gmail:
     authorization flow. Add another alias to connect another Gmail account.
   </Step>
   <Step title="Develop locally">
-    The CLI gives the local project a short-lived, scoped route to the managed
+    The CLI gives the local agent a short-lived, scoped route to the managed
     connection.
   </Step>
   <Step title="Run when deployed">
     The managed session receives the same connection capability inside its
-    sandbox. Provider credentials remain outside the project and model output.
+    sandbox. Provider credentials remain outside the project and agent output.
   </Step>
 </Steps>
 
-Project instructions should still define explicit approval boundaries.
+An agent's instructions should still define explicit approval boundaries.
 Connection scope controls which service operations are possible; instructions
-control when the project should use them.
+control when the agent should use them.
 
 The Gmail connection is centralized for the OpenComputer user. Local
 development does not create a second local OAuth installation:
@@ -131,7 +131,7 @@ development does not create a second local OAuth installation:
                 scoped local    │         │ scoped managed
                 capability      │         │ capability
                     ┌───────────▼─┐     ┌─▼──────────────┐
-                    │Local project│     │Deployed project│
+                    │ Local agent │     │ Deployed agent │
                     │ + OpenCode  │     │ + sandbox      │
                     └───────────┬─┘     └─┬──────────────┘
                                 │         │
@@ -157,9 +157,9 @@ stay outside Git and are never given directly to the model.
 | Runtime | OpenCode on your machine | OpenCode in an isolated OpenComputer sandbox |
 | Connections | Scoped through the local CLI | Scoped through the managed runtime |
 | Best for | Iteration and debugging | Durable, repeatable execution |
-| Command | `opencomputer session` | `opencomputer session create --remote` or `opencomputer run <project>` |
+| Command | `opencomputer session` | `opencomputer session create --remote` or `opencomputer run <agent>` |
 
-This symmetry is intentional: develop the actual project locally, then deploy
+This symmetry is intentional: develop the actual agent locally, then deploy
 the same directory instead of rebuilding the workflow in a dashboard.
 
 Managed sessions can be listed, inspected, attached to, resumed with another
@@ -172,28 +172,28 @@ the sandbox runtime may suspend between turns and resume when needed.
 sequenceDiagram
     participant Developer
     participant CLI as OpenComputer CLI
-    participant Control as Project control plane
+    participant Control as Agent control plane
     participant Runtime as Managed sandbox
     participant Service as Connected service
 
     Developer->>CLI: opencomputer deploy
     CLI->>CLI: Build canonical source artifact
-    CLI->>Control: Publish source for stable project ID
+    CLI->>Control: Publish source for stable agent ID
     Control-->>CLI: Immutable deployment ID
     Developer->>CLI: opencomputer run gmail-summarizer "..."
     CLI->>Control: Start session from production alias
     Control->>Runtime: Load deployment and start OpenCode
     Runtime->>Service: Use scoped managed connection
-    Runtime-->>Control: Stream project events and result
+    Runtime-->>Control: Stream agent events and result
     Control-->>CLI: Stream result
 ```
 
 ## Security boundaries
 
-- Project source and identity are reviewable and commit-friendly.
+- Agent source and identity are reviewable and commit-friendly.
 - OAuth credentials are managed separately from source code.
 - Local connection access uses a scoped session capability.
-- Deployed projects run inside isolated sandboxes.
+- Deployed agents run inside isolated sandboxes.
 - The public CLI and API do not expose infrastructure-provider credentials or
   storage implementation details.
 - Consequential actions should remain behind explicit instructions and user

--- a/docs/agents/architecture.mdx
+++ b/docs/agents/architecture.mdx
@@ -8,6 +8,9 @@ the infrastructure required to run it. You work with one public surface—the
 `opencomputer` CLI—and the same project can run locally or in a managed
 sandbox.
 
+In the product hierarchy, **Serverless agents** is the category and
+**projects** are the deployable resources it contains.
+
 ```mermaid
 flowchart LR
     A["Project source<br/>Git + local files"] --> B["OpenComputer CLI"]

--- a/docs/agents/architecture.mdx
+++ b/docs/agents/architecture.mdx
@@ -1,0 +1,198 @@
+---
+title: "Architecture"
+description: "How agent projects become managed, connected deployments"
+---
+
+OpenComputer keeps the agent development experience code-first while managing
+the infrastructure required to run it. You work with one public surface—the
+`opencomputer` CLI—and the same agent project can run locally or in a managed
+sandbox.
+
+```mermaid
+flowchart LR
+    A["Agent project<br/>Git + local files"] --> B["OpenComputer CLI"]
+    B --> C["Agent control plane"]
+    C --> D["Immutable deployment<br/>stable ID + alias"]
+    D --> E["Managed session"]
+    E --> F["Isolated sandbox<br/>OpenCode + workspace"]
+    F --> G["Connection broker"]
+    G --> H["Gmail, Slack, and other services"]
+```
+
+## The layers
+
+### Agent project
+
+The project is the portable definition of the agent. Its committed files
+describe:
+
+- stable identity in `opencomputer.toml`
+- behavior and approval rules in `instructions.md`
+- runtime and model configuration
+- tools and skills
+- required connections and channels
+- initial workspace files and evaluations
+
+The project contains declarations and code, not provider credentials.
+
+### OpenComputer CLI
+
+The CLI owns the developer workflow:
+
+- discover templates
+- initialize a complete project
+- authenticate the developer
+- authorize managed connections
+- run the project locally with OpenCode
+- package and deploy the project
+- start sessions from deployed agents
+
+When you run `opencomputer deploy`, the CLI builds a canonical source artifact
+from the agent directory and sends it to OpenComputer. Infrastructure provider
+details are not part of the CLI contract.
+
+### Agent identity and deployments
+
+The `id` in `opencomputer.toml` identifies the agent across its lifetime. Each
+distinct source artifact becomes an immutable deployment.
+
+```text
+gmail-summarizer
+├── deployment A
+├── deployment B
+└── production ──> deployment B
+```
+
+Aliases such as `production` provide a stable target while preserving the
+exact source behind every deployment. Deploying unchanged source is
+idempotent; deploying changed source creates a new version.
+
+### Managed sessions and sandboxes
+
+A deployed run creates a managed session from the selected agent version.
+OpenComputer prepares an isolated sandbox, loads the agent source and
+workspace, starts OpenCode, and streams the result back to the CLI.
+
+The sandbox is an implementation detail of the agent experience. You do not
+need to create or manage a separate sandbox before deploying an agent.
+
+Each session has:
+
+- the exact deployed source version
+- an isolated filesystem and process environment
+- a workspace that the agent can use during the task
+- access to only the connections and channels declared for that agent
+- lifecycle management handled by OpenComputer
+
+### Connections
+
+Connections let agent tools act on services such as Gmail without committing
+OAuth tokens to Git.
+
+For Gmail:
+
+<Steps>
+  <Step title="Declare">
+    The template places a Google connection declaration in
+    `connections/google.json`.
+  </Step>
+  <Step title="Authorize">
+    `opencomputer connect google` opens the account authorization flow.
+  </Step>
+  <Step title="Develop locally">
+    The CLI gives the local agent a short-lived, scoped route to the managed
+    connection.
+  </Step>
+  <Step title="Run when deployed">
+    The managed session receives the same connection capability inside its
+    sandbox. Provider credentials remain outside the project and agent output.
+  </Step>
+</Steps>
+
+An agent's instructions should still define explicit approval boundaries.
+Connection scope controls which service operations are possible; instructions
+control when the agent should use them.
+
+The Gmail connection is centralized for the OpenComputer user. Local
+development does not create a second local OAuth installation:
+
+```text
+                         ┌───────────────────────┐
+                         │  OpenComputer user    │
+                         └───────────┬───────────┘
+                                     │ authorizes once
+                         ┌───────────▼───────────┐
+                         │ Managed Gmail         │
+                         │ connection            │
+                         └──────┬─────────┬──────┘
+                                │         │
+                scoped local    │         │ scoped managed
+                capability      │         │ capability
+                    ┌───────────▼─┐     ┌─▼──────────────┐
+                    │ Local agent │     │ Deployed agent │
+                    │ + OpenCode  │     │ + sandbox      │
+                    └───────────┬─┘     └─┬──────────────┘
+                                │         │
+                                └────┬────┘
+                                     │
+                            ┌────────▼────────┐
+                            │    Gmail API    │
+                            └─────────────────┘
+```
+
+The repository contains only the connection declaration. OAuth credentials
+stay outside Git and are never given directly to the model.
+
+## Local and deployed execution
+
+| | Local session | Deployed session |
+|---|---|---|
+| Source | Current working directory | Immutable deployed artifact |
+| Runtime | OpenCode on your machine | OpenCode in an isolated OpenComputer sandbox |
+| Connections | Scoped through the local CLI | Scoped through the managed runtime |
+| Best for | Iteration and debugging | Durable, repeatable execution |
+| Command | `opencomputer session` | `opencomputer session create --remote` or `opencomputer run <agent>` |
+
+This symmetry is intentional: develop the actual agent locally, then deploy
+the same directory instead of rebuilding the workflow in a dashboard.
+
+Managed sessions can be listed, inspected, attached to, resumed with another
+turn, and ended from the CLI. A session is the durable unit of interaction;
+the sandbox runtime may suspend between turns and resume when needed.
+
+## Deployment sequence
+
+```mermaid
+sequenceDiagram
+    participant Developer
+    participant CLI as OpenComputer CLI
+    participant Control as Agent control plane
+    participant Runtime as Managed sandbox
+    participant Service as Connected service
+
+    Developer->>CLI: opencomputer deploy
+    CLI->>CLI: Build canonical source artifact
+    CLI->>Control: Publish source for stable agent ID
+    Control-->>CLI: Immutable deployment ID
+    Developer->>CLI: opencomputer run gmail-summarizer "..."
+    CLI->>Control: Start session from production alias
+    Control->>Runtime: Load deployment and start OpenCode
+    Runtime->>Service: Use scoped managed connection
+    Runtime-->>Control: Stream agent events and result
+    Control-->>CLI: Stream result
+```
+
+## Security boundaries
+
+- Agent source and identity are reviewable and commit-friendly.
+- OAuth credentials are managed separately from source code.
+- Local connection access uses a scoped session capability.
+- Deployed agents run inside isolated sandboxes.
+- The public CLI and API do not expose infrastructure-provider credentials or
+  storage implementation details.
+- Consequential actions should remain behind explicit instructions and user
+  approval.
+
+<Card title="Deploy a Gmail summarizer" icon="rocket" href="/agents/quickstart">
+  Follow the complete CLI workflow.
+</Card>

--- a/docs/agents/architecture.mdx
+++ b/docs/agents/architecture.mdx
@@ -145,6 +145,10 @@ development does not create a second local OAuth installation:
 The repository contains only the connection declaration. OAuth credentials
 stay outside Git and are never given directly to the model.
 
+<Card title="Connections and aliases" icon="plug" href="/agents/connections">
+  Learn how connection declarations, user identity, and multiple accounts work.
+</Card>
+
 ## Local and deployed execution
 
 | | Local session | Deployed session |

--- a/docs/agents/architecture.mdx
+++ b/docs/agents/architecture.mdx
@@ -1,17 +1,17 @@
 ---
 title: "Architecture"
-description: "How agent projects become managed, connected deployments"
+description: "How projects become managed, connected deployments"
 ---
 
-OpenComputer keeps the agent development experience code-first while managing
+OpenComputer keeps project development code-first while managing
 the infrastructure required to run it. You work with one public surface—the
-`opencomputer` CLI—and the same agent project can run locally or in a managed
+`opencomputer` CLI—and the same project can run locally or in a managed
 sandbox.
 
 ```mermaid
 flowchart LR
-    A["Agent project<br/>Git + local files"] --> B["OpenComputer CLI"]
-    B --> C["Agent control plane"]
+    A["Project source<br/>Git + local files"] --> B["OpenComputer CLI"]
+    B --> C["Project control plane"]
     C --> D["Immutable deployment<br/>stable ID + alias"]
     D --> E["Managed session"]
     E --> F["Isolated sandbox<br/>OpenCode + workspace"]
@@ -21,9 +21,9 @@ flowchart LR
 
 ## The layers
 
-### Agent project
+### Project source
 
-The project is the portable definition of the agent. Its committed files
+The project is the portable definition of the hosted agent. Its committed files
 describe:
 
 - stable UUID and readable display name in `opencomputer.toml`
@@ -45,17 +45,17 @@ The CLI owns the developer workflow:
 - authorize managed connections
 - run the project locally with OpenCode
 - package and deploy the project
-- start sessions from deployed agents
+- start sessions from deployed projects
 
 When you run `opencomputer deploy`, the CLI builds a canonical source artifact
-from the agent directory and sends it to OpenComputer. Infrastructure provider
+from the project directory and sends it to OpenComputer. Infrastructure provider
 details are not part of the CLI contract.
 
-### Agent identity and deployments
+### Project identity and deployments
 
-The UUID in `opencomputer.toml` identifies the agent across its lifetime. Its
+The UUID in `opencomputer.toml` identifies the project across its lifetime. Its
 two-word name is display metadata and can change without creating a different
-agent. Each distinct source artifact becomes an immutable deployment.
+project. Each distinct source artifact becomes an immutable deployment.
 
 ```text
 0195f5fb-2d5d-4aa4-b28e-b0df0af60cd8 (Gentle Falcon)
@@ -70,24 +70,24 @@ idempotent; deploying changed source creates a new version.
 
 ### Managed sessions and sandboxes
 
-A deployed run creates a managed session from the selected agent version.
-OpenComputer prepares an isolated sandbox, loads the agent source and
+A deployed run creates a managed session from the selected project version.
+OpenComputer prepares an isolated sandbox, loads the project source and
 workspace, starts OpenCode, and streams the result back to the CLI.
 
-The sandbox is an implementation detail of the agent experience. You do not
-need to create or manage a separate sandbox before deploying an agent.
+The sandbox is an implementation detail of the project experience. You do not
+need to create or manage a separate sandbox before deploying a project.
 
 Each session has:
 
 - the exact deployed source version
 - an isolated filesystem and process environment
-- a workspace that the agent can use during the task
-- access to only the connections and channels declared for that agent
+- a workspace that the project can use during the task
+- access to only the connections and channels declared for that project
 - lifecycle management handled by OpenComputer
 
 ### Connections
 
-Connections let agent tools act on services such as Gmail without committing
+Connections let project tools act on services such as Gmail without committing
 OAuth tokens to Git.
 
 For Gmail:
@@ -102,18 +102,18 @@ For Gmail:
     authorization flow. Add another alias to connect another Gmail account.
   </Step>
   <Step title="Develop locally">
-    The CLI gives the local agent a short-lived, scoped route to the managed
+    The CLI gives the local project a short-lived, scoped route to the managed
     connection.
   </Step>
   <Step title="Run when deployed">
     The managed session receives the same connection capability inside its
-    sandbox. Provider credentials remain outside the project and agent output.
+    sandbox. Provider credentials remain outside the project and model output.
   </Step>
 </Steps>
 
-An agent's instructions should still define explicit approval boundaries.
+Project instructions should still define explicit approval boundaries.
 Connection scope controls which service operations are possible; instructions
-control when the agent should use them.
+control when the project should use them.
 
 The Gmail connection is centralized for the OpenComputer user. Local
 development does not create a second local OAuth installation:
@@ -131,7 +131,7 @@ development does not create a second local OAuth installation:
                 scoped local    │         │ scoped managed
                 capability      │         │ capability
                     ┌───────────▼─┐     ┌─▼──────────────┐
-                    │ Local agent │     │ Deployed agent │
+                    │Local project│     │Deployed project│
                     │ + OpenCode  │     │ + sandbox      │
                     └───────────┬─┘     └─┬──────────────┘
                                 │         │
@@ -157,9 +157,9 @@ stay outside Git and are never given directly to the model.
 | Runtime | OpenCode on your machine | OpenCode in an isolated OpenComputer sandbox |
 | Connections | Scoped through the local CLI | Scoped through the managed runtime |
 | Best for | Iteration and debugging | Durable, repeatable execution |
-| Command | `opencomputer session` | `opencomputer session create --remote` or `opencomputer run <agent>` |
+| Command | `opencomputer session` | `opencomputer session create --remote` or `opencomputer run <project>` |
 
-This symmetry is intentional: develop the actual agent locally, then deploy
+This symmetry is intentional: develop the actual project locally, then deploy
 the same directory instead of rebuilding the workflow in a dashboard.
 
 Managed sessions can be listed, inspected, attached to, resumed with another
@@ -172,28 +172,28 @@ the sandbox runtime may suspend between turns and resume when needed.
 sequenceDiagram
     participant Developer
     participant CLI as OpenComputer CLI
-    participant Control as Agent control plane
+    participant Control as Project control plane
     participant Runtime as Managed sandbox
     participant Service as Connected service
 
     Developer->>CLI: opencomputer deploy
     CLI->>CLI: Build canonical source artifact
-    CLI->>Control: Publish source for stable agent ID
+    CLI->>Control: Publish source for stable project ID
     Control-->>CLI: Immutable deployment ID
     Developer->>CLI: opencomputer run gmail-summarizer "..."
     CLI->>Control: Start session from production alias
     Control->>Runtime: Load deployment and start OpenCode
     Runtime->>Service: Use scoped managed connection
-    Runtime-->>Control: Stream agent events and result
+    Runtime-->>Control: Stream project events and result
     Control-->>CLI: Stream result
 ```
 
 ## Security boundaries
 
-- Agent source and identity are reviewable and commit-friendly.
+- Project source and identity are reviewable and commit-friendly.
 - OAuth credentials are managed separately from source code.
 - Local connection access uses a scoped session capability.
-- Deployed agents run inside isolated sandboxes.
+- Deployed projects run inside isolated sandboxes.
 - The public CLI and API do not expose infrastructure-provider credentials or
   storage implementation details.
 - Consequential actions should remain behind explicit instructions and user

--- a/docs/agents/architecture.mdx
+++ b/docs/agents/architecture.mdx
@@ -98,7 +98,8 @@ For Gmail:
     `connections/google.json`.
   </Step>
   <Step title="Authorize">
-    `opencomputer connect google` opens the account authorization flow.
+    `opencomputer connection add gmail --alias personal` opens the account
+    authorization flow. Add another alias to connect another Gmail account.
   </Step>
   <Step title="Develop locally">
     The CLI gives the local agent a short-lived, scoped route to the managed

--- a/docs/agents/architecture.mdx
+++ b/docs/agents/architecture.mdx
@@ -26,7 +26,7 @@ flowchart LR
 The project is the portable definition of the agent. Its committed files
 describe:
 
-- stable identity in `opencomputer.toml`
+- stable UUID and readable display name in `opencomputer.toml`
 - behavior and approval rules in `instructions.md`
 - runtime and model configuration
 - tools and skills
@@ -53,11 +53,12 @@ details are not part of the CLI contract.
 
 ### Agent identity and deployments
 
-The `id` in `opencomputer.toml` identifies the agent across its lifetime. Each
-distinct source artifact becomes an immutable deployment.
+The UUID in `opencomputer.toml` identifies the agent across its lifetime. Its
+two-word name is display metadata and can change without creating a different
+agent. Each distinct source artifact becomes an immutable deployment.
 
 ```text
-gmail-summarizer
+0195f5fb-2d5d-4aa4-b28e-b0df0af60cd8 (Gentle Falcon)
 ├── deployment A
 ├── deployment B
 └── production ──> deployment B

--- a/docs/agents/architecture.mdx
+++ b/docs/agents/architecture.mdx
@@ -8,9 +8,6 @@ the infrastructure required to run it. You work with one public surface—the
 `opencomputer` CLI—and the same project can run locally or in a managed
 sandbox.
 
-In the product hierarchy, **Serverless agents** is the category and
-**projects** are the deployable resources it contains.
-
 ```mermaid
 flowchart LR
     A["Project source<br/>Git + local files"] --> B["OpenComputer CLI"]

--- a/docs/agents/channels.mdx
+++ b/docs/agents/channels.mdx
@@ -1,0 +1,109 @@
+---
+title: "Channels"
+description: "Run deployed agents from Slack and other conversational interfaces"
+---
+
+Channels make a deployed agent available from an external interface such as
+Slack. The agent's behavior remains defined by its source repository; the
+channel supplies messages to sessions and returns the streamed result.
+
+## Channel declarations
+
+Channel support is part of the agent repository. Adding Slack creates the
+channel declaration and Slack application manifest:
+
+```bash
+opencomputer channels add slack
+```
+
+```text
+support-agent/
+├── channels/
+│   └── slack.ts
+└── slack/
+    └── manifest.json
+```
+
+These files describe events and application behavior and are safe to commit.
+Slack installation credentials are managed separately from source code.
+
+Deploy the channel declaration before connecting the remote channel:
+
+```bash
+opencomputer deploy
+opencomputer channels connect slack --remote
+opencomputer channels list
+```
+
+The channel targets a deployed agent alias, so new deployments can advance
+that alias without reinstalling the Slack application.
+
+## Sessions from channels
+
+Each supported Slack conversation creates or resumes a managed agent session.
+Messages in the same user thread continue the same multi-turn session, while
+other users and threads remain isolated.
+
+Channel sessions use the same deployed source and runtime behavior as sessions
+started from the CLI or dashboard. They appear in the agent's session history
+so you can inspect their status and activity.
+
+## Linking a channel identity
+
+A Slack identity is not automatically treated as the person who installed the
+Slack application. Before an agent can access personal connections, each Slack
+user links their own OpenComputer identity.
+
+<Steps>
+  <Step title="Message the agent">
+    If the Slack user is not linked, the agent replies with a short-lived
+    OpenComputer dashboard link.
+  </Step>
+  <Step title="Sign in to OpenComputer">
+    Opening the link associates that Slack user with the authenticated
+    OpenComputer user.
+  </Step>
+  <Step title="Connect required services">
+    If the agent requires Gmail or another service, OpenComputer shows the
+    connection instructions for that user.
+  </Step>
+  <Step title="Message the agent again">
+    The channel session can now use only the connections owned by the linked
+    user.
+  </Step>
+</Steps>
+
+This prevents a shared Slack channel from inheriting the installer's Gmail or
+another teammate's connected accounts.
+
+## Connections and channels are different
+
+| Concept | Purpose | Ownership |
+| --- | --- | --- |
+| Connection | Authorizes an external service such as Gmail | Individual OpenComputer user |
+| Channel | Provides an interface for invoking a deployed agent | Agent deployment and installed workspace |
+| Channel identity link | Maps an external user to an OpenComputer user | Individual external user |
+
+A channel does not grant service access by itself. It identifies who sent the
+message, and the managed session resolves only that user's connections.
+
+## Disconnect a channel
+
+List remote channel installations and disconnect the one you no longer want:
+
+```bash
+opencomputer channels list --remote
+opencomputer channels disconnect slack <connection-id> --remote
+```
+
+Disconnecting a channel stops new messages from reaching the agent. It does not
+delete the agent, its deployments, or users' personal service connections.
+
+<CardGroup cols={2}>
+  <Card title="Connections" icon="plug" href="/agents/connections">
+    Authorize multiple user-scoped accounts with recognizable aliases.
+  </Card>
+  <Card title="Agents architecture" icon="diagram-project" href="/agents/architecture">
+    See how source, deployments, sessions, connections, and channels fit together.
+  </Card>
+</CardGroup>

--- a/docs/agents/channels.mdx
+++ b/docs/agents/channels.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Channels"
-description: "Run deployed agents from Slack and other conversational interfaces"
+description: "Run deployed projects from Slack and other conversational interfaces"
 ---
 
-Channels make a deployed agent available from an external interface such as
-Slack. The agent's behavior remains defined by its source repository; the
+Channels make a deployed project available from an external interface such as
+Slack. The project's behavior remains defined by its source repository; the
 channel supplies messages to sessions and returns the streamed result.
 
 ## Channel declarations
 
-Channel support is part of the agent repository. Adding Slack creates the
+Channel support is part of the project repository. Adding Slack creates the
 channel declaration and Slack application manifest:
 
 ```bash
@@ -17,7 +17,7 @@ opencomputer channels add slack
 ```
 
 ```text
-support-agent/
+support-project/
 ├── channels/
 │   └── slack.ts
 └── slack/
@@ -35,28 +35,28 @@ opencomputer channels connect slack --remote
 opencomputer channels list
 ```
 
-The channel targets a deployed agent alias, so new deployments can advance
+The channel targets a deployed project alias, so new deployments can advance
 that alias without reinstalling the Slack application.
 
 ## Sessions from channels
 
-Each supported Slack conversation creates or resumes a managed agent session.
+Each supported Slack conversation creates or resumes a managed project session.
 Messages in the same user thread continue the same multi-turn session, while
 other users and threads remain isolated.
 
 Channel sessions use the same deployed source and runtime behavior as sessions
-started from the CLI or dashboard. They appear in the agent's session history
+started from the CLI or dashboard. They appear in the project's session history
 so you can inspect their status and activity.
 
 ## Linking a channel identity
 
 A Slack identity is not automatically treated as the person who installed the
-Slack application. Before an agent can access personal connections, each Slack
+Slack application. Before a project can access personal connections, each Slack
 user links their own OpenComputer identity.
 
 <Steps>
-  <Step title="Message the agent">
-    If the Slack user is not linked, the agent replies with a short-lived
+  <Step title="Message the project">
+    If the Slack user is not linked, the project replies with a short-lived
     OpenComputer dashboard link.
   </Step>
   <Step title="Sign in to OpenComputer">
@@ -64,10 +64,10 @@ user links their own OpenComputer identity.
     OpenComputer user.
   </Step>
   <Step title="Connect required services">
-    If the agent requires Gmail or another service, OpenComputer shows the
+    If the project requires Gmail or another service, OpenComputer shows the
     connection instructions for that user.
   </Step>
-  <Step title="Message the agent again">
+  <Step title="Message the project again">
     The channel session can now use only the connections owned by the linked
     user.
   </Step>
@@ -81,7 +81,7 @@ another teammate's connected accounts.
 | Concept | Purpose | Ownership |
 | --- | --- | --- |
 | Connection | Authorizes an external service such as Gmail | Individual OpenComputer user |
-| Channel | Provides an interface for invoking a deployed agent | Agent deployment and installed workspace |
+| Channel | Provides an interface for invoking a deployed project | Project deployment and installed workspace |
 | Channel identity link | Maps an external user to an OpenComputer user | Individual external user |
 
 A channel does not grant service access by itself. It identifies who sent the
@@ -96,14 +96,14 @@ opencomputer channels list --remote
 opencomputer channels disconnect slack <connection-id> --remote
 ```
 
-Disconnecting a channel stops new messages from reaching the agent. It does not
-delete the agent, its deployments, or users' personal service connections.
+Disconnecting a channel stops new messages from reaching the project. It does not
+delete the project, its deployments, or users' personal service connections.
 
 <CardGroup cols={2}>
   <Card title="Connections" icon="plug" href="/agents/connections">
     Authorize multiple user-scoped accounts with recognizable aliases.
   </Card>
-  <Card title="Agents architecture" icon="diagram-project" href="/agents/architecture">
+  <Card title="Projects architecture" icon="diagram-project" href="/agents/architecture">
     See how source, deployments, sessions, connections, and channels fit together.
   </Card>
 </CardGroup>

--- a/docs/agents/channels.mdx
+++ b/docs/agents/channels.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Channels"
-description: "Run deployed projects from Slack and other conversational interfaces"
+description: "Run deployed agents from Slack and other conversational interfaces"
 ---
 
-Channels make a deployed project available from an external interface such as
-Slack. The project's behavior remains defined by its source repository; the
+Channels make a deployed agent available from an external interface such as
+Slack. The agent's behavior remains defined by its source repository; the
 channel supplies messages to sessions and returns the streamed result.
 
 ## Channel declarations
 
-Channel support is part of the project repository. Adding Slack creates the
+Channel support is part of the agent repository. Adding Slack creates the
 channel declaration and Slack application manifest:
 
 ```bash
@@ -17,7 +17,7 @@ opencomputer channels add slack
 ```
 
 ```text
-support-project/
+support-agent/
 ├── channels/
 │   └── slack.ts
 └── slack/
@@ -35,28 +35,28 @@ opencomputer channels connect slack --remote
 opencomputer channels list
 ```
 
-The channel targets a deployed project alias, so new deployments can advance
+The channel targets a deployed agent alias, so new deployments can advance
 that alias without reinstalling the Slack application.
 
 ## Sessions from channels
 
-Each supported Slack conversation creates or resumes a managed project session.
+Each supported Slack conversation creates or resumes a managed agent session.
 Messages in the same user thread continue the same multi-turn session, while
 other users and threads remain isolated.
 
 Channel sessions use the same deployed source and runtime behavior as sessions
-started from the CLI or dashboard. They appear in the project's session history
+started from the CLI or dashboard. They appear in the agent's session history
 so you can inspect their status and activity.
 
 ## Linking a channel identity
 
 A Slack identity is not automatically treated as the person who installed the
-Slack application. Before a project can access personal connections, each Slack
+Slack application. Before an agent can access personal connections, each Slack
 user links their own OpenComputer identity.
 
 <Steps>
-  <Step title="Message the project">
-    If the Slack user is not linked, the project replies with a short-lived
+  <Step title="Message the agent">
+    If the Slack user is not linked, the agent replies with a short-lived
     OpenComputer dashboard link.
   </Step>
   <Step title="Sign in to OpenComputer">
@@ -64,10 +64,10 @@ user links their own OpenComputer identity.
     OpenComputer user.
   </Step>
   <Step title="Connect required services">
-    If the project requires Gmail or another service, OpenComputer shows the
+    If the agent requires Gmail or another service, OpenComputer shows the
     connection instructions for that user.
   </Step>
-  <Step title="Message the project again">
+  <Step title="Message the agent again">
     The channel session can now use only the connections owned by the linked
     user.
   </Step>
@@ -81,7 +81,7 @@ another teammate's connected accounts.
 | Concept | Purpose | Ownership |
 | --- | --- | --- |
 | Connection | Authorizes an external service such as Gmail | Individual OpenComputer user |
-| Channel | Provides an interface for invoking a deployed project | Project deployment and installed workspace |
+| Channel | Provides an interface for invoking a deployed agent | Agent deployment and installed workspace |
 | Channel identity link | Maps an external user to an OpenComputer user | Individual external user |
 
 A channel does not grant service access by itself. It identifies who sent the
@@ -96,14 +96,14 @@ opencomputer channels list --remote
 opencomputer channels disconnect slack <connection-id> --remote
 ```
 
-Disconnecting a channel stops new messages from reaching the project. It does not
-delete the project, its deployments, or users' personal service connections.
+Disconnecting a channel stops new messages from reaching the agent. It does not
+delete the agent, its deployments, or users' personal service connections.
 
 <CardGroup cols={2}>
   <Card title="Connections" icon="plug" href="/agents/connections">
     Authorize multiple user-scoped accounts with recognizable aliases.
   </Card>
-  <Card title="Projects architecture" icon="diagram-project" href="/agents/architecture">
+  <Card title="Agents architecture" icon="diagram-project" href="/agents/architecture">
     See how source, deployments, sessions, connections, and channels fit together.
   </Card>
 </CardGroup>

--- a/docs/agents/connections.mdx
+++ b/docs/agents/connections.mdx
@@ -1,0 +1,111 @@
+---
+title: "Connections"
+description: "Give agents user-scoped access to services such as Gmail"
+---
+
+Connections let an agent use an external service without storing OAuth tokens
+or provider credentials in the agent repository. A connection belongs to an
+OpenComputer user and can be used during both local development and deployed
+sessions.
+
+## Declarations and authorizations
+
+An agent repository declares the kinds of connections its tools can use. For
+example, a Gmail agent contains a Google connection declaration alongside its
+source:
+
+```text
+email-triage/
+├── opencomputer.toml
+├── connections/
+│   └── google.json
+└── tools/
+    └── gmail.ts
+```
+
+The declaration is safe to commit. It describes the provider, services, and
+requested scopes, but contains no user credentials.
+
+Authorization is separate. Each user connects their own account through the
+OpenComputer CLI:
+
+```bash
+opencomputer connection add gmail --alias personal
+```
+
+OpenComputer opens the provider authorization page and stores the resulting
+connection outside the repository.
+
+<Note>
+Deploying an agent does not grant it access to the developer's account. At run
+time, OpenComputer resolves connections using the identity of the user who
+started the session.
+</Note>
+
+## Multiple accounts and aliases
+
+Aliases distinguish multiple connections of the same type. For example, one
+user can connect personal and work Gmail accounts:
+
+```bash
+opencomputer connection add gmail --alias personal
+opencomputer connection add gmail --alias work
+opencomputer connection list
+```
+
+Agent tools can select the appropriate alias for a request. If no alias is
+specified, they use the `default` connection.
+
+Use short, recognizable aliases made from letters, numbers, dots, dashes, or
+underscores. An alias identifies a connection within your own OpenComputer
+identity; it does not expose or share that account with another user.
+
+## Using connections in sessions
+
+The same managed connection works in both execution modes:
+
+| Session | How access is provided |
+| --- | --- |
+| Local development | The CLI gives the local session a temporary connection capability. |
+| Deployed agent | OpenComputer gives the managed session a user-scoped connection capability. |
+
+Provider credentials remain outside the agent's source, workspace, prompts,
+and model output.
+
+When an agent needs a connection that the current user has not authorized,
+the session returns an authorization command and, when available, a dashboard
+link. This makes the same flow usable from the CLI, the playground, or a
+connected channel.
+
+## List and remove connections
+
+```bash
+opencomputer connection list
+opencomputer connection remove work
+```
+
+You can remove a connection by alias or by its connection ID. Use the ID when
+more than one listed connection has the same alias.
+
+Removing a connection prevents future sessions from using it. Agent source and
+existing deployments are unchanged.
+
+## Identity and security
+
+- Connections belong to an authenticated OpenComputer user, not a device,
+  directory, agent, or organization-wide shared pool.
+- Two users running the same deployed agent receive access to their own
+  connections only.
+- A connection declaration limits which integrations an agent expects, while
+  the provider authorization limits the scopes that are actually available.
+- Agent instructions should still require confirmation before consequential
+  actions such as sending messages or modifying external data.
+
+<CardGroup cols={2}>
+  <Card title="Deploy a Gmail summarizer" icon="envelope" href="/agents/quickstart">
+    Create an agent, authorize Gmail, test it locally, and deploy it.
+  </Card>
+  <Card title="Channels" icon="comments" href="/agents/channels">
+    Let people invoke deployed agents from Slack and other interfaces.
+  </Card>
+</CardGroup>

--- a/docs/agents/connections.mdx
+++ b/docs/agents/connections.mdx
@@ -1,17 +1,17 @@
 ---
 title: "Connections"
-description: "Give projects user-scoped access to services such as Gmail"
+description: "Give agents user-scoped access to services such as Gmail"
 ---
 
-Connections let a project use an external service without storing OAuth tokens
-or provider credentials in the project repository. A connection belongs to an
+Connections let an agent use an external service without storing OAuth tokens
+or provider credentials in the agent repository. A connection belongs to an
 OpenComputer user and can be used during both local development and deployed
 sessions.
 
 ## Declarations and authorizations
 
-Project source declares the kinds of connections its tools can use. For
-example, a Gmail project contains a Google connection declaration alongside its
+An agent repository declares the kinds of connections its tools can use. For
+example, a Gmail agent contains a Google connection declaration alongside its
 source:
 
 ```text
@@ -37,7 +37,7 @@ OpenComputer opens the provider authorization page and stores the resulting
 connection outside the repository.
 
 <Note>
-Deploying a project does not grant it access to the developer's account. At run
+Deploying an agent does not grant it access to the developer's account. At run
 time, OpenComputer resolves connections using the identity of the user who
 started the session.
 </Note>
@@ -53,7 +53,7 @@ opencomputer connection add gmail --alias work
 opencomputer connection list
 ```
 
-Project tools can select the appropriate alias for a request. If no alias is
+Agent tools can select the appropriate alias for a request. If no alias is
 specified, they use the `default` connection.
 
 Use short, recognizable aliases made from letters, numbers, dots, dashes, or
@@ -67,12 +67,12 @@ The same managed connection works in both execution modes:
 | Session | How access is provided |
 | --- | --- |
 | Local development | The CLI gives the local session a temporary connection capability. |
-| Deployed project | OpenComputer gives the managed session a user-scoped connection capability. |
+| Deployed agent | OpenComputer gives the managed session a user-scoped connection capability. |
 
-Provider credentials remain outside the project's source, workspace, prompts,
+Provider credentials remain outside the agent's source, workspace, prompts,
 and model output.
 
-When a project needs a connection that the current user has not authorized,
+When an agent needs a connection that the current user has not authorized,
 the session returns an authorization command and, when available, a dashboard
 link. This makes the same flow usable from the CLI, the playground, or a
 connected channel.
@@ -87,25 +87,25 @@ opencomputer connection remove work
 You can remove a connection by alias or by its connection ID. Use the ID when
 more than one listed connection has the same alias.
 
-Removing a connection prevents future sessions from using it. Project source and
+Removing a connection prevents future sessions from using it. Agent source and
 existing deployments are unchanged.
 
 ## Identity and security
 
 - Connections belong to an authenticated OpenComputer user, not a device,
-  directory, project, or organization-wide shared pool.
-- Two users running the same deployed project receive access to their own
+  directory, agent, or organization-wide shared pool.
+- Two users running the same deployed agent receive access to their own
   connections only.
-- A connection declaration limits which integrations a project expects, while
+- A connection declaration limits which integrations an agent expects, while
   the provider authorization limits the scopes that are actually available.
-- Project instructions should still require confirmation before consequential
+- Agent instructions should still require confirmation before consequential
   actions such as sending messages or modifying external data.
 
 <CardGroup cols={2}>
   <Card title="Deploy a Gmail summarizer" icon="envelope" href="/agents/quickstart">
-    Create a project, authorize Gmail, test it locally, and deploy it.
+    Create an agent, authorize Gmail, test it locally, and deploy it.
   </Card>
   <Card title="Channels" icon="comments" href="/agents/channels">
-    Let people invoke deployed projects from Slack and other interfaces.
+    Let people invoke deployed agents from Slack and other interfaces.
   </Card>
 </CardGroup>

--- a/docs/agents/connections.mdx
+++ b/docs/agents/connections.mdx
@@ -1,17 +1,17 @@
 ---
 title: "Connections"
-description: "Give agents user-scoped access to services such as Gmail"
+description: "Give projects user-scoped access to services such as Gmail"
 ---
 
-Connections let an agent use an external service without storing OAuth tokens
-or provider credentials in the agent repository. A connection belongs to an
+Connections let a project use an external service without storing OAuth tokens
+or provider credentials in the project repository. A connection belongs to an
 OpenComputer user and can be used during both local development and deployed
 sessions.
 
 ## Declarations and authorizations
 
-An agent repository declares the kinds of connections its tools can use. For
-example, a Gmail agent contains a Google connection declaration alongside its
+Project source declares the kinds of connections its tools can use. For
+example, a Gmail project contains a Google connection declaration alongside its
 source:
 
 ```text
@@ -37,7 +37,7 @@ OpenComputer opens the provider authorization page and stores the resulting
 connection outside the repository.
 
 <Note>
-Deploying an agent does not grant it access to the developer's account. At run
+Deploying a project does not grant it access to the developer's account. At run
 time, OpenComputer resolves connections using the identity of the user who
 started the session.
 </Note>
@@ -53,7 +53,7 @@ opencomputer connection add gmail --alias work
 opencomputer connection list
 ```
 
-Agent tools can select the appropriate alias for a request. If no alias is
+Project tools can select the appropriate alias for a request. If no alias is
 specified, they use the `default` connection.
 
 Use short, recognizable aliases made from letters, numbers, dots, dashes, or
@@ -67,12 +67,12 @@ The same managed connection works in both execution modes:
 | Session | How access is provided |
 | --- | --- |
 | Local development | The CLI gives the local session a temporary connection capability. |
-| Deployed agent | OpenComputer gives the managed session a user-scoped connection capability. |
+| Deployed project | OpenComputer gives the managed session a user-scoped connection capability. |
 
-Provider credentials remain outside the agent's source, workspace, prompts,
+Provider credentials remain outside the project's source, workspace, prompts,
 and model output.
 
-When an agent needs a connection that the current user has not authorized,
+When a project needs a connection that the current user has not authorized,
 the session returns an authorization command and, when available, a dashboard
 link. This makes the same flow usable from the CLI, the playground, or a
 connected channel.
@@ -87,25 +87,25 @@ opencomputer connection remove work
 You can remove a connection by alias or by its connection ID. Use the ID when
 more than one listed connection has the same alias.
 
-Removing a connection prevents future sessions from using it. Agent source and
+Removing a connection prevents future sessions from using it. Project source and
 existing deployments are unchanged.
 
 ## Identity and security
 
 - Connections belong to an authenticated OpenComputer user, not a device,
-  directory, agent, or organization-wide shared pool.
-- Two users running the same deployed agent receive access to their own
+  directory, project, or organization-wide shared pool.
+- Two users running the same deployed project receive access to their own
   connections only.
-- A connection declaration limits which integrations an agent expects, while
+- A connection declaration limits which integrations a project expects, while
   the provider authorization limits the scopes that are actually available.
-- Agent instructions should still require confirmation before consequential
+- Project instructions should still require confirmation before consequential
   actions such as sending messages or modifying external data.
 
 <CardGroup cols={2}>
   <Card title="Deploy a Gmail summarizer" icon="envelope" href="/agents/quickstart">
-    Create an agent, authorize Gmail, test it locally, and deploy it.
+    Create a project, authorize Gmail, test it locally, and deploy it.
   </Card>
   <Card title="Channels" icon="comments" href="/agents/channels">
-    Let people invoke deployed agents from Slack and other interfaces.
+    Let people invoke deployed projects from Slack and other interfaces.
   </Card>
 </CardGroup>

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -1,0 +1,157 @@
+---
+title: "Agents"
+description: "Build, test, connect, and deploy agents as code"
+---
+
+An OpenComputer agent is a source-controlled project that contains its
+identity, instructions, tools, connections, and runtime configuration. You
+develop it locally with the `opencomputer` CLI, test it with the same
+connections it will use when deployed, and publish new immutable versions
+without changing the agent's identity.
+
+<CardGroup cols={2}>
+  <Card title="Agents as code" icon="code">
+    Prompts, tools, skills, connections, and runtime settings live together in
+    a normal directory you can review and commit.
+  </Card>
+  <Card title="Local development" icon="terminal">
+    Run the agent locally with OpenCode, your project files, and managed
+    connections before deploying it.
+  </Card>
+  <Card title="Versioned deployment" icon="code-branch">
+    A stable agent ID points to immutable deployments. Deploying again updates
+    an alias such as `production`.
+  </Card>
+  <Card title="Managed execution" icon="cloud">
+    Deployed agents run in isolated OpenComputer sandboxes while the platform
+    manages lifecycle, persistence, and connected services.
+  </Card>
+</CardGroup>
+
+## Project structure
+
+Initialize an agent from a template:
+
+```bash
+opencomputer init email-triage gmail-summarizer
+```
+
+The CLI creates a flat, editable project:
+
+```text
+gmail-summarizer/
+├── opencomputer.toml
+├── opencomputer.config.ts
+├── agent.ts
+├── instructions.md
+├── package.json
+├── tools/
+│   └── gmail.ts
+├── connections/
+│   └── google.json
+├── skills/
+├── channels/
+├── workspace/
+└── evals/
+```
+
+The important files are:
+
+| File | Purpose |
+|---|---|
+| `opencomputer.toml` | Committed identity for the agent. Keep its `id` stable across deployments. |
+| `instructions.md` | The agent's role, operating rules, and approval boundaries. |
+| `agent.ts` | Model and runtime permissions used by OpenCode. |
+| `opencomputer.config.ts` | OpenComputer runtime configuration. |
+| `tools/` | Code-native tools available to the agent. |
+| `connections/` | Declarations for managed services such as Gmail. |
+| `skills/` | Reusable domain knowledge and workflows. |
+| `channels/` | Interfaces such as Slack through which people can reach the agent. |
+| `workspace/` | Durable working files packaged with the agent. |
+| `evals/` | Repeatable checks for agent behavior. |
+
+## Identity and versions
+
+`opencomputer.toml` is the source of truth for identity:
+
+```toml
+schema = 1
+id = "gmail-summarizer"
+name = "Email triage"
+template = "email-triage"
+```
+
+Commit this file to Git. The first deployment creates `gmail-summarizer`.
+Later deployments with the same ID create new versions of that agent rather
+than separate agents.
+
+An alias gives callers a stable name for a version:
+
+```bash
+opencomputer deploy --alias production
+```
+
+## Development workflow
+
+<Steps>
+  <Step title="Start from a template">
+    Browse use cases with `opencomputer templates`, then initialize the one
+    closest to your job.
+  </Step>
+  <Step title="Develop locally">
+    Edit the instructions, tools, and skills in your editor. Use
+    `opencomputer session` for a single task or `opencomputer dev` for an
+    interactive OpenCode session.
+  </Step>
+  <Step title="Connect services">
+    Authorize account-level connections through the CLI. OAuth credentials
+    remain managed by OpenComputer rather than being written into the project.
+  </Step>
+  <Step title="Deploy a version">
+    Run `opencomputer deploy`. The CLI packages the project, publishes an
+    immutable version, and moves the selected alias to that version.
+  </Step>
+</Steps>
+
+## Sessions
+
+`opencomputer session` runs the current source locally. For a deployed agent,
+the CLI also exposes the complete managed session lifecycle:
+
+```bash
+opencomputer session create --remote \
+  --agent gmail-summarizer@production
+opencomputer session list
+opencomputer session send <session-id> "Summarize today's inbox."
+opencomputer session inspect <session-id>
+opencomputer session attach <session-id>
+opencomputer session end <session-id>
+```
+
+By default, a completed remote turn suspends its runtime. A later
+`session send` resumes it, preserving the session and its workspace. Pass
+`--keep` to leave the runtime running after a turn.
+
+## Channels
+
+Channels let people invoke a deployed agent from another interface. To add
+Slack to an agent:
+
+```bash
+opencomputer channels add slack
+opencomputer deploy
+opencomputer channels connect slack --remote
+opencomputer channels list
+```
+
+The channel declaration and Slack project configuration live with the source.
+The installation credentials remain managed outside the repository.
+
+<CardGroup cols={2}>
+  <Card title="Build a Gmail summarizer" icon="envelope" href="/agents/quickstart">
+    Create, connect, test, and deploy an agent from a template.
+  </Card>
+  <Card title="Architecture" icon="diagram-project" href="/agents/architecture">
+    See how local projects, deployments, sandboxes, and connections fit together.
+  </Card>
+</CardGroup>

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -1,40 +1,36 @@
 ---
-title: "Projects"
-description: "Build, test, connect, and deploy projects from source"
+title: "Serverless Agents"
+description: "Build, test, connect, and deploy agents as code"
 ---
 
-An OpenComputer project is a source-controlled directory containing its
+An OpenComputer agent is a source-controlled project that contains its
 identity, instructions, tools, connections, and runtime configuration. You
 develop it locally with the `opencomputer` CLI, test it with the same
 connections it will use when deployed, and publish new immutable versions
-without changing the project's identity.
-
-Conceptually, an OpenComputer project is similar to a Supabase project, but
-for hosting agents: it groups the source, configuration, deployments,
-connections, channels, and sessions for one agent-powered application.
+without changing the agent's identity.
 
 <CardGroup cols={2}>
-  <Card title="Projects as code" icon="code">
+  <Card title="Agents as code" icon="code">
     Prompts, tools, skills, connections, and runtime settings live together in
     a normal directory you can review and commit.
   </Card>
   <Card title="Local development" icon="terminal">
-    Run the project locally with your source files and managed
+    Run the agent locally with OpenCode, your project files, and managed
     connections before deploying it.
   </Card>
   <Card title="Versioned deployment" icon="code-branch">
-    A stable project ID points to immutable deployments. Deploying again updates
+    A stable agent ID points to immutable deployments. Deploying again updates
     an alias such as `production`.
   </Card>
   <Card title="Managed execution" icon="cloud">
-    Deployed projects run in isolated OpenComputer sandboxes while the platform
+    Deployed agents run in isolated OpenComputer sandboxes while the platform
     manages lifecycle, persistence, and connected services.
   </Card>
 </CardGroup>
 
 ## Project structure
 
-Initialize a project from a template:
+Initialize an agent from a template:
 
 ```bash
 opencomputer init email-triage gmail-summarizer
@@ -63,16 +59,16 @@ The important files are:
 
 | File | Purpose |
 |---|---|
-| `opencomputer.toml` | Committed identity for the project. Keep its `id` stable across deployments. |
-| `instructions.md` | The project's role, operating rules, and approval boundaries. |
+| `opencomputer.toml` | Committed identity for the agent. Keep its `id` stable across deployments. |
+| `instructions.md` | The agent's role, operating rules, and approval boundaries. |
 | `agent.ts` | Model and runtime permissions used by OpenCode. |
 | `opencomputer.config.ts` | OpenComputer runtime configuration. |
-| `tools/` | Code-native tools available to the project runtime. |
+| `tools/` | Code-native tools available to the agent. |
 | `connections/` | Declarations for managed services such as Gmail. |
 | `skills/` | Reusable domain knowledge and workflows. |
-| `channels/` | Interfaces such as Slack through which people can reach the project. |
-| `workspace/` | Durable working files packaged with the project. |
-| `evals/` | Repeatable checks for project behavior. |
+| `channels/` | Interfaces such as Slack through which people can reach the agent. |
+| `workspace/` | Durable working files packaged with the agent. |
+| `evals/` | Repeatable checks for agent behavior. |
 
 ## Identity and versions
 
@@ -86,8 +82,8 @@ template = "email-triage"
 ```
 
 Commit this file to Git. The readable name appears in the dashboard, while the
-UUID identifies the project in deployments and APIs. Later deployments with the
-same UUID create new versions of that project rather than separate projects.
+UUID identifies the agent in deployments and APIs. Later deployments with the
+same UUID create new versions of that agent rather than separate agents.
 
 An alias gives callers a stable name for a version:
 
@@ -119,12 +115,12 @@ opencomputer deploy --alias production
 
 ## Sessions
 
-`opencomputer session` runs the current source locally. For a deployed project,
+`opencomputer session` runs the current source locally. For a deployed agent,
 the CLI also exposes the complete managed session lifecycle:
 
 ```bash
 opencomputer session create --remote \
-  --project gmail-summarizer@production
+  --agent gmail-summarizer@production
 opencomputer session list
 opencomputer session send <session-id> "Summarize today's inbox."
 opencomputer session inspect <session-id>
@@ -138,8 +134,8 @@ By default, a completed remote turn suspends its runtime. A later
 
 ## Channels
 
-Channels let people invoke a deployed project from another interface. To add
-Slack to a project:
+Channels let people invoke a deployed agent from another interface. To add
+Slack to an agent:
 
 ```bash
 opencomputer channels add slack
@@ -156,13 +152,13 @@ The installation credentials remain managed outside the repository.
     Connect multiple user-owned service accounts with aliases.
   </Card>
   <Card title="Channels" icon="comments" href="/agents/channels">
-    Invoke deployed projects from Slack with per-user identity isolation.
+    Invoke deployed agents from Slack with per-user identity isolation.
   </Card>
 </CardGroup>
 
 <CardGroup cols={2}>
   <Card title="Build a Gmail summarizer" icon="envelope" href="/agents/quickstart">
-    Create, connect, test, and deploy a project from a template.
+    Create, connect, test, and deploy an agent from a template.
   </Card>
   <Card title="Architecture" icon="diagram-project" href="/agents/architecture">
     See how local projects, deployments, sandboxes, and connections fit together.

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -9,10 +9,6 @@ develop it locally with the `opencomputer` CLI, test it with the same
 connections it will use when deployed, and publish new immutable versions
 without changing the project's identity.
 
-**Serverless agents** is the OpenComputer product category. A **project** is
-the main resource inside it: each project packages an agent's source and owns
-its deployments, connections, channels, and sessions.
-
 Conceptually, an OpenComputer project is similar to a Supabase project, but
 for hosting agents: it groups the source, configuration, deployments,
 connections, channels, and sessions for one agent-powered application.

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -1,36 +1,40 @@
 ---
-title: "Serverless Agents"
-description: "Build, test, connect, and deploy agents as code"
+title: "Projects"
+description: "Build, test, connect, and deploy projects from source"
 ---
 
-An OpenComputer agent is a source-controlled project that contains its
+An OpenComputer project is a source-controlled directory containing its
 identity, instructions, tools, connections, and runtime configuration. You
 develop it locally with the `opencomputer` CLI, test it with the same
 connections it will use when deployed, and publish new immutable versions
-without changing the agent's identity.
+without changing the project's identity.
+
+Conceptually, an OpenComputer project is similar to a Supabase project, but
+for hosting agents: it groups the source, configuration, deployments,
+connections, channels, and sessions for one agent-powered application.
 
 <CardGroup cols={2}>
-  <Card title="Agents as code" icon="code">
+  <Card title="Projects as code" icon="code">
     Prompts, tools, skills, connections, and runtime settings live together in
     a normal directory you can review and commit.
   </Card>
   <Card title="Local development" icon="terminal">
-    Run the agent locally with OpenCode, your project files, and managed
+    Run the project locally with your source files and managed
     connections before deploying it.
   </Card>
   <Card title="Versioned deployment" icon="code-branch">
-    A stable agent ID points to immutable deployments. Deploying again updates
+    A stable project ID points to immutable deployments. Deploying again updates
     an alias such as `production`.
   </Card>
   <Card title="Managed execution" icon="cloud">
-    Deployed agents run in isolated OpenComputer sandboxes while the platform
+    Deployed projects run in isolated OpenComputer sandboxes while the platform
     manages lifecycle, persistence, and connected services.
   </Card>
 </CardGroup>
 
 ## Project structure
 
-Initialize an agent from a template:
+Initialize a project from a template:
 
 ```bash
 opencomputer init email-triage gmail-summarizer
@@ -59,16 +63,16 @@ The important files are:
 
 | File | Purpose |
 |---|---|
-| `opencomputer.toml` | Committed identity for the agent. Keep its `id` stable across deployments. |
-| `instructions.md` | The agent's role, operating rules, and approval boundaries. |
+| `opencomputer.toml` | Committed identity for the project. Keep its `id` stable across deployments. |
+| `instructions.md` | The project's role, operating rules, and approval boundaries. |
 | `agent.ts` | Model and runtime permissions used by OpenCode. |
 | `opencomputer.config.ts` | OpenComputer runtime configuration. |
-| `tools/` | Code-native tools available to the agent. |
+| `tools/` | Code-native tools available to the project runtime. |
 | `connections/` | Declarations for managed services such as Gmail. |
 | `skills/` | Reusable domain knowledge and workflows. |
-| `channels/` | Interfaces such as Slack through which people can reach the agent. |
-| `workspace/` | Durable working files packaged with the agent. |
-| `evals/` | Repeatable checks for agent behavior. |
+| `channels/` | Interfaces such as Slack through which people can reach the project. |
+| `workspace/` | Durable working files packaged with the project. |
+| `evals/` | Repeatable checks for project behavior. |
 
 ## Identity and versions
 
@@ -82,8 +86,8 @@ template = "email-triage"
 ```
 
 Commit this file to Git. The readable name appears in the dashboard, while the
-UUID identifies the agent in deployments and APIs. Later deployments with the
-same UUID create new versions of that agent rather than separate agents.
+UUID identifies the project in deployments and APIs. Later deployments with the
+same UUID create new versions of that project rather than separate projects.
 
 An alias gives callers a stable name for a version:
 
@@ -115,12 +119,12 @@ opencomputer deploy --alias production
 
 ## Sessions
 
-`opencomputer session` runs the current source locally. For a deployed agent,
+`opencomputer session` runs the current source locally. For a deployed project,
 the CLI also exposes the complete managed session lifecycle:
 
 ```bash
 opencomputer session create --remote \
-  --agent gmail-summarizer@production
+  --project gmail-summarizer@production
 opencomputer session list
 opencomputer session send <session-id> "Summarize today's inbox."
 opencomputer session inspect <session-id>
@@ -134,8 +138,8 @@ By default, a completed remote turn suspends its runtime. A later
 
 ## Channels
 
-Channels let people invoke a deployed agent from another interface. To add
-Slack to an agent:
+Channels let people invoke a deployed project from another interface. To add
+Slack to a project:
 
 ```bash
 opencomputer channels add slack
@@ -152,13 +156,13 @@ The installation credentials remain managed outside the repository.
     Connect multiple user-owned service accounts with aliases.
   </Card>
   <Card title="Channels" icon="comments" href="/agents/channels">
-    Invoke deployed agents from Slack with per-user identity isolation.
+    Invoke deployed projects from Slack with per-user identity isolation.
   </Card>
 </CardGroup>
 
 <CardGroup cols={2}>
   <Card title="Build a Gmail summarizer" icon="envelope" href="/agents/quickstart">
-    Create, connect, test, and deploy an agent from a template.
+    Create, connect, test, and deploy a project from a template.
   </Card>
   <Card title="Architecture" icon="diagram-project" href="/agents/architecture">
     See how local projects, deployments, sandboxes, and connections fit together.

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Agents"
+title: "Serverless Agents"
 description: "Build, test, connect, and deploy agents as code"
 ---
 
@@ -146,6 +146,15 @@ opencomputer channels list
 
 The channel declaration and Slack project configuration live with the source.
 The installation credentials remain managed outside the repository.
+
+<CardGroup cols={2}>
+  <Card title="Connections" icon="plug" href="/agents/connections">
+    Connect multiple user-owned service accounts with aliases.
+  </Card>
+  <Card title="Channels" icon="comments" href="/agents/channels">
+    Invoke deployed agents from Slack with per-user identity isolation.
+  </Card>
+</CardGroup>
 
 <CardGroup cols={2}>
   <Card title="Build a Gmail summarizer" icon="envelope" href="/agents/quickstart">

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -9,6 +9,10 @@ develop it locally with the `opencomputer` CLI, test it with the same
 connections it will use when deployed, and publish new immutable versions
 without changing the project's identity.
 
+**Serverless agents** is the OpenComputer product category. A **project** is
+the main resource inside it: each project packages an agent's source and owns
+its deployments, connections, channels, and sessions.
+
 Conceptually, an OpenComputer project is similar to a Supabase project, but
 for hosting agents: it groups the source, configuration, deployments,
 connections, channels, and sessions for one agent-powered application.

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -76,14 +76,14 @@ The important files are:
 
 ```toml
 schema = 1
-id = "gmail-summarizer"
-name = "Email triage"
+id = "0195f5fb-2d5d-4aa4-b28e-b0df0af60cd8"
+name = "Gentle Falcon"
 template = "email-triage"
 ```
 
-Commit this file to Git. The first deployment creates `gmail-summarizer`.
-Later deployments with the same ID create new versions of that agent rather
-than separate agents.
+Commit this file to Git. The readable name appears in the dashboard, while the
+UUID identifies the agent in deployments and APIs. Later deployments with the
+same UUID create new versions of that agent rather than separate agents.
 
 An alias gives callers a stable name for a version:
 

--- a/docs/agents/quickstart.mdx
+++ b/docs/agents/quickstart.mdx
@@ -1,0 +1,184 @@
+---
+title: "Quickstart"
+description: "Deploy a Gmail summarizer agent with the OpenComputer CLI"
+---
+
+This quickstart creates a source-controlled Gmail summarizer, connects your
+Google account, tests the agent locally, and deploys it to OpenComputer.
+
+## Prerequisites
+
+- Node.js 22 or newer
+- An OpenComputer account
+- A Google account you can authorize for Gmail
+
+## 1. Install and log in
+
+Install the agents-focused OpenComputer CLI:
+
+```bash
+npm install --global @opencomputer/cli
+```
+
+Log in and confirm the account the CLI will use:
+
+```bash
+opencomputer login
+opencomputer whoami
+```
+
+`opencomputer whoami` prints your user, organization, and OpenComputer API.
+
+## 2. Choose a template
+
+List the available agent use cases:
+
+```bash
+opencomputer templates
+```
+
+Create a Gmail summarizer from the `email-triage` template:
+
+```bash
+opencomputer init email-triage gmail-summarizer
+cd gmail-summarizer
+npm install
+```
+
+The directory name becomes the default agent ID. Confirm it before the first
+deployment:
+
+```bash
+cat opencomputer.toml
+```
+
+You should see:
+
+```toml
+schema = 1
+id = "gmail-summarizer"
+name = "Email triage"
+template = "email-triage"
+```
+
+<Warning>
+Keep the `id` stable after the first deployment. Changing it creates a
+different agent instead of a new version.
+</Warning>
+
+## 3. Customize the agent
+
+Open `instructions.md` and describe the job and its approval boundaries. For
+example:
+
+```md
+Summarize unread and recent Gmail threads.
+
+- Group messages into urgent, needs action, and informational.
+- Identify deadlines and messages that need a reply.
+- Never send, archive, label, mark read, or otherwise modify mail without
+  explicit approval.
+```
+
+The generated project already includes the Gmail tool and its Google
+connection declaration.
+
+## 4. Commit the agent
+
+Treat the project like any other codebase:
+
+```bash
+git init
+git add .
+git commit -m "Initialize Gmail summarizer agent"
+```
+
+This commits `opencomputer.toml`, so future deployments use the same identity.
+Files containing local runtime state and environment secrets are ignored.
+
+## 5. Connect Gmail
+
+Start the Google authorization flow:
+
+```bash
+opencomputer connect google
+```
+
+Open the authorization link, select the Google account, and approve the
+requested access. The CLI waits until the connection becomes active.
+
+<Note>
+Connections belong to your OpenComputer account, not to one local directory.
+If Gmail is already connected, the CLI reuses that connection.
+</Note>
+
+## 6. Test locally
+
+Run one task with the local agent:
+
+```bash
+opencomputer session "Summarize up to 10 unread Gmail messages. Group them into urgent, needs action, and informational. Include sender, subject, a one-sentence summary, and any deadline. Do not modify any email."
+```
+
+The CLI starts OpenCode with the project files and a scoped connection to
+Gmail. You can edit `instructions.md` or the tools and run the command again
+until the behavior is right.
+
+For an interactive development session, run:
+
+```bash
+opencomputer dev
+```
+
+## 7. Deploy
+
+Publish the current source as the `production` version:
+
+```bash
+opencomputer deploy --alias production
+```
+
+The result includes the stable agent ID and an immutable deployment ID:
+
+```text
+Deployed gmail-summarizer@production
+Deployment: gmail-summarizer:<source-digest>
+Source ID:  opencomputer.toml
+```
+
+Verify that the agent is registered:
+
+```bash
+opencomputer agents
+```
+
+Run the deployed agent:
+
+```bash
+opencomputer run gmail-summarizer \
+  "Summarize my unread inbox and call out anything urgent."
+```
+
+## Ship an update
+
+Edit any source file, commit the change, and deploy again:
+
+```bash
+git add .
+git commit -m "Refine inbox urgency rules"
+opencomputer deploy --alias production
+```
+
+The agent remains `gmail-summarizer`; the `production` alias moves to the new
+immutable version.
+
+## Next
+
+<CardGroup cols={2}>
+  <Card title="Agents overview" icon="robot" href="/agents/overview">
+    Learn the project structure and versioning model.
+  </Card>
+  <Card title="Architecture" icon="diagram-project" href="/agents/architecture">
+    Follow source from local development to managed execution.
+  </Card>
+</CardGroup>

--- a/docs/agents/quickstart.mdx
+++ b/docs/agents/quickstart.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Quickstart"
-description: "Deploy a Gmail summarizer agent with the OpenComputer CLI"
+description: "Deploy a Gmail summarizer project with the OpenComputer CLI"
 ---
 
 This quickstart creates a source-controlled Gmail summarizer, connects your
-Google account, tests the agent locally, and deploys it to OpenComputer.
+Google account, tests the project locally, and deploys it to OpenComputer.
 
 ## Prerequisites
 
@@ -14,7 +14,7 @@ Google account, tests the agent locally, and deploys it to OpenComputer.
 
 ## 1. Install and log in
 
-Install the agents-focused OpenComputer CLI:
+Install the project-focused OpenComputer CLI:
 
 ```bash
 npm install --global @opencomputer/cli
@@ -31,7 +31,7 @@ opencomputer whoami
 
 ## 2. Choose a template
 
-List the available agent use cases:
+List the available project use cases:
 
 ```bash
 opencomputer templates
@@ -63,14 +63,14 @@ template = "email-triage"
 
 The generated name is what people see in the dashboard. The UUID is the
 unique identifier used by deployments, sessions, channels, and APIs. Generated
-names vary and can be edited without changing the agent's identity.
+names vary and can be edited without changing the project's identity.
 
 <Warning>
 Keep the `id` stable after the first deployment. Changing it creates a
-different agent instead of a new version.
+different project instead of a new version.
 </Warning>
 
-## 3. Customize the agent
+## 3. Customize the project
 
 Open `instructions.md` and describe the job and its approval boundaries. For
 example:
@@ -87,14 +87,14 @@ Summarize unread and recent Gmail threads.
 The generated project already includes the Gmail tool and its Google
 connection declaration.
 
-## 4. Commit the agent
+## 4. Commit the project
 
 Treat the project like any other codebase:
 
 ```bash
 git init
 git add .
-git commit -m "Initialize Gmail summarizer agent"
+git commit -m "Initialize Gmail summarizer project"
 ```
 
 This commits `opencomputer.toml`, so future deployments use the same identity.
@@ -119,7 +119,7 @@ more than one Gmail account without sharing either account with another user.
 
 ## 6. Test locally
 
-Run one task with the local agent:
+Run one task with the local project:
 
 ```bash
 opencomputer session "Summarize up to 10 unread Gmail messages. Group them into urgent, needs action, and informational. Include sender, subject, a one-sentence summary, and any deadline. Do not modify any email."
@@ -143,7 +143,7 @@ Publish the current source as the `production` version:
 opencomputer deploy --alias production
 ```
 
-The result includes the stable agent ID and an immutable deployment ID:
+The result includes the stable project ID and an immutable deployment ID:
 
 ```text
 Deployed gmail-summarizer@production
@@ -151,13 +151,13 @@ Deployment: gmail-summarizer:<source-digest>
 Source ID:  opencomputer.toml
 ```
 
-Verify that the agent is registered:
+Verify that the project is registered:
 
 ```bash
-opencomputer agents
+opencomputer projects
 ```
 
-Run the deployed agent:
+Run the deployed project:
 
 ```bash
 opencomputer run gmail-summarizer \
@@ -174,13 +174,13 @@ git commit -m "Refine inbox urgency rules"
 opencomputer deploy --alias production
 ```
 
-The agent remains `gmail-summarizer`; the `production` alias moves to the new
+The project remains `gmail-summarizer`; the `production` alias moves to the new
 immutable version.
 
 ## Next
 
 <CardGroup cols={2}>
-  <Card title="Agents overview" icon="robot" href="/agents/overview">
+  <Card title="Projects overview" icon="robot" href="/agents/overview">
     Learn the project structure and versioning model.
   </Card>
   <Card title="Architecture" icon="diagram-project" href="/agents/architecture">

--- a/docs/agents/quickstart.mdx
+++ b/docs/agents/quickstart.mdx
@@ -45,8 +45,8 @@ cd gmail-summarizer
 npm install
 ```
 
-The directory name becomes the default agent ID. Confirm it before the first
-deployment:
+Initialization generates an immutable UUID and a readable two-word name.
+Confirm both before the first deployment:
 
 ```bash
 cat opencomputer.toml
@@ -56,10 +56,14 @@ You should see:
 
 ```toml
 schema = 1
-id = "gmail-summarizer"
-name = "Email triage"
+id = "0195f5fb-2d5d-4aa4-b28e-b0df0af60cd8"
+name = "Gentle Falcon"
 template = "email-triage"
 ```
+
+The generated name is what people see in the dashboard. The UUID is the
+unique identifier used by deployments, sessions, channels, and APIs. Generated
+names vary and can be edited without changing the agent's identity.
 
 <Warning>
 Keep the `id` stable after the first deployment. Changing it creates a

--- a/docs/agents/quickstart.mdx
+++ b/docs/agents/quickstart.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Quickstart"
-description: "Deploy a Gmail summarizer project with the OpenComputer CLI"
+description: "Deploy a Gmail summarizer agent with the OpenComputer CLI"
 ---
 
 This quickstart creates a source-controlled Gmail summarizer, connects your
-Google account, tests the project locally, and deploys it to OpenComputer.
+Google account, tests the agent locally, and deploys it to OpenComputer.
 
 ## Prerequisites
 
@@ -14,7 +14,7 @@ Google account, tests the project locally, and deploys it to OpenComputer.
 
 ## 1. Install and log in
 
-Install the project-focused OpenComputer CLI:
+Install the agents-focused OpenComputer CLI:
 
 ```bash
 npm install --global @opencomputer/cli
@@ -31,7 +31,7 @@ opencomputer whoami
 
 ## 2. Choose a template
 
-List the available project use cases:
+List the available agent use cases:
 
 ```bash
 opencomputer templates
@@ -63,14 +63,14 @@ template = "email-triage"
 
 The generated name is what people see in the dashboard. The UUID is the
 unique identifier used by deployments, sessions, channels, and APIs. Generated
-names vary and can be edited without changing the project's identity.
+names vary and can be edited without changing the agent's identity.
 
 <Warning>
 Keep the `id` stable after the first deployment. Changing it creates a
-different project instead of a new version.
+different agent instead of a new version.
 </Warning>
 
-## 3. Customize the project
+## 3. Customize the agent
 
 Open `instructions.md` and describe the job and its approval boundaries. For
 example:
@@ -87,14 +87,14 @@ Summarize unread and recent Gmail threads.
 The generated project already includes the Gmail tool and its Google
 connection declaration.
 
-## 4. Commit the project
+## 4. Commit the agent
 
 Treat the project like any other codebase:
 
 ```bash
 git init
 git add .
-git commit -m "Initialize Gmail summarizer project"
+git commit -m "Initialize Gmail summarizer agent"
 ```
 
 This commits `opencomputer.toml`, so future deployments use the same identity.
@@ -119,7 +119,7 @@ more than one Gmail account without sharing either account with another user.
 
 ## 6. Test locally
 
-Run one task with the local project:
+Run one task with the local agent:
 
 ```bash
 opencomputer session "Summarize up to 10 unread Gmail messages. Group them into urgent, needs action, and informational. Include sender, subject, a one-sentence summary, and any deadline. Do not modify any email."
@@ -143,7 +143,7 @@ Publish the current source as the `production` version:
 opencomputer deploy --alias production
 ```
 
-The result includes the stable project ID and an immutable deployment ID:
+The result includes the stable agent ID and an immutable deployment ID:
 
 ```text
 Deployed gmail-summarizer@production
@@ -151,13 +151,13 @@ Deployment: gmail-summarizer:<source-digest>
 Source ID:  opencomputer.toml
 ```
 
-Verify that the project is registered:
+Verify that the agent is registered:
 
 ```bash
-opencomputer projects
+opencomputer agents
 ```
 
-Run the deployed project:
+Run the deployed agent:
 
 ```bash
 opencomputer run gmail-summarizer \
@@ -174,13 +174,13 @@ git commit -m "Refine inbox urgency rules"
 opencomputer deploy --alias production
 ```
 
-The project remains `gmail-summarizer`; the `production` alias moves to the new
+The agent remains `gmail-summarizer`; the `production` alias moves to the new
 immutable version.
 
 ## Next
 
 <CardGroup cols={2}>
-  <Card title="Projects overview" icon="robot" href="/agents/overview">
+  <Card title="Agents overview" icon="robot" href="/agents/overview">
     Learn the project structure and versioning model.
   </Card>
   <Card title="Architecture" icon="diagram-project" href="/agents/architecture">

--- a/docs/agents/quickstart.mdx
+++ b/docs/agents/quickstart.mdx
@@ -105,15 +105,16 @@ Files containing local runtime state and environment secrets are ignored.
 Start the Google authorization flow:
 
 ```bash
-opencomputer connect google
+opencomputer connection add gmail --alias personal
 ```
 
 Open the authorization link, select the Google account, and approve the
 requested access. The CLI waits until the connection becomes active.
 
 <Note>
-Connections belong to your OpenComputer account, not to one local directory.
-If Gmail is already connected, the CLI reuses that connection.
+Connections belong to your OpenComputer user identity, not to one local
+directory. Give each account an alias, such as `personal` or `work`, to connect
+more than one Gmail account without sharing either account with another user.
 </Note>
 
 ## 6. Test locally

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,7 +32,7 @@
         ]
       },
       {
-        "group": "Serverless Agents",
+        "group": "Projects",
         "pages": [
           "agents/overview",
           "agents/quickstart",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,7 +32,7 @@
         ]
       },
       {
-        "group": "Projects",
+        "group": "Serverless Agents",
         "pages": [
           "agents/overview",
           "agents/quickstart",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,6 +32,14 @@
         ]
       },
       {
+        "group": "Agents",
+        "pages": [
+          "agents/overview",
+          "agents/quickstart",
+          "agents/architecture"
+        ]
+      },
+      {
         "group": "Sandboxes",
         "pages": [
           "sandboxes/overview",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,7 +32,7 @@
         ]
       },
       {
-        "group": "Projects",
+        "group": "Serverless agents",
         "pages": [
           "agents/overview",
           "agents/quickstart",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,7 +32,7 @@
         ]
       },
       {
-        "group": "Serverless agents",
+        "group": "Projects",
         "pages": [
           "agents/overview",
           "agents/quickstart",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,10 +32,12 @@
         ]
       },
       {
-        "group": "Agents",
+        "group": "Serverless Agents",
         "pages": [
           "agents/overview",
           "agents/quickstart",
+          "agents/connections",
+          "agents/channels",
           "agents/architecture"
         ]
       },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "opensandbox-dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/react": "^4.0.50",
         "@fontsource-variable/geist-mono": "^5.2.8",
         "@fontsource-variable/inter": "^5.2.8",
         "@posthog/react": "^1.10.3",
@@ -15,6 +16,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
+        "ai": "^7.0.47",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.21.0",
@@ -22,7 +24,9 @@
         "radix-ui": "^1.6.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^7.18.0",
+        "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "tw-animate-css": "^1.4.0",
@@ -51,7 +55,92 @@
         "vitest": "^4.1.10"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "4.0.36",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.36.tgz",
+      "integrity": "sha512-N1P6bdW/aC5rxLeuGYgx3X4el3DoZy8UWlky+g+AeIZSmxaEi/AToHJL4cmZ6nCPHk1byqJWwC+PaOZG0hK0dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.22.tgz",
+      "integrity": "sha512-j3jPwKFTffZCJzYGpN69yKu/y646uu2gWoEwh1jgVyYVpzfu6ErFU+YAd/+xTPxsUTx8FEIEUHTlEsDuOe+ytQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18",
+        "pkce-challenge": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.4.tgz",
+      "integrity": "sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.18",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.18.tgz",
+      "integrity": "sha512-UBNCrkxS5llgN2/RXLBRkjCFTIuL6YB1Goq5c+yRecnznhtX4XPjTwLHz2hrsTltTVZ0rqVegtnwFXdPBkjDHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "4.0.50",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-4.0.50.tgz",
+      "integrity": "sha512-fbC0V2WdCwZaioSJ0CGT/YnrhzpNbiDFqoBlrJ7HL0OY95sIUQrPDVlGYz489/hj4Lze4tr7RfPc8ghgc/5wcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/mcp": "2.0.22",
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18",
+        "ai": "7.0.47",
+        "swr": "^2.4.1",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -746,474 +835,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3564,7 +3185,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -3944,6 +3564,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3955,14 +3584,46 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -3979,7 +3640,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4001,6 +3661,12 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
       "version": "4.0.2",
@@ -4282,6 +3948,21 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
@@ -4416,6 +4097,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
@@ -4472,6 +4159,23 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "7.0.47",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.47.tgz",
+      "integrity": "sha512-e0MpNtufu6JmcmwMUTgM1smCRkP5z014iPaKgnCm7kmMsTSIZbOJN2vglhPq0WIj/6x7ewVi6W0FyIR0pjaE3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.36",
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -4760,6 +4464,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -4999,6 +4713,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -5020,6 +4744,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/class-variance-authority": {
@@ -5098,6 +4862,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -5341,7 +5115,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -5425,7 +5198,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5437,6 +5209,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dedent": {
@@ -5560,6 +5345,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -5575,6 +5369,19 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/diff": {
       "version": "8.0.4",
@@ -5907,50 +5714,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.1",
-        "@esbuild/android-arm": "0.28.1",
-        "@esbuild/android-arm64": "0.28.1",
-        "@esbuild/android-x64": "0.28.1",
-        "@esbuild/darwin-arm64": "0.28.1",
-        "@esbuild/darwin-x64": "0.28.1",
-        "@esbuild/freebsd-arm64": "0.28.1",
-        "@esbuild/freebsd-x64": "0.28.1",
-        "@esbuild/linux-arm": "0.28.1",
-        "@esbuild/linux-arm64": "0.28.1",
-        "@esbuild/linux-ia32": "0.28.1",
-        "@esbuild/linux-loong64": "0.28.1",
-        "@esbuild/linux-mips64el": "0.28.1",
-        "@esbuild/linux-ppc64": "0.28.1",
-        "@esbuild/linux-riscv64": "0.28.1",
-        "@esbuild/linux-s390x": "0.28.1",
-        "@esbuild/linux-x64": "0.28.1",
-        "@esbuild/netbsd-arm64": "0.28.1",
-        "@esbuild/netbsd-x64": "0.28.1",
-        "@esbuild/openbsd-arm64": "0.28.1",
-        "@esbuild/openbsd-x64": "0.28.1",
-        "@esbuild/openharmony-arm64": "0.28.1",
-        "@esbuild/sunos-x64": "0.28.1",
-        "@esbuild/win32-arm64": "0.28.1",
-        "@esbuild/win32-ia32": "0.28.1",
-        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -6415,6 +6178,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -6462,7 +6235,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -6567,6 +6339,12 @@
       "peerDependencies": {
         "express": ">= 4.11"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -7177,6 +6955,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -7202,6 +7020,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/http-errors": {
@@ -7296,6 +7124,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -7329,6 +7163,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -7457,6 +7315,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -7546,6 +7414,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-in-ssh": {
@@ -7660,7 +7538,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7969,6 +7846,12 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -8406,6 +8289,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -8435,6 +8328,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -8443,6 +8346,288 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/media-typer": {
@@ -8484,6 +8669,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -8592,7 +9340,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -8995,6 +9742,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -9106,7 +9878,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -9362,6 +10133,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -9558,6 +10339,33 @@
         "react": "^19.2.7"
       }
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -9747,6 +10555,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-from-string": {
@@ -10308,6 +11182,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -10481,6 +11365,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stringify-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
@@ -10561,6 +11459,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10572,6 +11488,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
+      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/systeminformation": {
@@ -10630,6 +11559,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tiny-invariant": {
@@ -10704,6 +11645,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -10945,7 +11906,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
       "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -10969,6 +11929,93 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/universalify": {
@@ -11075,6 +12122,15 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -11100,6 +12156,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -11543,6 +12627,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "dev": "vite",
@@ -18,6 +18,7 @@
     "typecheck": "tsc -b"
   },
   "dependencies": {
+    "@ai-sdk/react": "^4.0.50",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@fontsource-variable/inter": "^5.2.8",
     "@posthog/react": "^1.10.3",
@@ -25,6 +26,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "ai": "^7.0.47",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.21.0",
@@ -32,7 +34,9 @@
     "radix-ui": "^1.6.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.18.0",
+    "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate } from 'react-router-dom'
 import { AuthProvider } from './hooks/auth-provider'
 import ProtectedRoute from './components/ProtectedRoute'
 import AppShell from './components/app-shell'
+import { managedAgentsExperimentEnabled } from './managed-agents/feature'
 
 // Route pages are code-split so the initial bundle stays small; the heaviest
 // deps (xterm, in Terminal/LogsPanel) only load on SandboxDetail when opened.
@@ -25,6 +26,7 @@ const Billing = lazy(() => import('./pages/Billing'))
 const SandboxDetail = lazy(() => import('./pages/SandboxDetail'))
 const SandboxWebhooks = lazy(() => import('./pages/SandboxWebhooks'))
 const DeferredAction = lazy(() => import('./pages/DeferredAction'))
+const ManagedAgentsHome = lazy(() => import('./managed-agents/Home'))
 
 export default function App() {
   return (
@@ -35,8 +37,26 @@ export default function App() {
         <Route path="do" element={<DeferredAction />} />
         <Route element={<ProtectedRoute />}>
           <Route element={<AppShell />}>
-            <Route index element={<Dashboard />} />
-            <Route path="getting-started" element={<Dashboard />} />
+            <Route
+              index
+              element={
+                managedAgentsExperimentEnabled ? (
+                  <ManagedAgentsHome />
+                ) : (
+                  <Dashboard />
+                )
+              }
+            />
+            <Route
+              path="getting-started"
+              element={
+                managedAgentsExperimentEnabled ? (
+                  <ManagedAgentsHome />
+                ) : (
+                  <Dashboard />
+                )
+              }
+            />
             {/* Agent plane */}
             <Route path="agents" element={<Agents />} />
             <Route path="agents/new" element={<AgentNew />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,6 +27,11 @@ const SandboxDetail = lazy(() => import('./pages/SandboxDetail'))
 const SandboxWebhooks = lazy(() => import('./pages/SandboxWebhooks'))
 const DeferredAction = lazy(() => import('./pages/DeferredAction'))
 const ManagedAgentsHome = lazy(() => import('./managed-agents/Home'))
+const ManagedAgentDetail = lazy(() => import('./managed-agents/Detail'))
+const ManagedAgentConnections = lazy(
+  () => import('./managed-agents/Connections'),
+)
+const ManagedAgentChannels = lazy(() => import('./managed-agents/Channels'))
 
 export default function App() {
   return (
@@ -56,6 +61,22 @@ export default function App() {
                   <Dashboard />
                 )
               }
+            />
+            <Route
+              path="managed-agents/connections"
+              element={<ManagedAgentConnections />}
+            />
+            <Route
+              path="managed-agents/channels"
+              element={<ManagedAgentChannels />}
+            />
+            <Route
+              path="managed-agents/new"
+              element={<ManagedAgentsHome startersOnly />}
+            />
+            <Route
+              path="managed-agents/:agentId"
+              element={<ManagedAgentDetail />}
             />
             {/* Agent plane */}
             <Route path="agents" element={<Agents />} />

--- a/web/src/api/mock-contracts.test.ts
+++ b/web/src/api/mock-contracts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { mockFetch } from './mock'
 import {
   AgentListSchema,
+  AgentSecurityNotificationListSchema,
   RepositoryAccessSchema,
   RepositorySourceInspectionSchema,
   SessionListSchema,
@@ -39,6 +40,16 @@ describe('preview API contracts', () => {
     ).not.toThrow()
     expect(() =>
       SessionTurnListSchema.parse(mockFetch('/v3/sessions/ses_a1b2c3/turns')),
+    ).not.toThrow()
+  })
+
+  it('keeps the global agent-security fixture valid', () => {
+    expect(() =>
+      AgentSecurityNotificationListSchema.parse(
+        mockFetch(
+          '/agent-security-notifications?include_acknowledged=false&limit=100',
+        ),
+      ),
     ).not.toThrow()
   })
 

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -1208,9 +1208,76 @@ type Handler = () => unknown
 // missing resource) — used for an agent with no deployment-source link.
 const NOT_FOUND = Symbol('not_found')
 
+const managedAgentTemplates = [
+  {
+    id: 'email-triage',
+    name: 'Email triage',
+    description:
+      'Summarize your inbox, surface messages that need replies, and leave every action under your control.',
+    category: 'Comms',
+    integrations: ['Gmail', 'OpenComputer'],
+    suggestedPrompts: [
+      "Triage today's inbox and show me the messages that need a reply.",
+    ],
+  },
+  {
+    id: 'github-changelog',
+    name: 'GitHub changelog',
+    description:
+      'Turn merged work into a clear changelog and keep product documentation current.',
+    category: 'Operations',
+    integrations: ['GitHub', 'Confluence'],
+    suggestedPrompts: [
+      "Draft this week's changelog from merged pull requests.",
+    ],
+  },
+  {
+    id: 'collect-receipts',
+    name: 'Collect receipts',
+    description:
+      'Find purchase receipts, name them consistently, and file them in the correct expense folder.',
+    category: 'Admin',
+    integrations: ['Gmail', 'Google Drive'],
+    suggestedPrompts: ["Find this month's receipts and prepare a filing plan."],
+  },
+]
+
+let managedAgentItems: Array<{
+  id: string
+  activeAlias: string
+  deploymentCount: number
+  createdAt: string
+  updatedAt: string
+}> = []
+
 // Ordered most-specific first. Matched against the path (without /api/dashboard).
 const ROUTES: Array<[RegExp, Handler]> = [
   [/^\/me$/, () => me],
+  [
+    /^\/agent-security-notifications(?:\?.*)?$/,
+    () => ({ data: [], next_cursor: null }),
+  ],
+  [
+    /^\/managed-agents\/templates$/,
+    () => ({ templates: managedAgentTemplates }),
+  ],
+  [/^\/managed-agents\/agents$/, () => ({ agents: managedAgentItems })],
+  [
+    /^\/managed-agents\/sessions\/[^/]+\/events(?:\?.*)?$/,
+    () => ({
+      events: [
+        { seq: 1, type: 'runtime.connected', data: {} },
+        {
+          seq: 2,
+          type: 'message.completed',
+          data: {
+            text: 'Here is a concise response from your deployed agent.',
+          },
+        },
+        { seq: 3, type: 'turn.completed', data: {} },
+      ],
+    }),
+  ],
   [/^\/sessions\/[^/]+\/stats$/, () => sandboxStats],
   [/^\/sessions\/[^/]+$/, () => sessionDetail],
   [/^\/sessions(\?.*)?$/, () => sandboxes],
@@ -1307,6 +1374,55 @@ const ROUTES: Array<[RegExp, Handler]> = [
 // Mutations the preview needs to echo something parseable (e.g. the Slack
 // wizard's POST …/slack/manifest → manifest+steps). Everything else 204-ish.
 const POST_ROUTES: [RegExp, () => unknown][] = [
+  [
+    /^\/managed-agents\/templates\/[^/]+\/deploy$/,
+    () => {
+      const template = managedAgentTemplates[0]
+      const timestamp = new Date(BASE).toISOString()
+      managedAgentItems = [
+        {
+          id: template.id,
+          activeAlias: 'production',
+          deploymentCount: 1,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ]
+      return {
+        template,
+        deployment: {
+          id: `${template.id}:preview`,
+          agentId: template.id,
+          alias: 'production',
+          channels: [],
+          connections: [],
+          createdAt: timestamp,
+        },
+      }
+    },
+  ],
+  [
+    /^\/managed-agents\/sessions$/,
+    () => ({
+      session: { id: 'session_preview', status: 'connecting' },
+      deployment: {
+        id: 'research-assistant:preview',
+        agentId: 'research-assistant',
+        alias: 'production',
+        channels: [],
+        connections: [],
+        createdAt: new Date(BASE).toISOString(),
+      },
+    }),
+  ],
+  [
+    /^\/managed-agents\/sessions\/[^/]+\/turns$/,
+    () => ({ turnId: 'turn_preview', duplicate: false }),
+  ],
+  [
+    /^\/managed-agents\/sessions\/[^/]+\/suspend$/,
+    () => ({ id: 'session_preview', status: 'suspended' }),
+  ],
   [/^\/v3\/agents\/[^/]+\/repository-access$/, () => repositoryAccess],
   [/^\/v3\/github\/deploy-app\/inspect$/, () => flueInspection],
   [

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -1244,7 +1244,9 @@ const managedAgentTemplates = [
 
 let managedAgentItems: Array<{
   id: string
+  name: string
   activeAlias: string
+  activeDeploymentId: string
   deploymentCount: number
   createdAt: string
   updatedAt: string
@@ -1262,6 +1264,69 @@ const ROUTES: Array<[RegExp, Handler]> = [
     () => ({ templates: managedAgentTemplates }),
   ],
   [/^\/managed-agents\/agents$/, () => ({ agents: managedAgentItems })],
+  [
+    /^\/managed-agents\/connections$/,
+    () => ({
+      connections: [
+        {
+          id: 'connection_google_preview',
+          kind: 'tool',
+          provider: 'google',
+          label: 'gmail',
+          agentId: 'email-triage',
+          alias: 'production',
+          displayName: 'Gmail',
+          status: 'connected',
+          createdAt: new Date(BASE).toISOString(),
+          updatedAt: new Date(BASE).toISOString(),
+        },
+      ],
+    }),
+  ],
+  [
+    /^\/managed-agents\/channels$/,
+    () => ({
+      channels: [
+        {
+          id: 'channel_slack_preview',
+          channel: 'slack',
+          agentId: 'research-assistant',
+          alias: 'production',
+          teamName: 'OpenComputer',
+          status: 'connected',
+          createdAt: new Date(BASE).toISOString(),
+          updatedAt: new Date(BASE).toISOString(),
+        },
+      ],
+    }),
+  ],
+  [
+    /^\/managed-agents\/deployments\/[^/]+$/,
+    () => ({
+      id: 'research-assistant:preview',
+      agentId: 'research-assistant',
+      alias: 'production',
+      channels: [],
+      connections: [],
+      createdAt: new Date(BASE).toISOString(),
+    }),
+  ],
+  [
+    /^\/managed-agents\/sessions$/,
+    () => ({
+      sessions: [
+        {
+          id: 'session_preview',
+          agentId: 'research-assistant',
+          deploymentId: 'research-assistant:preview',
+          status: 'suspended',
+          createdAt: new Date(BASE).toISOString(),
+          updatedAt: new Date(BASE).toISOString(),
+          turns: [],
+        },
+      ],
+    }),
+  ],
   [
     /^\/managed-agents\/sessions\/[^/]+\/events(?:\?.*)?$/,
     () => ({
@@ -1382,7 +1447,9 @@ const POST_ROUTES: [RegExp, () => unknown][] = [
       managedAgentItems = [
         {
           id: template.id,
+          name: template.name,
           activeAlias: 'production',
+          activeDeploymentId: `${template.id}:preview`,
           deploymentCount: 1,
           createdAt: timestamp,
           updatedAt: timestamp,

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -1301,6 +1301,21 @@ const ROUTES: Array<[RegExp, Handler]> = [
     }),
   ],
   [
+    /^\/managed-agents\/deployments\?agentId=[^&]+$/,
+    () => ({
+      deployments: [
+        {
+          id: 'research-assistant:preview',
+          agentId: 'research-assistant',
+          alias: 'production',
+          channels: ['slack'],
+          connections: ['gmail'],
+          createdAt: new Date(BASE).toISOString(),
+        },
+      ],
+    }),
+  ],
+  [
     /^\/managed-agents\/deployments\/[^/]+$/,
     () => ({
       id: 'research-assistant:preview',
@@ -1320,6 +1335,8 @@ const ROUTES: Array<[RegExp, Handler]> = [
           agentId: 'research-assistant',
           deploymentId: 'research-assistant:preview',
           status: 'suspended',
+          source: 'channel',
+          microvmState: 'suspended',
           createdAt: new Date(BASE).toISOString(),
           updatedAt: new Date(BASE).toISOString(),
           turns: [],
@@ -1341,6 +1358,20 @@ const ROUTES: Array<[RegExp, Handler]> = [
         },
         { seq: 3, type: 'turn.completed', data: {} },
       ],
+    }),
+  ],
+  [
+    /^\/managed-agents\/sessions\/[^/]+$/,
+    () => ({
+      id: 'session_preview',
+      agentId: 'research-assistant',
+      deploymentId: 'research-assistant:preview',
+      status: 'suspended',
+      source: 'playground',
+      microvmState: 'suspended',
+      createdAt: new Date(BASE).toISOString(),
+      updatedAt: new Date(BASE).toISOString(),
+      turns: [],
     }),
   ],
   [/^\/sessions\/[^/]+\/stats$/, () => sandboxStats],

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -128,11 +128,11 @@ const LEGACY_NAV: NavGroup[] = [
 
 const MANAGED_AGENTS_NAV: NavGroup[] = [
   {
-    label: 'Serverless agents',
+    label: 'Projects',
     collapsible: true,
     landingTo: '/',
     items: [
-      { to: '/', label: 'Agents', icon: Bot, end: true },
+      { to: '/', label: 'Projects', icon: Bot, end: true },
       {
         to: '/managed-agents/connections',
         label: 'Connections',
@@ -262,7 +262,7 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
       group.collapsible &&
       group.label &&
       ((managedAgentsExperimentEnabled &&
-        group.label === 'Serverless agents' &&
+        group.label === 'Projects' &&
         location.pathname.startsWith('/managed-agents/')) ||
         group.items.some(
           (item) =>
@@ -270,12 +270,18 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
             (item.to !== '/' && location.pathname.startsWith(`${item.to}/`)),
         )),
   )?.label
-  const [openGroup, setOpenGroup] = useState<string | undefined>(
-    activeCollapsibleGroup,
+  const [openGroups, setOpenGroups] = useState<Set<string>>(
+    () => new Set(activeCollapsibleGroup ? [activeCollapsibleGroup] : []),
   )
 
   useEffect(() => {
-    if (activeCollapsibleGroup) setOpenGroup(activeCollapsibleGroup)
+    if (!activeCollapsibleGroup) return
+    setOpenGroups((current) => {
+      if (current.has(activeCollapsibleGroup)) return current
+      const next = new Set(current)
+      next.add(activeCollapsibleGroup)
+      return next
+    })
   }, [activeCollapsibleGroup])
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -292,16 +298,21 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
               <button
                 type="button"
                 onClick={() => {
-                  setOpenGroup(group.label)
+                  setOpenGroups((current) => {
+                    const next = new Set(current)
+                    if (next.has(group.label!)) next.delete(group.label!)
+                    else next.add(group.label!)
+                    return next
+                  })
                   if (group.landingTo) void navigate(group.landingTo)
                 }}
                 className="text-muted-foreground/70 hover:text-foreground flex w-full items-center gap-1 px-3 pb-1 text-left text-[10px] font-medium tracking-wider uppercase transition-colors"
-                aria-expanded={openGroup === group.label}
+                aria-expanded={openGroups.has(group.label)}
               >
                 <ChevronRight
                   className={cn(
                     'size-3 transition-transform',
-                    openGroup === group.label && 'rotate-90',
+                    openGroups.has(group.label) && 'rotate-90',
                   )}
                 />
                 {group.label}
@@ -311,7 +322,7 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
                 {group.label}
               </div>
             ) : null}
-            {(!group.collapsible || openGroup === group.label) &&
+            {(!group.collapsible || openGroups.has(group.label ?? '')) &&
               group.items.map((item) => (
                 <NavLink
                   key={item.to}

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -1,5 +1,11 @@
-import { Suspense, useState } from 'react'
-import { Link, NavLink, Outlet, useLocation } from 'react-router-dom'
+import { Suspense, useEffect, useState } from 'react'
+import {
+  Link,
+  NavLink,
+  Outlet,
+  useLocation,
+  useNavigate,
+} from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import {
   LayoutGrid,
@@ -55,7 +61,12 @@ type NavItem = {
   end?: boolean
   preview?: boolean
 }
-type NavGroup = { label?: string; items: NavItem[]; collapsible?: boolean }
+type NavGroup = {
+  label?: string
+  items: NavItem[]
+  collapsible?: boolean
+  landingTo?: string
+}
 
 // Two planes, subtly separated: the durable-agent plane and the raw-compute
 // (sandbox) plane, plus account/org. Groups render with spacing + a small muted
@@ -117,6 +128,9 @@ const LEGACY_NAV: NavGroup[] = [
 
 const MANAGED_AGENTS_NAV: NavGroup[] = [
   {
+    label: 'Serverless agents',
+    collapsible: true,
+    landingTo: '/',
     items: [
       { to: '/', label: 'Agents', icon: Bot, end: true },
       {
@@ -134,6 +148,7 @@ const MANAGED_AGENTS_NAV: NavGroup[] = [
   {
     label: 'Durable sessions',
     collapsible: true,
+    landingTo: '/agents',
     items: [
       { to: '/agents', label: 'Agents', icon: Bot, preview: true },
       {
@@ -153,12 +168,13 @@ const MANAGED_AGENTS_NAV: NavGroup[] = [
   {
     label: 'Infrastructure',
     collapsible: true,
+    landingTo: '/sandboxes',
     items: [
-      { to: '/browsers', label: 'Browsers', icon: Monitor },
       { to: '/sandboxes', label: 'Sandboxes', icon: Boxes },
       { to: '/checkpoints', label: 'Checkpoints', icon: Layers },
       { to: '/templates', label: 'Sandbox templates', icon: Package },
       { to: '/sandbox-webhooks', label: 'Webhooks', icon: Webhook },
+      { to: '/browsers', label: 'Browsers', icon: Monitor },
     ],
   },
   {
@@ -239,21 +255,28 @@ function OrgSwitcher() {
 function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
   const { user } = useAuth()
   const location = useLocation()
+  const navigate = useNavigate()
   const nav = managedAgentsExperimentEnabled ? MANAGED_AGENTS_NAV : LEGACY_NAV
-  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() =>
-    Object.fromEntries(
-      nav
-        .filter((group) => group.collapsible && group.label)
-        .map((group) => [
-          group.label!,
-          group.items.some(
-            (item) =>
-              location.pathname === item.to ||
-              location.pathname.startsWith(`${item.to}/`),
-          ),
-        ]),
-    ),
+  const activeCollapsibleGroup = nav.find(
+    (group) =>
+      group.collapsible &&
+      group.label &&
+      ((managedAgentsExperimentEnabled &&
+        group.label === 'Serverless agents' &&
+        location.pathname.startsWith('/managed-agents/')) ||
+        group.items.some(
+          (item) =>
+            location.pathname === item.to ||
+            (item.to !== '/' && location.pathname.startsWith(`${item.to}/`)),
+        )),
+  )?.label
+  const [openGroup, setOpenGroup] = useState<string | undefined>(
+    activeCollapsibleGroup,
   )
+
+  useEffect(() => {
+    if (activeCollapsibleGroup) setOpenGroup(activeCollapsibleGroup)
+  }, [activeCollapsibleGroup])
   return (
     <div className="flex h-full min-h-0 flex-col">
       {(user?.orgs?.length ?? 0) > 1 ? (
@@ -268,19 +291,17 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
             {group.label && group.collapsible ? (
               <button
                 type="button"
-                onClick={() =>
-                  setOpenGroups((current) => ({
-                    ...current,
-                    [group.label!]: !current[group.label!],
-                  }))
-                }
+                onClick={() => {
+                  setOpenGroup(group.label)
+                  if (group.landingTo) void navigate(group.landingTo)
+                }}
                 className="text-muted-foreground/70 hover:text-foreground flex w-full items-center gap-1 px-3 pb-1 text-left text-[10px] font-medium tracking-wider uppercase transition-colors"
-                aria-expanded={openGroups[group.label] ?? false}
+                aria-expanded={openGroup === group.label}
               >
                 <ChevronRight
                   className={cn(
                     'size-3 transition-transform',
-                    openGroups[group.label] && 'rotate-90',
+                    openGroup === group.label && 'rotate-90',
                   )}
                 />
                 {group.label}
@@ -290,7 +311,7 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
                 {group.label}
               </div>
             ) : null}
-            {(!group.collapsible || openGroups[group.label ?? '']) &&
+            {(!group.collapsible || openGroup === group.label) &&
               group.items.map((item) => (
                 <NavLink
                   key={item.to}

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -128,11 +128,11 @@ const LEGACY_NAV: NavGroup[] = [
 
 const MANAGED_AGENTS_NAV: NavGroup[] = [
   {
-    label: 'Projects',
+    label: 'Serverless agents',
     collapsible: true,
     landingTo: '/',
     items: [
-      { to: '/', label: 'Projects', icon: Bot, end: true },
+      { to: '/', label: 'Agents', icon: Bot, end: true },
       {
         to: '/managed-agents/connections',
         label: 'Connections',
@@ -262,7 +262,7 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
       group.collapsible &&
       group.label &&
       ((managedAgentsExperimentEnabled &&
-        group.label === 'Projects' &&
+        group.label === 'Serverless agents' &&
         location.pathname.startsWith('/managed-agents/')) ||
         group.items.some(
           (item) =>

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -21,6 +21,7 @@ import {
   Menu,
   Loader2,
   CircleAlert,
+  ChevronRight,
   type LucideIcon,
 } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
@@ -43,6 +44,7 @@ import {
 import { ErrorBoundary } from '@/components/error-boundary'
 import { AgentSecurityAlertBanner } from '@/components/agent-security-alert'
 import { cn } from '@/lib/utils'
+import { managedAgentsExperimentEnabled } from '@/managed-agents/feature'
 
 type NavItem = {
   to: string
@@ -51,12 +53,12 @@ type NavItem = {
   end?: boolean
   preview?: boolean
 }
-type NavGroup = { label?: string; items: NavItem[] }
+type NavGroup = { label?: string; items: NavItem[]; collapsible?: boolean }
 
 // Two planes, subtly separated: the durable-agent plane and the raw-compute
 // (sandbox) plane, plus account/org. Groups render with spacing + a small muted
 // label rather than hard dividers.
-const NAV: NavGroup[] = [
+const LEGACY_NAV: NavGroup[] = [
   {
     items: [
       { to: '/', label: 'Dashboard', icon: LayoutGrid, end: true },
@@ -98,6 +100,31 @@ const NAV: NavGroup[] = [
       { to: '/sandboxes', label: 'Sandboxes', icon: Boxes },
       { to: '/checkpoints', label: 'Checkpoints', icon: Layers },
       { to: '/templates', label: 'Templates', icon: Package },
+      { to: '/sandbox-webhooks', label: 'Webhooks', icon: Webhook },
+    ],
+  },
+  {
+    label: 'Account',
+    items: [
+      { to: '/api-keys', label: 'API Keys', icon: KeyRound },
+      { to: '/billing', label: 'Billing', icon: CreditCard },
+      { to: '/settings', label: 'Settings', icon: Settings },
+    ],
+  },
+]
+
+const MANAGED_AGENTS_NAV: NavGroup[] = [
+  {
+    items: [{ to: '/', label: 'Agents', icon: Bot, end: true }],
+  },
+  {
+    label: 'Infrastructure',
+    collapsible: true,
+    items: [
+      { to: '/browsers', label: 'Browsers', icon: Monitor },
+      { to: '/sandboxes', label: 'Sandboxes', icon: Boxes },
+      { to: '/checkpoints', label: 'Checkpoints', icon: Layers },
+      { to: '/templates', label: 'Sandbox templates', icon: Package },
       { to: '/sandbox-webhooks', label: 'Webhooks', icon: Webhook },
     ],
   },
@@ -178,6 +205,8 @@ function OrgSwitcher() {
 
 function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
   const { user } = useAuth()
+  const [infrastructureOpen, setInfrastructureOpen] = useState(false)
+  const nav = managedAgentsExperimentEnabled ? MANAGED_AGENTS_NAV : LEGACY_NAV
   return (
     <div className="flex h-full min-h-0 flex-col">
       {(user?.orgs?.length ?? 0) > 1 ? (
@@ -187,41 +216,57 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
       ) : null}
 
       <nav className="flex-1 space-y-5 overflow-y-auto p-3">
-        {NAV.map((group, gi) => (
+        {nav.map((group, gi) => (
           <div key={group.label ?? gi} className="space-y-0.5">
-            {group.label ? (
+            {group.label && group.collapsible ? (
+              <button
+                type="button"
+                onClick={() => setInfrastructureOpen((open) => !open)}
+                className="text-muted-foreground/70 hover:text-foreground flex w-full items-center gap-1 px-3 pb-1 text-left text-[10px] font-medium tracking-wider uppercase transition-colors"
+                aria-expanded={infrastructureOpen}
+              >
+                <ChevronRight
+                  className={cn(
+                    'size-3 transition-transform',
+                    infrastructureOpen && 'rotate-90',
+                  )}
+                />
+                {group.label}
+              </button>
+            ) : group.label ? (
               <div className="text-muted-foreground/55 px-3 pb-1 text-[10px] font-medium tracking-wider uppercase">
                 {group.label}
               </div>
             ) : null}
-            {group.items.map((item) => (
-              <NavLink
-                key={item.to}
-                to={item.to}
-                end={item.end}
-                onClick={onNavigate}
-                className={({ isActive }) =>
-                  cn(
-                    'flex min-h-9 items-center gap-2.5 rounded-md px-3 font-mono text-sm tracking-tight transition-colors',
-                    isActive
-                      ? 'bg-sidebar-accent text-foreground font-medium'
-                      : 'text-muted-foreground hover:bg-sidebar-accent/60 hover:text-foreground',
-                  )
-                }
-              >
-                <item.icon
-                  className="size-4 shrink-0 opacity-50"
-                  strokeWidth={1.25}
-                  aria-hidden
-                />
-                {item.label}
-                {item.preview ? (
-                  <span className="border-border/70 text-muted-foreground ml-auto rounded border px-1 py-px font-sans text-[9px] font-medium tracking-wide uppercase">
-                    Preview
-                  </span>
-                ) : null}
-              </NavLink>
-            ))}
+            {(!group.collapsible || infrastructureOpen) &&
+              group.items.map((item) => (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  end={item.end}
+                  onClick={onNavigate}
+                  className={({ isActive }) =>
+                    cn(
+                      'flex min-h-9 items-center gap-2.5 rounded-md px-3 font-mono text-sm tracking-tight transition-colors',
+                      isActive
+                        ? 'bg-sidebar-accent text-foreground font-medium'
+                        : 'text-muted-foreground hover:bg-sidebar-accent/60 hover:text-foreground',
+                    )
+                  }
+                >
+                  <item.icon
+                    className="size-4 shrink-0 opacity-50"
+                    strokeWidth={1.25}
+                    aria-hidden
+                  />
+                  {item.label}
+                  {item.preview ? (
+                    <span className="border-border/70 text-muted-foreground ml-auto rounded border px-1 py-px font-sans text-[9px] font-medium tracking-wide uppercase">
+                      Preview
+                    </span>
+                  ) : null}
+                </NavLink>
+              ))}
           </div>
         ))}
       </nav>

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -128,7 +128,7 @@ const LEGACY_NAV: NavGroup[] = [
 
 const MANAGED_AGENTS_NAV: NavGroup[] = [
   {
-    label: 'Projects',
+    label: 'Serverless agents',
     collapsible: true,
     landingTo: '/',
     items: [
@@ -262,7 +262,7 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
       group.collapsible &&
       group.label &&
       ((managedAgentsExperimentEnabled &&
-        group.label === 'Projects' &&
+        group.label === 'Serverless agents' &&
         location.pathname.startsWith('/managed-agents/')) ||
         group.items.some(
           (item) =>

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -22,6 +22,8 @@ import {
   Loader2,
   CircleAlert,
   ChevronRight,
+  Plug,
+  Radio,
   type LucideIcon,
 } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
@@ -115,7 +117,38 @@ const LEGACY_NAV: NavGroup[] = [
 
 const MANAGED_AGENTS_NAV: NavGroup[] = [
   {
-    items: [{ to: '/', label: 'Agents', icon: Bot, end: true }],
+    items: [
+      { to: '/', label: 'Agents', icon: Bot, end: true },
+      {
+        to: '/managed-agents/connections',
+        label: 'Connections',
+        icon: Plug,
+      },
+      {
+        to: '/managed-agents/channels',
+        label: 'Channels',
+        icon: Radio,
+      },
+    ],
+  },
+  {
+    label: 'Durable sessions',
+    collapsible: true,
+    items: [
+      { to: '/agents', label: 'Agents', icon: Bot, preview: true },
+      {
+        to: '/sessions',
+        label: 'Sessions',
+        icon: MessagesSquare,
+        preview: true,
+      },
+      {
+        to: '/credentials',
+        label: 'Credentials',
+        icon: KeySquare,
+        preview: true,
+      },
+    ],
   },
   {
     label: 'Infrastructure',
@@ -205,8 +238,22 @@ function OrgSwitcher() {
 
 function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
   const { user } = useAuth()
-  const [infrastructureOpen, setInfrastructureOpen] = useState(false)
+  const location = useLocation()
   const nav = managedAgentsExperimentEnabled ? MANAGED_AGENTS_NAV : LEGACY_NAV
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(
+      nav
+        .filter((group) => group.collapsible && group.label)
+        .map((group) => [
+          group.label!,
+          group.items.some(
+            (item) =>
+              location.pathname === item.to ||
+              location.pathname.startsWith(`${item.to}/`),
+          ),
+        ]),
+    ),
+  )
   return (
     <div className="flex h-full min-h-0 flex-col">
       {(user?.orgs?.length ?? 0) > 1 ? (
@@ -221,14 +268,19 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
             {group.label && group.collapsible ? (
               <button
                 type="button"
-                onClick={() => setInfrastructureOpen((open) => !open)}
+                onClick={() =>
+                  setOpenGroups((current) => ({
+                    ...current,
+                    [group.label!]: !current[group.label!],
+                  }))
+                }
                 className="text-muted-foreground/70 hover:text-foreground flex w-full items-center gap-1 px-3 pb-1 text-left text-[10px] font-medium tracking-wider uppercase transition-colors"
-                aria-expanded={infrastructureOpen}
+                aria-expanded={openGroups[group.label] ?? false}
               >
                 <ChevronRight
                   className={cn(
                     'size-3 transition-transform',
-                    infrastructureOpen && 'rotate-90',
+                    openGroups[group.label] && 'rotate-90',
                   )}
                 />
                 {group.label}
@@ -238,7 +290,7 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
                 {group.label}
               </div>
             ) : null}
-            {(!group.collapsible || infrastructureOpen) &&
+            {(!group.collapsible || openGroups[group.label ?? '']) &&
               group.items.map((item) => (
                 <NavLink
                   key={item.to}

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -448,7 +448,14 @@ export default function AppShell() {
           <HaltBanner />
           <AgentSecurityAlertBanner />
         </div>
-        <main className="mx-auto max-w-7xl px-4 py-6 sm:px-8">
+        <main
+          className={cn(
+            'mx-auto px-4 py-6 sm:px-8',
+            location.pathname.startsWith('/managed-agents/')
+              ? 'max-w-[1600px]'
+              : 'max-w-7xl',
+          )}
+        >
           {/* Keyed by org + route: clears a page error on navigation AND
               remounts org-scoped pages on org switch so local draft/filter
               state can't bleed across orgs. */}

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -128,7 +128,7 @@ const LEGACY_NAV: NavGroup[] = [
 
 const MANAGED_AGENTS_NAV: NavGroup[] = [
   {
-    label: 'Serverless agents',
+    label: 'Projects',
     collapsible: true,
     landingTo: '/',
     items: [
@@ -262,7 +262,7 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
       group.collapsible &&
       group.label &&
       ((managedAgentsExperimentEnabled &&
-        group.label === 'Serverless agents' &&
+        group.label === 'Projects' &&
         location.pathname.startsWith('/managed-agents/')) ||
         group.items.some(
           (item) =>

--- a/web/src/components/status-badge.tsx
+++ b/web/src/components/status-badge.tsx
@@ -27,9 +27,16 @@ const STATUS: Record<string, Meta> = {
   running: { tone: 'running', label: 'Running', icon: CircleCheck },
   ready: { tone: 'running', label: 'Ready', icon: CircleCheck },
   active: { tone: 'running', label: 'Active', icon: CircleCheck },
+  connected: { tone: 'running', label: 'Connected', icon: CircleCheck },
   success: { tone: 'running', label: 'Success', icon: CircleCheck },
   resolved: { tone: 'running', label: 'Resolved', icon: CircleCheck },
   stopped: { tone: 'stopped', label: 'Stopped', icon: CircleSlash },
+  disconnected: {
+    tone: 'stopped',
+    label: 'Disconnected',
+    icon: CircleSlash,
+  },
+  expired: { tone: 'stopped', label: 'Expired', icon: CircleSlash },
   not_deployed: {
     tone: 'stopped',
     label: 'Not deployed',

--- a/web/src/managed-agents/Channels.tsx
+++ b/web/src/managed-agents/Channels.tsx
@@ -1,0 +1,103 @@
+import { useQuery } from '@tanstack/react-query'
+import { Loader2, Radio } from 'lucide-react'
+import { PageHeader } from '@/components/page-header'
+import { Panel, PanelContent } from '@/components/panel'
+import { StatusBadge } from '@/components/status-badge'
+import { Button } from '@/components/ui/button'
+import {
+  displayManagedAgentName,
+  getManagedAgentChannels,
+  getManagedAgents,
+} from './api'
+
+function displayResourceName(value: string) {
+  return value
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, (character) => character.toUpperCase())
+}
+
+export default function ManagedAgentChannels() {
+  const channels = useQuery({
+    queryKey: ['managed-agent-channels'],
+    queryFn: getManagedAgentChannels,
+  })
+  const agents = useQuery({
+    queryKey: ['managed-agents'],
+    queryFn: getManagedAgents,
+  })
+  const agentNames = new Map(
+    (agents.data ?? []).map((agent) => [
+      agent.id,
+      displayManagedAgentName(agent),
+    ]),
+  )
+
+  return (
+    <div>
+      <PageHeader
+        title="Channels"
+        description="Places where agents can receive and send messages."
+      />
+
+      {channels.isLoading ? (
+        <div className="flex min-h-48 items-center justify-center">
+          <Loader2 className="text-muted-foreground size-5 animate-spin" />
+        </div>
+      ) : channels.isError ? (
+        <Panel>
+          <PanelContent className="flex min-h-40 flex-col items-center justify-center gap-4 text-center">
+            <div>
+              <p className="text-sm font-medium">
+                Channels are temporarily unavailable
+              </p>
+              <p className="text-muted-foreground mt-1 text-sm">
+                Try loading this page again.
+              </p>
+            </div>
+            <Button variant="outline" onClick={() => void channels.refetch()}>
+              Try again
+            </Button>
+          </PanelContent>
+        </Panel>
+      ) : channels.data?.length ? (
+        <div className="grid gap-3 md:grid-cols-2">
+          {channels.data.map((channel) => {
+            const agentName = agentNames.get(channel.agentId)
+            return (
+              <Panel key={channel.id}>
+                <PanelContent className="flex items-center gap-3">
+                  <div className="bg-muted text-muted-foreground flex size-9 shrink-0 items-center justify-center rounded-md">
+                    <Radio className="size-4" aria-hidden />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">
+                      {channel.teamName ||
+                        `${displayResourceName(channel.channel)} workspace`}
+                    </p>
+                    <p className="text-muted-foreground truncate text-xs">
+                      {displayResourceName(channel.channel)}
+                      {agentName ? ` · ${agentName}` : ''}
+                    </p>
+                  </div>
+                  <StatusBadge status={channel.status} />
+                </PanelContent>
+              </Panel>
+            )
+          })}
+        </div>
+      ) : (
+        <Panel>
+          <PanelContent className="flex min-h-40 flex-col items-center justify-center text-center">
+            <div className="bg-muted text-muted-foreground mb-3 flex size-10 items-center justify-center rounded-full">
+              <Radio className="size-4" aria-hidden />
+            </div>
+            <p className="text-sm font-medium">No channels yet</p>
+            <p className="text-muted-foreground mt-1 max-w-sm text-sm">
+              Add a channel with the OpenComputer CLI and it will appear here.
+            </p>
+          </PanelContent>
+        </Panel>
+      )}
+    </div>
+  )
+}

--- a/web/src/managed-agents/Channels.tsx
+++ b/web/src/managed-agents/Channels.tsx
@@ -36,7 +36,7 @@ export default function ManagedAgentChannels() {
     <div>
       <PageHeader
         title="Channels"
-        description="Places where agents can receive and send messages."
+        description="Places where projects can receive and send messages."
       />
 
       {channels.isLoading ? (

--- a/web/src/managed-agents/Channels.tsx
+++ b/web/src/managed-agents/Channels.tsx
@@ -36,7 +36,7 @@ export default function ManagedAgentChannels() {
     <div>
       <PageHeader
         title="Channels"
-        description="Places where projects can receive and send messages."
+        description="Places where agents can receive and send messages."
       />
 
       {channels.isLoading ? (

--- a/web/src/managed-agents/Connections.tsx
+++ b/web/src/managed-agents/Connections.tsx
@@ -61,7 +61,7 @@ export default function ManagedAgentConnections() {
     <div>
       <PageHeader
         title="Connections"
-        description="Connected accounts available to your agents."
+        description="Connected accounts available to your projects."
       />
 
       {channelLinkState !== 'idle' && (
@@ -69,9 +69,9 @@ export default function ManagedAgentConnections() {
           <PanelContent className="text-sm">
             {channelLinkState === 'linking' && 'Linking your channel identity…'}
             {channelLinkState === 'linked' &&
-              'Channel identity linked. This agent can now use your connections when you message it.'}
+              'Channel identity linked. This project can now use your connections when you message it.'}
             {channelLinkState === 'failed' &&
-              'This channel link is invalid or expired. Ask the agent for a new link.'}
+              'This channel link is invalid or expired. Ask the project for a new link.'}
           </PanelContent>
         </Panel>
       )}

--- a/web/src/managed-agents/Connections.tsx
+++ b/web/src/managed-agents/Connections.tsx
@@ -1,11 +1,14 @@
+import { useEffect, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Loader2, Plug } from 'lucide-react'
+import { useSearchParams } from 'react-router-dom'
 import { PageHeader } from '@/components/page-header'
 import { Panel, PanelContent } from '@/components/panel'
 import { StatusBadge } from '@/components/status-badge'
 import { Button } from '@/components/ui/button'
 import {
   displayManagedAgentName,
+  claimManagedAgentChannelIdentity,
   getManagedAgentConnections,
   getManagedAgents,
 } from './api'
@@ -17,6 +20,13 @@ function displayResourceName(value: string) {
 }
 
 export default function ManagedAgentConnections() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const channelLinkStarted = useRef(false)
+  const [channelLinkState, setChannelLinkState] = useState<
+    'idle' | 'linking' | 'linked' | 'failed'
+  >('idle')
+  const requestedService = searchParams.get('service')
+  const requestedAlias = searchParams.get('alias') || 'default'
   const connections = useQuery({
     queryKey: ['managed-agent-connections'],
     queryFn: getManagedAgentConnections,
@@ -32,12 +42,57 @@ export default function ManagedAgentConnections() {
     ]),
   )
 
+  useEffect(() => {
+    const token = searchParams.get('channel_link')
+    if (!token || channelLinkStarted.current) return
+    channelLinkStarted.current = true
+    setChannelLinkState('linking')
+    void claimManagedAgentChannelIdentity(token)
+      .then(() => {
+        setChannelLinkState('linked')
+        const next = new URLSearchParams(searchParams)
+        next.delete('channel_link')
+        setSearchParams(next, { replace: true })
+      })
+      .catch(() => setChannelLinkState('failed'))
+  }, [searchParams, setSearchParams])
+
   return (
     <div>
       <PageHeader
         title="Connections"
         description="Connected accounts available to your agents."
       />
+
+      {channelLinkState !== 'idle' && (
+        <Panel className="mb-4">
+          <PanelContent className="text-sm">
+            {channelLinkState === 'linking' && 'Linking your channel identity…'}
+            {channelLinkState === 'linked' &&
+              'Channel identity linked. This agent can now use your connections when you message it.'}
+            {channelLinkState === 'failed' &&
+              'This channel link is invalid or expired. Ask the agent for a new link.'}
+          </PanelContent>
+        </Panel>
+      )}
+
+      {requestedService && (
+        <Panel className="mb-4">
+          <PanelContent>
+            <p className="text-sm font-medium">
+              Connect {displayResourceName(requestedService)} as “
+              {requestedAlias}”
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Run{' '}
+              <code className="bg-muted rounded px-1.5 py-0.5 font-mono text-xs">
+                opencomputer connection add {requestedService} --alias{' '}
+                {requestedAlias}
+              </code>
+            </p>
+          </PanelContent>
+        </Panel>
+      )}
 
       {connections.isLoading ? (
         <div className="flex min-h-48 items-center justify-center">

--- a/web/src/managed-agents/Connections.tsx
+++ b/web/src/managed-agents/Connections.tsx
@@ -1,0 +1,109 @@
+import { useQuery } from '@tanstack/react-query'
+import { Loader2, Plug } from 'lucide-react'
+import { PageHeader } from '@/components/page-header'
+import { Panel, PanelContent } from '@/components/panel'
+import { StatusBadge } from '@/components/status-badge'
+import { Button } from '@/components/ui/button'
+import {
+  displayManagedAgentName,
+  getManagedAgentConnections,
+  getManagedAgents,
+} from './api'
+
+function displayResourceName(value: string) {
+  return value
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, (character) => character.toUpperCase())
+}
+
+export default function ManagedAgentConnections() {
+  const connections = useQuery({
+    queryKey: ['managed-agent-connections'],
+    queryFn: getManagedAgentConnections,
+  })
+  const agents = useQuery({
+    queryKey: ['managed-agents'],
+    queryFn: getManagedAgents,
+  })
+  const agentNames = new Map(
+    (agents.data ?? []).map((agent) => [
+      agent.id,
+      displayManagedAgentName(agent),
+    ]),
+  )
+
+  return (
+    <div>
+      <PageHeader
+        title="Connections"
+        description="Connected accounts available to your agents."
+      />
+
+      {connections.isLoading ? (
+        <div className="flex min-h-48 items-center justify-center">
+          <Loader2 className="text-muted-foreground size-5 animate-spin" />
+        </div>
+      ) : connections.isError ? (
+        <Panel>
+          <PanelContent className="flex min-h-40 flex-col items-center justify-center gap-4 text-center">
+            <div>
+              <p className="text-sm font-medium">
+                Connections are temporarily unavailable
+              </p>
+              <p className="text-muted-foreground mt-1 text-sm">
+                Try loading this page again.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => void connections.refetch()}
+            >
+              Try again
+            </Button>
+          </PanelContent>
+        </Panel>
+      ) : connections.data?.length ? (
+        <div className="grid gap-3 md:grid-cols-2">
+          {connections.data.map((connection) => {
+            const agentName = agentNames.get(connection.agentId)
+            return (
+              <Panel key={connection.id}>
+                <PanelContent className="flex items-center gap-3">
+                  <div className="bg-muted text-muted-foreground flex size-9 shrink-0 items-center justify-center rounded-md">
+                    <Plug className="size-4" aria-hidden />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">
+                      {connection.displayName ||
+                        displayResourceName(
+                          connection.label || connection.provider,
+                        )}
+                    </p>
+                    <p className="text-muted-foreground truncate text-xs">
+                      {displayResourceName(connection.provider)}
+                      {agentName ? ` · ${agentName}` : ''}
+                    </p>
+                  </div>
+                  <StatusBadge status={connection.status} />
+                </PanelContent>
+              </Panel>
+            )
+          })}
+        </div>
+      ) : (
+        <Panel>
+          <PanelContent className="flex min-h-40 flex-col items-center justify-center text-center">
+            <div className="bg-muted text-muted-foreground mb-3 flex size-10 items-center justify-center rounded-full">
+              <Plug className="size-4" aria-hidden />
+            </div>
+            <p className="text-sm font-medium">No connections yet</p>
+            <p className="text-muted-foreground mt-1 max-w-sm text-sm">
+              Connect an account with the OpenComputer CLI and it will appear
+              here.
+            </p>
+          </PanelContent>
+        </Panel>
+      )}
+    </div>
+  )
+}

--- a/web/src/managed-agents/Connections.tsx
+++ b/web/src/managed-agents/Connections.tsx
@@ -61,7 +61,7 @@ export default function ManagedAgentConnections() {
     <div>
       <PageHeader
         title="Connections"
-        description="Connected accounts available to your projects."
+        description="Connected accounts available to your agents."
       />
 
       {channelLinkState !== 'idle' && (
@@ -69,9 +69,9 @@ export default function ManagedAgentConnections() {
           <PanelContent className="text-sm">
             {channelLinkState === 'linking' && 'Linking your channel identity…'}
             {channelLinkState === 'linked' &&
-              'Channel identity linked. This project can now use your connections when you message it.'}
+              'Channel identity linked. This agent can now use your connections when you message it.'}
             {channelLinkState === 'failed' &&
-              'This channel link is invalid or expired. Ask the project for a new link.'}
+              'This channel link is invalid or expired. Ask the agent for a new link.'}
           </PanelContent>
         </Panel>
       )}

--- a/web/src/managed-agents/Detail.tsx
+++ b/web/src/managed-agents/Detail.tsx
@@ -1,19 +1,25 @@
-import { useMemo, useState } from 'react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useChat } from '@ai-sdk/react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { isDynamicToolUIPart, type DynamicToolUIPart, type UIMessage } from 'ai'
 import { Link, useParams } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import {
   ArrowLeft,
   Bot,
   ChevronRight,
-  CircleDashed,
   Clock3,
   GitCommitHorizontal,
   Loader2,
-  MessageSquareText,
+  Plus,
+  Radio,
   Send,
+  Square,
   TerminalSquare,
   Wrench,
 } from 'lucide-react'
+import { ChatTextarea } from '@/components/chat-textarea'
 import { EmptyState } from '@/components/empty-state'
 import { PageHeader } from '@/components/page-header'
 import {
@@ -27,23 +33,23 @@ import { ResourceTable, type Column } from '@/components/resource-table'
 import { StatusBadge } from '@/components/status-badge'
 import { Button } from '@/components/ui/button'
 import { notifyError } from '@/lib/errors'
+import { cn } from '@/lib/utils'
 import {
   displayManagedAgentName,
   getManagedAgentDeployment,
+  getManagedAgentDeployments,
+  getManagedAgentChannels,
   getManagedAgentSessionEvents,
   getManagedAgents,
   getManagedAgentSessions,
-  runManagedAgent,
   type ManagedAgentEvent,
+  type ManagedAgentChannel,
   type ManagedAgentSession,
 } from './api'
+import { ManagedAgentChatTransport } from './chat-transport'
+import { isNearScrollEnd } from './scroll-follow'
 
-type ToolActivity = {
-  id: string
-  name: string
-  title?: string
-  status: 'running' | 'completed' | 'failed'
-}
+type DetailTab = 'playground' | 'deployments' | 'sessions' | 'channels'
 
 function formatDate(value: string) {
   return new Date(value).toLocaleString()
@@ -53,85 +59,183 @@ function eventText(event: ManagedAgentEvent) {
   return typeof event.data.text === 'string' ? event.data.text : ''
 }
 
-function RunActivity({
-  events,
+function AgentMarkdown({ children }: { children: string }) {
+  return (
+    <div className="text-sm leading-6">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          h1: (props) => (
+            <h1
+              className="mt-6 mb-3 text-xl font-semibold first:mt-0"
+              {...props}
+            />
+          ),
+          h2: (props) => (
+            <h2
+              className="mt-5 mb-2 text-lg font-semibold first:mt-0"
+              {...props}
+            />
+          ),
+          h3: (props) => (
+            <h3
+              className="mt-4 mb-2 text-base font-semibold first:mt-0"
+              {...props}
+            />
+          ),
+          p: (props) => <p className="mb-3 last:mb-0" {...props} />,
+          ul: (props) => (
+            <ul
+              className="mb-3 list-disc space-y-1 pl-5 last:mb-0"
+              {...props}
+            />
+          ),
+          ol: (props) => (
+            <ol
+              className="mb-3 list-decimal space-y-1 pl-5 last:mb-0"
+              {...props}
+            />
+          ),
+          li: (props) => <li className="pl-0.5" {...props} />,
+          blockquote: (props) => (
+            <blockquote
+              className="text-muted-foreground my-3 border-l-2 pl-4 italic"
+              {...props}
+            />
+          ),
+          a: (props) => (
+            <a
+              className="underline underline-offset-4"
+              target="_blank"
+              rel="noreferrer"
+              {...props}
+            />
+          ),
+          code: (props) => (
+            <code
+              className="bg-muted rounded px-1 py-0.5 font-mono text-[0.85em]"
+              {...props}
+            />
+          ),
+          pre: (props) => (
+            <pre
+              className="bg-muted my-3 overflow-x-auto rounded-md border p-3 text-xs leading-5 [&_code]:bg-transparent [&_code]:p-0"
+              {...props}
+            />
+          ),
+          hr: (props) => <hr className="my-5" {...props} />,
+          table: (props) => (
+            <div className="my-3 overflow-x-auto rounded-md border">
+              <table
+                className="w-full border-collapse text-left text-xs"
+                {...props}
+              />
+            </div>
+          ),
+          th: (props) => (
+            <th
+              className="bg-muted border-b px-3 py-2 font-medium"
+              {...props}
+            />
+          ),
+          td: (props) => <td className="border-b px-3 py-2" {...props} />,
+        }}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  )
+}
+
+function historicalMessages(
+  session: ManagedAgentSession | undefined,
+  events: ManagedAgentEvent[],
+): UIMessage[] {
+  if (!session) return []
+  const completedByTurn = new Map<string, string>()
+  for (const event of events) {
+    if (event.type === 'message.completed' && event.turnId) {
+      completedByTurn.set(event.turnId, eventText(event))
+    }
+  }
+  return session.turns.flatMap((turn) => {
+    const messages: UIMessage[] = [
+      {
+        id: `${turn.id}:user`,
+        role: 'user',
+        parts: [{ type: 'text', text: turn.input }],
+      },
+    ]
+    const response = completedByTurn.get(turn.id)
+    if (response) {
+      messages.push({
+        id: `${turn.id}:assistant`,
+        role: 'assistant',
+        parts: [{ type: 'text', text: response }],
+      })
+    }
+    return messages
+  })
+}
+
+function toolStatus(tool: DynamicToolUIPart) {
+  if (tool.state === 'output-available') return 'Completed'
+  if (tool.state === 'output-error') return 'Failed'
+  return 'Running'
+}
+
+function MessageActivity({
+  message,
   running,
 }: {
-  events: ManagedAgentEvent[]
+  message: UIMessage
   running: boolean
 }) {
-  const reasoning = events
-    .filter((event) => event.type === 'reasoning.delta')
-    .map(eventText)
+  const reasoning = message.parts
+    .filter((part) => part.type === 'reasoning')
+    .map((part) => part.text)
     .join('')
-  const tools = new Map<string, ToolActivity>()
-  for (const event of events) {
-    if (!event.type.startsWith('tool.')) continue
-    const id =
-      typeof event.data.callId === 'string'
-        ? event.data.callId
-        : `${event.type}:${event.seq}`
-    const previous = tools.get(id)
-    tools.set(id, {
-      id,
-      name:
-        typeof event.data.tool === 'string'
-          ? event.data.tool
-          : (previous?.name ?? 'tool'),
-      title:
-        typeof event.data.title === 'string'
-          ? event.data.title
-          : previous?.title,
-      status:
-        event.type === 'tool.completed'
-          ? 'completed'
-          : event.type === 'tool.failed'
-            ? 'failed'
-            : 'running',
-    })
-  }
-  const activity = [...tools.values()]
-  if (!reasoning && activity.length === 0 && !running) return null
+  const tools = message.parts.filter(isDynamicToolUIPart)
+  if (!reasoning && tools.length === 0) return null
 
   return (
     <details
-      key={running ? 'running' : 'settled'}
       open={running}
-      className="group bg-muted/25 text-muted-foreground rounded-md border"
+      className="group bg-muted/30 text-muted-foreground mb-3 rounded-md border"
     >
       <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs select-none [&::-webkit-details-marker]:hidden">
         {running ? (
           <Loader2 className="size-3.5 animate-spin" aria-hidden />
         ) : (
-          <CircleDashed className="size-3.5" aria-hidden />
+          <Wrench className="size-3.5" aria-hidden />
         )}
-        <span>{running ? 'Agent activity' : 'Activity'}</span>
+        <span>{running ? 'Agent is working' : 'Activity'}</span>
         <span className="ml-auto text-[10px]">
-          {activity.length > 0
-            ? `${activity.length} tool ${activity.length === 1 ? 'call' : 'calls'}`
-            : 'Thinking'}
+          {tools.length > 0
+            ? `${tools.length} tool ${tools.length === 1 ? 'call' : 'calls'}`
+            : 'Reasoning'}
         </span>
         <ChevronRight className="size-3.5 transition-transform group-open:rotate-90" />
       </summary>
       <div className="space-y-2 border-t px-3 py-2.5">
         {reasoning ? (
-          <p className="line-clamp-4 text-xs leading-5 whitespace-pre-wrap opacity-75">
+          <p className="line-clamp-5 text-xs leading-5 whitespace-pre-wrap opacity-75">
             {reasoning}
           </p>
         ) : null}
-        {activity.map((tool) => (
+        {tools.map((tool) => (
           <div
-            key={tool.id}
-            className="flex items-center gap-2 text-xs opacity-80"
+            key={tool.toolCallId}
+            className="flex items-center gap-2 text-xs"
           >
-            {tool.status === 'running' ? (
+            {toolStatus(tool) === 'Running' ? (
               <Loader2 className="size-3 animate-spin" aria-hidden />
             ) : (
               <Wrench className="size-3" aria-hidden />
             )}
-            <span className="font-mono">{tool.name}</span>
+            <span className="font-mono">{tool.toolName}</span>
             {tool.title ? <span className="truncate">{tool.title}</span> : null}
-            <span className="ml-auto capitalize">{tool.status}</span>
+            <span className="ml-auto">{toolStatus(tool)}</span>
           </div>
         ))}
       </div>
@@ -139,11 +243,188 @@ function RunActivity({
   )
 }
 
-export default function ManagedAgentDetail() {
-  const { agentId = '' } = useParams()
+function PlaygroundChat({
+  agentId,
+  session,
+  events,
+}: {
+  agentId: string
+  session?: ManagedAgentSession
+  events: ManagedAgentEvent[]
+}) {
   const queryClient = useQueryClient()
   const [prompt, setPrompt] = useState('')
-  const [events, setEvents] = useState<ManagedAgentEvent[]>([])
+  const [liveSessionId, setLiveSessionId] = useState(session?.id)
+  const timelineRef = useRef<HTMLDivElement>(null)
+  const composerRef = useRef<HTMLDivElement>(null)
+  const followOutputRef = useRef(true)
+  const initializedScrollRef = useRef(false)
+  const initialMessages = useMemo(
+    () => historicalMessages(session, events),
+    [events, session],
+  )
+  const transport = useMemo(
+    () =>
+      new ManagedAgentChatTransport(agentId, session?.id, (sessionId) => {
+        setLiveSessionId(sessionId)
+      }),
+    [agentId, session?.id],
+  )
+  const { messages, sendMessage, status, stop, error } = useChat({
+    id: session?.id ?? `new-${agentId}`,
+    messages: initialMessages,
+    transport,
+    throttle: 30,
+    onError: (chatError) => notifyError("Couldn't run this agent.", chatError),
+    onFinish: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ['managed-agent-sessions', agentId],
+      })
+    },
+  })
+  const running = status === 'submitted' || status === 'streaming'
+
+  useLayoutEffect(() => {
+    const timeline = timelineRef.current
+    if (!timeline) return
+    if (!initializedScrollRef.current || followOutputRef.current) {
+      timeline.scrollTop = timeline.scrollHeight
+      followOutputRef.current = true
+    }
+    initializedScrollRef.current = true
+  }, [messages, status])
+
+  const send = () => {
+    const input = prompt.trim()
+    if (!input || running) return
+    followOutputRef.current = true
+    setPrompt('')
+    void sendMessage({ text: input })
+    requestAnimationFrame(() =>
+      composerRef.current?.querySelector('textarea')?.focus(),
+    )
+  }
+
+  return (
+    <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+      <div className="flex items-center justify-between border-b px-5 py-3">
+        <div>
+          <p className="text-sm font-medium">
+            {session?.turns[0]?.input || 'New playground session'}
+          </p>
+          <p className="text-muted-foreground mt-0.5 font-mono text-[10px]">
+            {liveSessionId ?? 'A session is created when you send a message'}
+          </p>
+        </div>
+        {running ? (
+          <div className="text-muted-foreground flex items-center gap-2 text-xs">
+            <span className="bg-foreground size-1.5 animate-pulse rounded-full" />
+            Agent is working
+          </div>
+        ) : null}
+      </div>
+
+      <div
+        ref={timelineRef}
+        onScroll={(event) => {
+          followOutputRef.current = isNearScrollEnd(event.currentTarget)
+        }}
+        className="min-h-0 flex-1 space-y-6 overflow-y-auto overscroll-contain px-5 py-6"
+      >
+        {messages.length === 0 ? (
+          <div className="text-muted-foreground flex min-h-80 flex-col items-center justify-center text-center">
+            <Bot className="mb-3 size-7" aria-hidden />
+            <p className="text-foreground text-sm font-medium">
+              Start a conversation
+            </p>
+            <p className="mt-1 max-w-sm text-sm">
+              This runs the active deployment and keeps context across every
+              message in this playground session.
+            </p>
+          </div>
+        ) : (
+          messages.map((message, index) => {
+            const isLast = index === messages.length - 1
+            const messageRunning =
+              running && isLast && message.role === 'assistant'
+            const text = message.parts
+              .filter((part) => part.type === 'text')
+              .map((part) => part.text)
+              .join('')
+            return (
+              <div
+                key={message.id}
+                className={cn(
+                  'max-w-3xl',
+                  message.role === 'user' && 'ml-auto max-w-2xl',
+                )}
+              >
+                <p className="text-muted-foreground mb-1.5 text-[10px] font-semibold tracking-wider uppercase">
+                  {message.role === 'user' ? 'You' : 'Agent'}
+                </p>
+                {message.role === 'assistant' ? (
+                  <MessageActivity message={message} running={messageRunning} />
+                ) : null}
+                {text ? (
+                  message.role === 'user' ? (
+                    <div className="bg-muted rounded-xl rounded-br-sm px-3.5 py-2.5 text-sm leading-6 whitespace-pre-wrap">
+                      {text}
+                    </div>
+                  ) : (
+                    <AgentMarkdown>{text}</AgentMarkdown>
+                  )
+                ) : messageRunning ? (
+                  <div className="text-muted-foreground flex items-center gap-2 text-sm">
+                    <Loader2 className="size-4 animate-spin" />
+                    Starting the agent…
+                  </div>
+                ) : null}
+              </div>
+            )
+          })
+        )}
+      </div>
+
+      <div className="bg-panel shrink-0 border-t p-4">
+        {error ? (
+          <p className="text-destructive mb-2 text-xs">{error.message}</p>
+        ) : null}
+        <div
+          ref={composerRef}
+          className="bg-background focus-within:border-ring/60 rounded-lg border p-2 transition-colors"
+        >
+          <ChatTextarea
+            value={prompt}
+            onChange={(event) => setPrompt(event.target.value)}
+            onSend={send}
+            placeholder="Message this agent…"
+            className="min-h-12 border-0 px-2 shadow-none focus-visible:border-transparent"
+          />
+          <div className="flex items-center justify-between gap-3 px-1 pt-1">
+            <p className="text-muted-foreground text-[10px]">
+              Enter to send · Shift + Enter for a new line
+            </p>
+            {running ? (
+              <Button variant="outline" size="sm" onClick={() => void stop()}>
+                <Square className="fill-current" /> Stop
+              </Button>
+            ) : (
+              <Button size="sm" disabled={!prompt.trim()} onClick={send}>
+                <Send /> Send
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function ManagedAgentDetail() {
+  const { agentId = '' } = useParams()
+  const [activeTab, setActiveTab] = useState<DetailTab>('playground')
+  const [selectedPlaygroundId, setSelectedPlaygroundId] = useState<string>()
+  const [newSessionKey, setNewSessionKey] = useState(() => crypto.randomUUID())
   const [expandedSessionId, setExpandedSessionId] = useState<string>()
 
   const agents = useQuery({
@@ -151,51 +432,94 @@ export default function ManagedAgentDetail() {
     queryFn: getManagedAgents,
   })
   const agent = agents.data?.find((candidate) => candidate.id === agentId)
-  const deployment = useQuery({
+  const activeDeployment = useQuery({
     queryKey: ['managed-agent-deployment', agent?.activeDeploymentId],
     queryFn: () => getManagedAgentDeployment(agent!.activeDeploymentId!),
     enabled: Boolean(agent?.activeDeploymentId),
+  })
+  const deployments = useQuery({
+    queryKey: ['managed-agent-deployments', agentId],
+    queryFn: () => getManagedAgentDeployments(agentId),
   })
   const sessions = useQuery({
     queryKey: ['managed-agent-sessions', agentId],
     queryFn: () => getManagedAgentSessions(agentId),
     refetchInterval: 5_000,
   })
+  const channels = useQuery({
+    queryKey: ['managed-agent-channels'],
+    queryFn: getManagedAgentChannels,
+  })
+  const selectedPlayground = sessions.data?.find(
+    (session) => session.id === selectedPlaygroundId,
+  )
+  const selectedPlaygroundEvents = useQuery({
+    queryKey: ['managed-agent-session-events', selectedPlaygroundId],
+    queryFn: () => getManagedAgentSessionEvents(selectedPlaygroundId!),
+    enabled: Boolean(selectedPlaygroundId),
+  })
   const sessionEvents = useQuery({
     queryKey: ['managed-agent-session-events', expandedSessionId],
     queryFn: () => getManagedAgentSessionEvents(expandedSessionId!),
     enabled: Boolean(expandedSessionId),
   })
-  const run = useMutation({
-    mutationFn: (input: string) =>
-      runManagedAgent(agentId, input, (event) => {
-        setEvents((current) => {
-          if (current.some((candidate) => candidate.seq === event.seq)) {
-            return current
-          }
-          return [...current, event]
-        })
-      }),
-    onSettled: () => {
-      void queryClient.invalidateQueries({
-        queryKey: ['managed-agent-sessions', agentId],
-      })
-    },
-    onError: (error) => notifyError("Couldn't run this agent.", error),
-  })
 
-  const streamedText = useMemo(
-    () =>
-      events
-        .filter((event) => event.type === 'message.delta')
-        .map(eventText)
-        .join(''),
-    [events],
+  const playgroundSessions = (sessions.data ?? []).filter(
+    (session) => session.source === 'playground',
   )
-  const completedText = [...events]
-    .reverse()
-    .find((event) => event.type === 'message.completed')
-  const response = completedText ? eventText(completedText) : streamedText
+  const externalSessions = (sessions.data ?? []).filter(
+    (session) => session.source !== 'playground',
+  )
+  const agentChannels = (channels.data ?? []).filter(
+    (channel) => channel.agentId === agentId,
+  )
+
+  const channelColumns: Column<ManagedAgentChannel>[] = [
+    {
+      key: 'channel',
+      header: 'Channel',
+      cell: (channel) => (
+        <span className="flex items-center gap-2 text-sm capitalize">
+          <Radio className="text-muted-foreground size-3.5" />
+          {channel.channel}
+        </span>
+      ),
+    },
+    {
+      key: 'workspace',
+      header: 'Workspace',
+      cell: (channel) => (
+        <span className="text-muted-foreground text-sm">
+          {channel.teamName || '—'}
+        </span>
+      ),
+    },
+    {
+      key: 'alias',
+      header: 'Deployment alias',
+      cell: (channel) => (
+        <span className="font-mono text-xs">{channel.alias}</span>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      cell: (channel) => <StatusBadge status={channel.status} />,
+    },
+    {
+      key: 'updated',
+      header: 'Updated',
+      align: 'right',
+      cell: (channel) => (
+        <time
+          className="text-muted-foreground text-xs"
+          dateTime={channel.updatedAt}
+        >
+          {formatDate(channel.updatedAt)}
+        </time>
+      ),
+    },
+  ]
 
   const sessionColumns: Column<ManagedAgentSession>[] = [
     {
@@ -203,6 +527,15 @@ export default function ManagedAgentDetail() {
       header: 'Session',
       cell: (session) => (
         <span className="font-mono text-xs">{session.id}</span>
+      ),
+    },
+    {
+      key: 'source',
+      header: 'Source',
+      cell: (session) => (
+        <span className="text-muted-foreground text-xs capitalize">
+          {session.source}
+        </span>
       ),
     },
     {
@@ -251,260 +584,293 @@ export default function ManagedAgentDetail() {
     )
   }
 
+  const tabs: Array<{ id: DetailTab; label: string }> = [
+    { id: 'playground', label: 'Playground' },
+    { id: 'deployments', label: 'Deployments' },
+    { id: 'sessions', label: 'Sessions' },
+    { id: 'channels', label: 'Channels' },
+  ]
+
   return (
-    <div className="space-y-6">
+    <div
+      className={cn(
+        activeTab === 'playground'
+          ? 'flex h-[calc(100dvh-7rem)] min-h-0 flex-col gap-5 overflow-hidden'
+          : 'space-y-5',
+      )}
+    >
       <PageHeader
         title={agent ? displayManagedAgentName(agent) : 'Agent'}
-        description={agent ? `Agent ID · ${agent.id}` : 'Loading agent…'}
+        description={
+          activeDeployment.data
+            ? `Active deployment · ${activeDeployment.data.alias}`
+            : 'Loading active deployment…'
+        }
         actions={
           <Button asChild variant="outline" size="sm">
             <Link to="/">
-              <ArrowLeft />
-              All agents
+              <ArrowLeft /> All agents
             </Link>
           </Button>
         }
+        className={activeTab === 'playground' ? 'mb-0 shrink-0' : undefined}
       />
 
-      <div className="grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.55fr)]">
-        <Panel>
-          <PanelHeader>
-            <div>
-              <PanelTitle>Test the deployed agent</PanelTitle>
-              <PanelDescription className="mt-1">
-                Start a new cloud session and watch its response as it runs.
-              </PanelDescription>
-            </div>
-          </PanelHeader>
-          <PanelContent className="space-y-4">
-            <div className="bg-background rounded-lg border px-4 py-4">
-              {response ? (
-                <div className="space-y-3">
-                  <RunActivity
-                    events={events}
-                    running={run.isPending && !response}
-                  />
-                  <div>
-                    <p className="text-muted-foreground mb-1 text-[10px] font-medium tracking-wider uppercase">
-                      Agent
-                    </p>
-                    <p className="text-sm leading-6 whitespace-pre-wrap">
-                      {response}
-                    </p>
-                  </div>
-                </div>
-              ) : run.isPending || events.length > 0 ? (
-                <RunActivity events={events} running={run.isPending} />
-              ) : (
-                <div className="text-muted-foreground flex min-h-28 flex-col items-center justify-center text-center">
-                  <Bot className="mb-2 size-5" aria-hidden />
-                  <p className="text-sm">
-                    Send a message to start a fresh session.
-                  </p>
-                </div>
+      <div className="flex shrink-0 items-end justify-between gap-6 border-b">
+        <nav className="flex gap-5" aria-label="Agent details">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActiveTab(tab.id)}
+              className={cn(
+                '-mb-px border-b-2 px-0.5 pb-3 text-sm font-medium transition-colors',
+                activeTab === tab.id
+                  ? 'border-foreground text-foreground'
+                  : 'text-muted-foreground hover:text-foreground border-transparent',
               )}
-            </div>
-            <label htmlFor="managed-agent-detail-prompt" className="sr-only">
-              Message
-            </label>
-            <textarea
-              id="managed-agent-detail-prompt"
-              value={prompt}
-              onChange={(event) => setPrompt(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' && !event.shiftKey && prompt.trim()) {
-                  event.preventDefault()
-                  setEvents([])
-                  run.mutate(prompt.trim())
-                }
-              }}
-              placeholder="Ask your agent to do something…"
-              rows={3}
-              disabled={run.isPending}
-              className="border-input bg-background placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 w-full resize-y rounded-md border px-3 py-2 text-sm outline-none focus-visible:ring-3 disabled:opacity-60"
-            />
-            <div className="flex items-center justify-between gap-3">
-              <p className="text-muted-foreground text-xs">
-                Enter to send · Shift + Enter for a new line
-              </p>
-              <Button
-                disabled={!prompt.trim() || run.isPending}
-                onClick={() => {
-                  setEvents([])
-                  run.mutate(prompt.trim())
-                }}
-              >
-                {run.isPending ? (
-                  <Loader2 className="animate-spin" />
-                ) : (
-                  <Send />
-                )}
-                {run.isPending ? 'Running…' : 'Start session'}
-              </Button>
-            </div>
-          </PanelContent>
-        </Panel>
-
-        <Panel>
-          <PanelHeader>
-            <div>
-              <PanelTitle>Agent details</PanelTitle>
-              <PanelDescription className="mt-1">
-                Current cloud deployment.
-              </PanelDescription>
-            </div>
-          </PanelHeader>
-          <PanelContent className="space-y-5">
-            <div>
-              <p className="text-muted-foreground text-xs">Status</p>
-              <div className="mt-1">
-                <StatusBadge status="active" />
-              </div>
-            </div>
-            <div>
-              <p className="text-muted-foreground text-xs">Alias</p>
-              <p className="mt-1 font-mono text-sm">
-                {agent?.activeAlias ?? '—'}
-              </p>
-            </div>
-            <div>
-              <p className="text-muted-foreground text-xs">Last deployed</p>
-              <p className="mt-1 text-sm">
-                {deployment.data ? formatDate(deployment.data.createdAt) : '—'}
-              </p>
-            </div>
-            <div>
-              <p className="text-muted-foreground text-xs">Connections</p>
-              <p className="mt-1 text-sm">
-                {deployment.data?.connections.join(', ') || 'None'}
-              </p>
-            </div>
-            <div>
-              <p className="text-muted-foreground text-xs">Channels</p>
-              <p className="mt-1 text-sm">
-                {deployment.data?.channels.join(', ') || 'None'}
-              </p>
-            </div>
-          </PanelContent>
-        </Panel>
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+        <div className="text-muted-foreground hidden gap-5 pb-3 text-xs lg:flex">
+          <span>{agent?.deploymentCount ?? 0} deployments</span>
+          <span>
+            {activeDeployment.data?.connections.length ?? 0} connections
+          </span>
+          <span>{agentChannels.length} channels</span>
+        </div>
       </div>
 
-      <Panel className="overflow-hidden">
-        <PanelHeader>
-          <div>
-            <PanelTitle>Deployments and revisions</PanelTitle>
-            <PanelDescription className="mt-1">
-              The active immutable version, deployed from the checked-out agent
-              source.
-            </PanelDescription>
-          </div>
-          <span className="text-muted-foreground text-xs">
-            {agent?.deploymentCount ?? 0} total
-          </span>
-        </PanelHeader>
-        {deployment.data ? (
-          <div className="grid gap-4 px-5 py-4 sm:grid-cols-3">
-            <div className="flex items-start gap-2">
-              <GitCommitHorizontal className="text-muted-foreground mt-0.5 size-4" />
-              <div>
-                <p className="text-xs font-medium">Active revision</p>
-                <p className="text-muted-foreground mt-1 font-mono text-xs">
-                  {deployment.data.id}
+      {activeTab === 'playground' ? (
+        <Panel className="min-h-0 flex-1 overflow-hidden">
+          <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] lg:grid-cols-[17rem_minmax(0,1fr)] lg:grid-rows-1">
+            <aside className="bg-muted/15 flex min-h-0 flex-col overflow-hidden border-b lg:border-r lg:border-b-0">
+              <div className="flex items-center justify-between border-b px-4 py-3">
+                <p className="text-xs font-semibold tracking-wide uppercase">
+                  Sessions
                 </p>
+                <Button
+                  size="icon-sm"
+                  variant="ghost"
+                  aria-label="New playground session"
+                  onClick={() => {
+                    setSelectedPlaygroundId(undefined)
+                    setNewSessionKey(crypto.randomUUID())
+                  }}
+                >
+                  <Plus />
+                </Button>
               </div>
-            </div>
-            <div>
-              <p className="text-muted-foreground text-xs">Alias</p>
-              <p className="mt-1 text-sm">{deployment.data.alias}</p>
-            </div>
-            <div>
-              <p className="text-muted-foreground text-xs">Created</p>
-              <p className="mt-1 text-sm">
-                {formatDate(deployment.data.createdAt)}
-              </p>
-            </div>
-          </div>
-        ) : (
-          <PanelContent className="text-muted-foreground text-sm">
-            {deployment.isLoading
-              ? 'Loading the active revision…'
-              : 'Active revision details are unavailable.'}
-          </PanelContent>
-        )}
-      </Panel>
-
-      <Panel className="overflow-hidden">
-        <PanelHeader>
-          <div>
-            <PanelTitle>Sessions</PanelTitle>
-            <PanelDescription className="mt-1">
-              Cloud sessions are visible here. Lifecycle controls stay with the
-              checked-out agent code.
-            </PanelDescription>
-          </div>
-          <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
-            <Clock3 className="size-3.5" />
-            Refreshes automatically
-          </div>
-        </PanelHeader>
-        <ResourceTable
-          columns={sessionColumns}
-          rows={sessions.data ?? []}
-          rowKey={(session) => session.id}
-          loading={sessions.isLoading}
-          onRowClick={(session) =>
-            setExpandedSessionId((current) =>
-              current === session.id ? undefined : session.id,
-            )
-          }
-          renderSubRow={(session) => {
-            if (expandedSessionId !== session.id) return null
-            const replies = (sessionEvents.data ?? []).filter(
-              (event) => event.type === 'message.completed',
-            )
-            return (
-              <div className="bg-muted/20 space-y-3 border-y px-5 py-4">
-                {session.turns.map((turn) => (
-                  <div key={turn.id}>
-                    <p className="text-muted-foreground mb-1 text-[10px] font-medium tracking-wider uppercase">
-                      You · {turn.status}
-                    </p>
-                    <p className="text-sm whitespace-pre-wrap">{turn.input}</p>
-                  </div>
-                ))}
-                {replies.map((event) => (
-                  <div key={event.id ?? event.seq}>
-                    <p className="text-muted-foreground mb-1 text-[10px] font-medium tracking-wider uppercase">
-                      Agent
-                    </p>
-                    <p className="text-sm leading-6 whitespace-pre-wrap">
-                      {eventText(event)}
-                    </p>
-                  </div>
-                ))}
-                {sessionEvents.isLoading ? (
-                  <div className="text-muted-foreground flex items-center gap-2 text-xs">
-                    <Loader2 className="size-3.5 animate-spin" />
-                    Loading session events…
-                  </div>
-                ) : session.turns.length === 0 && replies.length === 0 ? (
-                  <div className="text-muted-foreground flex items-center gap-2 text-xs">
-                    <MessageSquareText className="size-3.5" />
-                    This session has no visible messages yet.
-                  </div>
+              <div className="max-h-48 min-h-0 overflow-y-auto overscroll-contain p-2 lg:max-h-none lg:flex-1">
+                {!selectedPlaygroundId ? (
+                  <button
+                    type="button"
+                    className="bg-muted text-foreground mb-1 w-full rounded-md px-3 py-2 text-left"
+                  >
+                    <span className="block truncate text-xs font-medium">
+                      New session
+                    </span>
+                    <span className="text-muted-foreground mt-0.5 block text-[10px]">
+                      Playground
+                    </span>
+                  </button>
                 ) : null}
+                {playgroundSessions.map((session) => (
+                  <button
+                    key={session.id}
+                    type="button"
+                    onClick={() => setSelectedPlaygroundId(session.id)}
+                    className={cn(
+                      'hover:bg-muted/70 mb-1 w-full rounded-md px-3 py-2 text-left transition-colors',
+                      selectedPlaygroundId === session.id && 'bg-muted',
+                    )}
+                  >
+                    <span className="block truncate text-xs font-medium">
+                      {session.turns[0]?.input || 'Playground session'}
+                    </span>
+                    <span className="text-muted-foreground mt-0.5 block text-[10px]">
+                      {session.turns.length}{' '}
+                      {session.turns.length === 1 ? 'turn' : 'turns'} ·{' '}
+                      {formatDate(session.updatedAt)}
+                    </span>
+                  </button>
+                ))}
               </div>
-            )
-          }}
-          empty={
-            <EmptyState
-              icon={TerminalSquare}
-              title="No sessions yet"
-              description="Start a session above to test this deployment."
-            />
-          }
-        />
-      </Panel>
+            </aside>
+            {selectedPlaygroundId && selectedPlaygroundEvents.isLoading ? (
+              <div className="text-muted-foreground flex min-h-0 items-center justify-center gap-2 text-sm">
+                <Loader2 className="size-4 animate-spin" /> Loading session…
+              </div>
+            ) : (
+              <PlaygroundChat
+                key={selectedPlaygroundId ?? newSessionKey}
+                agentId={agentId}
+                session={selectedPlayground}
+                events={selectedPlaygroundEvents.data ?? []}
+              />
+            )}
+          </div>
+        </Panel>
+      ) : null}
+
+      {activeTab === 'deployments' ? (
+        <Panel className="overflow-hidden">
+          <PanelHeader>
+            <div>
+              <PanelTitle>Deployments</PanelTitle>
+              <PanelDescription className="mt-1">
+                Immutable versions published from this agent's source.
+              </PanelDescription>
+            </div>
+          </PanelHeader>
+          {(deployments.data ?? []).length > 0 ? (
+            <div className="divide-y">
+              {(deployments.data ?? []).map((deployment) => (
+                <div
+                  key={deployment.id}
+                  className="grid gap-4 px-5 py-4 sm:grid-cols-[minmax(14rem,1fr)_1fr_1fr_auto]"
+                >
+                  <div className="flex min-w-0 items-start gap-2">
+                    <GitCommitHorizontal className="text-muted-foreground mt-0.5 size-4 shrink-0" />
+                    <div className="min-w-0">
+                      <p className="truncate font-mono text-xs">
+                        {deployment.id}
+                      </p>
+                      {deployment.id === agent?.activeDeploymentId ? (
+                        <span className="text-muted-foreground mt-1 block text-[10px] font-medium uppercase">
+                          Active
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-muted-foreground text-xs">Alias</p>
+                    <p className="mt-1 text-sm">{deployment.alias}</p>
+                  </div>
+                  <div>
+                    <p className="text-muted-foreground text-xs">Created</p>
+                    <p className="mt-1 text-sm">
+                      {formatDate(deployment.createdAt)}
+                    </p>
+                  </div>
+                  <StatusBadge
+                    status={
+                      deployment.id === agent?.activeDeploymentId
+                        ? 'active'
+                        : 'inactive'
+                    }
+                  />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <PanelContent className="text-muted-foreground text-sm">
+              {deployments.isLoading
+                ? 'Loading deployments…'
+                : 'No deployments found.'}
+            </PanelContent>
+          )}
+        </Panel>
+      ) : null}
+
+      {activeTab === 'sessions' ? (
+        <Panel className="overflow-hidden">
+          <PanelHeader>
+            <div>
+              <PanelTitle>Sessions</PanelTitle>
+              <PanelDescription className="mt-1">
+                Sessions started through channels and the API. Playground
+                sessions stay in the playground.
+              </PanelDescription>
+            </div>
+            <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
+              <Clock3 className="size-3.5" /> Refreshes automatically
+            </div>
+          </PanelHeader>
+          <ResourceTable
+            columns={sessionColumns}
+            rows={externalSessions}
+            rowKey={(session) => session.id}
+            loading={sessions.isLoading}
+            onRowClick={(session) =>
+              setExpandedSessionId((current) =>
+                current === session.id ? undefined : session.id,
+              )
+            }
+            renderSubRow={(session) => {
+              if (expandedSessionId !== session.id) return null
+              const replies = (sessionEvents.data ?? []).filter(
+                (event) => event.type === 'message.completed',
+              )
+              return (
+                <div className="bg-muted/20 space-y-4 border-y px-5 py-4">
+                  {session.turns.map((turn) => (
+                    <div key={turn.id}>
+                      <p className="text-muted-foreground mb-1 text-[10px] font-medium tracking-wider uppercase">
+                        You · {turn.status}
+                      </p>
+                      <p className="text-sm whitespace-pre-wrap">
+                        {turn.input}
+                      </p>
+                    </div>
+                  ))}
+                  {replies.map((event) => (
+                    <div key={event.id ?? event.seq}>
+                      <p className="text-muted-foreground mb-1 text-[10px] font-medium tracking-wider uppercase">
+                        Agent
+                      </p>
+                      <p className="text-sm leading-6 whitespace-pre-wrap">
+                        {eventText(event)}
+                      </p>
+                    </div>
+                  ))}
+                  {sessionEvents.isLoading ? (
+                    <div className="text-muted-foreground flex items-center gap-2 text-xs">
+                      <Loader2 className="size-3.5 animate-spin" /> Loading
+                      session events…
+                    </div>
+                  ) : null}
+                </div>
+              )
+            }}
+            empty={
+              <EmptyState
+                icon={TerminalSquare}
+                title="No channel or API sessions yet"
+                description="Sessions created outside the playground will appear here."
+              />
+            }
+          />
+        </Panel>
+      ) : null}
+
+      {activeTab === 'channels' ? (
+        <Panel className="overflow-hidden">
+          <PanelHeader>
+            <div>
+              <PanelTitle>Channels</PanelTitle>
+              <PanelDescription className="mt-1">
+                Messaging channels connected to this deployed agent.
+              </PanelDescription>
+            </div>
+          </PanelHeader>
+          <ResourceTable
+            columns={channelColumns}
+            rows={agentChannels}
+            rowKey={(channel) => channel.id}
+            loading={channels.isLoading}
+            empty={
+              <EmptyState
+                icon={Radio}
+                title="No channels connected"
+                description="Connect Slack, Discord, or another channel from your checked-out agent project."
+              />
+            }
+          />
+        </Panel>
+      ) : null}
     </div>
   )
 }

--- a/web/src/managed-agents/Detail.tsx
+++ b/web/src/managed-agents/Detail.tsx
@@ -209,7 +209,7 @@ function MessageActivity({
         ) : (
           <Wrench className="size-3.5" aria-hidden />
         )}
-        <span>{running ? 'Project is working' : 'Activity'}</span>
+        <span>{running ? 'Agent is working' : 'Activity'}</span>
         <span className="ml-auto text-[10px]">
           {tools.length > 0
             ? `${tools.length} tool ${tools.length === 1 ? 'call' : 'calls'}`
@@ -275,8 +275,7 @@ function PlaygroundChat({
     messages: initialMessages,
     transport,
     throttle: 30,
-    onError: (chatError) =>
-      notifyError("Couldn't run this project.", chatError),
+    onError: (chatError) => notifyError("Couldn't run this agent.", chatError),
     onFinish: () => {
       void queryClient.invalidateQueries({
         queryKey: ['managed-agent-sessions', agentId],
@@ -320,7 +319,7 @@ function PlaygroundChat({
         {running ? (
           <div className="text-muted-foreground flex items-center gap-2 text-xs">
             <span className="bg-foreground size-1.5 animate-pulse rounded-full" />
-            Project is working
+            Agent is working
           </div>
         ) : null}
       </div>
@@ -361,7 +360,7 @@ function PlaygroundChat({
                 )}
               >
                 <p className="text-muted-foreground mb-1.5 text-[10px] font-semibold tracking-wider uppercase">
-                  {message.role === 'user' ? 'You' : 'Project'}
+                  {message.role === 'user' ? 'You' : 'Agent'}
                 </p>
                 {message.role === 'assistant' ? (
                   <MessageActivity message={message} running={messageRunning} />
@@ -377,7 +376,7 @@ function PlaygroundChat({
                 ) : messageRunning ? (
                   <div className="text-muted-foreground flex items-center gap-2 text-sm">
                     <Loader2 className="size-4 animate-spin" />
-                    Starting the project…
+                    Starting the agent…
                   </div>
                 ) : null}
               </div>
@@ -398,7 +397,7 @@ function PlaygroundChat({
             value={prompt}
             onChange={(event) => setPrompt(event.target.value)}
             onSend={send}
-            placeholder="Message this project…"
+            placeholder="Message this agent…"
             className="min-h-12 border-0 px-2 shadow-none focus-visible:border-transparent"
           />
           <div className="flex items-center justify-between gap-3 px-1 pt-1">
@@ -573,11 +572,11 @@ export default function ManagedAgentDetail() {
       <Panel>
         <EmptyState
           icon={Bot}
-          title="Project not found"
-          description="This project is not available in your organization."
+          title="Agent not found"
+          description="This agent is not available in your organization."
           action={
             <Button asChild variant="outline">
-              <Link to="/">Back to projects</Link>
+              <Link to="/">Back to agents</Link>
             </Button>
           }
         />
@@ -601,7 +600,7 @@ export default function ManagedAgentDetail() {
       )}
     >
       <PageHeader
-        title={agent ? displayManagedAgentName(agent) : 'Project'}
+        title={agent ? displayManagedAgentName(agent) : 'Agent'}
         description={
           activeDeployment.data
             ? `Active deployment · ${activeDeployment.data.alias}`
@@ -610,7 +609,7 @@ export default function ManagedAgentDetail() {
         actions={
           <Button asChild variant="outline" size="sm">
             <Link to="/">
-              <ArrowLeft /> All projects
+              <ArrowLeft /> All agents
             </Link>
           </Button>
         }
@@ -618,7 +617,7 @@ export default function ManagedAgentDetail() {
       />
 
       <div className="flex shrink-0 items-end justify-between gap-6 border-b">
-        <nav className="flex gap-5" aria-label="Project details">
+        <nav className="flex gap-5" aria-label="Agent details">
           {tabs.map((tab) => (
             <button
               key={tab.id}
@@ -722,7 +721,7 @@ export default function ManagedAgentDetail() {
             <div>
               <PanelTitle>Deployments</PanelTitle>
               <PanelDescription className="mt-1">
-                Immutable versions published from this project's source.
+                Immutable versions published from this agent's source.
               </PanelDescription>
             </div>
           </PanelHeader>
@@ -820,7 +819,7 @@ export default function ManagedAgentDetail() {
                   {replies.map((event) => (
                     <div key={event.id ?? event.seq}>
                       <p className="text-muted-foreground mb-1 text-[10px] font-medium tracking-wider uppercase">
-                        Project
+                        Agent
                       </p>
                       <p className="text-sm leading-6 whitespace-pre-wrap">
                         {eventText(event)}
@@ -853,7 +852,7 @@ export default function ManagedAgentDetail() {
             <div>
               <PanelTitle>Channels</PanelTitle>
               <PanelDescription className="mt-1">
-                Messaging channels connected to this deployed project.
+                Messaging channels connected to this deployed agent.
               </PanelDescription>
             </div>
           </PanelHeader>
@@ -866,7 +865,7 @@ export default function ManagedAgentDetail() {
               <EmptyState
                 icon={Radio}
                 title="No channels connected"
-                description="Connect Slack, Discord, or another channel from your checked-out project."
+                description="Connect Slack, Discord, or another channel from your checked-out agent project."
               />
             }
           />

--- a/web/src/managed-agents/Detail.tsx
+++ b/web/src/managed-agents/Detail.tsx
@@ -1,0 +1,510 @@
+import { useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link, useParams } from 'react-router-dom'
+import {
+  ArrowLeft,
+  Bot,
+  ChevronRight,
+  CircleDashed,
+  Clock3,
+  GitCommitHorizontal,
+  Loader2,
+  MessageSquareText,
+  Send,
+  TerminalSquare,
+  Wrench,
+} from 'lucide-react'
+import { EmptyState } from '@/components/empty-state'
+import { PageHeader } from '@/components/page-header'
+import {
+  Panel,
+  PanelContent,
+  PanelDescription,
+  PanelHeader,
+  PanelTitle,
+} from '@/components/panel'
+import { ResourceTable, type Column } from '@/components/resource-table'
+import { StatusBadge } from '@/components/status-badge'
+import { Button } from '@/components/ui/button'
+import { notifyError } from '@/lib/errors'
+import {
+  displayManagedAgentName,
+  getManagedAgentDeployment,
+  getManagedAgentSessionEvents,
+  getManagedAgents,
+  getManagedAgentSessions,
+  runManagedAgent,
+  type ManagedAgentEvent,
+  type ManagedAgentSession,
+} from './api'
+
+type ToolActivity = {
+  id: string
+  name: string
+  title?: string
+  status: 'running' | 'completed' | 'failed'
+}
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleString()
+}
+
+function eventText(event: ManagedAgentEvent) {
+  return typeof event.data.text === 'string' ? event.data.text : ''
+}
+
+function RunActivity({
+  events,
+  running,
+}: {
+  events: ManagedAgentEvent[]
+  running: boolean
+}) {
+  const reasoning = events
+    .filter((event) => event.type === 'reasoning.delta')
+    .map(eventText)
+    .join('')
+  const tools = new Map<string, ToolActivity>()
+  for (const event of events) {
+    if (!event.type.startsWith('tool.')) continue
+    const id =
+      typeof event.data.callId === 'string'
+        ? event.data.callId
+        : `${event.type}:${event.seq}`
+    const previous = tools.get(id)
+    tools.set(id, {
+      id,
+      name:
+        typeof event.data.tool === 'string'
+          ? event.data.tool
+          : (previous?.name ?? 'tool'),
+      title:
+        typeof event.data.title === 'string'
+          ? event.data.title
+          : previous?.title,
+      status:
+        event.type === 'tool.completed'
+          ? 'completed'
+          : event.type === 'tool.failed'
+            ? 'failed'
+            : 'running',
+    })
+  }
+  const activity = [...tools.values()]
+  if (!reasoning && activity.length === 0 && !running) return null
+
+  return (
+    <details
+      key={running ? 'running' : 'settled'}
+      open={running}
+      className="group bg-muted/25 text-muted-foreground rounded-md border"
+    >
+      <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs select-none [&::-webkit-details-marker]:hidden">
+        {running ? (
+          <Loader2 className="size-3.5 animate-spin" aria-hidden />
+        ) : (
+          <CircleDashed className="size-3.5" aria-hidden />
+        )}
+        <span>{running ? 'Agent activity' : 'Activity'}</span>
+        <span className="ml-auto text-[10px]">
+          {activity.length > 0
+            ? `${activity.length} tool ${activity.length === 1 ? 'call' : 'calls'}`
+            : 'Thinking'}
+        </span>
+        <ChevronRight className="size-3.5 transition-transform group-open:rotate-90" />
+      </summary>
+      <div className="space-y-2 border-t px-3 py-2.5">
+        {reasoning ? (
+          <p className="line-clamp-4 text-xs leading-5 whitespace-pre-wrap opacity-75">
+            {reasoning}
+          </p>
+        ) : null}
+        {activity.map((tool) => (
+          <div
+            key={tool.id}
+            className="flex items-center gap-2 text-xs opacity-80"
+          >
+            {tool.status === 'running' ? (
+              <Loader2 className="size-3 animate-spin" aria-hidden />
+            ) : (
+              <Wrench className="size-3" aria-hidden />
+            )}
+            <span className="font-mono">{tool.name}</span>
+            {tool.title ? <span className="truncate">{tool.title}</span> : null}
+            <span className="ml-auto capitalize">{tool.status}</span>
+          </div>
+        ))}
+      </div>
+    </details>
+  )
+}
+
+export default function ManagedAgentDetail() {
+  const { agentId = '' } = useParams()
+  const queryClient = useQueryClient()
+  const [prompt, setPrompt] = useState('')
+  const [events, setEvents] = useState<ManagedAgentEvent[]>([])
+  const [expandedSessionId, setExpandedSessionId] = useState<string>()
+
+  const agents = useQuery({
+    queryKey: ['managed-agents'],
+    queryFn: getManagedAgents,
+  })
+  const agent = agents.data?.find((candidate) => candidate.id === agentId)
+  const deployment = useQuery({
+    queryKey: ['managed-agent-deployment', agent?.activeDeploymentId],
+    queryFn: () => getManagedAgentDeployment(agent!.activeDeploymentId!),
+    enabled: Boolean(agent?.activeDeploymentId),
+  })
+  const sessions = useQuery({
+    queryKey: ['managed-agent-sessions', agentId],
+    queryFn: () => getManagedAgentSessions(agentId),
+    refetchInterval: 5_000,
+  })
+  const sessionEvents = useQuery({
+    queryKey: ['managed-agent-session-events', expandedSessionId],
+    queryFn: () => getManagedAgentSessionEvents(expandedSessionId!),
+    enabled: Boolean(expandedSessionId),
+  })
+  const run = useMutation({
+    mutationFn: (input: string) =>
+      runManagedAgent(agentId, input, (event) => {
+        setEvents((current) => {
+          if (current.some((candidate) => candidate.seq === event.seq)) {
+            return current
+          }
+          return [...current, event]
+        })
+      }),
+    onSettled: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ['managed-agent-sessions', agentId],
+      })
+    },
+    onError: (error) => notifyError("Couldn't run this agent.", error),
+  })
+
+  const streamedText = useMemo(
+    () =>
+      events
+        .filter((event) => event.type === 'message.delta')
+        .map(eventText)
+        .join(''),
+    [events],
+  )
+  const completedText = [...events]
+    .reverse()
+    .find((event) => event.type === 'message.completed')
+  const response = completedText ? eventText(completedText) : streamedText
+
+  const sessionColumns: Column<ManagedAgentSession>[] = [
+    {
+      key: 'session',
+      header: 'Session',
+      cell: (session) => (
+        <span className="font-mono text-xs">{session.id}</span>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      cell: (session) => <StatusBadge status={session.status} />,
+    },
+    {
+      key: 'turns',
+      header: 'Turns',
+      cell: (session) => (
+        <span className="text-muted-foreground text-xs">
+          {session.turns.length}
+        </span>
+      ),
+    },
+    {
+      key: 'updated',
+      header: 'Updated',
+      align: 'right',
+      cell: (session) => (
+        <time
+          className="text-muted-foreground text-xs"
+          dateTime={session.updatedAt}
+        >
+          {formatDate(session.updatedAt)}
+        </time>
+      ),
+    },
+  ]
+
+  if (!agents.isLoading && !agent) {
+    return (
+      <Panel>
+        <EmptyState
+          icon={Bot}
+          title="Agent not found"
+          description="This agent is not available in your organization."
+          action={
+            <Button asChild variant="outline">
+              <Link to="/">Back to agents</Link>
+            </Button>
+          }
+        />
+      </Panel>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={agent ? displayManagedAgentName(agent) : 'Agent'}
+        description={agent ? `Agent ID · ${agent.id}` : 'Loading agent…'}
+        actions={
+          <Button asChild variant="outline" size="sm">
+            <Link to="/">
+              <ArrowLeft />
+              All agents
+            </Link>
+          </Button>
+        }
+      />
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.55fr)]">
+        <Panel>
+          <PanelHeader>
+            <div>
+              <PanelTitle>Test the deployed agent</PanelTitle>
+              <PanelDescription className="mt-1">
+                Start a new cloud session and watch its response as it runs.
+              </PanelDescription>
+            </div>
+          </PanelHeader>
+          <PanelContent className="space-y-4">
+            <div className="bg-background rounded-lg border px-4 py-4">
+              {response ? (
+                <div className="space-y-3">
+                  <RunActivity
+                    events={events}
+                    running={run.isPending && !response}
+                  />
+                  <div>
+                    <p className="text-muted-foreground mb-1 text-[10px] font-medium tracking-wider uppercase">
+                      Agent
+                    </p>
+                    <p className="text-sm leading-6 whitespace-pre-wrap">
+                      {response}
+                    </p>
+                  </div>
+                </div>
+              ) : run.isPending || events.length > 0 ? (
+                <RunActivity events={events} running={run.isPending} />
+              ) : (
+                <div className="text-muted-foreground flex min-h-28 flex-col items-center justify-center text-center">
+                  <Bot className="mb-2 size-5" aria-hidden />
+                  <p className="text-sm">
+                    Send a message to start a fresh session.
+                  </p>
+                </div>
+              )}
+            </div>
+            <label htmlFor="managed-agent-detail-prompt" className="sr-only">
+              Message
+            </label>
+            <textarea
+              id="managed-agent-detail-prompt"
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' && !event.shiftKey && prompt.trim()) {
+                  event.preventDefault()
+                  setEvents([])
+                  run.mutate(prompt.trim())
+                }
+              }}
+              placeholder="Ask your agent to do something…"
+              rows={3}
+              disabled={run.isPending}
+              className="border-input bg-background placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 w-full resize-y rounded-md border px-3 py-2 text-sm outline-none focus-visible:ring-3 disabled:opacity-60"
+            />
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-muted-foreground text-xs">
+                Enter to send · Shift + Enter for a new line
+              </p>
+              <Button
+                disabled={!prompt.trim() || run.isPending}
+                onClick={() => {
+                  setEvents([])
+                  run.mutate(prompt.trim())
+                }}
+              >
+                {run.isPending ? (
+                  <Loader2 className="animate-spin" />
+                ) : (
+                  <Send />
+                )}
+                {run.isPending ? 'Running…' : 'Start session'}
+              </Button>
+            </div>
+          </PanelContent>
+        </Panel>
+
+        <Panel>
+          <PanelHeader>
+            <div>
+              <PanelTitle>Agent details</PanelTitle>
+              <PanelDescription className="mt-1">
+                Current cloud deployment.
+              </PanelDescription>
+            </div>
+          </PanelHeader>
+          <PanelContent className="space-y-5">
+            <div>
+              <p className="text-muted-foreground text-xs">Status</p>
+              <div className="mt-1">
+                <StatusBadge status="active" />
+              </div>
+            </div>
+            <div>
+              <p className="text-muted-foreground text-xs">Alias</p>
+              <p className="mt-1 font-mono text-sm">
+                {agent?.activeAlias ?? '—'}
+              </p>
+            </div>
+            <div>
+              <p className="text-muted-foreground text-xs">Last deployed</p>
+              <p className="mt-1 text-sm">
+                {deployment.data ? formatDate(deployment.data.createdAt) : '—'}
+              </p>
+            </div>
+            <div>
+              <p className="text-muted-foreground text-xs">Connections</p>
+              <p className="mt-1 text-sm">
+                {deployment.data?.connections.join(', ') || 'None'}
+              </p>
+            </div>
+            <div>
+              <p className="text-muted-foreground text-xs">Channels</p>
+              <p className="mt-1 text-sm">
+                {deployment.data?.channels.join(', ') || 'None'}
+              </p>
+            </div>
+          </PanelContent>
+        </Panel>
+      </div>
+
+      <Panel className="overflow-hidden">
+        <PanelHeader>
+          <div>
+            <PanelTitle>Deployments and revisions</PanelTitle>
+            <PanelDescription className="mt-1">
+              The active immutable version, deployed from the checked-out agent
+              source.
+            </PanelDescription>
+          </div>
+          <span className="text-muted-foreground text-xs">
+            {agent?.deploymentCount ?? 0} total
+          </span>
+        </PanelHeader>
+        {deployment.data ? (
+          <div className="grid gap-4 px-5 py-4 sm:grid-cols-3">
+            <div className="flex items-start gap-2">
+              <GitCommitHorizontal className="text-muted-foreground mt-0.5 size-4" />
+              <div>
+                <p className="text-xs font-medium">Active revision</p>
+                <p className="text-muted-foreground mt-1 font-mono text-xs">
+                  {deployment.data.id}
+                </p>
+              </div>
+            </div>
+            <div>
+              <p className="text-muted-foreground text-xs">Alias</p>
+              <p className="mt-1 text-sm">{deployment.data.alias}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground text-xs">Created</p>
+              <p className="mt-1 text-sm">
+                {formatDate(deployment.data.createdAt)}
+              </p>
+            </div>
+          </div>
+        ) : (
+          <PanelContent className="text-muted-foreground text-sm">
+            {deployment.isLoading
+              ? 'Loading the active revision…'
+              : 'Active revision details are unavailable.'}
+          </PanelContent>
+        )}
+      </Panel>
+
+      <Panel className="overflow-hidden">
+        <PanelHeader>
+          <div>
+            <PanelTitle>Sessions</PanelTitle>
+            <PanelDescription className="mt-1">
+              Cloud sessions are visible here. Lifecycle controls stay with the
+              checked-out agent code.
+            </PanelDescription>
+          </div>
+          <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
+            <Clock3 className="size-3.5" />
+            Refreshes automatically
+          </div>
+        </PanelHeader>
+        <ResourceTable
+          columns={sessionColumns}
+          rows={sessions.data ?? []}
+          rowKey={(session) => session.id}
+          loading={sessions.isLoading}
+          onRowClick={(session) =>
+            setExpandedSessionId((current) =>
+              current === session.id ? undefined : session.id,
+            )
+          }
+          renderSubRow={(session) => {
+            if (expandedSessionId !== session.id) return null
+            const replies = (sessionEvents.data ?? []).filter(
+              (event) => event.type === 'message.completed',
+            )
+            return (
+              <div className="bg-muted/20 space-y-3 border-y px-5 py-4">
+                {session.turns.map((turn) => (
+                  <div key={turn.id}>
+                    <p className="text-muted-foreground mb-1 text-[10px] font-medium tracking-wider uppercase">
+                      You · {turn.status}
+                    </p>
+                    <p className="text-sm whitespace-pre-wrap">{turn.input}</p>
+                  </div>
+                ))}
+                {replies.map((event) => (
+                  <div key={event.id ?? event.seq}>
+                    <p className="text-muted-foreground mb-1 text-[10px] font-medium tracking-wider uppercase">
+                      Agent
+                    </p>
+                    <p className="text-sm leading-6 whitespace-pre-wrap">
+                      {eventText(event)}
+                    </p>
+                  </div>
+                ))}
+                {sessionEvents.isLoading ? (
+                  <div className="text-muted-foreground flex items-center gap-2 text-xs">
+                    <Loader2 className="size-3.5 animate-spin" />
+                    Loading session events…
+                  </div>
+                ) : session.turns.length === 0 && replies.length === 0 ? (
+                  <div className="text-muted-foreground flex items-center gap-2 text-xs">
+                    <MessageSquareText className="size-3.5" />
+                    This session has no visible messages yet.
+                  </div>
+                ) : null}
+              </div>
+            )
+          }}
+          empty={
+            <EmptyState
+              icon={TerminalSquare}
+              title="No sessions yet"
+              description="Start a session above to test this deployment."
+            />
+          }
+        />
+      </Panel>
+    </div>
+  )
+}

--- a/web/src/managed-agents/Detail.tsx
+++ b/web/src/managed-agents/Detail.tsx
@@ -209,7 +209,7 @@ function MessageActivity({
         ) : (
           <Wrench className="size-3.5" aria-hidden />
         )}
-        <span>{running ? 'Agent is working' : 'Activity'}</span>
+        <span>{running ? 'Project is working' : 'Activity'}</span>
         <span className="ml-auto text-[10px]">
           {tools.length > 0
             ? `${tools.length} tool ${tools.length === 1 ? 'call' : 'calls'}`
@@ -275,7 +275,8 @@ function PlaygroundChat({
     messages: initialMessages,
     transport,
     throttle: 30,
-    onError: (chatError) => notifyError("Couldn't run this agent.", chatError),
+    onError: (chatError) =>
+      notifyError("Couldn't run this project.", chatError),
     onFinish: () => {
       void queryClient.invalidateQueries({
         queryKey: ['managed-agent-sessions', agentId],
@@ -319,7 +320,7 @@ function PlaygroundChat({
         {running ? (
           <div className="text-muted-foreground flex items-center gap-2 text-xs">
             <span className="bg-foreground size-1.5 animate-pulse rounded-full" />
-            Agent is working
+            Project is working
           </div>
         ) : null}
       </div>
@@ -360,7 +361,7 @@ function PlaygroundChat({
                 )}
               >
                 <p className="text-muted-foreground mb-1.5 text-[10px] font-semibold tracking-wider uppercase">
-                  {message.role === 'user' ? 'You' : 'Agent'}
+                  {message.role === 'user' ? 'You' : 'Project'}
                 </p>
                 {message.role === 'assistant' ? (
                   <MessageActivity message={message} running={messageRunning} />
@@ -376,7 +377,7 @@ function PlaygroundChat({
                 ) : messageRunning ? (
                   <div className="text-muted-foreground flex items-center gap-2 text-sm">
                     <Loader2 className="size-4 animate-spin" />
-                    Starting the agent…
+                    Starting the project…
                   </div>
                 ) : null}
               </div>
@@ -397,7 +398,7 @@ function PlaygroundChat({
             value={prompt}
             onChange={(event) => setPrompt(event.target.value)}
             onSend={send}
-            placeholder="Message this agent…"
+            placeholder="Message this project…"
             className="min-h-12 border-0 px-2 shadow-none focus-visible:border-transparent"
           />
           <div className="flex items-center justify-between gap-3 px-1 pt-1">
@@ -572,11 +573,11 @@ export default function ManagedAgentDetail() {
       <Panel>
         <EmptyState
           icon={Bot}
-          title="Agent not found"
-          description="This agent is not available in your organization."
+          title="Project not found"
+          description="This project is not available in your organization."
           action={
             <Button asChild variant="outline">
-              <Link to="/">Back to agents</Link>
+              <Link to="/">Back to projects</Link>
             </Button>
           }
         />
@@ -600,7 +601,7 @@ export default function ManagedAgentDetail() {
       )}
     >
       <PageHeader
-        title={agent ? displayManagedAgentName(agent) : 'Agent'}
+        title={agent ? displayManagedAgentName(agent) : 'Project'}
         description={
           activeDeployment.data
             ? `Active deployment · ${activeDeployment.data.alias}`
@@ -609,7 +610,7 @@ export default function ManagedAgentDetail() {
         actions={
           <Button asChild variant="outline" size="sm">
             <Link to="/">
-              <ArrowLeft /> All agents
+              <ArrowLeft /> All projects
             </Link>
           </Button>
         }
@@ -617,7 +618,7 @@ export default function ManagedAgentDetail() {
       />
 
       <div className="flex shrink-0 items-end justify-between gap-6 border-b">
-        <nav className="flex gap-5" aria-label="Agent details">
+        <nav className="flex gap-5" aria-label="Project details">
           {tabs.map((tab) => (
             <button
               key={tab.id}
@@ -721,7 +722,7 @@ export default function ManagedAgentDetail() {
             <div>
               <PanelTitle>Deployments</PanelTitle>
               <PanelDescription className="mt-1">
-                Immutable versions published from this agent's source.
+                Immutable versions published from this project's source.
               </PanelDescription>
             </div>
           </PanelHeader>
@@ -819,7 +820,7 @@ export default function ManagedAgentDetail() {
                   {replies.map((event) => (
                     <div key={event.id ?? event.seq}>
                       <p className="text-muted-foreground mb-1 text-[10px] font-medium tracking-wider uppercase">
-                        Agent
+                        Project
                       </p>
                       <p className="text-sm leading-6 whitespace-pre-wrap">
                         {eventText(event)}
@@ -852,7 +853,7 @@ export default function ManagedAgentDetail() {
             <div>
               <PanelTitle>Channels</PanelTitle>
               <PanelDescription className="mt-1">
-                Messaging channels connected to this deployed agent.
+                Messaging channels connected to this deployed project.
               </PanelDescription>
             </div>
           </PanelHeader>
@@ -865,7 +866,7 @@ export default function ManagedAgentDetail() {
               <EmptyState
                 icon={Radio}
                 title="No channels connected"
-                description="Connect Slack, Discord, or another channel from your checked-out agent project."
+                description="Connect Slack, Discord, or another channel from your checked-out project."
               />
             }
           />

--- a/web/src/managed-agents/Home.tsx
+++ b/web/src/managed-agents/Home.tsx
@@ -48,26 +48,26 @@ type Category = (typeof categories)[number]
 
 const starterCopy = [
   {
-    title: 'Choose a job for your next agent.',
+    title: 'Choose a job for your next project.',
     description:
-      'Pick a starting point, copy its build prompt, and turn it into an agent you can develop and deploy from source.',
+      'Pick a starting point, copy its build prompt, and turn it into a project you can develop and deploy from source.',
     sectionTitle: 'Ideas to start with',
     sectionDescription:
-      'Each prompt creates an editable agent repository you can make your own.',
+      'Each prompt creates an editable project repository you can make your own.',
   },
   {
-    title: 'What should your agent take care of?',
+    title: 'What should your project take care of?',
     description:
       'Start with a useful workflow, shape the source locally, and deploy it when it is ready.',
     sectionTitle: 'Pick a starting point',
     sectionDescription:
-      'Copy an agent prompt, then adapt the generated source to your workflow.',
+      'Copy a project prompt, then adapt the generated source to your workflow.',
   },
   {
     title: 'Start with a real task.',
     description:
-      'Choose a workflow below and use the generated source as the beginning of your next agent.',
-    sectionTitle: 'Agent ideas',
+      'Choose a workflow below and use the generated source as the beginning of your next project.',
+    sectionTitle: 'Project ideas',
     sectionDescription:
       'Explore a use case, copy its prompt, and keep building from the generated repository.',
   },
@@ -100,15 +100,15 @@ function buildSetupPrompt(template: ManagedAgentTemplate, origin: string) {
   const integrations = template.integrations.join(', ')
   const firstPrompt =
     template.suggestedPrompts[0] ?? `Help me configure ${template.name}.`
-  return `Create a local "${template.name}" OpenComputer agent repository for me.
+  return `Create a local "${template.name}" OpenComputer project repository for me.
 
-The agent's job:
+The project's job:
 ${template.description}
 
 Suggested integrations:
 ${integrations}
 
-Use the OpenComputer CLI and keep the agent as editable source code in this workspace.
+Use the OpenComputer CLI and keep the project as editable source code in this workspace.
 
 1. Check whether the \`opencomputer\` command is available. If it is missing, install the \`@opencomputer/cli\` package.
 2. Authenticate interactively:
@@ -117,12 +117,12 @@ Use the OpenComputer CLI and keep the agent as editable source code in this work
    ${cliCommand(origin, `init ${template.id} .`)}
 4. Run \`npm install\` in the repository.
 5. Inspect and tailor the checked-in source: \`opencomputer.toml\`, \`instructions.md\`, \`agent.ts\`, \`tools/\`, \`connections/\`, \`channels/\`, \`skills/\`, \`workspace/\`, and \`evals/\`.
-6. Keep the stable \`id\` in \`opencomputer.toml\`; future deployments of this repository must create new versions of that same agent.
+6. Keep the stable \`id\` in \`opencomputer.toml\`; future deployments of this repository must create new versions of that same project.
 7. Add and authorize only supported integrations. For Gmail, use \`opencomputer tools add gmail\` and \`${cliCommand(origin, 'connect google')}\`. For Slack, use \`opencomputer channels add slack\`.
-8. Test the editable agent locally with OpenCode:
+8. Test the editable project locally:
    \`opencomputer session "${firstPrompt.replace(/"/g, '\\"')}"\`
 9. Make any necessary source changes and test again.
-10. Commit the agent source, including \`opencomputer.toml\`, to Git.
+10. Commit the project source, including \`opencomputer.toml\`, to Git.
 11. Deploy from inside the repository:
    ${cliCommand(origin, 'deploy')}
 
@@ -191,7 +191,7 @@ function TemplateCard({
           onClick={onCopy}
         >
           {copied ? <Check /> : <Clipboard />}
-          {copied ? 'Agent prompt copied' : 'Copy agent prompt'}
+          {copied ? 'Project prompt copied' : 'Copy project prompt'}
         </Button>
       </PanelContent>
     </Panel>
@@ -240,27 +240,27 @@ export default function ManagedAgentsHome({
         buildSetupPrompt(template, window.location.origin),
       )
       setCopiedTemplateId(template.id)
-      toast.success(`${template.name} agent prompt copied`)
+      toast.success(`${template.name} project prompt copied`)
     } catch (error) {
-      notifyError("Couldn't copy the agent prompt.", error)
+      notifyError("Couldn't copy the project prompt.", error)
     }
   }
 
   return (
     <div className="space-y-8">
       <PageHeader
-        title={startersOnly ? 'Deploy another agent' : 'Agents'}
+        title={startersOnly ? 'Deploy another project' : 'Projects'}
         description={
           startersOnly
-            ? 'Choose a starting point for your next agent repository.'
-            : 'Develop locally, then deploy versioned agents with the OpenComputer CLI.'
+            ? 'Choose a starting point for your next project repository.'
+            : 'Develop locally, then deploy versioned projects with the OpenComputer CLI.'
         }
         actions={
           !startersOnly && deployedAgents.length > 0 ? (
             <Button asChild>
               <Link to="/managed-agents/new">
                 <Plus />
-                Deploy another agent
+                Deploy another project
               </Link>
             </Button>
           ) : undefined
@@ -272,7 +272,7 @@ export default function ManagedAgentsHome({
           <div className="max-w-2xl">
             <div className="bg-primary/10 text-primary mb-4 inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium">
               <Sparkles className="size-3.5" />
-              {firstRun ? 'Your first agent' : 'Your next agent'}
+              {firstRun ? 'Your first project' : 'Your next project'}
             </div>
             <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">
               {copy.title}
@@ -292,8 +292,8 @@ export default function ManagedAgentsHome({
         <Panel>
           <EmptyState
             icon={Bot}
-            title="Your agents are temporarily unavailable"
-            description="Try loading the agents page again."
+            title="Your projects are temporarily unavailable"
+            description="Try loading the projects page again."
             action={
               <Button variant="outline" onClick={() => void agents.refetch()}>
                 Try again
@@ -304,9 +304,9 @@ export default function ManagedAgentsHome({
       ) : !startersOnly && deployedAgents.length > 0 ? (
         <section className="space-y-3">
           <div>
-            <h2 className="text-base font-semibold">Your agents</h2>
+            <h2 className="text-base font-semibold">Your projects</h2>
             <p className="text-muted-foreground text-sm">
-              Select an agent to view its deployment and sessions.
+              Select a project to view its deployments and sessions.
             </p>
           </div>
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
@@ -358,8 +358,8 @@ export default function ManagedAgentsHome({
             <Panel>
               <EmptyState
                 icon={Bot}
-                title="Agent templates are temporarily unavailable"
-                description="Check the managed-agent service configuration and try again."
+                title="Project templates are temporarily unavailable"
+                description="Check the project service configuration and try again."
                 action={
                   <Button
                     variant="outline"
@@ -378,7 +378,7 @@ export default function ManagedAgentsHome({
               <div
                 className="bg-muted/30 flex gap-1 overflow-x-auto rounded-lg border p-1"
                 role="tablist"
-                aria-label="Agent categories"
+                aria-label="Project categories"
               >
                 {categoryOrder.map((category) => {
                   const Icon = categoryIcons[category]

--- a/web/src/managed-agents/Home.tsx
+++ b/web/src/managed-agents/Home.tsx
@@ -253,7 +253,7 @@ export default function ManagedAgentsHome({
         description={
           startersOnly
             ? 'Choose a starting point for your next project repository.'
-            : 'Develop locally, then deploy versioned projects with the OpenComputer CLI.'
+            : 'Develop agents locally, then deploy versioned projects with the OpenComputer CLI.'
         }
         actions={
           !startersOnly && deployedAgents.length > 0 ? (

--- a/web/src/managed-agents/Home.tsx
+++ b/web/src/managed-agents/Home.tsx
@@ -48,26 +48,26 @@ type Category = (typeof categories)[number]
 
 const starterCopy = [
   {
-    title: 'Choose a job for your next project.',
+    title: 'Choose a job for your next agent.',
     description:
-      'Pick a starting point, copy its build prompt, and turn it into a project you can develop and deploy from source.',
+      'Pick a starting point, copy its build prompt, and turn it into an agent you can develop and deploy from source.',
     sectionTitle: 'Ideas to start with',
     sectionDescription:
-      'Each prompt creates an editable project repository you can make your own.',
+      'Each prompt creates an editable agent repository you can make your own.',
   },
   {
-    title: 'What should your project take care of?',
+    title: 'What should your agent take care of?',
     description:
       'Start with a useful workflow, shape the source locally, and deploy it when it is ready.',
     sectionTitle: 'Pick a starting point',
     sectionDescription:
-      'Copy a project prompt, then adapt the generated source to your workflow.',
+      'Copy an agent prompt, then adapt the generated source to your workflow.',
   },
   {
     title: 'Start with a real task.',
     description:
-      'Choose a workflow below and use the generated source as the beginning of your next project.',
-    sectionTitle: 'Project ideas',
+      'Choose a workflow below and use the generated source as the beginning of your next agent.',
+    sectionTitle: 'Agent ideas',
     sectionDescription:
       'Explore a use case, copy its prompt, and keep building from the generated repository.',
   },
@@ -100,15 +100,15 @@ function buildSetupPrompt(template: ManagedAgentTemplate, origin: string) {
   const integrations = template.integrations.join(', ')
   const firstPrompt =
     template.suggestedPrompts[0] ?? `Help me configure ${template.name}.`
-  return `Create a local "${template.name}" OpenComputer project repository for me.
+  return `Create a local "${template.name}" OpenComputer agent repository for me.
 
-The project's job:
+The agent's job:
 ${template.description}
 
 Suggested integrations:
 ${integrations}
 
-Use the OpenComputer CLI and keep the project as editable source code in this workspace.
+Use the OpenComputer CLI and keep the agent as editable source code in this workspace.
 
 1. Check whether the \`opencomputer\` command is available. If it is missing, install the \`@opencomputer/cli\` package.
 2. Authenticate interactively:
@@ -117,12 +117,12 @@ Use the OpenComputer CLI and keep the project as editable source code in this wo
    ${cliCommand(origin, `init ${template.id} .`)}
 4. Run \`npm install\` in the repository.
 5. Inspect and tailor the checked-in source: \`opencomputer.toml\`, \`instructions.md\`, \`agent.ts\`, \`tools/\`, \`connections/\`, \`channels/\`, \`skills/\`, \`workspace/\`, and \`evals/\`.
-6. Keep the stable \`id\` in \`opencomputer.toml\`; future deployments of this repository must create new versions of that same project.
+6. Keep the stable \`id\` in \`opencomputer.toml\`; future deployments of this repository must create new versions of that same agent.
 7. Add and authorize only supported integrations. For Gmail, use \`opencomputer tools add gmail\` and \`${cliCommand(origin, 'connect google')}\`. For Slack, use \`opencomputer channels add slack\`.
-8. Test the editable project locally:
+8. Test the editable agent locally with OpenCode:
    \`opencomputer session "${firstPrompt.replace(/"/g, '\\"')}"\`
 9. Make any necessary source changes and test again.
-10. Commit the project source, including \`opencomputer.toml\`, to Git.
+10. Commit the agent source, including \`opencomputer.toml\`, to Git.
 11. Deploy from inside the repository:
    ${cliCommand(origin, 'deploy')}
 
@@ -191,7 +191,7 @@ function TemplateCard({
           onClick={onCopy}
         >
           {copied ? <Check /> : <Clipboard />}
-          {copied ? 'Project prompt copied' : 'Copy project prompt'}
+          {copied ? 'Agent prompt copied' : 'Copy agent prompt'}
         </Button>
       </PanelContent>
     </Panel>
@@ -240,27 +240,27 @@ export default function ManagedAgentsHome({
         buildSetupPrompt(template, window.location.origin),
       )
       setCopiedTemplateId(template.id)
-      toast.success(`${template.name} project prompt copied`)
+      toast.success(`${template.name} agent prompt copied`)
     } catch (error) {
-      notifyError("Couldn't copy the project prompt.", error)
+      notifyError("Couldn't copy the agent prompt.", error)
     }
   }
 
   return (
     <div className="space-y-8">
       <PageHeader
-        title={startersOnly ? 'Deploy another project' : 'Projects'}
+        title={startersOnly ? 'Deploy another agent' : 'Agents'}
         description={
           startersOnly
-            ? 'Choose a starting point for your next project repository.'
-            : 'Develop locally, then deploy versioned projects with the OpenComputer CLI.'
+            ? 'Choose a starting point for your next agent repository.'
+            : 'Develop locally, then deploy versioned agents with the OpenComputer CLI.'
         }
         actions={
           !startersOnly && deployedAgents.length > 0 ? (
             <Button asChild>
               <Link to="/managed-agents/new">
                 <Plus />
-                Deploy another project
+                Deploy another agent
               </Link>
             </Button>
           ) : undefined
@@ -272,7 +272,7 @@ export default function ManagedAgentsHome({
           <div className="max-w-2xl">
             <div className="bg-primary/10 text-primary mb-4 inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium">
               <Sparkles className="size-3.5" />
-              {firstRun ? 'Your first project' : 'Your next project'}
+              {firstRun ? 'Your first agent' : 'Your next agent'}
             </div>
             <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">
               {copy.title}
@@ -292,8 +292,8 @@ export default function ManagedAgentsHome({
         <Panel>
           <EmptyState
             icon={Bot}
-            title="Your projects are temporarily unavailable"
-            description="Try loading the projects page again."
+            title="Your agents are temporarily unavailable"
+            description="Try loading the agents page again."
             action={
               <Button variant="outline" onClick={() => void agents.refetch()}>
                 Try again
@@ -304,9 +304,9 @@ export default function ManagedAgentsHome({
       ) : !startersOnly && deployedAgents.length > 0 ? (
         <section className="space-y-3">
           <div>
-            <h2 className="text-base font-semibold">Your projects</h2>
+            <h2 className="text-base font-semibold">Your agents</h2>
             <p className="text-muted-foreground text-sm">
-              Select a project to view its deployments and sessions.
+              Select an agent to view its deployment and sessions.
             </p>
           </div>
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
@@ -358,8 +358,8 @@ export default function ManagedAgentsHome({
             <Panel>
               <EmptyState
                 icon={Bot}
-                title="Project templates are temporarily unavailable"
-                description="Check the project service configuration and try again."
+                title="Agent templates are temporarily unavailable"
+                description="Check the managed-agent service configuration and try again."
                 action={
                   <Button
                     variant="outline"
@@ -378,7 +378,7 @@ export default function ManagedAgentsHome({
               <div
                 className="bg-muted/30 flex gap-1 overflow-x-auto rounded-lg border p-1"
                 role="tablist"
-                aria-label="Project categories"
+                aria-label="Agent categories"
               >
                 {categoryOrder.map((category) => {
                   const Icon = categoryIcons[category]

--- a/web/src/managed-agents/Home.tsx
+++ b/web/src/managed-agents/Home.tsx
@@ -253,7 +253,7 @@ export default function ManagedAgentsHome({
         description={
           startersOnly
             ? 'Choose a starting point for your next project repository.'
-            : 'Develop agents locally, then deploy versioned projects with the OpenComputer CLI.'
+            : 'Develop locally, then deploy versioned projects with the OpenComputer CLI.'
         }
         actions={
           !startersOnly && deployedAgents.length > 0 ? (

--- a/web/src/managed-agents/Home.tsx
+++ b/web/src/managed-agents/Home.tsx
@@ -1,0 +1,431 @@
+import { useMemo, useState } from 'react'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import {
+  Bot,
+  BriefcaseBusiness,
+  Check,
+  Clipboard,
+  ClipboardCheck,
+  Lightbulb,
+  Loader2,
+  MessageSquareText,
+  Send,
+  Sparkles,
+  TrendingUp,
+  Workflow,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { EmptyState } from '@/components/empty-state'
+import { PageHeader } from '@/components/page-header'
+import {
+  Panel,
+  PanelContent,
+  PanelDescription,
+  PanelHeader,
+  PanelTitle,
+} from '@/components/panel'
+import { Button } from '@/components/ui/button'
+import { notifyError } from '@/lib/errors'
+import { cn } from '@/lib/utils'
+import {
+  getManagedAgents,
+  getManagedAgentTemplates,
+  invokeManagedAgent,
+  type ManagedAgentTemplate,
+} from './api'
+
+const categories = [
+  'Comms',
+  'Operations',
+  'Admin',
+  'Growth',
+  'Insights',
+] as const
+
+type Category = (typeof categories)[number]
+
+const categoryIcons = {
+  Comms: MessageSquareText,
+  Operations: Workflow,
+  Admin: BriefcaseBusiness,
+  Growth: TrendingUp,
+  Insights: Lightbulb,
+} satisfies Record<Category, typeof Sparkles>
+
+function cliCommand(origin: string, command: string) {
+  const apiOption =
+    origin === 'https://app.opencomputer.dev' ? '' : ` --api-url ${origin}`
+  return `opencomputer${apiOption} ${command}`
+}
+
+function buildSetupPrompt(template: ManagedAgentTemplate, origin: string) {
+  const integrations = template.integrations.join(', ')
+  const firstPrompt =
+    template.suggestedPrompts[0] ?? `Help me configure ${template.name}.`
+  return `Create a local "${template.name}" OpenComputer agent repository for me.
+
+The agent's job:
+${template.description}
+
+Suggested integrations:
+${integrations}
+
+Use the OpenComputer CLI and keep the agent as editable source code in this workspace.
+
+1. Check whether the \`opencomputer\` command is available. If it is missing, install the \`@opencomputer/cli\` package.
+2. Authenticate interactively:
+   ${cliCommand(origin, 'login')}
+3. Initialize the source template in the current repository:
+   ${cliCommand(origin, `init ${template.id} .`)}
+4. Run \`npm install\` in the repository.
+5. Inspect and tailor the checked-in source: \`opencomputer.toml\`, \`instructions.md\`, \`agent.ts\`, \`tools/\`, \`connections/\`, \`channels/\`, \`skills/\`, \`workspace/\`, and \`evals/\`.
+6. Keep the stable \`id\` in \`opencomputer.toml\`; future deployments of this repository must create new versions of that same agent.
+7. Add and authorize only supported integrations. For Gmail, use \`opencomputer tools add gmail\` and \`${cliCommand(origin, 'connect google')}\`. For Slack, use \`opencomputer channels add slack\`.
+8. Test the editable agent locally with OpenCode:
+   \`opencomputer session "${firstPrompt.replace(/"/g, '\\"')}"\`
+9. Make any necessary source changes and test again.
+10. Commit the agent source, including \`opencomputer.toml\`, to Git.
+11. Deploy from inside the repository:
+   ${cliCommand(origin, 'deploy')}
+
+Connect only integrations that are actually available. Ask me for authorization when a connection requires it, never print credentials, and do not claim an integration or deployment succeeded unless the CLI confirms it.`
+}
+
+function TemplateCard({
+  template,
+  deployed,
+  copied,
+  onCopy,
+}: {
+  template: ManagedAgentTemplate
+  deployed: boolean
+  copied: boolean
+  onCopy: () => void
+}) {
+  const Icon = categoryIcons[template.category as Category] ?? ClipboardCheck
+  return (
+    <Panel className="flex h-full flex-col overflow-hidden">
+      <PanelHeader className="border-0 pb-2">
+        <div className="flex min-w-0 items-start gap-3">
+          <div className="bg-primary/8 text-primary flex size-9 shrink-0 items-center justify-center rounded-md">
+            <Icon className="size-4" strokeWidth={1.6} aria-hidden />
+          </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <PanelTitle className="text-base">{template.name}</PanelTitle>
+              {deployed ? (
+                <span className="bg-status-running-bg text-status-running rounded-full px-2 py-0.5 text-[10px] font-medium">
+                  Deployed
+                </span>
+              ) : null}
+            </div>
+            <p className="text-muted-foreground mt-0.5 text-xs">
+              {template.category}
+            </p>
+          </div>
+        </div>
+      </PanelHeader>
+      <PanelContent className="flex flex-1 flex-col pt-1">
+        <PanelDescription className="min-h-10">
+          {template.description}
+        </PanelDescription>
+        <div className="mt-4 flex flex-wrap gap-1.5">
+          {template.integrations.map((integration) => (
+            <span
+              key={integration}
+              className="bg-muted text-muted-foreground rounded-md border px-2 py-1 text-[10px] font-medium"
+            >
+              {integration}
+            </span>
+          ))}
+        </div>
+        <div className="mt-5 space-y-2">
+          <p className="text-muted-foreground text-[10px] font-medium tracking-wider uppercase">
+            First task
+          </p>
+          <p className="text-foreground/80 text-sm">
+            “{template.suggestedPrompts[0]}”
+          </p>
+        </div>
+        <Button
+          className="mt-6 w-full"
+          variant={copied ? 'secondary' : 'default'}
+          onClick={onCopy}
+        >
+          {copied ? <Check /> : <Clipboard />}
+          {copied ? 'Setup prompt copied' : 'Copy setup prompt'}
+        </Button>
+      </PanelContent>
+    </Panel>
+  )
+}
+
+export default function ManagedAgentsHome() {
+  const [selectedCategory, setSelectedCategory] = useState<Category>('Comms')
+  const [copiedTemplateId, setCopiedTemplateId] = useState<string>()
+  const [selectedAgentId, setSelectedAgentId] = useState<string>()
+  const [prompt, setPrompt] = useState('')
+  const [lastResponse, setLastResponse] = useState('')
+  const templates = useQuery({
+    queryKey: ['managed-agent-templates'],
+    queryFn: getManagedAgentTemplates,
+  })
+  const agents = useQuery({
+    queryKey: ['managed-agents'],
+    queryFn: getManagedAgents,
+  })
+  const invoke = useMutation({
+    mutationFn: ({ agentId, input }: { agentId: string; input: string }) =>
+      invokeManagedAgent(agentId, input),
+    onSuccess: (result) => setLastResponse(result.output),
+    onError: (error) => notifyError("Couldn't run this agent.", error),
+  })
+
+  const loading = templates.isLoading || agents.isLoading
+  const failed = templates.isError || agents.isError
+  const deployedAgents = agents.data ?? []
+  const firstRun = !loading && deployedAgents.length === 0
+  const activeAgentId = selectedAgentId ?? deployedAgents[0]?.id
+  const visibleTemplates = useMemo(
+    () =>
+      (templates.data ?? []).filter(
+        (template) => template.category === selectedCategory,
+      ),
+    [selectedCategory, templates.data],
+  )
+
+  async function copySetupPrompt(template: ManagedAgentTemplate) {
+    try {
+      await navigator.clipboard.writeText(
+        buildSetupPrompt(template, window.location.origin),
+      )
+      setCopiedTemplateId(template.id)
+      toast.success(`${template.name} setup prompt copied`)
+    } catch (error) {
+      notifyError("Couldn't copy the setup prompt.", error)
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="Agents"
+        description="Start from source, develop locally with OpenCode, then deploy versioned agents with the OpenComputer CLI."
+      />
+
+      {firstRun ? (
+        <div className="relative overflow-hidden rounded-xl border bg-[radial-gradient(circle_at_top_right,color-mix(in_oklch,var(--primary)_12%,transparent),transparent_45%)] px-6 py-8 sm:px-8">
+          <div className="max-w-2xl">
+            <div className="bg-primary/10 text-primary mb-4 inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium">
+              <Sparkles className="size-3.5" />
+              Your first agent
+            </div>
+            <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+              Pick a job. Create the agent repository.
+            </h2>
+            <p className="text-muted-foreground mt-3 max-w-xl text-sm leading-6">
+              Copy a ready-to-run setup prompt into Codex, Claude Code, or
+              OpenCode. It will create editable source, install its OpenCode
+              packages, test it locally, and deploy it through the OpenComputer
+              CLI.
+            </p>
+            <code className="bg-muted text-muted-foreground mt-5 inline-block rounded-md border px-3 py-2 font-mono text-xs">
+              opencomputer init email-triage
+            </code>
+          </div>
+        </div>
+      ) : null}
+
+      {deployedAgents.length > 0 ? (
+        <section className="space-y-3">
+          <div>
+            <h2 className="text-base font-semibold">Your agents</h2>
+            <p className="text-muted-foreground text-sm">
+              Managed deployments available to your organization.
+            </p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {deployedAgents.map((agent) => (
+              <Panel
+                key={agent.id}
+                className={cn(
+                  activeAgentId === agent.id && 'border-primary/40',
+                )}
+              >
+                <PanelContent className="flex items-center gap-3">
+                  <div className="bg-status-running-bg text-status-running flex size-9 shrink-0 items-center justify-center rounded-full">
+                    <Bot className="size-4" aria-hidden />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate font-mono text-sm font-medium">
+                      {agent.id}
+                    </p>
+                    <p className="text-muted-foreground mt-0.5 text-xs">
+                      {agent.activeAlias} · {agent.deploymentCount}{' '}
+                      {agent.deploymentCount === 1
+                        ? 'deployment'
+                        : 'deployments'}
+                    </p>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant={
+                      activeAgentId === agent.id ? 'secondary' : 'outline'
+                    }
+                    onClick={() => {
+                      setSelectedAgentId(agent.id)
+                      setLastResponse('')
+                    }}
+                  >
+                    Test
+                  </Button>
+                </PanelContent>
+              </Panel>
+            ))}
+          </div>
+          {activeAgentId ? (
+            <Panel className="mt-4">
+              <PanelHeader>
+                <div>
+                  <PanelTitle>Test {activeAgentId}</PanelTitle>
+                  <PanelDescription className="mt-1">
+                    Start a managed run without leaving the agent experience.
+                  </PanelDescription>
+                </div>
+              </PanelHeader>
+              <PanelContent className="space-y-3">
+                <label
+                  htmlFor="managed-agent-prompt"
+                  className="text-sm font-medium"
+                >
+                  Message
+                </label>
+                <textarea
+                  id="managed-agent-prompt"
+                  value={prompt}
+                  onChange={(event) => setPrompt(event.target.value)}
+                  placeholder="Ask your agent to do something…"
+                  rows={3}
+                  className="border-input bg-background placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 w-full resize-y rounded-md border px-3 py-2 text-sm outline-none focus-visible:ring-3"
+                />
+                <div className="flex justify-end">
+                  <Button
+                    disabled={!prompt.trim() || invoke.isPending}
+                    onClick={() => {
+                      setLastResponse('')
+                      invoke.mutate({
+                        agentId: activeAgentId,
+                        input: prompt.trim(),
+                      })
+                    }}
+                  >
+                    {invoke.isPending ? (
+                      <Loader2 className="animate-spin" />
+                    ) : (
+                      <Send />
+                    )}
+                    {invoke.isPending ? 'Agent is working…' : 'Run agent'}
+                  </Button>
+                </div>
+                {lastResponse ? (
+                  <div className="bg-muted/60 rounded-md border px-4 py-3">
+                    <p className="text-muted-foreground mb-2 text-[10px] font-medium tracking-wider uppercase">
+                      Response
+                    </p>
+                    <p className="text-sm leading-6 whitespace-pre-wrap">
+                      {lastResponse}
+                    </p>
+                  </div>
+                ) : null}
+              </PanelContent>
+            </Panel>
+          ) : null}
+        </section>
+      ) : null}
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-base font-semibold">Agent starters</h2>
+          <p className="text-muted-foreground text-sm">
+            Copy a ready-to-run setup prompt for your coding agent.
+          </p>
+        </div>
+
+        {loading ? (
+          <div className="flex min-h-64 items-center justify-center">
+            <Loader2 className="text-muted-foreground size-5 animate-spin" />
+          </div>
+        ) : failed ? (
+          <Panel>
+            <EmptyState
+              icon={Bot}
+              title="Agent templates are temporarily unavailable"
+              description="Check the managed-agent service configuration and try again."
+              action={
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    void templates.refetch()
+                    void agents.refetch()
+                  }}
+                >
+                  Try again
+                </Button>
+              }
+            />
+          </Panel>
+        ) : (
+          <>
+            <div
+              className="bg-muted/30 flex gap-1 overflow-x-auto rounded-lg border p-1"
+              role="tablist"
+              aria-label="Agent categories"
+            >
+              {categories.map((category) => {
+                const Icon = categoryIcons[category]
+                const count = (templates.data ?? []).filter(
+                  (template) => template.category === category,
+                ).length
+                return (
+                  <button
+                    key={category}
+                    type="button"
+                    role="tab"
+                    aria-selected={selectedCategory === category}
+                    onClick={() => setSelectedCategory(category)}
+                    className={cn(
+                      'flex min-w-max flex-1 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                      selectedCategory === category
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground',
+                    )}
+                  >
+                    <Icon className="size-3.5" aria-hidden />
+                    {category}
+                    <span className="text-[10px] opacity-60">{count}</span>
+                  </button>
+                )
+              })}
+            </div>
+            <div
+              className="grid gap-4 md:grid-cols-2 xl:grid-cols-3"
+              role="tabpanel"
+            >
+              {visibleTemplates.map((template) => (
+                <TemplateCard
+                  key={template.id}
+                  template={template}
+                  deployed={deployedAgents.some(
+                    (agent) => agent.id === template.id,
+                  )}
+                  copied={copiedTemplateId === template.id}
+                  onCopy={() => void copySetupPrompt(template)}
+                />
+              ))}
+            </div>
+          </>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/web/src/managed-agents/Home.tsx
+++ b/web/src/managed-agents/Home.tsx
@@ -1,15 +1,17 @@
 import { useMemo, useState } from 'react'
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
 import {
   Bot,
   BriefcaseBusiness,
   Check,
+  ChevronRight,
   Clipboard,
   ClipboardCheck,
   Lightbulb,
   Loader2,
   MessageSquareText,
-  Send,
+  Plus,
   Sparkles,
   TrendingUp,
   Workflow,
@@ -28,9 +30,9 @@ import { Button } from '@/components/ui/button'
 import { notifyError } from '@/lib/errors'
 import { cn } from '@/lib/utils'
 import {
+  displayManagedAgentName,
   getManagedAgents,
   getManagedAgentTemplates,
-  invokeManagedAgent,
   type ManagedAgentTemplate,
 } from './api'
 
@@ -44,6 +46,33 @@ const categories = [
 
 type Category = (typeof categories)[number]
 
+const starterCopy = [
+  {
+    title: 'Choose a job for your next agent.',
+    description:
+      'Pick a starting point, copy its build prompt, and turn it into an agent you can develop and deploy from source.',
+    sectionTitle: 'Ideas to start with',
+    sectionDescription:
+      'Each prompt creates an editable agent repository you can make your own.',
+  },
+  {
+    title: 'What should your agent take care of?',
+    description:
+      'Start with a useful workflow, shape the source locally, and deploy it when it is ready.',
+    sectionTitle: 'Pick a starting point',
+    sectionDescription:
+      'Copy an agent prompt, then adapt the generated source to your workflow.',
+  },
+  {
+    title: 'Start with a real task.',
+    description:
+      'Choose a workflow below and use the generated source as the beginning of your next agent.',
+    sectionTitle: 'Agent ideas',
+    sectionDescription:
+      'Explore a use case, copy its prompt, and keep building from the generated repository.',
+  },
+] as const
+
 const categoryIcons = {
   Comms: MessageSquareText,
   Operations: Workflow,
@@ -51,6 +80,15 @@ const categoryIcons = {
   Growth: TrendingUp,
   Insights: Lightbulb,
 } satisfies Record<Category, typeof Sparkles>
+
+function shuffled<T>(values: readonly T[]) {
+  const result = [...values]
+  for (let index = result.length - 1; index > 0; index -= 1) {
+    const other = Math.floor(Math.random() * (index + 1))
+    ;[result[index], result[other]] = [result[other], result[index]]
+  }
+  return result
+}
 
 function cliCommand(origin: string, command: string) {
   const apiOption =
@@ -153,45 +191,47 @@ function TemplateCard({
           onClick={onCopy}
         >
           {copied ? <Check /> : <Clipboard />}
-          {copied ? 'Setup prompt copied' : 'Copy setup prompt'}
+          {copied ? 'Agent prompt copied' : 'Copy agent prompt'}
         </Button>
       </PanelContent>
     </Panel>
   )
 }
 
-export default function ManagedAgentsHome() {
+export default function ManagedAgentsHome({
+  startersOnly = false,
+}: {
+  startersOnly?: boolean
+}) {
   const [selectedCategory, setSelectedCategory] = useState<Category>('Comms')
   const [copiedTemplateId, setCopiedTemplateId] = useState<string>()
-  const [selectedAgentId, setSelectedAgentId] = useState<string>()
-  const [prompt, setPrompt] = useState('')
-  const [lastResponse, setLastResponse] = useState('')
-  const templates = useQuery({
-    queryKey: ['managed-agent-templates'],
-    queryFn: getManagedAgentTemplates,
-  })
+  const [categoryOrder] = useState(() => shuffled(categories))
+  const [copy] = useState(
+    () => starterCopy[Math.floor(Math.random() * starterCopy.length)],
+  )
   const agents = useQuery({
     queryKey: ['managed-agents'],
     queryFn: getManagedAgents,
   })
-  const invoke = useMutation({
-    mutationFn: ({ agentId, input }: { agentId: string; input: string }) =>
-      invokeManagedAgent(agentId, input),
-    onSuccess: (result) => setLastResponse(result.output),
-    onError: (error) => notifyError("Couldn't run this agent.", error),
-  })
-
-  const loading = templates.isLoading || agents.isLoading
-  const failed = templates.isError || agents.isError
   const deployedAgents = agents.data ?? []
-  const firstRun = !loading && deployedAgents.length === 0
-  const activeAgentId = selectedAgentId ?? deployedAgents[0]?.id
+  const firstRun =
+    !agents.isLoading && !agents.isError && deployedAgents.length === 0
+  const showStarters = startersOnly || firstRun
+  const templates = useQuery({
+    queryKey: ['managed-agent-templates'],
+    queryFn: getManagedAgentTemplates,
+    enabled: showStarters,
+  })
+  const randomizedTemplates = useMemo(
+    () => shuffled(templates.data ?? []),
+    [templates.data],
+  )
   const visibleTemplates = useMemo(
     () =>
-      (templates.data ?? []).filter(
+      randomizedTemplates.filter(
         (template) => template.category === selectedCategory,
       ),
-    [selectedCategory, templates.data],
+    [randomizedTemplates, selectedCategory],
   )
 
   async function copySetupPrompt(template: ManagedAgentTemplate) {
@@ -200,232 +240,192 @@ export default function ManagedAgentsHome() {
         buildSetupPrompt(template, window.location.origin),
       )
       setCopiedTemplateId(template.id)
-      toast.success(`${template.name} setup prompt copied`)
+      toast.success(`${template.name} agent prompt copied`)
     } catch (error) {
-      notifyError("Couldn't copy the setup prompt.", error)
+      notifyError("Couldn't copy the agent prompt.", error)
     }
   }
 
   return (
     <div className="space-y-8">
       <PageHeader
-        title="Agents"
-        description="Start from source, develop locally with OpenCode, then deploy versioned agents with the OpenComputer CLI."
+        title={startersOnly ? 'Deploy another agent' : 'Agents'}
+        description={
+          startersOnly
+            ? 'Choose a starting point for your next agent repository.'
+            : 'Develop locally, then deploy versioned agents with the OpenComputer CLI.'
+        }
+        actions={
+          !startersOnly && deployedAgents.length > 0 ? (
+            <Button asChild>
+              <Link to="/managed-agents/new">
+                <Plus />
+                Deploy another agent
+              </Link>
+            </Button>
+          ) : undefined
+        }
       />
 
-      {firstRun ? (
+      {showStarters ? (
         <div className="relative overflow-hidden rounded-xl border bg-[radial-gradient(circle_at_top_right,color-mix(in_oklch,var(--primary)_12%,transparent),transparent_45%)] px-6 py-8 sm:px-8">
           <div className="max-w-2xl">
             <div className="bg-primary/10 text-primary mb-4 inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium">
               <Sparkles className="size-3.5" />
-              Your first agent
+              {firstRun ? 'Your first agent' : 'Your next agent'}
             </div>
             <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">
-              Pick a job. Create the agent repository.
+              {copy.title}
             </h2>
             <p className="text-muted-foreground mt-3 max-w-xl text-sm leading-6">
-              Copy a ready-to-run setup prompt into Codex, Claude Code, or
-              OpenCode. It will create editable source, install its OpenCode
-              packages, test it locally, and deploy it through the OpenComputer
-              CLI.
+              {copy.description}
             </p>
-            <code className="bg-muted text-muted-foreground mt-5 inline-block rounded-md border px-3 py-2 font-mono text-xs">
-              opencomputer init email-triage
-            </code>
           </div>
         </div>
       ) : null}
 
-      {deployedAgents.length > 0 ? (
+      {!startersOnly && agents.isLoading ? (
+        <div className="flex min-h-48 items-center justify-center">
+          <Loader2 className="text-muted-foreground size-5 animate-spin" />
+        </div>
+      ) : !startersOnly && agents.isError ? (
+        <Panel>
+          <EmptyState
+            icon={Bot}
+            title="Your agents are temporarily unavailable"
+            description="Try loading the agents page again."
+            action={
+              <Button variant="outline" onClick={() => void agents.refetch()}>
+                Try again
+              </Button>
+            }
+          />
+        </Panel>
+      ) : !startersOnly && deployedAgents.length > 0 ? (
         <section className="space-y-3">
           <div>
             <h2 className="text-base font-semibold">Your agents</h2>
             <p className="text-muted-foreground text-sm">
-              Managed deployments available to your organization.
+              Select an agent to view its deployment and sessions.
             </p>
           </div>
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {deployedAgents.map((agent) => (
-              <Panel
+              <Link
                 key={agent.id}
-                className={cn(
-                  activeAgentId === agent.id && 'border-primary/40',
-                )}
+                to={`/managed-agents/${encodeURIComponent(agent.id)}`}
+                className="group focus-visible:ring-ring/50 rounded-lg outline-none focus-visible:ring-3"
               >
-                <PanelContent className="flex items-center gap-3">
-                  <div className="bg-status-running-bg text-status-running flex size-9 shrink-0 items-center justify-center rounded-full">
-                    <Bot className="size-4" aria-hidden />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate font-mono text-sm font-medium">
-                      {agent.id}
-                    </p>
-                    <p className="text-muted-foreground mt-0.5 text-xs">
-                      {agent.activeAlias} · {agent.deploymentCount}{' '}
-                      {agent.deploymentCount === 1
-                        ? 'deployment'
-                        : 'deployments'}
-                    </p>
-                  </div>
-                  <Button
-                    size="sm"
-                    variant={
-                      activeAgentId === agent.id ? 'secondary' : 'outline'
-                    }
-                    onClick={() => {
-                      setSelectedAgentId(agent.id)
-                      setLastResponse('')
-                    }}
-                  >
-                    Test
-                  </Button>
-                </PanelContent>
-              </Panel>
+                <Panel className="group-hover:border-foreground/20 group-hover:bg-muted/25 h-full transition-colors">
+                  <PanelContent className="flex items-center gap-3">
+                    <div className="bg-status-running-bg text-status-running flex size-9 shrink-0 items-center justify-center rounded-full">
+                      <Bot className="size-4" aria-hidden />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium">
+                        {displayManagedAgentName(agent)}
+                      </p>
+                      <p className="text-muted-foreground mt-0.5 text-xs">
+                        {agent.activeAlias} · {agent.deploymentCount}{' '}
+                        {agent.deploymentCount === 1
+                          ? 'deployment'
+                          : 'deployments'}
+                      </p>
+                    </div>
+                    <ChevronRight className="text-muted-foreground size-4 shrink-0 transition-transform group-hover:translate-x-0.5" />
+                  </PanelContent>
+                </Panel>
+              </Link>
             ))}
           </div>
-          {activeAgentId ? (
-            <Panel className="mt-4">
-              <PanelHeader>
-                <div>
-                  <PanelTitle>Test {activeAgentId}</PanelTitle>
-                  <PanelDescription className="mt-1">
-                    Start a managed run without leaving the agent experience.
-                  </PanelDescription>
-                </div>
-              </PanelHeader>
-              <PanelContent className="space-y-3">
-                <label
-                  htmlFor="managed-agent-prompt"
-                  className="text-sm font-medium"
-                >
-                  Message
-                </label>
-                <textarea
-                  id="managed-agent-prompt"
-                  value={prompt}
-                  onChange={(event) => setPrompt(event.target.value)}
-                  placeholder="Ask your agent to do something…"
-                  rows={3}
-                  className="border-input bg-background placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 w-full resize-y rounded-md border px-3 py-2 text-sm outline-none focus-visible:ring-3"
-                />
-                <div className="flex justify-end">
-                  <Button
-                    disabled={!prompt.trim() || invoke.isPending}
-                    onClick={() => {
-                      setLastResponse('')
-                      invoke.mutate({
-                        agentId: activeAgentId,
-                        input: prompt.trim(),
-                      })
-                    }}
-                  >
-                    {invoke.isPending ? (
-                      <Loader2 className="animate-spin" />
-                    ) : (
-                      <Send />
-                    )}
-                    {invoke.isPending ? 'Agent is working…' : 'Run agent'}
-                  </Button>
-                </div>
-                {lastResponse ? (
-                  <div className="bg-muted/60 rounded-md border px-4 py-3">
-                    <p className="text-muted-foreground mb-2 text-[10px] font-medium tracking-wider uppercase">
-                      Response
-                    </p>
-                    <p className="text-sm leading-6 whitespace-pre-wrap">
-                      {lastResponse}
-                    </p>
-                  </div>
-                ) : null}
-              </PanelContent>
-            </Panel>
-          ) : null}
         </section>
       ) : null}
 
-      <section className="space-y-4">
-        <div>
-          <h2 className="text-base font-semibold">Agent starters</h2>
-          <p className="text-muted-foreground text-sm">
-            Copy a ready-to-run setup prompt for your coding agent.
-          </p>
-        </div>
-
-        {loading ? (
-          <div className="flex min-h-64 items-center justify-center">
-            <Loader2 className="text-muted-foreground size-5 animate-spin" />
+      {showStarters ? (
+        <section className="space-y-4">
+          <div>
+            <h2 className="text-base font-semibold">{copy.sectionTitle}</h2>
+            <p className="text-muted-foreground text-sm">
+              {copy.sectionDescription}
+            </p>
           </div>
-        ) : failed ? (
-          <Panel>
-            <EmptyState
-              icon={Bot}
-              title="Agent templates are temporarily unavailable"
-              description="Check the managed-agent service configuration and try again."
-              action={
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    void templates.refetch()
-                    void agents.refetch()
-                  }}
-                >
-                  Try again
-                </Button>
-              }
-            />
-          </Panel>
-        ) : (
-          <>
-            <div
-              className="bg-muted/30 flex gap-1 overflow-x-auto rounded-lg border p-1"
-              role="tablist"
-              aria-label="Agent categories"
-            >
-              {categories.map((category) => {
-                const Icon = categoryIcons[category]
-                const count = (templates.data ?? []).filter(
-                  (template) => template.category === category,
-                ).length
-                return (
-                  <button
-                    key={category}
-                    type="button"
-                    role="tab"
-                    aria-selected={selectedCategory === category}
-                    onClick={() => setSelectedCategory(category)}
-                    className={cn(
-                      'flex min-w-max flex-1 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                      selectedCategory === category
-                        ? 'bg-background text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:text-foreground',
-                    )}
+
+          {templates.isLoading ? (
+            <div className="flex min-h-64 items-center justify-center">
+              <Loader2 className="text-muted-foreground size-5 animate-spin" />
+            </div>
+          ) : templates.isError ? (
+            <Panel>
+              <EmptyState
+                icon={Bot}
+                title="Agent templates are temporarily unavailable"
+                description="Check the managed-agent service configuration and try again."
+                action={
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      void templates.refetch()
+                      void agents.refetch()
+                    }}
                   >
-                    <Icon className="size-3.5" aria-hidden />
-                    {category}
-                    <span className="text-[10px] opacity-60">{count}</span>
-                  </button>
-                )
-              })}
-            </div>
-            <div
-              className="grid gap-4 md:grid-cols-2 xl:grid-cols-3"
-              role="tabpanel"
-            >
-              {visibleTemplates.map((template) => (
-                <TemplateCard
-                  key={template.id}
-                  template={template}
-                  deployed={deployedAgents.some(
-                    (agent) => agent.id === template.id,
-                  )}
-                  copied={copiedTemplateId === template.id}
-                  onCopy={() => void copySetupPrompt(template)}
-                />
-              ))}
-            </div>
-          </>
-        )}
-      </section>
+                    Try again
+                  </Button>
+                }
+              />
+            </Panel>
+          ) : (
+            <>
+              <div
+                className="bg-muted/30 flex gap-1 overflow-x-auto rounded-lg border p-1"
+                role="tablist"
+                aria-label="Agent categories"
+              >
+                {categoryOrder.map((category) => {
+                  const Icon = categoryIcons[category]
+                  const count = (templates.data ?? []).filter(
+                    (template) => template.category === category,
+                  ).length
+                  return (
+                    <button
+                      key={category}
+                      type="button"
+                      role="tab"
+                      aria-selected={selectedCategory === category}
+                      onClick={() => setSelectedCategory(category)}
+                      className={cn(
+                        'flex min-w-max flex-1 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                        selectedCategory === category
+                          ? 'bg-background text-foreground shadow-sm'
+                          : 'text-muted-foreground hover:text-foreground',
+                      )}
+                    >
+                      <Icon className="size-3.5" aria-hidden />
+                      {category}
+                      <span className="text-[10px] opacity-60">{count}</span>
+                    </button>
+                  )
+                })}
+              </div>
+              <div
+                className="grid gap-4 md:grid-cols-2 xl:grid-cols-3"
+                role="tabpanel"
+              >
+                {visibleTemplates.map((template) => (
+                  <TemplateCard
+                    key={template.id}
+                    template={template}
+                    deployed={deployedAgents.some(
+                      (agent) => agent.id === template.id,
+                    )}
+                    copied={copiedTemplateId === template.id}
+                    onCopy={() => void copySetupPrompt(template)}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </section>
+      ) : null}
     </div>
   )
 }

--- a/web/src/managed-agents/api.test.ts
+++ b/web/src/managed-agents/api.test.ts
@@ -8,7 +8,7 @@ describe('displayManagedAgentName', () => {
         id: '8d25ba55-d9de-4345-bedd-92ac5a3f1485',
         name: '8d25ba55-d9de-4345-bedd-92ac5a3f1485',
       }),
-    ).toBe('Untitled project')
+    ).toBe('Untitled agent')
     expect(
       displayManagedAgentName({ id: 'email-triage', name: 'email-triage' }),
     ).toBe('email-triage')

--- a/web/src/managed-agents/api.test.ts
+++ b/web/src/managed-agents/api.test.ts
@@ -8,7 +8,7 @@ describe('displayManagedAgentName', () => {
         id: '8d25ba55-d9de-4345-bedd-92ac5a3f1485',
         name: '8d25ba55-d9de-4345-bedd-92ac5a3f1485',
       }),
-    ).toBe('Untitled agent')
+    ).toBe('Untitled project')
     expect(
       displayManagedAgentName({ id: 'email-triage', name: 'email-triage' }),
     ).toBe('email-triage')

--- a/web/src/managed-agents/api.test.ts
+++ b/web/src/managed-agents/api.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { displayManagedAgentName } from './api'
+
+describe('displayManagedAgentName', () => {
+  it('hides UUID-shaped legacy names without hiding readable stable names', () => {
+    expect(
+      displayManagedAgentName({
+        id: '8d25ba55-d9de-4345-bedd-92ac5a3f1485',
+        name: '8d25ba55-d9de-4345-bedd-92ac5a3f1485',
+      }),
+    ).toBe('Untitled agent')
+    expect(
+      displayManagedAgentName({ id: 'email-triage', name: 'email-triage' }),
+    ).toBe('email-triage')
+    expect(
+      displayManagedAgentName({ id: 'stable-id', name: 'Gentle Falcon' }),
+    ).toBe('Gentle Falcon')
+  })
+})

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -69,6 +69,8 @@ const connectionsResponseSchema = z.object({
   connections: z.array(connectionSchema),
 })
 
+const channelIdentityLinkSchema = z.object({ linked: z.literal(true) })
+
 const channelsResponseSchema = z.object({
   channels: z.array(channelSchema),
 })
@@ -163,6 +165,17 @@ export async function getManagedAgentConnections() {
       connectionsResponseSchema,
     )
   ).connections.filter((connection) => connection.kind === 'tool')
+}
+
+export async function claimManagedAgentChannelIdentity(token: string) {
+  return apiFetch(
+    '/managed-agents/connections/channel-identity/link',
+    {
+      method: 'POST',
+      body: JSON.stringify({ token }),
+    },
+    channelIdentityLinkSchema,
+  )
 }
 
 export async function getManagedAgentChannels() {

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -138,7 +138,7 @@ export function displayManagedAgentName(
   agent: Pick<ManagedAgentSummary, 'id' | 'name'>,
 ) {
   const name = agent.name.trim()
-  return !name || UUID_NAME.test(name) ? 'Untitled project' : name
+  return !name || UUID_NAME.test(name) ? 'Untitled agent' : name
 }
 
 export async function getManagedAgentTemplates() {
@@ -268,14 +268,14 @@ async function waitForAgentEvent(
             ? event.data.reason
             : typeof event.data.message === 'string'
               ? event.data.message
-              : 'The project runtime disconnected.',
+              : 'The agent runtime disconnected.',
         )
       }
       if (terminal(event)) return { event, cursor }
     }
     await sleep(600)
   }
-  throw new Error('Timed out waiting for the project.')
+  throw new Error('Timed out waiting for the agent.')
 }
 
 export async function runManagedAgent(
@@ -332,7 +332,7 @@ export async function runManagedAgent(
       throw new Error(
         typeof completed.event.data.message === 'string'
           ? completed.event.data.message
-          : 'The project could not complete this request.',
+          : 'The agent could not complete this request.',
       )
     }
     return { sessionId, turnId: turn.turnId }
@@ -398,7 +398,7 @@ export async function continueManagedAgentSession(
       throw new Error(
         typeof completed.event.data.message === 'string'
           ? completed.event.data.message
-          : 'The project could not complete this request.',
+          : 'The agent could not complete this request.',
       )
     }
     return { sessionId, turnId: turn.turnId }
@@ -463,7 +463,7 @@ export async function invokeManagedAgent(agentId: string, input: string) {
       throw new Error(
         typeof completed.event.data.message === 'string'
           ? completed.event.data.message
-          : 'The project could not complete this request.',
+          : 'The agent could not complete this request.',
       )
     }
     return {

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -1,0 +1,186 @@
+import { z } from 'zod'
+import { apiFetch } from '@/api/client'
+
+const templateSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  category: z.string(),
+  integrations: z.array(z.string()),
+  suggestedPrompts: z.array(z.string()),
+})
+
+const agentSchema = z.object({
+  id: z.string(),
+  activeAlias: z.string(),
+  deploymentCount: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+const deploymentSchema = z.object({
+  id: z.string(),
+  agentId: z.string(),
+  alias: z.string(),
+  channels: z.array(z.string()),
+  connections: z.array(z.string()),
+  createdAt: z.string(),
+})
+
+const templatesResponseSchema = z.object({
+  templates: z.array(templateSchema),
+})
+
+const agentsResponseSchema = z.object({
+  agents: z.array(agentSchema),
+})
+
+const sessionCreateSchema = z.object({
+  session: z.object({ id: z.string() }),
+  deployment: deploymentSchema.optional(),
+})
+
+const eventSchema = z.object({
+  seq: z.number(),
+  type: z.string(),
+  data: z.record(z.string(), z.unknown()),
+})
+
+const eventsResponseSchema = z.object({
+  events: z.array(eventSchema),
+})
+
+const turnSchema = z.object({
+  turnId: z.string(),
+  duplicate: z.boolean(),
+})
+
+export type ManagedAgentTemplate = z.infer<typeof templateSchema>
+export type ManagedAgentSummary = z.infer<typeof agentSchema>
+export type ManagedAgentDeployment = z.infer<typeof deploymentSchema>
+
+export async function getManagedAgentTemplates() {
+  return (
+    await apiFetch(
+      '/managed-agents/templates',
+      undefined,
+      templatesResponseSchema,
+    )
+  ).templates
+}
+
+export async function getManagedAgents() {
+  return (
+    await apiFetch('/managed-agents/agents', undefined, agentsResponseSchema)
+  ).agents
+}
+
+async function sleep(milliseconds: number) {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+async function waitForAgentEvent(
+  sessionId: string,
+  after: number,
+  terminal: (event: z.infer<typeof eventSchema>) => boolean,
+  onEvent: (event: z.infer<typeof eventSchema>) => void,
+  timeoutMs: number,
+) {
+  const deadline = Date.now() + timeoutMs
+  let cursor = after
+  while (Date.now() < deadline) {
+    const { events } = await apiFetch(
+      `/managed-agents/sessions/${encodeURIComponent(sessionId)}/events?after=${cursor}`,
+      undefined,
+      eventsResponseSchema,
+    )
+    for (const event of events) {
+      cursor = Math.max(cursor, event.seq)
+      onEvent(event)
+      if (
+        event.type === 'runtime.disconnected' ||
+        event.type === 'session.failed'
+      ) {
+        throw new Error(
+          typeof event.data.reason === 'string'
+            ? event.data.reason
+            : typeof event.data.message === 'string'
+              ? event.data.message
+              : 'The agent runtime disconnected.',
+        )
+      }
+      if (terminal(event)) return { event, cursor }
+    }
+    await sleep(600)
+  }
+  throw new Error('Timed out waiting for the agent.')
+}
+
+export async function invokeManagedAgent(agentId: string, input: string) {
+  const created = await apiFetch(
+    '/managed-agents/sessions',
+    {
+      method: 'POST',
+      body: JSON.stringify({ agentId }),
+    },
+    sessionCreateSchema,
+  )
+  const sessionId = created.session.id
+  try {
+    const connected = await waitForAgentEvent(
+      sessionId,
+      0,
+      (event) => event.type === 'runtime.connected',
+      () => undefined,
+      90_000,
+    )
+    const turn = await apiFetch(
+      `/managed-agents/sessions/${encodeURIComponent(sessionId)}/turns`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          input,
+          idempotencyKey: crypto.randomUUID(),
+        }),
+      },
+      turnSchema,
+    )
+    let streamedText = ''
+    let completedText = ''
+    const completed = await waitForAgentEvent(
+      sessionId,
+      connected.cursor,
+      (event) =>
+        event.type === 'turn.completed' || event.type === 'turn.failed',
+      (event) => {
+        if (event.type === 'message.delta') {
+          streamedText +=
+            typeof event.data.text === 'string' ? event.data.text : ''
+        } else if (
+          event.type === 'message.completed' &&
+          typeof event.data.text === 'string'
+        ) {
+          completedText = event.data.text
+        }
+      },
+      180_000,
+    )
+    if (completed.event.type === 'turn.failed') {
+      throw new Error(
+        typeof completed.event.data.message === 'string'
+          ? completed.event.data.message
+          : 'The agent could not complete this request.',
+      )
+    }
+    return {
+      sessionId,
+      turnId: turn.turnId,
+      output: streamedText || completedText || 'Done.',
+    }
+  } finally {
+    await apiFetch(
+      `/managed-agents/sessions/${encodeURIComponent(sessionId)}/suspend`,
+      { method: 'POST' },
+    ).catch(() => undefined)
+  }
+}

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -29,6 +29,10 @@ const deploymentSchema = z.object({
   createdAt: z.string(),
 })
 
+const deploymentsResponseSchema = z.object({
+  deployments: z.array(deploymentSchema),
+})
+
 const templatesResponseSchema = z.object({
   templates: z.array(templateSchema),
 })
@@ -98,6 +102,8 @@ const sessionSchema = z.object({
   agentId: z.string(),
   deploymentId: z.string(),
   status: z.string(),
+  source: z.enum(['api', 'channel', 'playground']).optional().default('api'),
+  microvmState: z.string().optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
   turns: z
@@ -177,6 +183,16 @@ export async function getManagedAgentDeployment(deploymentId: string) {
   )
 }
 
+export async function getManagedAgentDeployments(agentId: string) {
+  return (
+    await apiFetch(
+      `/managed-agents/deployments?agentId=${encodeURIComponent(agentId)}`,
+      undefined,
+      deploymentsResponseSchema,
+    )
+  ).deployments
+}
+
 export async function getManagedAgentSessions(agentId?: string) {
   const { sessions } = await apiFetch(
     '/managed-agents/sessions',
@@ -198,6 +214,14 @@ export async function getManagedAgentSessionEvents(sessionId: string) {
   ).events
 }
 
+export async function getManagedAgentSession(sessionId: string) {
+  return apiFetch(
+    `/managed-agents/sessions/${encodeURIComponent(sessionId)}`,
+    undefined,
+    sessionSchema,
+  )
+}
+
 async function sleep(milliseconds: number) {
   await new Promise((resolve) => setTimeout(resolve, milliseconds))
 }
@@ -208,13 +232,15 @@ async function waitForAgentEvent(
   terminal: (event: z.infer<typeof eventSchema>) => boolean,
   onEvent: (event: z.infer<typeof eventSchema>) => void,
   timeoutMs: number,
+  signal?: AbortSignal,
 ) {
   const deadline = Date.now() + timeoutMs
   let cursor = after
   while (Date.now() < deadline) {
+    if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
     const { events } = await apiFetch(
       `/managed-agents/sessions/${encodeURIComponent(sessionId)}/events?after=${cursor}`,
-      undefined,
+      { signal },
       eventsResponseSchema,
     )
     for (const event of events) {
@@ -243,16 +269,22 @@ export async function runManagedAgent(
   agentId: string,
   input: string,
   onEvent: (event: ManagedAgentEvent) => void,
+  options: {
+    onSession?: (sessionId: string) => void
+    signal?: AbortSignal
+  } = {},
 ) {
   const created = await apiFetch(
     '/managed-agents/sessions',
     {
       method: 'POST',
-      body: JSON.stringify({ agentId }),
+      body: JSON.stringify({ agentId, source: 'playground' }),
+      signal: options.signal,
     },
     sessionCreateSchema,
   )
   const sessionId = created.session.id
+  options.onSession?.(sessionId)
   try {
     const connected = await waitForAgentEvent(
       sessionId,
@@ -260,6 +292,7 @@ export async function runManagedAgent(
       (event) => event.type === 'runtime.connected',
       onEvent,
       90_000,
+      options.signal,
     )
     const turn = await apiFetch(
       `/managed-agents/sessions/${encodeURIComponent(sessionId)}/turns`,
@@ -269,6 +302,7 @@ export async function runManagedAgent(
           input,
           idempotencyKey: crypto.randomUUID(),
         }),
+        signal: options.signal,
       },
       turnSchema,
     )
@@ -279,6 +313,73 @@ export async function runManagedAgent(
         event.type === 'turn.completed' || event.type === 'turn.failed',
       onEvent,
       180_000,
+      options.signal,
+    )
+    if (completed.event.type === 'turn.failed') {
+      throw new Error(
+        typeof completed.event.data.message === 'string'
+          ? completed.event.data.message
+          : 'The agent could not complete this request.',
+      )
+    }
+    return { sessionId, turnId: turn.turnId }
+  } finally {
+    await apiFetch(
+      `/managed-agents/sessions/${encodeURIComponent(sessionId)}/suspend`,
+      { method: 'POST' },
+    ).catch(() => undefined)
+  }
+}
+
+export async function continueManagedAgentSession(
+  sessionId: string,
+  input: string,
+  onEvent: (event: ManagedAgentEvent) => void,
+  signal?: AbortSignal,
+) {
+  const existing = await getManagedAgentSessionEvents(sessionId)
+  let cursor = existing[existing.length - 1]?.seq ?? 0
+  const session = await getManagedAgentSession(sessionId)
+  if (session.microvmState === 'terminated' || session.status === 'ended') {
+    throw new Error('This playground session has ended. Start a new session.')
+  }
+  if (session.microvmState === 'suspended') {
+    await apiFetch(
+      `/managed-agents/sessions/${encodeURIComponent(sessionId)}/resume`,
+      { method: 'POST', signal },
+      sessionSchema,
+    )
+    const connected = await waitForAgentEvent(
+      sessionId,
+      cursor,
+      (event) => event.type === 'runtime.connected',
+      onEvent,
+      90_000,
+      signal,
+    )
+    cursor = connected.cursor
+  }
+  try {
+    const turn = await apiFetch(
+      `/managed-agents/sessions/${encodeURIComponent(sessionId)}/turns`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          input,
+          idempotencyKey: crypto.randomUUID(),
+        }),
+        signal,
+      },
+      turnSchema,
+    )
+    const completed = await waitForAgentEvent(
+      sessionId,
+      cursor,
+      (event) =>
+        event.type === 'turn.completed' || event.type === 'turn.failed',
+      onEvent,
+      180_000,
+      signal,
     )
     if (completed.event.type === 'turn.failed') {
       throw new Error(

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -138,7 +138,7 @@ export function displayManagedAgentName(
   agent: Pick<ManagedAgentSummary, 'id' | 'name'>,
 ) {
   const name = agent.name.trim()
-  return !name || UUID_NAME.test(name) ? 'Untitled agent' : name
+  return !name || UUID_NAME.test(name) ? 'Untitled project' : name
 }
 
 export async function getManagedAgentTemplates() {
@@ -268,14 +268,14 @@ async function waitForAgentEvent(
             ? event.data.reason
             : typeof event.data.message === 'string'
               ? event.data.message
-              : 'The agent runtime disconnected.',
+              : 'The project runtime disconnected.',
         )
       }
       if (terminal(event)) return { event, cursor }
     }
     await sleep(600)
   }
-  throw new Error('Timed out waiting for the agent.')
+  throw new Error('Timed out waiting for the project.')
 }
 
 export async function runManagedAgent(
@@ -332,7 +332,7 @@ export async function runManagedAgent(
       throw new Error(
         typeof completed.event.data.message === 'string'
           ? completed.event.data.message
-          : 'The agent could not complete this request.',
+          : 'The project could not complete this request.',
       )
     }
     return { sessionId, turnId: turn.turnId }
@@ -398,7 +398,7 @@ export async function continueManagedAgentSession(
       throw new Error(
         typeof completed.event.data.message === 'string'
           ? completed.event.data.message
-          : 'The agent could not complete this request.',
+          : 'The project could not complete this request.',
       )
     }
     return { sessionId, turnId: turn.turnId }
@@ -463,7 +463,7 @@ export async function invokeManagedAgent(agentId: string, input: string) {
       throw new Error(
         typeof completed.event.data.message === 'string'
           ? completed.event.data.message
-          : 'The agent could not complete this request.',
+          : 'The project could not complete this request.',
       )
     }
     return {

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -12,7 +12,9 @@ const templateSchema = z.object({
 
 const agentSchema = z.object({
   id: z.string(),
+  name: z.string(),
   activeAlias: z.string(),
+  activeDeploymentId: z.string().nullish(),
   deploymentCount: z.number(),
   createdAt: z.string(),
   updatedAt: z.string(),
@@ -35,13 +37,49 @@ const agentsResponseSchema = z.object({
   agents: z.array(agentSchema),
 })
 
+const connectionSchema = z.object({
+  id: z.string(),
+  kind: z.enum(['tool', 'channel']),
+  provider: z.string(),
+  label: z.string(),
+  agentId: z.string().optional().default(''),
+  alias: z.string().optional().default(''),
+  displayName: z.string().nullish(),
+  status: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+const channelSchema = z.object({
+  id: z.string(),
+  channel: z.string(),
+  agentId: z.string(),
+  alias: z.string(),
+  teamName: z.string().nullish(),
+  status: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+const connectionsResponseSchema = z.object({
+  connections: z.array(connectionSchema),
+})
+
+const channelsResponseSchema = z.object({
+  channels: z.array(channelSchema),
+})
+
 const sessionCreateSchema = z.object({
   session: z.object({ id: z.string() }),
   deployment: deploymentSchema.optional(),
 })
 
 const eventSchema = z.object({
+  id: z.string().optional(),
   seq: z.number(),
+  timestamp: z.string().optional(),
+  sessionId: z.string().optional(),
+  turnId: z.string().optional(),
   type: z.string(),
   data: z.record(z.string(), z.unknown()),
 })
@@ -55,9 +93,45 @@ const turnSchema = z.object({
   duplicate: z.boolean(),
 })
 
+const sessionSchema = z.object({
+  id: z.string(),
+  agentId: z.string(),
+  deploymentId: z.string(),
+  status: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  turns: z
+    .array(
+      z.object({
+        id: z.string(),
+        input: z.string(),
+        status: z.string(),
+        createdAt: z.string(),
+        updatedAt: z.string(),
+      }),
+    )
+    .default([]),
+})
+
+const sessionsResponseSchema = z.object({ sessions: z.array(sessionSchema) })
+
 export type ManagedAgentTemplate = z.infer<typeof templateSchema>
 export type ManagedAgentSummary = z.infer<typeof agentSchema>
 export type ManagedAgentDeployment = z.infer<typeof deploymentSchema>
+export type ManagedAgentEvent = z.infer<typeof eventSchema>
+export type ManagedAgentSession = z.infer<typeof sessionSchema>
+export type ManagedAgentConnection = z.infer<typeof connectionSchema>
+export type ManagedAgentChannel = z.infer<typeof channelSchema>
+
+const UUID_NAME =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+export function displayManagedAgentName(
+  agent: Pick<ManagedAgentSummary, 'id' | 'name'>,
+) {
+  const name = agent.name.trim()
+  return !name || UUID_NAME.test(name) ? 'Untitled agent' : name
+}
 
 export async function getManagedAgentTemplates() {
   return (
@@ -73,6 +147,55 @@ export async function getManagedAgents() {
   return (
     await apiFetch('/managed-agents/agents', undefined, agentsResponseSchema)
   ).agents
+}
+
+export async function getManagedAgentConnections() {
+  return (
+    await apiFetch(
+      '/managed-agents/connections',
+      undefined,
+      connectionsResponseSchema,
+    )
+  ).connections.filter((connection) => connection.kind === 'tool')
+}
+
+export async function getManagedAgentChannels() {
+  return (
+    await apiFetch(
+      '/managed-agents/channels',
+      undefined,
+      channelsResponseSchema,
+    )
+  ).channels
+}
+
+export async function getManagedAgentDeployment(deploymentId: string) {
+  return apiFetch(
+    `/managed-agents/deployments/${encodeURIComponent(deploymentId)}`,
+    undefined,
+    deploymentSchema,
+  )
+}
+
+export async function getManagedAgentSessions(agentId?: string) {
+  const { sessions } = await apiFetch(
+    '/managed-agents/sessions',
+    undefined,
+    sessionsResponseSchema,
+  )
+  return agentId
+    ? sessions.filter((session) => session.agentId === agentId)
+    : sessions
+}
+
+export async function getManagedAgentSessionEvents(sessionId: string) {
+  return (
+    await apiFetch(
+      `/managed-agents/sessions/${encodeURIComponent(sessionId)}/events?after=0`,
+      undefined,
+      eventsResponseSchema,
+    )
+  ).events
 }
 
 async function sleep(milliseconds: number) {
@@ -114,6 +237,63 @@ async function waitForAgentEvent(
     await sleep(600)
   }
   throw new Error('Timed out waiting for the agent.')
+}
+
+export async function runManagedAgent(
+  agentId: string,
+  input: string,
+  onEvent: (event: ManagedAgentEvent) => void,
+) {
+  const created = await apiFetch(
+    '/managed-agents/sessions',
+    {
+      method: 'POST',
+      body: JSON.stringify({ agentId }),
+    },
+    sessionCreateSchema,
+  )
+  const sessionId = created.session.id
+  try {
+    const connected = await waitForAgentEvent(
+      sessionId,
+      0,
+      (event) => event.type === 'runtime.connected',
+      onEvent,
+      90_000,
+    )
+    const turn = await apiFetch(
+      `/managed-agents/sessions/${encodeURIComponent(sessionId)}/turns`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          input,
+          idempotencyKey: crypto.randomUUID(),
+        }),
+      },
+      turnSchema,
+    )
+    const completed = await waitForAgentEvent(
+      sessionId,
+      connected.cursor,
+      (event) =>
+        event.type === 'turn.completed' || event.type === 'turn.failed',
+      onEvent,
+      180_000,
+    )
+    if (completed.event.type === 'turn.failed') {
+      throw new Error(
+        typeof completed.event.data.message === 'string'
+          ? completed.event.data.message
+          : 'The agent could not complete this request.',
+      )
+    }
+    return { sessionId, turnId: turn.turnId }
+  } finally {
+    await apiFetch(
+      `/managed-agents/sessions/${encodeURIComponent(sessionId)}/suspend`,
+      { method: 'POST' },
+    ).catch(() => undefined)
+  }
 }
 
 export async function invokeManagedAgent(agentId: string, input: string) {

--- a/web/src/managed-agents/chat-transport.test.ts
+++ b/web/src/managed-agents/chat-transport.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { UIMessage, UIMessageChunk } from 'ai'
+
+const { runManagedAgent, continueManagedAgentSession } = vi.hoisted(() => ({
+  runManagedAgent: vi.fn(),
+  continueManagedAgentSession: vi.fn(),
+}))
+
+vi.mock('./api', () => ({
+  runManagedAgent,
+  continueManagedAgentSession,
+}))
+
+import { ManagedAgentChatTransport } from './chat-transport'
+
+async function readChunks(stream: ReadableStream<UIMessageChunk>) {
+  const chunks: UIMessageChunk[] = []
+  for await (const chunk of stream) chunks.push(chunk)
+  return chunks
+}
+
+function messages(text: string): UIMessage[] {
+  return [
+    {
+      id: crypto.randomUUID(),
+      role: 'user',
+      parts: [{ type: 'text', text }],
+    },
+  ]
+}
+
+describe('ManagedAgentChatTransport', () => {
+  it('translates Blue events and continues the assigned session', async () => {
+    runManagedAgent.mockImplementation(
+      async (
+        _agentId: string,
+        _input: string,
+        onEvent: (event: unknown) => void,
+        options: { onSession: (sessionId: string) => void },
+      ) => {
+        options.onSession('session-1')
+        onEvent({
+          seq: 1,
+          type: 'reasoning.delta',
+          data: { text: 'Checking' },
+        })
+        onEvent({
+          seq: 2,
+          type: 'tool.started',
+          data: { callId: 'call-1', tool: 'gmail_search', input: {} },
+        })
+        onEvent({
+          seq: 3,
+          type: 'tool.completed',
+          data: { callId: 'call-1', tool: 'gmail_search', output: ['email'] },
+        })
+        onEvent({
+          seq: 4,
+          type: 'message.delta',
+          data: { text: 'Done' },
+        })
+        onEvent({
+          seq: 5,
+          type: 'message.completed',
+          data: { text: 'Done' },
+        })
+      },
+    )
+    continueManagedAgentSession.mockResolvedValue({
+      sessionId: 'session-1',
+      turnId: 'turn-2',
+    })
+    const assigned: string[] = []
+    const transport = new ManagedAgentChatTransport(
+      'agent-1',
+      undefined,
+      (sessionId) => assigned.push(sessionId),
+    )
+
+    const first = await readChunks(
+      await transport.sendMessages({
+        trigger: 'submit-message',
+        chatId: 'chat-1',
+        messageId: undefined,
+        messages: messages('List my email'),
+        abortSignal: undefined,
+      }),
+    )
+
+    expect(assigned).toEqual(['session-1'])
+    expect(first.map((chunk) => chunk.type)).toEqual([
+      'start',
+      'reasoning-start',
+      'reasoning-delta',
+      'tool-input-available',
+      'tool-output-available',
+      'text-start',
+      'text-delta',
+      'reasoning-end',
+      'text-end',
+      'finish',
+    ])
+    expect(first.filter((chunk) => chunk.type === 'text-delta')).toHaveLength(1)
+
+    await readChunks(
+      await transport.sendMessages({
+        trigger: 'submit-message',
+        chatId: 'chat-1',
+        messageId: undefined,
+        messages: messages('And the next one?'),
+        abortSignal: undefined,
+      }),
+    )
+
+    expect(continueManagedAgentSession).toHaveBeenCalledWith(
+      'session-1',
+      'And the next one?',
+      expect.any(Function),
+      undefined,
+    )
+    expect(runManagedAgent).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/managed-agents/chat-transport.ts
+++ b/web/src/managed-agents/chat-transport.ts
@@ -1,0 +1,176 @@
+import type { ChatTransport, UIMessage, UIMessageChunk } from 'ai'
+import {
+  continueManagedAgentSession,
+  runManagedAgent,
+  type ManagedAgentEvent,
+} from './api'
+
+function eventText(event: ManagedAgentEvent) {
+  return typeof event.data.text === 'string' ? event.data.text : ''
+}
+
+function eventError(event: ManagedAgentEvent) {
+  return typeof event.data.message === 'string'
+    ? event.data.message
+    : typeof event.data.reason === 'string'
+      ? event.data.reason
+      : 'The agent could not complete this request.'
+}
+
+function lastUserText(messages: UIMessage[]) {
+  const message = [...messages]
+    .reverse()
+    .find((candidate) => candidate.role === 'user')
+  return (
+    message?.parts
+      .filter((part) => part.type === 'text')
+      .map((part) => part.text)
+      .join('') ?? ''
+  )
+}
+
+export class ManagedAgentChatTransport implements ChatTransport<UIMessage> {
+  private sessionId?: string
+
+  constructor(
+    private readonly agentId: string,
+    sessionId: string | undefined,
+    private readonly onSession: (sessionId: string) => void,
+  ) {
+    this.sessionId = sessionId
+  }
+
+  async sendMessages({
+    messages,
+    abortSignal,
+  }: Parameters<ChatTransport<UIMessage>['sendMessages']>[0]) {
+    const input = lastUserText(messages).trim()
+    if (!input) throw new Error('Enter a message before sending.')
+
+    const messageId = crypto.randomUUID()
+    const textId = `${messageId}:text`
+    const reasoningId = `${messageId}:reasoning`
+
+    return new ReadableStream<UIMessageChunk>({
+      start: (controller) => {
+        let closed = false
+        let textStarted = false
+        let reasoningStarted = false
+        const startedTools = new Set<string>()
+
+        const enqueue = (chunk: UIMessageChunk) => {
+          if (!closed && !abortSignal?.aborted) controller.enqueue(chunk)
+        }
+        const finishParts = () => {
+          if (reasoningStarted)
+            enqueue({ type: 'reasoning-end', id: reasoningId })
+          if (textStarted) enqueue({ type: 'text-end', id: textId })
+        }
+        const onEvent = (event: ManagedAgentEvent) => {
+          if (event.type === 'reasoning.delta') {
+            if (!reasoningStarted) {
+              enqueue({ type: 'reasoning-start', id: reasoningId })
+              reasoningStarted = true
+            }
+            enqueue({
+              type: 'reasoning-delta',
+              id: reasoningId,
+              delta: eventText(event),
+            })
+            return
+          }
+          if (event.type === 'message.delta') {
+            if (!textStarted) {
+              enqueue({ type: 'text-start', id: textId })
+              textStarted = true
+            }
+            enqueue({ type: 'text-delta', id: textId, delta: eventText(event) })
+            return
+          }
+          if (event.type === 'message.completed' && !textStarted) {
+            enqueue({ type: 'text-start', id: textId })
+            textStarted = true
+            enqueue({ type: 'text-delta', id: textId, delta: eventText(event) })
+            return
+          }
+          if (!event.type.startsWith('tool.')) return
+
+          const toolCallId =
+            typeof event.data.callId === 'string'
+              ? event.data.callId
+              : `${event.type}:${event.seq}`
+          const toolName =
+            typeof event.data.tool === 'string' ? event.data.tool : 'tool'
+          if (!startedTools.has(toolCallId)) {
+            enqueue({
+              type: 'tool-input-available',
+              toolCallId,
+              toolName,
+              title:
+                typeof event.data.title === 'string'
+                  ? event.data.title
+                  : undefined,
+              input: event.data.input ?? {},
+              dynamic: true,
+            })
+            startedTools.add(toolCallId)
+          }
+          if (event.type === 'tool.completed') {
+            enqueue({
+              type: 'tool-output-available',
+              toolCallId,
+              output: event.data.output ?? null,
+              dynamic: true,
+            })
+          } else if (event.type === 'tool.failed') {
+            enqueue({
+              type: 'tool-output-error',
+              toolCallId,
+              errorText: eventError(event),
+              dynamic: true,
+            })
+          }
+        }
+
+        enqueue({ type: 'start', messageId })
+        void (
+          this.sessionId
+            ? continueManagedAgentSession(
+                this.sessionId,
+                input,
+                onEvent,
+                abortSignal,
+              )
+            : runManagedAgent(this.agentId, input, onEvent, {
+                signal: abortSignal,
+                onSession: (sessionId) => {
+                  this.sessionId = sessionId
+                  this.onSession(sessionId)
+                },
+              })
+        )
+          .then(() => {
+            finishParts()
+            enqueue({ type: 'finish', finishReason: 'stop' })
+          })
+          .catch((error: unknown) => {
+            if (abortSignal?.aborted) enqueue({ type: 'abort' })
+            else
+              enqueue({
+                type: 'error',
+                errorText:
+                  error instanceof Error ? error.message : String(error),
+              })
+          })
+          .finally(() => {
+            closed = true
+            controller.close()
+          })
+      },
+    })
+  }
+
+  async reconnectToStream() {
+    return null
+  }
+}

--- a/web/src/managed-agents/chat-transport.ts
+++ b/web/src/managed-agents/chat-transport.ts
@@ -14,7 +14,7 @@ function eventError(event: ManagedAgentEvent) {
     ? event.data.message
     : typeof event.data.reason === 'string'
       ? event.data.reason
-      : 'The agent could not complete this request.'
+      : 'The project could not complete this request.'
 }
 
 function lastUserText(messages: UIMessage[]) {

--- a/web/src/managed-agents/chat-transport.ts
+++ b/web/src/managed-agents/chat-transport.ts
@@ -14,7 +14,7 @@ function eventError(event: ManagedAgentEvent) {
     ? event.data.message
     : typeof event.data.reason === 'string'
       ? event.data.reason
-      : 'The project could not complete this request.'
+      : 'The agent could not complete this request.'
 }
 
 function lastUserText(messages: UIMessage[]) {

--- a/web/src/managed-agents/feature.ts
+++ b/web/src/managed-agents/feature.ts
@@ -1,0 +1,5 @@
+// The experiment is on by default for this launch. Set the build-time value to
+// "0" to restore the existing dashboard and navigation without removing any
+// legacy routes.
+export const managedAgentsExperimentEnabled =
+  import.meta.env.VITE_MANAGED_AGENTS_EXPERIMENT !== '0'

--- a/web/src/managed-agents/scroll-follow.test.ts
+++ b/web/src/managed-agents/scroll-follow.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { isNearScrollEnd } from './scroll-follow'
+
+describe('isNearScrollEnd', () => {
+  it('follows when the reader is at or near the newest content', () => {
+    expect(
+      isNearScrollEnd({
+        scrollHeight: 1_000,
+        scrollTop: 600,
+        clientHeight: 400,
+      }),
+    ).toBe(true)
+    expect(
+      isNearScrollEnd({
+        scrollHeight: 1_000,
+        scrollTop: 510,
+        clientHeight: 400,
+      }),
+    ).toBe(true)
+  })
+
+  it('preserves position after the reader scrolls away from the bottom', () => {
+    expect(
+      isNearScrollEnd({
+        scrollHeight: 1_000,
+        scrollTop: 400,
+        clientHeight: 400,
+      }),
+    ).toBe(false)
+  })
+})

--- a/web/src/managed-agents/scroll-follow.ts
+++ b/web/src/managed-agents/scroll-follow.ts
@@ -1,0 +1,15 @@
+export const SCROLL_FOLLOW_THRESHOLD = 96
+
+type ScrollMetrics = Pick<
+  HTMLElement,
+  'scrollHeight' | 'scrollTop' | 'clientHeight'
+>
+
+export function isNearScrollEnd(
+  metrics: ScrollMetrics,
+  threshold = SCROLL_FOLLOW_THRESHOLD,
+) {
+  return (
+    metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight <= threshold
+  )
+}

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -5,6 +5,8 @@ interface ImportMetaEnv {
   readonly VITE_PUBLIC_POSTHOG_HOST?: string
   /** Opt-in dev-only flag: serve mock data with no backend/auth (see api/mock.ts). */
   readonly VITE_PREVIEW?: string
+  /** "0" restores the legacy dashboard and navigation for experiment rollback. */
+  readonly VITE_MANAGED_AGENTS_EXPERIMENT?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- add the new TypeScript OpenComputer CLI for agent-as-code initialization, local OpenCode development, managed connections, Slack channels, versioned deployment, and session lifecycle
- add the authenticated public managed-agents API proxy while keeping backend/runtime provider details private
- make Agents the primary dashboard experience with template setup prompts and collapsible infrastructure navigation
- add Mintlify Agents overview, Gmail summarizer quickstart, architecture, and centralized-connection diagrams

## Repositories
- pairs with diggerhq/blue#1 for the private managed-agents backend

## Validation
- CLI: 6 tests passed; TypeScript build passed
- Dashboard: 161 tests passed; production build passed
- Dashboard changed files: ESLint and Prettier passed
- Managed-agent proxy: 7 tests passed after merging latest main
- Docs navigation JSON and diff checks passed

## Existing repository checks
- the repository-wide dashboard lint still reports 7 pre-existing errors in Terminal.tsx, guided-tour.tsx, Browsers.tsx, and SandboxDetail.tsx
- repository-wide Prettier reports 14 pre-existing files outside this change; all changed dashboard files pass