### PR TITLE
feat(web): harden PostHog analytics

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,4 +1,4 @@
-import posthog from 'posthog-js'
+import { resetAnalytics } from '../lib/analytics'
 import { z } from 'zod'
 import * as S from './schemas'
 import { ApiError } from './errors'
@@ -192,7 +192,7 @@ export async function logout(): Promise<void> {
   } catch {
     // ignore — fall back to /auth/login
   }
-  posthog.reset()
+  resetAnalytics()
   window.location.replace(dest)
 }
 

--- a/web/src/hooks/auth-provider.tsx
+++ b/web/src/hooks/auth-provider.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, type ReactNode } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import posthog from 'posthog-js'
 import { getMe, switchOrg as switchOrgApi } from '../api/client'
+import { identifyAnalyticsUser } from '../lib/analytics'
 import { AuthContext } from './useAuth'
 
 export function AuthProvider({ children }: { children: ReactNode }) {
@@ -21,7 +21,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Identify the analytics user once /me resolves (external-system sync).
   useEffect(() => {
     if (user?.id) {
-      posthog.identify(user.id, { email: user.email, org_id: user.orgId })
+      const activeOrg = user.orgs?.find((org) => org.isActive)
+      identifyAnalyticsUser({
+        id: user.id,
+        email: user.email,
+        orgId: user.orgId,
+        orgName: activeOrg?.name,
+      })
     }
   }, [user])
 

--- a/web/src/lib/analytics.test.ts
+++ b/web/src/lib/analytics.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const posthog = vi.hoisted(() => ({
+  init: vi.fn(),
+  identify: vi.fn(),
+  group: vi.fn(),
+  capture: vi.fn(),
+  reset: vi.fn(),
+}))
+
+vi.mock('posthog-js', () => ({ default: posthog }))
+
+describe('product analytics', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('stays disabled when no project token is configured', async () => {
+    const analytics = await import('./analytics')
+
+    analytics.initializeAnalytics(undefined, undefined)
+    analytics.identifyAnalyticsUser({
+      id: 'user-1',
+      email: 'person@example.com',
+      orgId: 'org-1',
+    })
+    analytics.captureAnalyticsEvent('sandbox_created')
+    analytics.resetAnalytics()
+
+    expect(posthog.init).not.toHaveBeenCalled()
+    expect(posthog.identify).not.toHaveBeenCalled()
+    expect(posthog.group).not.toHaveBeenCalled()
+    expect(posthog.capture).not.toHaveBeenCalled()
+    expect(posthog.reset).not.toHaveBeenCalled()
+  })
+
+  it('initializes once with SPA navigation and privacy-safe replay defaults', async () => {
+    const analytics = await import('./analytics')
+
+    analytics.initializeAnalytics('phc_project', 'https://eu.i.posthog.com')
+    analytics.initializeAnalytics('phc_other', undefined)
+
+    expect(posthog.init).toHaveBeenCalledOnce()
+    expect(posthog.init).toHaveBeenCalledWith('phc_project', {
+      api_host: 'https://eu.i.posthog.com',
+      defaults: '2026-06-25',
+      capture_pageview: 'history_change',
+      capture_pageleave: true,
+      person_profiles: 'identified_only',
+      mask_personal_data_properties: true,
+      custom_personal_data_properties: ['action', 'returnTo'],
+      session_recording: { maskAllInputs: true },
+    })
+  })
+
+  it('attributes events to both the signed-in user and active organization', async () => {
+    const analytics = await import('./analytics')
+    analytics.initializeAnalytics('phc_project', undefined)
+
+    analytics.identifyAnalyticsUser({
+      id: 'user-1',
+      email: 'person@example.com',
+      orgId: 'org-1',
+      orgName: 'Example Org',
+    })
+    analytics.captureAnalyticsEvent('sandbox_created', { region: 'us-east' })
+    analytics.resetAnalytics()
+
+    expect(posthog.identify).toHaveBeenCalledWith('user-1', {
+      email: 'person@example.com',
+      org_id: 'org-1',
+    })
+    expect(posthog.group).toHaveBeenCalledWith('organization', 'org-1', {
+      name: 'Example Org',
+    })
+    expect(posthog.capture).toHaveBeenCalledWith(
+      'sandbox_created',
+      { region: 'us-east' },
+      undefined,
+    )
+    expect(posthog.reset).toHaveBeenCalledOnce()
+  })
+})

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1,0 +1,65 @@
+import posthog, {
+  type CaptureOptions,
+  type EventName,
+  type Properties,
+} from 'posthog-js'
+
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com'
+
+let initialized = false
+
+export function initializeAnalytics(
+  projectToken: string | undefined,
+  host: string | undefined,
+): void {
+  if (!projectToken || initialized) return
+
+  posthog.init(projectToken, {
+    api_host: host || DEFAULT_POSTHOG_HOST,
+    defaults: '2026-06-25',
+    capture_pageview: 'history_change',
+    capture_pageleave: true,
+    person_profiles: 'identified_only',
+    mask_personal_data_properties: true,
+    custom_personal_data_properties: ['action', 'returnTo'],
+    session_recording: {
+      maskAllInputs: true,
+    },
+  })
+  initialized = true
+}
+
+interface AnalyticsUser {
+  id: string
+  email: string
+  orgId: string
+  orgName?: string
+}
+
+export function identifyAnalyticsUser(user: AnalyticsUser): void {
+  if (!initialized) return
+
+  posthog.identify(user.id, {
+    email: user.email,
+    org_id: user.orgId,
+  })
+  posthog.group(
+    'organization',
+    user.orgId,
+    user.orgName ? { name: user.orgName } : undefined,
+  )
+}
+
+export function captureAnalyticsEvent(
+  eventName: EventName,
+  properties?: Properties,
+  options?: CaptureOptions,
+): void {
+  if (!initialized) return
+  posthog.capture(eventName, properties, options)
+}
+
+export function resetAnalytics(): void {
+  if (!initialized) return
+  posthog.reset()
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -11,6 +11,7 @@ import {
   DefaultErrorFallback,
 } from './components/error-boundary'
 import { reloadForStaleChunk } from './lib/chunk-reload'
+import { initializeAnalytics } from './lib/analytics'
 import './index.css'
 
 const queryClient = new QueryClient({
@@ -22,15 +23,10 @@ const queryClient = new QueryClient({
   },
 })
 
-const PH_TOKEN = import.meta.env.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN
-const PH_HOST = import.meta.env.VITE_PUBLIC_POSTHOG_HOST
-if (PH_TOKEN) {
-  posthog.init(PH_TOKEN, {
-    api_host: PH_HOST || 'https://us.i.posthog.com',
-    defaults: '2025-05-24',
-    person_profiles: 'identified_only',
-  })
-}
+initializeAnalytics(
+  import.meta.env.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN,
+  import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+)
 
 // After a deploy, an open tab still references the previous build's hashed route
 // chunks; navigating to a not-yet-loaded route fails the dynamic import and Vite

--- a/web/src/pages/DeferredAction.tsx
+++ b/web/src/pages/DeferredAction.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { Loader2 } from 'lucide-react'
-import posthog from 'posthog-js'
 import { useAuth } from '@/hooks/useAuth'
 import { Button } from '@/components/ui/button'
 import {
@@ -9,6 +8,7 @@ import {
   decodeAction,
   type ActionEnvelope,
 } from '@/lib/deferred-actions'
+import { captureAnalyticsEvent } from '@/lib/analytics'
 
 // /do — the deferred-action executor. Reads ?action=<envelope>, and:
 //  - anonymous → captures the pre-auth `landed` event, then bounces to WorkOS
@@ -49,7 +49,7 @@ export default function DeferredAction() {
       const started = performance.now()
       try {
         const result = await handler(env.params)
-        posthog.capture('deferred_action_executed', {
+        captureAnalyticsEvent('deferred_action_executed', {
           action_type: env.type,
           ms: Math.round(performance.now() - started),
           ...(result.analytics ?? {}), // e.g. agent_id
@@ -59,7 +59,7 @@ export default function DeferredAction() {
           state: result.navigateState,
         })
       } catch (e) {
-        posthog.capture('deferred_action_failed', {
+        captureAnalyticsEvent('deferred_action_failed', {
           action_type: env.type,
           reason: 'api_error',
         })
@@ -75,7 +75,7 @@ export default function DeferredAction() {
     // Structurally invalid → record why and stop; no auth needed to show this.
     if (!supported) {
       executedRef.current = true
-      posthog.capture('deferred_action_failed', {
+      captureAnalyticsEvent('deferred_action_failed', {
         action_type: envelope?.type ?? null,
         reason: envelope ? 'unknown_type' : 'malformed',
       })
@@ -87,7 +87,7 @@ export default function DeferredAction() {
       // Anonymous: record the top of the funnel while the URL is intact, then
       // hand off to login. sendBeacon so the batched event survives the nav.
       executedRef.current = true
-      posthog.capture(
+      captureAnalyticsEvent(
         'deferred_action_landed',
         { action_type: envelope.type, authenticated: false },
         { transport: 'sendBeacon' },
@@ -100,7 +100,7 @@ export default function DeferredAction() {
     }
 
     executedRef.current = true
-    posthog.capture('deferred_action_landed', {
+    captureAnalyticsEvent('deferred_action_landed', {
       action_type: envelope.type,
       authenticated: true,
     })
@@ -124,8 +124,8 @@ export default function DeferredAction() {
             This link isn&rsquo;t supported.
           </p>
           <p className="text-muted-foreground max-w-sm text-sm">
-            It may be from a newer version of the site. Head to your dashboard to
-            keep going.
+            It may be from a newer version of the site. Head to your dashboard
+            to keep going.
           </p>
           <Link
             to="/"


### PR DESCRIPTION
## Summary

- centralize PostHog initialization and event capture behind a no-op-safe analytics boundary
- identify signed-in users and group subsequent events by the active OpenComputer organization
- capture SPA navigation/page-leave analytics while masking replay inputs and sensitive deferred-action URL parameters
- add focused coverage for disabled, configured, and identified analytics behavior

## Validation

- `npm test -- --run` (168 tests)
- `npm run typecheck`
- `npm run build`
- ESLint and Prettier on all changed files
- `git diff --check`

Repository-wide lint and format checks remain red on pre-existing files outside this change.