### PR TITLE
Focus agent onboarding on Gmail triage

### DIFF
--- a/web/src/managed-agents/Home.tsx
+++ b/web/src/managed-agents/Home.tsx
@@ -28,6 +28,14 @@ import {
   PanelTitle,
 } from '@/components/panel'
 import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { notifyError } from '@/lib/errors'
 import { cn } from '@/lib/utils'
 import {
@@ -46,7 +54,12 @@ const categories = [
 ] as const
 
 type Category = (typeof categories)[number]
-type CopyAction = 'codex' | 'cli'
+type CopyAction = 'prompt' | 'cli'
+
+type CliStep = {
+  title: string
+  commands: string[]
+}
 
 const availableTemplateIds = new Set(['email-triage'])
 
@@ -133,42 +146,67 @@ Use the OpenComputer CLI and keep the agent as editable source code in this work
 Connect only integrations that are actually available. Ask me for authorization when a connection requires it, never print credentials, and do not claim an integration or deployment succeeded unless the CLI confirms it.`
 }
 
-function buildCliInstructions(template: ManagedAgentTemplate, origin: string) {
+function buildCliSteps(
+  template: ManagedAgentTemplate,
+  origin: string,
+): CliStep[] {
   const firstPrompt =
     template.suggestedPrompts[0] ?? `Help me configure ${template.name}.`
-  return `# 1. Install the OpenComputer CLI
-npm install --global @opencomputer/cli
+  return [
+    {
+      title: 'Install the OpenComputer CLI',
+      commands: ['npm install --global @opencomputer/cli'],
+    },
+    {
+      title: 'Log in',
+      commands: [cliCommand(origin, 'login')],
+    },
+    {
+      title: 'Initialize the Gmail triage agent',
+      commands: [
+        'mkdir gmail-triage && cd gmail-triage',
+        cliCommand(origin, `init ${template.id} .`),
+        'npm install',
+      ],
+    },
+    {
+      title: 'Connect your Gmail account',
+      commands: [cliCommand(origin, 'connection add gmail --alias personal')],
+    },
+    {
+      title: 'Test the agent locally',
+      commands: [
+        cliCommand(origin, `session "${firstPrompt.replace(/"/g, '\\"')}"`),
+      ],
+    },
+    {
+      title: 'Deploy it',
+      commands: [cliCommand(origin, 'deploy --alias production')],
+    },
+  ]
+}
 
-# 2. Log in
-${cliCommand(origin, 'login')}
-
-# 3. Initialize the Gmail triage template in a new directory
-mkdir gmail-triage && cd gmail-triage
-${cliCommand(origin, `init ${template.id} .`)}
-npm install
-
-# 4. Connect your Gmail account
-${cliCommand(origin, 'connection add gmail --alias personal')}
-
-# 5. Test the agent locally
-${cliCommand(origin, `session "${firstPrompt.replace(/"/g, '\\"')}"`)}
-
-# 6. Deploy it
-${cliCommand(origin, 'deploy --alias production')}`
+function buildCliInstructions(template: ManagedAgentTemplate, origin: string) {
+  return buildCliSteps(template, origin)
+    .map(
+      (step, index) =>
+        `# ${index + 1}. ${step.title}\n${step.commands.join('\n')}`,
+    )
+    .join('\n\n')
 }
 
 function TemplateCard({
   template,
   deployed,
   copiedAction,
-  onCopyCodex,
-  onCopyCli,
+  onCopyPrompt,
+  onShowCli,
 }: {
   template: ManagedAgentTemplate
   deployed: boolean
   copiedAction?: CopyAction
-  onCopyCodex: () => void
-  onCopyCli: () => void
+  onCopyPrompt: () => void
+  onShowCli: () => void
 }) {
   const Icon = categoryIcons[template.category as Category] ?? ClipboardCheck
   const available = availableTemplateIds.has(template.id)
@@ -241,22 +279,17 @@ function TemplateCard({
             </p>
             <div className="grid gap-2 sm:grid-cols-2">
               <Button
-                variant={copiedAction === 'codex' ? 'secondary' : 'default'}
-                onClick={onCopyCodex}
+                variant={copiedAction === 'prompt' ? 'secondary' : 'default'}
+                onClick={onCopyPrompt}
               >
-                {copiedAction === 'codex' ? <Check /> : <Clipboard />}
-                {copiedAction === 'codex'
-                  ? 'Codex prompt copied'
-                  : 'Copy Codex prompt'}
+                {copiedAction === 'prompt' ? <Check /> : <Clipboard />}
+                {copiedAction === 'prompt'
+                  ? 'Agent prompt copied'
+                  : 'Copy agent prompt'}
               </Button>
-              <Button
-                variant={copiedAction === 'cli' ? 'secondary' : 'outline'}
-                onClick={onCopyCli}
-              >
-                {copiedAction === 'cli' ? <Check /> : <Clipboard />}
-                {copiedAction === 'cli'
-                  ? 'CLI steps copied'
-                  : 'Copy CLI instructions'}
+              <Button variant="outline" onClick={onShowCli}>
+                <Clipboard />
+                View CLI instructions
               </Button>
             </div>
           </div>
@@ -281,6 +314,7 @@ export default function ManagedAgentsHome({
     templateId: string
     action: CopyAction
   }>()
+  const [cliTemplate, setCliTemplate] = useState<ManagedAgentTemplate>()
   const [categoryOrder] = useState(() => shuffled(categories))
   const [copy] = useState(
     () => starterCopy[Math.floor(Math.random() * starterCopy.length)],
@@ -319,8 +353,8 @@ export default function ManagedAgentsHome({
       await navigator.clipboard.writeText(
         buildSetupPrompt(template, window.location.origin),
       )
-      setCopied({ templateId: template.id, action: 'codex' })
-      toast.success(`${template.name} Codex prompt copied`)
+      setCopied({ templateId: template.id, action: 'prompt' })
+      toast.success(`${template.name} agent prompt copied`)
     } catch (error) {
       notifyError("Couldn't copy the agent prompt.", error)
     }
@@ -514,8 +548,8 @@ export default function ManagedAgentsHome({
                         ? copied.action
                         : undefined
                     }
-                    onCopyCodex={() => void copySetupPrompt(template)}
-                    onCopyCli={() => void copyCliInstructions(template)}
+                    onCopyPrompt={() => void copySetupPrompt(template)}
+                    onShowCli={() => setCliTemplate(template)}
                   />
                 ))}
               </div>
@@ -523,6 +557,58 @@ export default function ManagedAgentsHome({
           )}
         </section>
       ) : null}
+
+      <Dialog
+        open={cliTemplate !== undefined}
+        onOpenChange={(open) => !open && setCliTemplate(undefined)}
+      >
+        <DialogContent className="max-h-[min(48rem,calc(100vh-2rem))] overflow-hidden sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Set up Gmail triage with the CLI</DialogTitle>
+            <DialogDescription>
+              Follow these commands in order to create, test, and deploy your
+              agent.
+            </DialogDescription>
+          </DialogHeader>
+          {cliTemplate ? (
+            <div className="min-h-0 space-y-4 overflow-y-auto pr-1">
+              {buildCliSteps(cliTemplate, window.location.origin).map(
+                (step, index) => (
+                  <div key={step.title} className="flex gap-3">
+                    <div className="bg-primary/10 text-primary flex size-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold">
+                      {index + 1}
+                    </div>
+                    <div className="min-w-0 flex-1 space-y-2">
+                      <p className="font-medium">{step.title}</p>
+                      <pre className="bg-muted overflow-x-auto rounded-md border px-3 py-2 text-xs leading-5">
+                        <code>{step.commands.join('\n')}</code>
+                      </pre>
+                    </div>
+                  </div>
+                ),
+              )}
+            </div>
+          ) : null}
+          <DialogFooter>
+            <Button
+              onClick={() => {
+                if (cliTemplate) void copyCliInstructions(cliTemplate)
+              }}
+            >
+              {copied?.templateId === cliTemplate?.id &&
+              copied?.action === 'cli' ? (
+                <Check />
+              ) : (
+                <Clipboard />
+              )}
+              {copied?.templateId === cliTemplate?.id &&
+              copied?.action === 'cli'
+                ? 'Instructions copied'
+                : 'Copy all instructions'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/web/src/managed-agents/Home.tsx
+++ b/web/src/managed-agents/Home.tsx
@@ -6,6 +6,7 @@ import {
   BriefcaseBusiness,
   Check,
   ChevronRight,
+  Clock3,
   Clipboard,
   ClipboardCheck,
   Lightbulb,
@@ -45,6 +46,9 @@ const categories = [
 ] as const
 
 type Category = (typeof categories)[number]
+type CopyAction = 'codex' | 'cli'
+
+const availableTemplateIds = new Set(['email-triage'])
 
 const starterCopy = [
   {
@@ -129,20 +133,54 @@ Use the OpenComputer CLI and keep the agent as editable source code in this work
 Connect only integrations that are actually available. Ask me for authorization when a connection requires it, never print credentials, and do not claim an integration or deployment succeeded unless the CLI confirms it.`
 }
 
+function buildCliInstructions(template: ManagedAgentTemplate, origin: string) {
+  const firstPrompt =
+    template.suggestedPrompts[0] ?? `Help me configure ${template.name}.`
+  return `# 1. Install the OpenComputer CLI
+npm install --global @opencomputer/cli
+
+# 2. Log in
+${cliCommand(origin, 'login')}
+
+# 3. Initialize the Gmail triage template in a new directory
+mkdir gmail-triage && cd gmail-triage
+${cliCommand(origin, `init ${template.id} .`)}
+npm install
+
+# 4. Connect your Gmail account
+${cliCommand(origin, 'connection add gmail --alias personal')}
+
+# 5. Test the agent locally
+${cliCommand(origin, `session "${firstPrompt.replace(/"/g, '\\"')}"`)}
+
+# 6. Deploy it
+${cliCommand(origin, 'deploy --alias production')}`
+}
+
 function TemplateCard({
   template,
   deployed,
-  copied,
-  onCopy,
+  copiedAction,
+  onCopyCodex,
+  onCopyCli,
 }: {
   template: ManagedAgentTemplate
   deployed: boolean
-  copied: boolean
-  onCopy: () => void
+  copiedAction?: CopyAction
+  onCopyCodex: () => void
+  onCopyCli: () => void
 }) {
   const Icon = categoryIcons[template.category as Category] ?? ClipboardCheck
+  const available = availableTemplateIds.has(template.id)
   return (
-    <Panel className="flex h-full flex-col overflow-hidden">
+    <Panel
+      className={cn(
+        'flex h-full flex-col overflow-hidden',
+        available
+          ? 'border-primary/30 bg-primary/[0.025] shadow-sm'
+          : 'bg-muted/15',
+      )}
+    >
       <PanelHeader className="border-0 pb-2">
         <div className="flex min-w-0 items-start gap-3">
           <div className="bg-primary/8 text-primary flex size-9 shrink-0 items-center justify-center rounded-md">
@@ -154,6 +192,17 @@ function TemplateCard({
               {deployed ? (
                 <span className="bg-status-running-bg text-status-running rounded-full px-2 py-0.5 text-[10px] font-medium">
                   Deployed
+                </span>
+              ) : null}
+              {available && !deployed ? (
+                <span className="bg-status-running-bg text-status-running rounded-full px-2 py-0.5 text-[10px] font-medium">
+                  Available now
+                </span>
+              ) : null}
+              {!available ? (
+                <span className="bg-muted text-muted-foreground inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium">
+                  <Clock3 className="size-3" aria-hidden />
+                  Coming soon
                 </span>
               ) : null}
             </div>
@@ -177,7 +226,7 @@ function TemplateCard({
             </span>
           ))}
         </div>
-        <div className="mt-5 space-y-2">
+        <div className={cn('mt-5 space-y-2', !available && 'opacity-65')}>
           <p className="text-muted-foreground text-[10px] font-medium tracking-wider uppercase">
             First task
           </p>
@@ -185,14 +234,38 @@ function TemplateCard({
             “{template.suggestedPrompts[0]}”
           </p>
         </div>
-        <Button
-          className="mt-6 w-full"
-          variant={copied ? 'secondary' : 'default'}
-          onClick={onCopy}
-        >
-          {copied ? <Check /> : <Clipboard />}
-          {copied ? 'Agent prompt copied' : 'Copy agent prompt'}
-        </Button>
+        {available ? (
+          <div className="mt-6 space-y-2">
+            <p className="text-muted-foreground text-xs leading-5">
+              Install → login → initialize → connect Gmail → test → deploy
+            </p>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <Button
+                variant={copiedAction === 'codex' ? 'secondary' : 'default'}
+                onClick={onCopyCodex}
+              >
+                {copiedAction === 'codex' ? <Check /> : <Clipboard />}
+                {copiedAction === 'codex'
+                  ? 'Codex prompt copied'
+                  : 'Copy Codex prompt'}
+              </Button>
+              <Button
+                variant={copiedAction === 'cli' ? 'secondary' : 'outline'}
+                onClick={onCopyCli}
+              >
+                {copiedAction === 'cli' ? <Check /> : <Clipboard />}
+                {copiedAction === 'cli'
+                  ? 'CLI steps copied'
+                  : 'Copy CLI instructions'}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Button className="mt-6 w-full" variant="outline" disabled>
+            <Clock3 />
+            Coming soon
+          </Button>
+        )}
       </PanelContent>
     </Panel>
   )
@@ -204,7 +277,10 @@ export default function ManagedAgentsHome({
   startersOnly?: boolean
 }) {
   const [selectedCategory, setSelectedCategory] = useState<Category>('Comms')
-  const [copiedTemplateId, setCopiedTemplateId] = useState<string>()
+  const [copied, setCopied] = useState<{
+    templateId: string
+    action: CopyAction
+  }>()
   const [categoryOrder] = useState(() => shuffled(categories))
   const [copy] = useState(
     () => starterCopy[Math.floor(Math.random() * starterCopy.length)],
@@ -228,9 +304,13 @@ export default function ManagedAgentsHome({
   )
   const visibleTemplates = useMemo(
     () =>
-      randomizedTemplates.filter(
-        (template) => template.category === selectedCategory,
-      ),
+      randomizedTemplates
+        .filter((template) => template.category === selectedCategory)
+        .sort((left, right) => {
+          const leftAvailable = availableTemplateIds.has(left.id) ? 0 : 1
+          const rightAvailable = availableTemplateIds.has(right.id) ? 0 : 1
+          return leftAvailable - rightAvailable
+        }),
     [randomizedTemplates, selectedCategory],
   )
 
@@ -239,10 +319,22 @@ export default function ManagedAgentsHome({
       await navigator.clipboard.writeText(
         buildSetupPrompt(template, window.location.origin),
       )
-      setCopiedTemplateId(template.id)
-      toast.success(`${template.name} agent prompt copied`)
+      setCopied({ templateId: template.id, action: 'codex' })
+      toast.success(`${template.name} Codex prompt copied`)
     } catch (error) {
       notifyError("Couldn't copy the agent prompt.", error)
+    }
+  }
+
+  async function copyCliInstructions(template: ManagedAgentTemplate) {
+    try {
+      await navigator.clipboard.writeText(
+        buildCliInstructions(template, window.location.origin),
+      )
+      setCopied({ templateId: template.id, action: 'cli' })
+      toast.success(`${template.name} CLI instructions copied`)
+    } catch (error) {
+      notifyError("Couldn't copy the CLI instructions.", error)
     }
   }
 
@@ -417,8 +509,13 @@ export default function ManagedAgentsHome({
                     deployed={deployedAgents.some(
                       (agent) => agent.id === template.id,
                     )}
-                    copied={copiedTemplateId === template.id}
-                    onCopy={() => void copySetupPrompt(template)}
+                    copiedAction={
+                      copied?.templateId === template.id
+                        ? copied.action
+                        : undefined
+                    }
+                    onCopyCodex={() => void copySetupPrompt(template)}
+                    onCopyCli={() => void copyCliInstructions(template)}
                   />
                 ))}
               </div>

--- a/web/src/managed-agents/Home.tsx
+++ b/web/src/managed-agents/Home.tsx
@@ -32,7 +32,6 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
@@ -54,8 +53,6 @@ const categories = [
 ] as const
 
 type Category = (typeof categories)[number]
-type CopyAction = 'prompt' | 'cli'
-
 type CliStep = {
   title: string
   commands: string[]
@@ -186,25 +183,16 @@ function buildCliSteps(
   ]
 }
 
-function buildCliInstructions(template: ManagedAgentTemplate, origin: string) {
-  return buildCliSteps(template, origin)
-    .map(
-      (step, index) =>
-        `# ${index + 1}. ${step.title}\n${step.commands.join('\n')}`,
-    )
-    .join('\n\n')
-}
-
 function TemplateCard({
   template,
   deployed,
-  copiedAction,
+  promptCopied,
   onCopyPrompt,
   onShowCli,
 }: {
   template: ManagedAgentTemplate
   deployed: boolean
-  copiedAction?: CopyAction
+  promptCopied: boolean
   onCopyPrompt: () => void
   onShowCli: () => void
 }) {
@@ -279,13 +267,11 @@ function TemplateCard({
             </p>
             <div className="grid gap-2 sm:grid-cols-2">
               <Button
-                variant={copiedAction === 'prompt' ? 'secondary' : 'default'}
+                variant={promptCopied ? 'secondary' : 'default'}
                 onClick={onCopyPrompt}
               >
-                {copiedAction === 'prompt' ? <Check /> : <Clipboard />}
-                {copiedAction === 'prompt'
-                  ? 'Agent prompt copied'
-                  : 'Copy agent prompt'}
+                {promptCopied ? <Check /> : <Clipboard />}
+                {promptCopied ? 'Agent prompt copied' : 'Copy agent prompt'}
               </Button>
               <Button variant="outline" onClick={onShowCli}>
                 <Clipboard />
@@ -310,10 +296,8 @@ export default function ManagedAgentsHome({
   startersOnly?: boolean
 }) {
   const [selectedCategory, setSelectedCategory] = useState<Category>('Comms')
-  const [copied, setCopied] = useState<{
-    templateId: string
-    action: CopyAction
-  }>()
+  const [copiedPromptId, setCopiedPromptId] = useState<string>()
+  const [copiedCliStep, setCopiedCliStep] = useState<string>()
   const [cliTemplate, setCliTemplate] = useState<ManagedAgentTemplate>()
   const [categoryOrder] = useState(() => shuffled(categories))
   const [copy] = useState(
@@ -353,22 +337,20 @@ export default function ManagedAgentsHome({
       await navigator.clipboard.writeText(
         buildSetupPrompt(template, window.location.origin),
       )
-      setCopied({ templateId: template.id, action: 'prompt' })
+      setCopiedPromptId(template.id)
       toast.success(`${template.name} agent prompt copied`)
     } catch (error) {
       notifyError("Couldn't copy the agent prompt.", error)
     }
   }
 
-  async function copyCliInstructions(template: ManagedAgentTemplate) {
+  async function copyCliStep(template: ManagedAgentTemplate, step: CliStep) {
     try {
-      await navigator.clipboard.writeText(
-        buildCliInstructions(template, window.location.origin),
-      )
-      setCopied({ templateId: template.id, action: 'cli' })
-      toast.success(`${template.name} CLI instructions copied`)
+      await navigator.clipboard.writeText(step.commands.join('\n'))
+      setCopiedCliStep(`${template.id}:${step.title}`)
+      toast.success(`${step.title} copied`)
     } catch (error) {
-      notifyError("Couldn't copy the CLI instructions.", error)
+      notifyError("Couldn't copy this command.", error)
     }
   }
 
@@ -543,11 +525,7 @@ export default function ManagedAgentsHome({
                     deployed={deployedAgents.some(
                       (agent) => agent.id === template.id,
                     )}
-                    copiedAction={
-                      copied?.templateId === template.id
-                        ? copied.action
-                        : undefined
-                    }
+                    promptCopied={copiedPromptId === template.id}
                     onCopyPrompt={() => void copySetupPrompt(template)}
                     onShowCli={() => setCliTemplate(template)}
                   />
@@ -580,33 +558,32 @@ export default function ManagedAgentsHome({
                     </div>
                     <div className="min-w-0 flex-1 space-y-2">
                       <p className="font-medium">{step.title}</p>
-                      <pre className="bg-muted overflow-x-auto rounded-md border px-3 py-2 text-xs leading-5">
-                        <code>{step.commands.join('\n')}</code>
-                      </pre>
+                      <div className="relative">
+                        <pre className="bg-muted overflow-x-auto rounded-md border py-2 pr-11 pl-3 text-xs leading-5">
+                          <code>{step.commands.join('\n')}</code>
+                        </pre>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-sm"
+                          className="bg-muted absolute top-1.5 right-1.5"
+                          aria-label={`Copy ${step.title.toLowerCase()} commands`}
+                          onClick={() => void copyCliStep(cliTemplate, step)}
+                        >
+                          {copiedCliStep ===
+                          `${cliTemplate.id}:${step.title}` ? (
+                            <Check />
+                          ) : (
+                            <Clipboard />
+                          )}
+                        </Button>
+                      </div>
                     </div>
                   </div>
                 ),
               )}
             </div>
           ) : null}
-          <DialogFooter>
-            <Button
-              onClick={() => {
-                if (cliTemplate) void copyCliInstructions(cliTemplate)
-              }}
-            >
-              {copied?.templateId === cliTemplate?.id &&
-              copied?.action === 'cli' ? (
-                <Check />
-              ) : (
-                <Clipboard />
-              )}
-              {copied?.templateId === cliTemplate?.id &&
-              copied?.action === 'cli'
-                ? 'Instructions copied'
-                : 'Copy all instructions'}
-            </Button>
-          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>


### PR DESCRIPTION
## Summary
- make Gmail triage the only currently actionable starter template and mark the remaining templates as coming soon
- rename the generic setup action to **Copy agent prompt**
- add a step-by-step CLI setup modal with independent copy controls for each command block

## Validation
- `eslint src/managed-agents/Home.tsx`
- `npm run typecheck`
- `npm run build`
- API edge test suite: 81 passing
- API edge TypeScript check
- Wrangler deployment dry run

## Development preview
Deployed to `https://mo-oc-dev.com` as Worker version `927fe550-5dd3-432e-b1e8-1b77aa834ec9`.