### PR TITLE
Fix prod edge

### DIFF
--- a/cloudflare-workers/api-edge/wrangler.prod.toml
+++ b/cloudflare-workers/api-edge/wrangler.prod.toml
@@ -58,9 +58,31 @@ name = "CREDIT_ACCOUNT"
 class_name = "CreditAccount"
 script_name = "opencomputer-edge-prod"
 
+# Edge claim (src/pool_stock.ts): per-cell stock of pre-reserved hot pool boxes
+# so default-shape creates are answered at the edge.
+[[durable_objects.bindings]]
+name = "POOL_STOCK"
+class_name = "PoolStock"
+script_name = "opencomputer-edge-prod"
+
+# VM-DO exec data plane (src/vm_session.ts): one DO per sandbox holds the
+# host-dialed WebSocket to the QEMU worker.
+[[durable_objects.bindings]]
+name = "VM_SESSIONS"
+class_name = "VmSession"
+script_name = "opencomputer-edge-prod"
+
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["CreditAccount"]
+
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["PoolStock"]
+
+[[migrations]]
+tag = "v3"
+new_sqlite_classes = ["VmSession"]
 
 # Secrets (set via `wrangler secret put --config wrangler.prod.toml`):
 #   SESSION_JWT_SECRET     — fresh prod HMAC (DO NOT reuse dev secret)


### PR DESCRIPTION
The prod edge (wrangler.prod.toml) only bound CreditAccount — POOL_STOCK (edge-claim) and VM_SESSIONS (VM-DO exec plane) lived only in the dev wrangler.toml. So on prod, edge-claim creates fell to the cold CP path and VM-DO /connect dials 500'd: both fast paths were dead. Adds both DO bindings + migrations v2/v3 (classes already exported; ledger at v1 applies them additively). Workers already dial in a retry loop, so this flips them 500→101 on the edge redeploy.