### PR TITLE
Keep PTO agents on managed Calendar tools

### DIFF
--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -244,3 +244,17 @@ test("the PTO template creates Calendar tools without checked-in channel state",
     await rm(root, { recursive: true, force: true });
   }
 });
+
+test("an incomplete PTO project cannot be packaged without Calendar tools", async () => {
+  const root = await mkdtemp(resolve(tmpdir(), "pto-calendar-incomplete-"));
+  try {
+    await initializeAgentProject(ptoTemplate, root);
+    await rm(resolve(root, "tools", "calendar.ts"));
+    await assert.rejects(
+      buildAgentArtifact(root),
+      /opencomputer tools add calendar/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -222,6 +222,22 @@ test("the PTO template creates Calendar tools without checked-in channel state",
       await readFile(resolve(root, "opencode.json"), "utf8"),
       /calendar_create_time_off/,
     );
+    const opencode = JSON.parse(
+      await readFile(resolve(root, "opencode.json"), "utf8"),
+    ) as { permission: { bash: string } };
+    assert.equal(opencode.permission.bash, "deny");
+    assert.match(
+      await readFile(resolve(root, "agent.ts"), "utf8"),
+      /shell: "deny"/,
+    );
+    assert.match(
+      await readFile(resolve(root, "instructions.md"), "utf8"),
+      /Never[\s\S]*curl[\s\S]*managed connection/,
+    );
+    assert.match(
+      await readFile(resolve(root, "skills", "manage-pto", "SKILL.md"), "utf8"),
+      /Never use bash[\s\S]*direct Google API requests/,
+    );
     await assert.rejects(stat(resolve(root, "channels", "slack.ts")));
     await assert.rejects(stat(resolve(root, "slack", "manifest.json")));
   } finally {

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -104,6 +104,10 @@ test("the compiler maps flat source into an OpenCode runtime", async () => {
     );
     assert.match(runtimeInstructions, /You are an OpenComputer agent/);
     assert.match(runtimeInstructions, /Never direct users to OpenCode/);
+    assert.match(
+      runtimeInstructions,
+      /Never use an interactive question tool[\s\S]*normal assistant message/,
+    );
     assert.match(runtimeInstructions, /Email triage/);
     assert.equal(
       (await stat(resolve(runtime, ".opencode", "tools", "gmail.ts"))).isFile(),
@@ -138,6 +142,10 @@ test("the compiler maps flat source into an OpenCode runtime", async () => {
       (await stat(resolve(runtime, "opencode.json"))).isFile(),
       true,
     );
+    const runtimeOpenCode = JSON.parse(
+      await readFile(resolve(runtime, "opencode.json"), "utf8"),
+    ) as { tools: { question: boolean } };
+    assert.equal(runtimeOpenCode.tools.question, false);
     assert.match(runtimeInstructions, /start with the `gmail_search` tool/);
     assert.match(runtimeInstructions, /summary count exactly matches/);
     assert.equal(
@@ -224,8 +232,9 @@ test("the PTO template creates Calendar tools without checked-in channel state",
     );
     const opencode = JSON.parse(
       await readFile(resolve(root, "opencode.json"), "utf8"),
-    ) as { permission: { bash: string } };
+    ) as { permission: { bash: string }; tools: { question: boolean } };
     assert.equal(opencode.permission.bash, "deny");
+    assert.equal(opencode.tools.question, false);
     assert.match(
       await readFile(resolve(root, "agent.ts"), "utf8"),
       /shell: "deny"/,

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -1237,11 +1237,35 @@ async function collectFiles(
   return result;
 }
 
+async function validateTemplateRequirements(
+  root: string,
+  manifest: AgentManifest,
+): Promise<void> {
+  if (manifest.template !== "pto-calendar") return;
+  let calendarDeclared = false;
+  try {
+    const declaration = JSON.parse(
+      await readFile(resolve(root, "connections", "google.json"), "utf8"),
+    ) as { services?: unknown };
+    calendarDeclared =
+      Array.isArray(declaration.services) &&
+      declaration.services.includes("calendar");
+  } catch {
+    // Report one actionable error below for an incomplete PTO project.
+  }
+  if (!(await exists(resolve(root, "tools", "calendar.ts"))) || !calendarDeclared) {
+    throw new Error(
+      "PTO calendar tools are missing. Run `opencomputer tools add calendar` before deploying.",
+    );
+  }
+}
+
 export async function buildAgentArtifact(
   root: string,
 ): Promise<BuiltAgentArtifact> {
   const startedAt = performance.now();
   const manifest = await readManifest(root);
+  await validateTemplateRequirements(root, manifest);
   const runtime = await prepareAgent(root);
   const channels = await collectNames(root, "channels");
   const connections = await collectNames(root, "connections");

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -237,6 +237,10 @@ ${template.description}
 6. Report only the event details returned by Google Calendar. Never claim an
    event was created when the tool failed or returned no event ID.
 
+Use only the injected \`calendar_*\` tools for Calendar reads and writes. Never
+use shell commands, \`curl\`, or direct Google API requests: they bypass the
+user's managed connection and cannot authenticate as that user.
+
 ## Safety and user control
 
 - Never create, update, move, or delete a calendar event without fresh,
@@ -927,7 +931,7 @@ export async function initializeAgentProject(
     `export default {
   model: process.env.OPENCOMPUTER_MODEL,
   permissions: {
-    shell: "ask",
+    shell: "${template.id === "pto-calendar" ? "deny" : "ask"}",
     files: "allow",
   },
 };
@@ -939,7 +943,7 @@ export async function initializeAgentProject(
       {
         $schema: "https://opencode.ai/config.json",
         permission: {
-          bash: "ask",
+          bash: template.id === "pto-calendar" ? "deny" : "ask",
           ...(template.integrations.includes("Gmail")
             ? {
                 gmail_modify: "ask",
@@ -1097,6 +1101,10 @@ Use this workflow when the user asks to schedule or review time off.
 5. Ask for explicit confirmation of that exact proposal.
 6. Only after confirmation, call \`calendar_create_time_off\`.
 7. Report the returned event ID and link. Do not claim success without them.
+
+Use only the injected \`calendar_*\` tools. Never use bash, shell commands,
+\`curl\`, or direct Google API requests for Calendar operations. Those paths do
+not carry the user's managed Calendar identity.
 
 Calendar connections are injected by OpenComputer at runtime. If none is
 available, use the OpenComputer connection request tool with service

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -942,6 +942,9 @@ export async function initializeAgentProject(
     `${JSON.stringify(
       {
         $schema: "https://opencode.ai/config.json",
+        tools: {
+          question: false,
+        },
         permission: {
           bash: template.id === "pto-calendar" ? "deny" : "ask",
           ...(template.integrations.includes("Gmail")
@@ -1166,6 +1169,9 @@ the product or support surface presented to users.
 - Identify yourself and your environment as OpenComputer.
 - Never direct users to OpenCode commands, settings, websites, repositories,
   issue trackers, or support channels.
+- Never use an interactive question tool. Ask clarification questions in a
+  normal assistant message, then end the turn so the user can reply through
+  the current OpenComputer interface.
 - Before saying an external account is unavailable, use the built-in
   OpenComputer connection tools to list or request the required connection.
 - When the user asks for another account of the same service, request a new
@@ -1181,7 +1187,28 @@ ${await readFile(resolve(root, "instructions.md"), "utf8")}`,
   );
   const openCodeConfig = resolve(root, "opencode.json");
   if (await exists(openCodeConfig)) {
-    await cp(openCodeConfig, resolve(runtime, "opencode.json"));
+    const parsed: unknown = JSON.parse(await readFile(openCodeConfig, "utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("opencode.json must contain a JSON object");
+    }
+    const config = parsed as Record<string, unknown>;
+    const configuredTools =
+      config.tools &&
+      typeof config.tools === "object" &&
+      !Array.isArray(config.tools)
+        ? (config.tools as Record<string, unknown>)
+        : {};
+    await writeFile(
+      resolve(runtime, "opencode.json"),
+      `${JSON.stringify(
+        {
+          ...config,
+          tools: { ...configuredTools, question: false },
+        },
+        null,
+        2,
+      )}\n`,
+    );
   }
   for (const directory of ["skills", "tools"]) {
     const source = resolve(root, directory);


### PR DESCRIPTION
Prevents PTO agents from bypassing identity-bound Calendar tools with bash or curl. Newly initialized PTO projects deny shell/bash, instructions explicitly require calendar_* tools, and packaging rejects incomplete PTO projects with an actionable opencomputer tools add calendar message.\n\nExisting project repair: opencomputer tools add calendar, then opencomputer deploy.\n\nValidation: full CLI build and all 12 CLI tests pass.