### PR TITLE
Fix PTO tool policy and publish CLI 0.3.11

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/cli",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "dependencies": {
         "@opencode-ai/sdk": "1.18.4",
         "@opentui/core": "^0.4.5",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Build, test, connect, deploy, and share OpenComputer agents as code.",
   "type": "module",
   "bin": {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,7 +2,7 @@
 
 import { runCommand, type GlobalOptions } from "./commands.js";
 
-const VERSION = "0.3.10";
+const VERSION = "0.3.11";
 
 const BANNER = String.raw`   ____                   ______                            __
   / __ \____  ___  ____  / ____/___  ____ ___  ____  __  / /____  _____

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -106,7 +106,7 @@ test("the compiler maps flat source into an OpenCode runtime", async () => {
     assert.match(runtimeInstructions, /Never direct users to OpenCode/);
     assert.match(
       runtimeInstructions,
-      /Never use an interactive question tool[\s\S]*normal assistant message/,
+      /Use the question tool[\s\S]*resumes when the user replies/,
     );
     assert.match(runtimeInstructions, /Email triage/);
     assert.equal(
@@ -156,6 +156,38 @@ test("the compiler maps flat source into an OpenCode runtime", async () => {
       (await stat(resolve(runtime, "README.md"))).isFile(),
       true,
     );
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+test("the compiler preserves an explicit question denial", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-runtime-"));
+  const root = resolve(parent, "no-questions");
+  try {
+    await initializeAgentProject(emailTemplate, root);
+    const sourceConfig = JSON.parse(
+      await readFile(resolve(root, "opencode.json"), "utf8"),
+    ) as {
+      tools: Record<string, unknown>;
+      permission: Record<string, unknown>;
+    };
+    sourceConfig.tools.question = false;
+    sourceConfig.permission.question = "deny";
+    await writeFile(
+      resolve(root, "opencode.json"),
+      `${JSON.stringify(sourceConfig, null, 2)}\n`,
+    );
+
+    const runtime = await prepareAgent(root);
+    const runtimeConfig = JSON.parse(
+      await readFile(resolve(runtime, "opencode.json"), "utf8"),
+    ) as {
+      tools: { question: boolean };
+      permission: { question: string };
+    };
+    assert.equal(runtimeConfig.tools.question, false);
+    assert.equal(runtimeConfig.permission.question, "deny");
   } finally {
     await rm(parent, { recursive: true, force: true });
   }

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -144,8 +144,12 @@ test("the compiler maps flat source into an OpenCode runtime", async () => {
     );
     const runtimeOpenCode = JSON.parse(
       await readFile(resolve(runtime, "opencode.json"), "utf8"),
-    ) as { tools: { question: boolean } };
-    assert.equal(runtimeOpenCode.tools.question, false);
+    ) as {
+      tools: { question: boolean };
+      permission: { question: string; calendar_create_time_off?: string };
+    };
+    assert.equal(runtimeOpenCode.tools.question, true);
+    assert.equal(runtimeOpenCode.permission.question, "allow");
     assert.match(runtimeInstructions, /start with the `gmail_search` tool/);
     assert.match(runtimeInstructions, /summary count exactly matches/);
     assert.equal(
@@ -232,9 +236,18 @@ test("the PTO template creates Calendar tools without checked-in channel state",
     );
     const opencode = JSON.parse(
       await readFile(resolve(root, "opencode.json"), "utf8"),
-    ) as { permission: { bash: string }; tools: { question: boolean } };
+    ) as {
+      permission: { bash: string; question: string };
+      tools: { question: boolean };
+    };
     assert.equal(opencode.permission.bash, "deny");
-    assert.equal(opencode.tools.question, false);
+    assert.equal(opencode.permission.question, "allow");
+    assert.equal(
+      (opencode.permission as { calendar_create_time_off?: string })
+        .calendar_create_time_off,
+      "allow",
+    );
+    assert.equal(opencode.tools.question, true);
     assert.match(
       await readFile(resolve(root, "agent.ts"), "utf8"),
       /shell: "deny"/,

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -943,9 +943,10 @@ export async function initializeAgentProject(
       {
         $schema: "https://opencode.ai/config.json",
         tools: {
-          question: false,
+          question: true,
         },
         permission: {
+          question: "allow",
           bash: template.id === "pto-calendar" ? "deny" : "ask",
           ...(template.integrations.includes("Gmail")
             ? {
@@ -955,7 +956,7 @@ export async function initializeAgentProject(
             : {}),
           ...(template.integrations.includes("Google Calendar")
             ? {
-                calendar_create_time_off: "ask",
+                calendar_create_time_off: "allow",
               }
             : {}),
         },
@@ -1198,12 +1199,25 @@ ${await readFile(resolve(root, "instructions.md"), "utf8")}`,
       !Array.isArray(config.tools)
         ? (config.tools as Record<string, unknown>)
         : {};
+    const configuredPermission =
+      config.permission &&
+      typeof config.permission === "object" &&
+      !Array.isArray(config.permission)
+        ? (config.permission as Record<string, unknown>)
+        : {};
     await writeFile(
       resolve(runtime, "opencode.json"),
       `${JSON.stringify(
         {
           ...config,
-          tools: { ...configuredTools, question: false },
+          tools: { ...configuredTools, question: true },
+          permission: {
+            ...configuredPermission,
+            ...(configuredPermission.calendar_create_time_off === "ask"
+              ? { calendar_create_time_off: "allow" }
+              : {}),
+            question: "allow",
+          },
         },
         null,
         2,

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -1170,9 +1170,8 @@ the product or support surface presented to users.
 - Identify yourself and your environment as OpenComputer.
 - Never direct users to OpenCode commands, settings, websites, repositories,
   issue trackers, or support channels.
-- Never use an interactive question tool. Ask clarification questions in a
-  normal assistant message, then end the turn so the user can reply through
-  the current OpenComputer interface.
+- Use the question tool when structured clarification is useful. OpenComputer
+  delivers it through the current chat and resumes when the user replies.
 - Before saying an external account is unavailable, use the built-in
   OpenComputer connection tools to list or request the required connection.
 - When the user asks for another account of the same service, request a new
@@ -1205,18 +1204,21 @@ ${await readFile(resolve(root, "instructions.md"), "utf8")}`,
       !Array.isArray(config.permission)
         ? (config.permission as Record<string, unknown>)
         : {};
+    const questionDenied =
+      configuredTools.question === false ||
+      configuredPermission.question === "deny";
     await writeFile(
       resolve(runtime, "opencode.json"),
       `${JSON.stringify(
         {
           ...config,
-          tools: { ...configuredTools, question: true },
+          tools: { ...configuredTools, question: !questionDenied },
           permission: {
             ...configuredPermission,
             ...(configuredPermission.calendar_create_time_off === "ask"
               ? { calendar_create_time_off: "allow" }
               : {}),
-            question: "allow",
+            question: questionDenied ? "deny" : "allow",
           },
         },
         null,


### PR DESCRIPTION
## Summary
- publish CLI 0.3.11
- keep the question tool enabled for hosted chat bridging
- deny shell access for the PTO template
- allow the managed calendar write tool after conversational confirmation

## Validation
- CLI test suite: 12 passed