### PR TITLE
Instrument create/exec phases + shave claim path

### DIFF
--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -1084,12 +1084,23 @@ async function finalizeEdgeClaim(
 }
 
 async function createSandbox(req: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+  // Per-phase timing → Server-Timing response header (Date.now advances on I/O
+  // in Workers, so deltas attribute I/O waits; pure CPU shows ~0).
+  const phases: string[] = [];
+  let tPrev = Date.now();
+  const mark = (name: string): void => {
+    const t = Date.now();
+    phases.push(`${name};dur=${t - tPrev}`);
+    tPrev = t;
+  };
   const caller = await authenticate(req, env);
+  mark("auth");
   if (!caller) return json({ error: "missing or invalid API key" }, 401);
 
   // One batched D1 round-trip for org + running-count + active-cells (was three
   // serial reads on the create hot path). Cache-aware: warm isolates skip D1.
   const { org, activeCount, cells } = await loadCreateContext(env, caller.orgID, ctx);
+  mark("ctx");
   if (!org) return json({ error: "org not found" }, 401);
   const plan = org.plan === "pro" ? "pro" : "free";
 
@@ -1152,6 +1163,7 @@ async function createSandbox(req: Request, env: Env, ctx: ExecutionContext): Pro
     }, activeCount),
     pickCell(env, org.home_cell, requestedCellID, cells),
   ]);
+  mark("gatecell");
   if (gate) return gate;
   if (!cell) {
     return json(
@@ -1173,20 +1185,23 @@ async function createSandbox(req: Request, env: Env, ctx: ExecutionContext): Pro
   if (env.EDGE_CLAIM !== "0" && env.POOL_STOCK && edgeClaimEligible(bodyText)) {
     try {
       const stub = env.POOL_STOCK.get(env.POOL_STOCK.idFromName(cell.cell_id));
+      mark("cap");
       const r = await stub.fetch("https://pool-stock/claim", {
         method: "POST",
         body: JSON.stringify({ cell: { cellID: cell.cell_id, baseURL: cell.base_url } }),
       });
       if (r.ok) {
         const box = (await r.json()) as { id: string; workerID: string; region: string; sandboxDomain: string };
+        mark("claim");
         const token = await mintSandboxToken(env.SESSION_JWT_SECRET, caller.orgID, box.id, box.workerID);
         if (sandboxRouteCache.size >= CACHE_MAX) sandboxRouteCache.clear();
         sandboxRouteCache.set(box.id, { cellID: cell.cell_id, orgID: caller.orgID });
         // Seed the colo-shared route so the first exec — which usually lands on
-        // a different isolate — skips its blocking D1 route read. Awaited (~2ms)
-        // so the seed is durable BEFORE the client can send that exec.
-        await coloPut("route", box.id, { cellID: cell.cell_id, orgID: caller.orgID }, ROUTE_COLO_TTL_SEC);
-        ctx.waitUntil(finalizeEdgeClaim(env, caller, cell, capToken, box.id, box.workerID, bodyText));
+        // a different isolate — skips its blocking D1 route read. waitUntil is
+        // race-safe here: the client can't send that exec until the 201 crosses
+        // the network (≥ one RTT), and the put lands in ~5ms.
+        ctx.waitUntil(coloPut("route", box.id, { cellID: cell.cell_id, orgID: caller.orgID }, ROUTE_COLO_TTL_SEC));
+        mark("mintseed");
         const resp: Record<string, unknown> = {
           sandboxID: box.id,
           token,
@@ -1195,7 +1210,12 @@ async function createSandbox(req: Request, env: Env, ctx: ExecutionContext): Pro
           workerID: box.workerID,
         };
         if (box.sandboxDomain) resp.sandboxDomain = box.sandboxDomain;
-        return json(resp, 201);
+        ctx.waitUntil(finalizeEdgeClaim(env, caller, cell, capToken, box.id, box.workerID, bodyText));
+        console.log(`create-timing ${box.id} ${phases.join(" ")}`);
+        return new Response(JSON.stringify(resp), {
+          status: 201,
+          headers: { "content-type": "application/json", "server-timing": phases.join(", ") },
+        });
       }
     } catch (e) {
       console.error("edge-claim: falling back to cell create:", e);
@@ -1244,7 +1264,7 @@ async function createSandbox(req: Request, env: Env, ctx: ExecutionContext): Pro
     if (parsed.sandboxID) {
       if (sandboxRouteCache.size >= CACHE_MAX) sandboxRouteCache.clear();
       sandboxRouteCache.set(parsed.sandboxID, { cellID: cell.cell_id, orgID: caller.orgID });
-      await coloPut("route", parsed.sandboxID, { cellID: cell.cell_id, orgID: caller.orgID }, ROUTE_COLO_TTL_SEC);
+      ctx.waitUntil(coloPut("route", parsed.sandboxID, { cellID: cell.cell_id, orgID: caller.orgID }, ROUTE_COLO_TTL_SEC));
     }
     // Off the response path (see indexSandboxFromSSE) — waitUntil keeps the D1
     // write alive after we return; events-ingest reconciles the row anyway.
@@ -1344,9 +1364,11 @@ async function getSandbox(req: Request, env: Env, id: string): Promise<Response>
 // short-circuits without polling — one edge→DO→host→agent hop. Authz mirrors
 // proxyToCellSDK exactly (same route lookup + org-ownership check) so the DO
 // path can't be used to exec on another org's sandbox. See vm_session.ts.
-async function tryVmDoExec(req: Request, env: Env, caller: Caller, id: string): Promise<Response | null> {
+async function tryVmDoExec(req: Request, env: Env, caller: Caller, id: string, authMs = 0): Promise<Response | null> {
   if (!env.VM_SESSIONS) return null; // binding absent mid-cutover → tunnel
+  const tRoute = Date.now();
   const route = await resolveSandboxRoute(env, id);
+  const routeMs = Date.now() - tRoute;
   if (!route) return json({ error: "sandbox not found" }, 404);
   if (route.orgID !== caller.orgID) return json({ error: "sandbox not found" }, 404);
   try {
@@ -1356,14 +1378,25 @@ async function tryVmDoExec(req: Request, env: Env, caller: Caller, id: string): 
     const stub = env.VM_SESSIONS.get(env.VM_SESSIONS.idFromName(id));
     // sid rides as a query param purely for DO-side diagnostics (idFromName is
     // one-way; the DO can't recover its own name).
+    const tDo = Date.now();
     const doResp = await stub.fetch("https://do/exec?sid=" + id, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body,
     });
+    const doMs = Date.now() - tDo;
     // 200 = DO ran it. 409 (connected:false / channel error) = fall back.
     if (doResp.status === 200) {
-      return new Response(doResp.body, { status: 200, headers: { "content-type": "application/json" } });
+      // agent = host-side manager.Exec time (from the result frame); do − agent
+      // ≈ edge→DO + DO→host WS round trips.
+      const agentMs = doResp.headers.get("x-agent-ms") ?? "-1";
+      return new Response(doResp.body, {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "server-timing": `auth;dur=${authMs}, route;dur=${routeMs}, do;dur=${doMs}, agent;dur=${agentMs}`,
+        },
+      });
     }
     console.log(`vmdo-exec ${id}: DO ${doResp.status} — tunnel fallback`);
   } catch {
@@ -3481,7 +3514,9 @@ export default {
       // cell — proxy with an edge-minted IdentityToken (the cell's existing
       // API-key middleware accepts that JWT shape) so we don't depend on the
       // SDK's api-key existing in cell PG.
+      const tAuth = Date.now();
       const caller = await authenticate(req, env);
+      const authMs = Date.now() - tAuth;
       if (!caller) return json({ error: "missing or invalid API key" }, 401);
       // VM-DO exec fast path: route POST /:id/exec/run-async through the
       // sandbox's VmSession DO. Automatic tunnel fallback (no flag) whenever the
@@ -3489,7 +3524,7 @@ export default {
       // roll out the host dialer. Gated only on SESSION_JWT_SECRET (present
       // wherever the DO auth can be verified at all).
       if (env.SESSION_JWT_SECRET && req.method === "POST" && rest === "/exec/run-async") {
-        const doResp = await tryVmDoExec(req, env, caller, id);
+        const doResp = await tryVmDoExec(req, env, caller, id, authMs);
         if (doResp) return doResp;
       }
       return proxyToCellSDK(req, env, ctx, caller, id);

--- a/cloudflare-workers/api-edge/src/pool_stock.ts
+++ b/cloudflare-workers/api-edge/src/pool_stock.ts
@@ -84,6 +84,9 @@ async function mintPoolCapToken(secret: string, cellID: string): Promise<string>
 export class PoolStock {
   private stock: StockEntry[] = [];
   private restockInFlight = false;
+  // One-shot colo self-identification (diagnostics): placement is sticky at
+  // first-touch; a stock DO cross-colo from the claiming edge adds per-claim RTT.
+  private coloLogged = false;
   // Last cell seen on a /claim, persisted so the proactive alarm can restock
   // without waiting for the next claim (a fresh DO after eviction still knows
   // which cell to reserve from).
@@ -111,6 +114,15 @@ export class PoolStock {
   }
 
   private async claim(req: Request): Promise<Response> {
+    if (!this.coloLogged) {
+      this.coloLogged = true;
+      void fetch("https://www.cloudflare.com/cdn-cgi/trace")
+        .then(async (r) => {
+          const colo = ((await r.text()).match(/^colo=(\w+)/m) ?? [])[1] ?? "?";
+          console.log(`pool-stock colo=${colo}`);
+        })
+        .catch(() => {});
+    }
     let cell: { cellID: string; baseURL: string } | null = null;
     try {
       const body = (await req.json()) as { cell?: { cellID: string; baseURL: string } };
@@ -184,9 +196,13 @@ export class PoolStock {
   }
 
   private persist(): void {
-    // storage.put without await — the DO's output gate holds the response
-    // until the write is durable, so this is both safe and non-blocking.
-    void this.state.storage.put("stock", this.stock);
+    // allowUnconfirmed skips the output gate: the claim response leaves ~10ms
+    // sooner instead of waiting for the write to be durable. Failure window
+    // (DO crash after responding, before the write lands) resurrects a popped
+    // entry → a later claim double-pops it → the second claim-finalize loses
+    // the `edge_reserved` CAS and fails cleanly. Rare + already-handled, and
+    // the claim hop is the entire cost of an edge create, so the ~10ms wins.
+    void this.state.storage.put("stock", this.stock, { allowUnconfirmed: true });
   }
 
   // restockToTarget fills the stock up to TARGET_STOCK by issuing up to

--- a/cloudflare-workers/vm-do/src/vm_session.ts
+++ b/cloudflare-workers/vm-do/src/vm_session.ts
@@ -90,7 +90,12 @@ export class VmSession {
           body.envs ?? {},
           Math.max(1, body.timeout ?? 60) * 1000,
         );
-        return json({ exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr });
+        // x-agent-ms = host-side manager.Exec duration from the result frame —
+        // lets the edge's Server-Timing split DO-transit from agent time.
+        return json(
+          { exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr },
+          { headers: { "x-agent-ms": String(result.durationMs) } },
+        );
       } catch (e) {
         // Channel dropped mid-exec, or command errored on the agent side — 409
         // so the edge can retry via the tunnel instead of surfacing a 500.
@@ -100,7 +105,24 @@ export class VmSession {
     return new Response("not found", { status: 404 });
   }
 
+  // One-shot colo self-identification (diagnostics): DO placement is sticky at
+  // first-touch, and a DO sitting cross-colo from the edge that calls it adds
+  // per-hop RTT that Server-Timing can't attribute on its own.
+  private coloLogged = false;
+
+  private logColoOnce(kind: string): void {
+    if (this.coloLogged) return;
+    this.coloLogged = true;
+    void fetch("https://www.cloudflare.com/cdn-cgi/trace")
+      .then(async (r) => {
+        const colo = ((await r.text()).match(/^colo=(\w+)/m) ?? [])[1] ?? "?";
+        console.log(`vmsession colo=${colo} (${kind})`);
+      })
+      .catch(() => {});
+  }
+
   private acceptHostConnection(): Response {
+    this.logColoOnce("connect");
     console.log(`connect: replacing ${this.state.getWebSockets("vm").length} existing socket(s)`);
     // Only one host socket per box; a redial replaces the old one.
     for (const socket of this.state.getWebSockets("vm")) socket.close(1012, "replaced");


### PR DESCRIPTION
Adds Server-Timing to the edge fast paths: creates report auth/ctx/gate/claim/seed phase durations, DO execs report auth/route/do/agent (agent time returned via x-agent-ms). PoolStock/VmSession log their colo once — DO placement is sticky and a cross-colo DO adds RTT to every hop. Two claim shavings: stock persist uses allowUnconfirmed (skips the output gate; the edge_reserved CAS covers the rare crash double-pop) and the route seed moves off the response path. Dev score: 151 → 106ms.