### PR TITLE
feat: simplify navigation for new users

### DIFF
--- a/cloudflare-workers/api-edge/migrations/0004_user_navigation_preferences.sql
+++ b/cloudflare-workers/api-edge/migrations/0004_user_navigation_preferences.sql
@@ -1,0 +1,12 @@
+-- Keep advanced navigation out of the default experience for new users.
+-- Existing users retain both advanced navigation sections after this migration.
+
+ALTER TABLE users
+  ADD COLUMN durable_sessions_enabled INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE users
+  ADD COLUMN infrastructure_enabled INTEGER NOT NULL DEFAULT 0;
+
+UPDATE users
+SET durable_sessions_enabled = 1,
+    infrastructure_enabled = 1;

--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -362,8 +362,16 @@ async function handleMe(req: Request, env: DashboardEnv, caller: Caller): Promis
   // Load user + org list. Org list joins via org_memberships; each row carries
   // the active flag so the UI can highlight the current org.
   const user = await env.OPENCOMPUTER_DB.prepare(
-    `SELECT id, email, name, workos_user_id FROM users WHERE id = ?1`,
-  ).bind(caller.userID).first<{ id: string; email: string; name: string | null; workos_user_id: string | null }>();
+    `SELECT id, email, name, workos_user_id, durable_sessions_enabled, infrastructure_enabled
+       FROM users WHERE id = ?1`,
+  ).bind(caller.userID).first<{
+    id: string;
+    email: string;
+    name: string | null;
+    workos_user_id: string | null;
+    durable_sessions_enabled: number;
+    infrastructure_enabled: number;
+  }>();
   if (!user) return json({ error: "user not found" }, 404);
 
   const { results } = await env.OPENCOMPUTER_DB.prepare(
@@ -376,8 +384,44 @@ async function handleMe(req: Request, env: DashboardEnv, caller: Caller): Promis
   }));
 
   return json({
-    id: user.id, email: user.email, name: user.name, orgId: caller.orgID, orgs,
+    id: user.id,
+    email: user.email,
+    name: user.name,
+    orgId: caller.orgID,
+    orgs,
+    durableSessionsEnabled: !!user.durable_sessions_enabled,
+    infrastructureEnabled: !!user.infrastructure_enabled,
   });
+}
+
+async function handleUpdateMePreferences(req: Request, env: DashboardEnv, caller: Caller): Promise<Response> {
+  type PreferenceUpdate = {
+    durableSessionsEnabled?: unknown;
+    infrastructureEnabled?: unknown;
+  };
+  const body = await req.json<PreferenceUpdate>().catch(() => ({} as PreferenceUpdate));
+  if (body.durableSessionsEnabled !== undefined && typeof body.durableSessionsEnabled !== "boolean") {
+    return json({ error: "durableSessionsEnabled must be a boolean" }, 400);
+  }
+  if (body.infrastructureEnabled !== undefined && typeof body.infrastructureEnabled !== "boolean") {
+    return json({ error: "infrastructureEnabled must be a boolean" }, 400);
+  }
+  if (body.durableSessionsEnabled === undefined && body.infrastructureEnabled === undefined) {
+    return json({ error: "at least one navigation preference is required" }, 400);
+  }
+  await env.OPENCOMPUTER_DB.prepare(
+    `UPDATE users
+        SET durable_sessions_enabled = COALESCE(?1, durable_sessions_enabled),
+            infrastructure_enabled = COALESCE(?2, infrastructure_enabled)
+      WHERE id = ?3`,
+  )
+    .bind(
+      typeof body.durableSessionsEnabled === "boolean" ? Number(body.durableSessionsEnabled) : null,
+      typeof body.infrastructureEnabled === "boolean" ? Number(body.infrastructureEnabled) : null,
+      caller.userID,
+    )
+    .run();
+  return handleMe(req, env, caller);
 }
 
 async function handleListOrgs(_req: Request, env: DashboardEnv, caller: Caller): Promise<Response> {
@@ -401,9 +445,14 @@ async function handleGetOrg(_req: Request, env: DashboardEnv, caller: Caller): P
 }
 
 async function handleUpdateOrg(req: Request, env: DashboardEnv, caller: Caller): Promise<Response> {
-  const body = await req.json<{ name?: string }>().catch(() => ({} as { name?: string }));
-  const name = (body.name ?? "").trim();
-  if (!name) return json({ error: "name is required" }, 400);
+  type OrgUpdate = { name?: unknown };
+  const body = await req.json<OrgUpdate>().catch(() => ({} as OrgUpdate));
+  if (body.name !== undefined && typeof body.name !== "string") {
+    return json({ error: "name must be a string" }, 400);
+  }
+  const name = typeof body.name === "string" ? body.name.trim() : undefined;
+  if (body.name !== undefined && !name) return json({ error: "name is required" }, 400);
+  if (name === undefined) return json({ error: "name is required" }, 400);
   const org = await env.OPENCOMPUTER_DB.prepare(`SELECT owner_user_id, workos_org_id FROM orgs WHERE id = ?1`).bind(caller.orgID).first<{ owner_user_id: string | null; workos_org_id: string | null }>();
   if (!org) return json({ error: "org not found" }, 404);
   if (org.owner_user_id !== caller.userID) return json({ error: "only owner can rename" }, 403);
@@ -412,7 +461,7 @@ async function handleUpdateOrg(req: Request, env: DashboardEnv, caller: Caller):
     .bind(name, Math.floor(Date.now() / 1000), caller.orgID).run();
 
   // Best-effort WorkOS sync. Errors logged, not surfaced.
-  if (org.workos_org_id) {
+  if (name && org.workos_org_id) {
     workosUpdateOrg(env, org.workos_org_id, name).catch((e) => console.error("workos org update failed", e));
   }
   const updated = await env.OPENCOMPUTER_DB.prepare(`SELECT * FROM orgs WHERE id = ?1`).bind(caller.orgID).first<OrgRow>();
@@ -958,6 +1007,7 @@ export async function handleDashboard(
   // ── identity / org ─────────────────────────────────────────────────────
   if (sub === "/me" && method === "GET") return handleMe(req, env, caller);
   if (sub === "/orgs" && method === "GET") return handleListOrgs(req, env, caller);
+  if (sub === "/me/preferences" && method === "PUT") return handleUpdateMePreferences(req, env, caller);
   if (sub === "/org" && method === "GET") return handleGetOrg(req, env, caller);
   if (sub === "/org" && method === "PUT") return handleUpdateOrg(req, env, caller);
   if (sub === "/org/switch" && method === "POST") return handleOrgSwitch(req, env, caller);

--- a/cloudflare-workers/api-edge/src/dashboard_preferences.test.ts
+++ b/cloudflare-workers/api-edge/src/dashboard_preferences.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { handleDashboard, type DashboardEnv } from "./dashboard";
+
+const secret = "dashboard-preferences-test-secret";
+const userID = "user-1";
+const orgID = "org-1";
+
+function b64url(value: string | ArrayBuffer): string {
+  const bytes =
+    typeof value === "string"
+      ? new TextEncoder().encode(value)
+      : new Uint8Array(value);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+async function sessionToken(): Promise<string> {
+  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = b64url(
+    JSON.stringify({
+      sub: userID,
+      iss: "opensandbox-session",
+      org_id: orgID,
+      user_id: userID,
+      plan: "free",
+      iat: 1,
+      exp: Math.floor(Date.now() / 1000) + 60,
+    }),
+  );
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(`${header}.${payload}`),
+  );
+  return `${header}.${payload}.${b64url(signature)}`;
+}
+
+function testEnv() {
+  const preferences = {
+    durableSessionsEnabled: false,
+    infrastructureEnabled: true,
+  };
+
+  class Statement {
+    private args: unknown[] = [];
+
+    constructor(private readonly sql: string) {}
+
+    bind(...args: unknown[]) {
+      this.args = args;
+      return this;
+    }
+
+    async first<T>(): Promise<T | null> {
+      if (this.sql.includes("FROM users WHERE id")) {
+        return {
+          id: userID,
+          email: "person@example.com",
+          name: "Person",
+          workos_user_id: "workos-1",
+          durable_sessions_enabled: Number(preferences.durableSessionsEnabled),
+          infrastructure_enabled: Number(preferences.infrastructureEnabled),
+        } as T;
+      }
+      return null;
+    }
+
+    async all<T>() {
+      if (this.sql.includes("JOIN org_memberships")) {
+        return {
+          results: [{ id: orgID, name: "Personal", is_personal: 1 }] as T[],
+        };
+      }
+      return { results: [] as T[] };
+    }
+
+    async run() {
+      if (this.sql.includes("UPDATE users")) {
+        if (this.args[0] !== null) {
+          preferences.durableSessionsEnabled = this.args[0] === 1;
+        }
+        if (this.args[1] !== null) {
+          preferences.infrastructureEnabled = this.args[1] === 1;
+        }
+      }
+      return {};
+    }
+  }
+
+  const env = {
+    SESSION_JWT_SECRET: secret,
+    OPENCOMPUTER_DB: {
+      prepare: (sql: string) => new Statement(sql),
+    },
+  } as unknown as DashboardEnv;
+
+  return { env, preferences };
+}
+
+async function request(body: unknown): Promise<Request> {
+  return new Request("https://app.test/api/dashboard/me/preferences", {
+    method: "PUT",
+    headers: {
+      cookie: `oc_session=${await sessionToken()}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("dashboard navigation preferences", () => {
+  it("updates one preference without changing the other", async () => {
+    const { env, preferences } = testEnv();
+    const response = await handleDashboard(
+      await request({ durableSessionsEnabled: true }),
+      env,
+      {} as ExecutionContext,
+      "/api/dashboard/me/preferences",
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      durableSessionsEnabled: true,
+      infrastructureEnabled: true,
+    });
+    expect(preferences).toEqual({
+      durableSessionsEnabled: true,
+      infrastructureEnabled: true,
+    });
+  });
+
+  it("rejects non-boolean preferences", async () => {
+    const { env, preferences } = testEnv();
+    const response = await handleDashboard(
+      await request({ infrastructureEnabled: "yes" }),
+      env,
+      {} as ExecutionContext,
+      "/api/dashboard/me/preferences",
+    );
+
+    expect(response.status).toBe(400);
+    expect(preferences.infrastructureEnabled).toBe(true);
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -334,11 +334,29 @@ export function streamSandboxLogs(
 
 export const getOrg = () => apiFetch('/org', {}, S.OrgSchema)
 
-export const updateOrg = (name: string) =>
+export type OrgUpdate = {
+  name?: string
+}
+
+export const updateOrg = (updates: OrgUpdate) =>
   apiFetch(
     '/org',
-    { method: 'PUT', body: JSON.stringify({ name }) },
+    { method: 'PUT', body: JSON.stringify(updates) },
     S.OrgSchema,
+  )
+
+export type NavigationPreferenceUpdate = {
+  durableSessionsEnabled?: boolean
+  infrastructureEnabled?: boolean
+}
+
+export const updateNavigationPreferences = (
+  updates: NavigationPreferenceUpdate,
+) =>
+  apiFetch(
+    '/me/preferences',
+    { method: 'PUT', body: JSON.stringify(updates) },
+    S.MeResponseSchema,
   )
 
 export const setCustomDomain = (domain: string) =>

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -21,6 +21,8 @@ const me = {
   id: 'user_2abc',
   email: 'igor@digger.dev',
   orgId: 'org_digger',
+  durableSessionsEnabled: true,
+  infrastructureEnabled: true,
   orgs: [
     { id: 'org_digger', name: 'Digger', isPersonal: false, isActive: true },
     { id: 'org_personal', name: 'Personal', isPersonal: true, isActive: false },
@@ -1552,6 +1554,13 @@ const POST_ROUTES: [RegExp, () => unknown][] = [
 
 export function mockFetch<T>(path: string, options: RequestInit = {}): T {
   const method = (options.method ?? 'GET').toUpperCase()
+  if (method === 'PUT' && path === '/me/preferences') {
+    const updates = JSON.parse(String(options.body ?? '{}')) as Partial<
+      Pick<typeof me, 'durableSessionsEnabled' | 'infrastructureEnabled'>
+    >
+    Object.assign(me, updates)
+    return me as T
+  }
   if (method !== 'GET') {
     for (const [re, handler] of POST_ROUTES) {
       if (re.test(path)) return handler() as T

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -19,6 +19,8 @@ export const MeResponseSchema = z.object({
   email: z.string(),
   orgId: z.string(),
   orgs: z.array(OrgInfoSchema).optional(),
+  durableSessionsEnabled: z.boolean(),
+  infrastructureEnabled: z.boolean(),
   authMode: z.string().optional(),
   capabilities: z
     .object({

--- a/web/src/components/app-shell.test.ts
+++ b/web/src/components/app-shell.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { managedAgentsNav } from './app-shell'
+
+describe('managed agents navigation', () => {
+  it('shows only unlabeled agents and connections by default', () => {
+    const nav = managedAgentsNav({
+      durableSessionsEnabled: false,
+      infrastructureEnabled: false,
+    })
+
+    expect(nav.map((group) => group.label)).toEqual([undefined])
+    expect(nav[0]?.collapsible).toBeUndefined()
+    expect(nav[0]?.items.map((item) => item.label)).toEqual([
+      'Agents',
+      'Connections',
+    ])
+  })
+
+  it('reveals each advanced group independently', () => {
+    expect(
+      managedAgentsNav({
+        durableSessionsEnabled: true,
+        infrastructureEnabled: false,
+      }).map((group) => group.label),
+    ).toContain('Durable sessions')
+
+    expect(
+      managedAgentsNav({
+        durableSessionsEnabled: false,
+        infrastructureEnabled: true,
+      }).map((group) => group.label),
+    ).toContain('Infrastructure')
+  })
+})

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -29,7 +29,6 @@ import {
   CircleAlert,
   ChevronRight,
   Plug,
-  Radio,
   type LucideIcon,
 } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
@@ -128,20 +127,12 @@ const LEGACY_NAV: NavGroup[] = [
 
 const MANAGED_AGENTS_NAV: NavGroup[] = [
   {
-    label: 'Serverless agents',
-    collapsible: true,
-    landingTo: '/',
     items: [
       { to: '/', label: 'Agents', icon: Bot, end: true },
       {
         to: '/managed-agents/connections',
         label: 'Connections',
         icon: Plug,
-      },
-      {
-        to: '/managed-agents/channels',
-        label: 'Channels',
-        icon: Radio,
       },
     ],
   },
@@ -177,15 +168,22 @@ const MANAGED_AGENTS_NAV: NavGroup[] = [
       { to: '/browsers', label: 'Browsers', icon: Monitor },
     ],
   },
-  {
-    label: 'Account',
-    items: [
-      { to: '/api-keys', label: 'API Keys', icon: KeyRound },
-      { to: '/billing', label: 'Billing', icon: CreditCard },
-      { to: '/settings', label: 'Settings', icon: Settings },
-    ],
-  },
 ]
+
+export function managedAgentsNav(preferences: {
+  durableSessionsEnabled: boolean
+  infrastructureEnabled: boolean
+}): NavGroup[] {
+  return MANAGED_AGENTS_NAV.filter((group) => {
+    if (group.label === 'Durable sessions') {
+      return preferences.durableSessionsEnabled
+    }
+    if (group.label === 'Infrastructure') {
+      return preferences.infrastructureEnabled
+    }
+    return true
+  })
+}
 
 function Brand() {
   return (
@@ -252,23 +250,86 @@ function OrgSwitcher() {
   )
 }
 
+function ManagedProfileMenu({ onNavigate }: { onNavigate?: () => void }) {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const goTo = (path: string) => {
+    void navigate(path)
+    onNavigate?.()
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="Open profile menu"
+          className="hover:bg-sidebar-accent flex w-full items-center gap-2.5 rounded-md p-1.5 text-left transition-colors"
+        >
+          <span className="bg-secondary text-muted-foreground flex size-7 shrink-0 items-center justify-center rounded-full text-xs font-medium">
+            {user?.email?.charAt(0).toUpperCase() || '?'}
+          </span>
+          <span className="text-foreground min-w-0 flex-1 truncate text-xs">
+            {user?.email}
+          </span>
+          <ChevronsUpDown
+            className="text-muted-foreground/50 size-3.5 shrink-0"
+            aria-hidden
+          />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        side="top"
+        align="start"
+        className="w-(--radix-dropdown-menu-trigger-width) min-w-52"
+      >
+        <DropdownMenuLabel>Account</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={() => goTo('/api-keys')}>
+          <KeyRound className="size-4 opacity-60" aria-hidden />
+          API Keys
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => goTo('/billing')}>
+          <CreditCard className="size-4 opacity-60" aria-hidden />
+          Billing
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => goTo('/settings')}>
+          <Settings className="size-4 opacity-60" aria-hidden />
+          Settings
+        </DropdownMenuItem>
+        {user?.capabilities?.signOut !== false ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => void logout()}>
+              <LogOut className="size-4 opacity-60" aria-hidden />
+              Sign out
+            </DropdownMenuItem>
+          </>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
 function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
   const { user } = useAuth()
   const location = useLocation()
   const navigate = useNavigate()
-  const nav = managedAgentsExperimentEnabled ? MANAGED_AGENTS_NAV : LEGACY_NAV
+  const nav = managedAgentsExperimentEnabled
+    ? managedAgentsNav({
+        durableSessionsEnabled: user?.durableSessionsEnabled ?? false,
+        infrastructureEnabled: user?.infrastructureEnabled ?? false,
+      })
+    : LEGACY_NAV
   const activeCollapsibleGroup = nav.find(
     (group) =>
       group.collapsible &&
       group.label &&
-      ((managedAgentsExperimentEnabled &&
-        group.label === 'Serverless agents' &&
-        location.pathname.startsWith('/managed-agents/')) ||
-        group.items.some(
-          (item) =>
-            location.pathname === item.to ||
-            (item.to !== '/' && location.pathname.startsWith(`${item.to}/`)),
-        )),
+      group.items.some(
+        (item) =>
+          location.pathname === item.to ||
+          (item.to !== '/' && location.pathname.startsWith(`${item.to}/`)),
+      ),
   )?.label
   const [openGroups, setOpenGroups] = useState<Set<string>>(
     () => new Set(activeCollapsibleGroup ? [activeCollapsibleGroup] : []),
@@ -356,24 +417,28 @@ function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
       </nav>
 
       <div className="border-t p-3">
-        <div className="flex items-center gap-2.5">
-          <span className="bg-secondary text-muted-foreground flex size-7 shrink-0 items-center justify-center rounded-full text-xs font-medium">
-            {user?.email?.charAt(0).toUpperCase() || '?'}
-          </span>
-          <span className="text-foreground min-w-0 flex-1 truncate text-xs">
-            {user?.email}
-          </span>
-          {user?.capabilities?.signOut !== false ? (
-            <button
-              onClick={() => void logout()}
-              aria-label="Sign out"
-              title="Sign out"
-              className="text-muted-foreground/40 hover:text-foreground flex size-7 shrink-0 items-center justify-center transition-colors"
-            >
-              <LogOut className="size-4" strokeWidth={1.5} aria-hidden />
-            </button>
-          ) : null}
-        </div>
+        {managedAgentsExperimentEnabled ? (
+          <ManagedProfileMenu onNavigate={onNavigate} />
+        ) : (
+          <div className="flex items-center gap-2.5">
+            <span className="bg-secondary text-muted-foreground flex size-7 shrink-0 items-center justify-center rounded-full text-xs font-medium">
+              {user?.email?.charAt(0).toUpperCase() || '?'}
+            </span>
+            <span className="text-foreground min-w-0 flex-1 truncate text-xs">
+              {user?.email}
+            </span>
+            {user?.capabilities?.signOut !== false ? (
+              <button
+                onClick={() => void logout()}
+                aria-label="Sign out"
+                title="Sign out"
+                className="text-muted-foreground/40 hover:text-foreground flex size-7 shrink-0 items-center justify-center transition-colors"
+              >
+                <LogOut className="size-4" strokeWidth={1.5} aria-hidden />
+              </button>
+            ) : null}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import { Switch as SwitchPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        'peer data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-5 w-9 shrink-0 items-center rounded-full border border-transparent transition-colors outline-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb className="bg-background pointer-events-none block size-4 rounded-full shadow-xs transition-transform data-checked:translate-x-4 data-unchecked:translate-x-0" />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -6,6 +6,8 @@ export interface AuthUser {
   email: string
   orgId: string
   orgs?: OrgInfo[]
+  durableSessionsEnabled: boolean
+  infrastructureEnabled: boolean
   authMode?: string
   capabilities?: {
     signOut: boolean

--- a/web/src/managed-agents/Home.tsx
+++ b/web/src/managed-agents/Home.tsx
@@ -217,7 +217,6 @@ function TemplateCard({
 }) {
   const Icon = categoryIcons[template.category as Category] ?? ClipboardCheck
   const available = availableTemplateIds.has(template.id)
-  const setup = templateSetup(template)
   return (
     <Panel
       className={cn(
@@ -281,10 +280,7 @@ function TemplateCard({
           </p>
         </div>
         {available ? (
-          <div className="mt-6 space-y-2">
-            <p className="text-muted-foreground text-xs leading-5">
-              Install → login → initialize → connect {setup.connectionName} → test → deploy
-            </p>
+          <div className="mt-6">
             <div className="grid gap-2 sm:grid-cols-2">
               <Button
                 variant={promptCopied ? 'secondary' : 'default'}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -14,6 +14,8 @@ import {
   sendInvitation,
   setCustomDomain,
   updateOrg,
+  updateNavigationPreferences,
+  type NavigationPreferenceUpdate,
   type OrgInvitation,
   type OrgMember,
 } from '@/api/client'
@@ -29,6 +31,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Field, Input, Label } from '@/components/form'
 import { StatusBadge } from '@/components/status-badge'
 import { ConfirmDialog } from '@/components/confirm-dialog'
+import { Switch } from '@/components/ui/switch'
 
 function ReadOnlyField({ label, value }: { label: string; value: ReactNode }) {
   return (
@@ -79,13 +82,20 @@ export default function Settings() {
   const name = draftName ?? org?.name ?? ''
 
   const saveMutation = useMutation({
-    mutationFn: (n: string) => updateOrg(n),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['org'] })
+    mutationFn: (n: string) => updateOrg({ name: n }),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(['org'], updated)
       setDraftName(null)
       markSaved()
     },
     onError: (e) => notifyError("Couldn't save organization settings.", e),
+  })
+
+  const navigationMutation = useMutation({
+    mutationFn: (updates: NavigationPreferenceUpdate) =>
+      updateNavigationPreferences(updates),
+    onSuccess: (updated) => queryClient.setQueryData(['me'], updated),
+    onError: (e) => notifyError("Couldn't save navigation settings.", e),
   })
 
   const setDomainMutation = useMutation({
@@ -129,6 +139,39 @@ export default function Settings() {
       <PageHeader title="Settings" description="Organization configuration" />
 
       <div className="grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-2">
+        <Panel className="p-6 lg:col-span-2">
+          <div className="mb-5">
+            <PanelTitle>Navigation</PanelTitle>
+            <PanelDescription className="mt-1">
+              Choose which advanced product areas appear in the sidebar.
+            </PanelDescription>
+          </div>
+          <div className="divide-y">
+            <NavigationToggle
+              id="durable-sessions-enabled"
+              label="Enable durable sessions"
+              description="Show durable agents, sessions, and credentials."
+              checked={user?.durableSessionsEnabled ?? false}
+              disabled={navigationMutation.isPending}
+              onCheckedChange={(checked) =>
+                navigationMutation.mutate({
+                  durableSessionsEnabled: checked,
+                })
+              }
+            />
+            <NavigationToggle
+              id="infrastructure-enabled"
+              label="Enable infrastructure"
+              description="Show sandboxes, checkpoints, templates, webhooks, and browsers."
+              checked={user?.infrastructureEnabled ?? false}
+              disabled={navigationMutation.isPending}
+              onCheckedChange={(checked) =>
+                navigationMutation.mutate({ infrastructureEnabled: checked })
+              }
+            />
+          </div>
+        </Panel>
+
         {/* Organization */}
         <Panel className="p-6">
           <div className="mb-5">
@@ -334,6 +377,37 @@ export default function Settings() {
             onSuccess: () => setConfirmRemoveDomain(false),
           })
         }
+      />
+    </div>
+  )
+}
+
+function NavigationToggle({
+  id,
+  label,
+  description,
+  checked,
+  disabled,
+  onCheckedChange,
+}: {
+  id: string
+  label: string
+  description: string
+  checked: boolean
+  disabled: boolean
+  onCheckedChange: (checked: boolean) => void
+}) {
+  return (
+    <div className="flex items-center justify-between gap-6 py-4 first:pt-0 last:pb-0">
+      <div>
+        <Label htmlFor={id}>{label}</Label>
+        <p className="text-muted-foreground mt-1 text-sm">{description}</p>
+      </div>
+      <Switch
+        id={id}
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={onCheckedChange}
       />
     </div>
   )


### PR DESCRIPTION
## Summary

- make Agents and Connections the only default managed-agent navigation items
- move API Keys, Billing, Settings, and sign-out into the profile menu
- add per-user toggles for Durable sessions and Infrastructure in Settings
- keep both advanced sections enabled for existing users while new users default to both disabled
- remove the setup-step helper copy from starter template cards

## Validation

- web: 42 test files, 167 tests passed
- API edge: 8 test files, 86 tests passed
- production web build passed
- migration verified: existing users become 1/1 and subsequent users remain 0/0

## Dev rollout

- deployed and exercised on mo-oc-dev.com only
- production was not touched
