### PR TITLE
pool refill + edge stock for the ComputeSDK full benchmark battery

### DIFF
--- a/cloudflare-workers/api-edge/src/pool_stock.ts
+++ b/cloudflare-workers/api-edge/src/pool_stock.ts
@@ -40,11 +40,15 @@ interface PoolStockEnv {
 // stays well under the cell's 15-min destroy backstop so an unclaimed box is
 // released back to the pool (cheap) long before the cell would destroy it.
 const ENTRY_TTL_MS = 10 * 60_000;
-const LOW_WATER = 40;
+// Sized for the ComputeSDK full battery (sequential 100 → staggered 100 @
+// 200ms → burst 100, back-to-back ≈ 300 boxes): the stock must hold ≥100 at
+// the moment burst fires, with the CP pool (OPENSANDBOX_POOL_TARGET × workers)
+// and refill pacing sized to match.
+const LOW_WATER = 100;
 const RESTOCK_BATCH = 50; // max boxes reserved per single edge-reserve call
-const TARGET_STOCK = 100; // fill the stock up to here (≈ the whole hot pool)
+const TARGET_STOCK = 200; // fill the stock up to here (≈ the whole hot pool)
 const ALARM_INTERVAL_MS = 10_000; // proactive top-up cadence
-const RESTOCK_MAX_CALLS = 3; // reserve calls per restock pass (batch × calls ≥ TARGET)
+const RESTOCK_MAX_CALLS = 4; // reserve calls per restock pass (batch × calls ≥ TARGET)
 
 // Synthetic org that owns parked pool boxes (db.PoolOrgID). Used as the cap
 // token subject for reserve/release calls — those endpoints are org-agnostic,

--- a/internal/config/keyvault.go
+++ b/internal/config/keyvault.go
@@ -78,6 +78,10 @@ var kvMapping = map[string]string{
 	"server-pool-target":   "OPENSANDBOX_POOL_TARGET",   // pooled boxes per worker (default 10; 0 disables)
 	"server-pool-enabled":  "OPENSANDBOX_POOL_ENABLED",  // "0" to disable (default on)
 	"server-pool-template": "OPENSANDBOX_POOL_TEMPLATE", // golden template name (default "base")
+	// Refill pacing — must outrun the ComputeSDK staggered benchmark's 5
+	// creates/s (100 boxes @ 200ms): batch 10 / interval 5000ms × 4 workers = 8/s.
+	"server-pool-refill-batch":       "OPENSANDBOX_POOL_REFILL_BATCH",       // boxes per worker per tick (default 3)
+	"server-pool-refill-interval-ms": "OPENSANDBOX_POOL_REFILL_INTERVAL_MS", // tick cadence (default 15000)
 
 	// Worker secrets
 	"worker-jwt-secret":         "OPENSANDBOX_JWT_SECRET",


### PR DESCRIPTION
The ComputeSDK daily battery runs sequential 100 → staggered 100 @200ms → burst 100 back-to-back (~300 boxes); our refill (3/worker/15s ≈ 0.8/s) can't outrun staggered's 5/s and burst needs ≥100 warm boxes on hand. Maps two existing refill knobs into keyvault.go (server-pool-refill-batch / server-pool-refill-interval-ms) and raises PoolStock TARGET_STOCK 100→200, LOW_WATER 40→100, RESTOCK_MAX_CALLS 3→4. Pairs with Infisical: pool-target 60, batch 10, interval 5000ms.
