### PR TITLE
replace stock shards (gen2) + idle self-decommission for retired shards

### DIFF
--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -1009,10 +1009,18 @@ function indexSandboxFromSSE(
 // Stock shard fan-out (see pool_stock.ts for sizing): shard 0 uses the bare
 // cellID as its DO name — that's the pre-sharding instance, kept addressable so
 // its stock drains via claims + surplus-trim instead of stranding until TTL.
+//
+// SHARD_GEN: bump to mint fresh DO instances when placement went wrong — a DO
+// pins to the colo of its FIRST request forever, so shards must only ever be
+// first-touched by traffic from the cell's own metro (create from a sandbox in
+// the cell, never a laptop). g1's shards 1-7 were armed from off-metro and
+// pinned cross-country; g2 exists to re-place them. Old-gen shards strand their
+// reservations at most ENTRY_TTL + the cell's 15-min reaper.
 const POOL_STOCK_SHARDS = 8;
+const POOL_STOCK_SHARD_GEN = "g2";
 
 function poolStockStub(env: Env, cellID: string, shard: number): DurableObjectStub {
-  const name = shard === 0 ? cellID : `${cellID}#${shard}`;
+  const name = shard === 0 ? cellID : `${cellID}#${POOL_STOCK_SHARD_GEN}#${shard}`;
   return env.POOL_STOCK.get(env.POOL_STOCK.idFromName(name));
 }
 

--- a/cloudflare-workers/api-edge/src/pool_stock.ts
+++ b/cloudflare-workers/api-edge/src/pool_stock.ts
@@ -54,6 +54,12 @@ const RESTOCK_BATCH = 25; // max boxes reserved per single edge-reserve call
 const TARGET_STOCK = 25; // per-shard fill level (× 8 shards = 200 fleet)
 const ALARM_INTERVAL_MS = 10_000; // proactive top-up cadence
 const RESTOCK_MAX_CALLS = 2; // reserve calls per restock pass (batch × calls ≥ TARGET)
+// Self-decommission: a shard that hasn't served a claim in this long releases
+// its whole stock and stops its alarm (a later claim re-arms it). This is what
+// lets a retired shard GENERATION (index.ts POOL_STOCK_SHARD_GEN bump — e.g.
+// after a placement mistake) drain instead of hoarding reservations forever,
+// and returns idle cells' boxes to the pool for non-default-shape creates.
+const IDLE_DECOMMISSION_MS = 30 * 60_000;
 
 // Synthetic org that owns parked pool boxes (db.PoolOrgID). Used as the cap
 // token subject for reserve/release calls — those endpoints are org-agnostic,
@@ -93,6 +99,7 @@ async function mintPoolCapToken(secret: string, cellID: string): Promise<string>
 export class PoolStock {
   private stock: StockEntry[] = [];
   private restockInFlight = false;
+  private lastClaimMs = 0;
   // One-shot colo self-identification (diagnostics): placement is sticky at
   // first-touch; a stock DO cross-colo from the claiming edge adds per-claim RTT.
   private coloLogged = false;
@@ -154,6 +161,8 @@ export class PoolStock {
     }
 
     const entry = this.stock.shift(); // FIFO — oldest first keeps the stock young
+    this.lastClaimMs = Date.now();
+    void this.state.storage.put("lastClaim", this.lastClaimMs, { allowUnconfirmed: true });
     this.persist();
 
     // Ensure the proactive top-up loop is running, and kick an immediate restock
@@ -190,6 +199,17 @@ export class PoolStock {
   async alarm(): Promise<void> {
     const cell = this.cell;
     if (!cell) return; // no cell known yet → nothing to reserve; a claim will arm it
+    // Idle self-decommission (see IDLE_DECOMMISSION_MS): release everything and
+    // let the alarm lapse. A future claim re-arms and restocks.
+    const lastClaim = this.lastClaimMs || ((await this.state.storage.get<number>("lastClaim")) ?? 0);
+    if (Date.now() - lastClaim > IDLE_DECOMMISSION_MS) {
+      if (this.stock.length > 0) {
+        const all = this.stock.splice(0);
+        await this.release(all);
+        this.persist();
+      }
+      return; // no reschedule — decommissioned until the next claim
+    }
     // Expire+release anything past TTL before topping up, so held boxes go back
     // to the pool well before the cell's 15-min destroy backstop.
     const now = Date.now();


### PR DESCRIPTION
DO placement is sticky at first request: shards 1–7 were first-touched from an off-metro client and pinned cross-country from IAD, so claim;dur rose 47→77ms — sharding made bursts worse. Bumps shard names to g2 (fresh DOs, to be armed from inside the cell's metro) and adds idle self-decommission: a shard with no claims for 30 min releases its stock and stops its alarm, a later claim re-arms it. That also drains the retired g1 shards, which would otherwise hoard ~175 pool reservations forever.