### PR TITLE
chore(cli): bump version to 0.3.13

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/cli",
-      "version": "0.3.12",
+      "version": "0.3.13",
       "dependencies": {
         "@opencode-ai/sdk": "1.18.4",
         "ai": "^7.0.45",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Build, test, connect, deploy, and share OpenComputer agents as code.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- bump `@opencomputer/cli` from `0.3.12` to `0.3.13`
- synchronize `cli/package.json` and `cli/package-lock.json`
- trigger the version-gated CLI publish workflow for the merged PR review readiness starter

## Validation

- `cd cli && npm test` — 18 tests passed
