### PR TITLE
fix: enable navigation for new users

### DIFF
--- a/cloudflare-workers/api-edge/migrations/0005_enable_navigation_by_default.sql
+++ b/cloudflare-workers/api-edge/migrations/0005_enable_navigation_by_default.sql
@@ -1,0 +1,8 @@
+-- Undo the short-lived hidden-by-default navigation state introduced in 0004.
+-- A user who changed only one preference keeps that explicit choice.
+
+UPDATE users
+SET durable_sessions_enabled = 1,
+    infrastructure_enabled = 1
+WHERE durable_sessions_enabled = 0
+  AND infrastructure_enabled = 0;

--- a/cloudflare-workers/api-edge/src/cli_auth.test.ts
+++ b/cloudflare-workers/api-edge/src/cli_auth.test.ts
@@ -535,6 +535,9 @@ describe("CLI device authorization edge contract", () => {
     const membershipInsert = db.executed.find((entry) => entry.sql.includes("INSERT INTO org_memberships"));
     const keyInsert = db.executed.find((entry) => entry.sql.includes("INSERT INTO api_keys"));
     expect(userInsert).toBeDefined();
+    expect(userInsert?.sql).toContain("durable_sessions_enabled");
+    expect(userInsert?.sql).toContain("infrastructure_enabled");
+    expect(userInsert?.sql).toMatch(/VALUES\s*\(\?1, \?2, \?3, \?4, \?5, 1, 1\)/);
     expect(orgInsert?.args[3]).toBe("azure-us-east-2-a");
     expect(membershipInsert?.args[0]).toBe(body.org.id);
     expect(membershipInsert?.args[1]).toBe(body.user.id);

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -1936,8 +1936,16 @@ async function provisionWorkOSIdentity(
   if (!userRow) {
     const candidateID = crypto.randomUUID();
     await env.OPENCOMPUTER_DB.prepare(
-      `INSERT INTO users (id, email, workos_user_id, name, created_at)
-       VALUES (?1, ?2, ?3, ?4, ?5)
+      `INSERT INTO users (
+         id,
+         email,
+         workos_user_id,
+         name,
+         created_at,
+         durable_sessions_enabled,
+         infrastructure_enabled
+       )
+       VALUES (?1, ?2, ?3, ?4, ?5, 1, 1)
        ON CONFLICT(email) DO UPDATE SET workos_user_id = excluded.workos_user_id`,
     )
       .bind(candidateID, profile.email, profile.id, displayName, nowSec)


### PR DESCRIPTION
## TL;DR

- New browser and CLI-provisioned users start with Durable sessions and Infrastructure visible.
- Migration 0005 changes only the short-lived 0/0 preference state to 1/1; selective 0/1 and 1/0 preferences are preserved.
- Existing Settings toggles and sidebar rendering remain unchanged.

## Consequential details

PR #588 introduced database-backed navigation preferences with both columns defaulting to hidden for users created after its backfill. This fixes the shared WorkOS provisioning path rather than adding frontend fallback behavior.

The migration applies:

```sql
UPDATE users
SET durable_sessions_enabled = 1,
    infrastructure_enabled = 1
WHERE durable_sessions_enabled = 0
  AND infrastructure_enabled = 0;
```

The database cannot distinguish the short-lived default 0/0 state from a user who explicitly hid both groups, so both are reset once. Users can still hide either group again in Settings.

## Verification

- API edge test suite: 86/86 passed
- TypeScript: passed
- Migration exercised locally against all four preference combinations
- No frontend visual or navigation-structure changes
