### PR TITLE
Revert claim-time verify/pre-warm and async destroys to pre-#597

### DIFF
--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -111,6 +111,7 @@ export interface Env extends DashboardEnv {
   // The host's /connect is authed by a per-sandbox HMAC over SESSION_JWT_SECRET
   // (see the /internal/vms/:id/connect route) — no dedicated secret.
   VM_SESSIONS: DurableObjectNamespace;
+  DIAG?: string; // "1" enables per-op diagnostic logging (create-timing etc.)
 }
 
 const DEFAULT_MAX_CONCURRENT_SANDBOXES = 50;
@@ -136,6 +137,29 @@ const b64url = (buf: ArrayBuffer | Uint8Array): string => {
 // org_id + cell_id + plan (+ optional user_id). Mirrors auth.CapabilityClaims
 // in Go. Plan flows through so the worker can tag usage_tick events without
 // a per-event PG lookup.
+// Cap-tokens are org+cell scoped with exp=120s — memoize for 60s so a battery's
+// ~400 mints (per-DELETE proxy, finalize, CP fallback) collapse to ~1/min of
+// HMAC CPU on the create/destroy hot path.
+const capTokenCache = new Map<string, { token: string; mintedAtMs: number }>();
+
+async function cachedCapToken(
+  secret: string,
+  orgID: string,
+  cellID: string,
+  plan: string,
+  billingProvider: string,
+  userID: string | null,
+): Promise<string> {
+  const key = `${orgID}|${cellID}|${plan}|${billingProvider}|${userID ?? ""}`;
+  const hit = capTokenCache.get(key);
+  const nowMs = Date.now();
+  if (hit && nowMs - hit.mintedAtMs < 60_000) return hit.token;
+  const token = await mintCapToken(secret, orgID, cellID, plan, billingProvider, userID);
+  if (capTokenCache.size >= CACHE_MAX) capTokenCache.clear();
+  capTokenCache.set(key, { token, mintedAtMs: nowMs });
+  return token;
+}
+
 async function mintCapToken(
   secret: string,
   orgID: string,
@@ -1062,16 +1086,16 @@ async function finalizeEdgeClaim(
   workerID: string,
   bodyText: string,
 ): Promise<void> {
-  try {
-    await insertSandboxIndex(env, caller, cell.cell_id, { sandboxID, workerID, status: "running", memoryMB: 4096 }, 1, 4096);
-  } catch (e) {
-    console.error(`edge-claim: index insert failed for ${sandboxID}:`, e);
-  }
+  // Index insert is DEFERRED below the finalize call + a short delay: D1 has a
+  // single writer, and a create burst otherwise queues ~100 inserts exactly
+  // when cold-isolate hot-path READS (auth/route/count) need D1. The colo route
+  // cache serves the box's own sub-ops, and events-ingest reconciles the row
+  // regardless — the insert only backstops dashboard/list visibility.
   try {
     // Minted HERE (off the response path) rather than on the create hot path —
     // only this finalize call ever consumes it on the edge-claim route, and the
     // HMAC sign was one of the larger CPU items at burst-100 concurrency.
-    const capToken = await mintCapToken(env.SESSION_JWT_SECRET, caller.orgID, cell.cell_id, plan, billingProvider, caller.userID);
+    const capToken = await cachedCapToken(env.SESSION_JWT_SECRET, caller.orgID, cell.cell_id, plan, billingProvider, caller.userID);
     let body: Record<string, unknown> = {};
     try {
       body = bodyText ? (JSON.parse(bodyText) as Record<string, unknown>) : {};
@@ -1088,6 +1112,10 @@ async function finalizeEdgeClaim(
       body: JSON.stringify(body),
     });
     if (!r.ok) throw new Error(`${r.status} ${await r.text()}`);
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    await insertSandboxIndex(env, caller, cell.cell_id, { sandboxID, workerID, status: "running", memoryMB: 4096 }, 1, 4096).catch((e) =>
+      console.error(`edge-claim: index insert failed for ${sandboxID}:`, e),
+    );
   } catch (e) {
     console.error(`edge-claim: FINALIZE FAILED for ${sandboxID} — marking error:`, e);
     sandboxRouteCache.delete(sandboxID);
@@ -1220,13 +1248,6 @@ async function createSandbox(req: Request, env: Env, ctx: ExecutionContext): Pro
       // coprime-ish to 8) — at full stock the first hit ends it; under sparse
       // stock (small cells, mid-battery drain) 3 samples cut the false-fallback
       // rate from ~(empty/8)² to ~(empty/8)³ for ~10ms per extra probe.
-      //
-      // Each popped box is then VERIFIED: one /status call to its VmSession —
-      // which doubles as the pre-warm (it wakes the DO hibernated since the
-      // manufacture dial, so the customer's first exec never pays the isolate
-      // wake) and as the liveness gate (dead host channel → swap to another
-      // box instead of letting the first exec discover it and tunnel ~1.3s).
-      // A rejected box stays edge_reserved; the cell's 15-min reaper collects it.
       let box: { id: string; workerID: string; region: string; sandboxDomain: string } | null = null;
       let shard = Math.floor(Math.random() * POOL_STOCK_SHARDS);
       const stride = 1 + Math.floor(Math.random() * (POOL_STOCK_SHARDS - 1));
@@ -1237,19 +1258,7 @@ async function createSandbox(req: Request, env: Env, ctx: ExecutionContext): Pro
         });
         shard = (shard + stride) % POOL_STOCK_SHARDS;
         if (!r.ok) continue;
-        const candidate = (await r.json()) as { id: string; workerID: string; region: string; sandboxDomain: string };
-        try {
-          const st = (await env.VM_SESSIONS.get(env.VM_SESSIONS.idFromName(candidate.id))
-            .fetch("https://do/status")
-            .then((sr) => sr.json())) as { connected?: boolean };
-          if (st.connected) {
-            box = candidate;
-          } else {
-            console.log(`edge-claim: ${candidate.id} exec channel down — swapping box`);
-          }
-        } catch {
-          console.log(`edge-claim: ${candidate.id} status check failed — swapping box`);
-        }
+        box = (await r.json()) as { id: string; workerID: string; region: string; sandboxDomain: string };
       }
       if (box) {
         mark("claim");
@@ -1271,7 +1280,7 @@ async function createSandbox(req: Request, env: Env, ctx: ExecutionContext): Pro
         };
         if (box.sandboxDomain) resp.sandboxDomain = box.sandboxDomain;
         ctx.waitUntil(finalizeEdgeClaim(env, caller, cell, plan, org.billing_provider, box.id, box.workerID, bodyText));
-        console.log(`create-timing ${box.id} ${phases.join(" ")}`);
+        if (env.DIAG === "1") console.log(`create-timing ${box.id} ${phases.join(" ")}`);
         return new Response(JSON.stringify(resp), {
           status: 201,
           headers: { "content-type": "application/json", "server-timing": phases.join(", ") },
@@ -1284,7 +1293,7 @@ async function createSandbox(req: Request, env: Env, ctx: ExecutionContext): Pro
 
   // CP fallback from here on — mint the cap-token the cell requires (the
   // edge-claim path above returns without ever needing it).
-  const capToken = await mintCapToken(env.SESSION_JWT_SECRET, caller.orgID, cell.cell_id, plan, org.billing_provider, caller.userID);
+  const capToken = await cachedCapToken(env.SESSION_JWT_SECRET, caller.orgID, cell.cell_id, plan, org.billing_provider, caller.userID);
 
   // SSE build streaming: image/snapshot creates can take minutes (apt installs,
   // etc.). Preserve live streaming, but index the final `result` event inline
@@ -1528,7 +1537,7 @@ async function proxyToCellSDK(req: Request, env: Env, ctx: ExecutionContext, cal
   // tokens and API keys), so the same handler chain that runs for SDK
   // X-API-Key auth runs here. cell_id in the token guards against replay
   // against a different cell.
-  const token = await mintCapToken(env.SESSION_JWT_SECRET, caller.orgID, route.cellID, orgPol?.plan ?? "free", "", caller.userID);
+  const token = await cachedCapToken(env.SESSION_JWT_SECRET, caller.orgID, route.cellID, orgPol?.plan ?? "free", "", caller.userID);
 
   const headers = new Headers();
   for (const [k, v] of req.headers.entries()) {

--- a/cloudflare-workers/vm-do/src/vm_session.ts
+++ b/cloudflare-workers/vm-do/src/vm_session.ts
@@ -13,6 +13,10 @@ import { decodeResult, encodeExec, type ExecResult } from "./protocol";
 // Extends DurableObject (cloudflare:workers) so execCommand is callable as a
 // native RPC method from the edge stub — cheaper than HTTP-over-fetch per hop.
 
+// Flip to true to re-enable per-exec socket-census logging (tail-consumer +
+// per-op cost otherwise; the colo/connect one-shot logs stay on).
+const DIAG = false;
+
 interface PendingCommand {
   resolve: (result: ExecResult) => void;
   reject: (error: Error) => void;
@@ -67,8 +71,10 @@ export class VmSession extends DurableObject {
     // internalMs = time spent INSIDE this method. The edge's do;dur minus this
     // = isolate wake + edge→DO transit — the unattributed gap in the exec tail.
     const tEntry = Date.now();
-    const socks = this.state.getWebSockets("vm");
-    console.log(`exec sid=${sid ?? "?"} sockets=${socks.length} states=[${socks.map((s) => s.readyState).join(",")}]`);
+    if (DIAG) {
+      const socks = this.state.getWebSockets("vm");
+      console.log(`exec sid=${sid ?? "?"} sockets=${socks.length} states=[${socks.map((s) => s.readyState).join(",")}]`);
+    }
     if (!this.connectedSocket()) {
       for (let waited = 0; waited < 400 && !this.connectedSocket(); waited += 50) {
         await new Promise((resolve) => setTimeout(resolve, 50));

--- a/internal/worker/grpc_server.go
+++ b/internal/worker/grpc_server.go
@@ -570,14 +570,6 @@ func (s *GRPCServer) ClaimSandbox(ctx context.Context, req *pb.ClaimSandboxReque
 		GoldenVersion: sb.GoldenVersion}, nil
 }
 
-// destroySem bounds background teardown concurrency. A bench/agent-shaped
-// workload destroys dozens of boxes in seconds; each Kill is QEMU-teardown +
-// overlay-unlink heavy, and running them foreground-concurrent competes with
-// live execs on the same host (measured as exec-tail blips). Ten at a time
-// drains a 100-destroy burst in ~10s so backlog never spills into the next
-// workload phase (3-wide let seq+staggered teardown pile into the burst window).
-var destroySem = make(chan struct{}, 10)
-
 func (s *GRPCServer) DestroySandbox(ctx context.Context, req *pb.DestroySandboxRequest) (*pb.DestroySandboxResponse, error) {
 	// Tear the VM-DO exec channel down first so an in-flight exec can't land on
 	// a box we're about to kill (it falls back to the tunnel, which 404s cleanly).
@@ -590,35 +582,26 @@ func (s *GRPCServer) DestroySandbox(ctx context.Context, req *pb.DestroySandboxR
 		}
 	}
 
+	if err := s.manager.Kill(ctx, req.SandboxId); err != nil {
+		return nil, fmt.Errorf("failed to destroy sandbox: %w", err)
+	}
+
 	// Unregister from sandbox router
 	if s.router != nil {
 		s.router.Unregister(req.SandboxId)
 	}
 
-	// The heavy teardown (QEMU kill + overlay unlink + SQLite flush) runs in the
-	// background, bounded by destroySem — the caller gets an immediate ack, and
-	// the CP's PG row is gone regardless. A failed/stuck Kill is collected by
-	// the orphan reaper, so deferring loses no safety, only foreground I/O.
-	go func(id string) {
-		destroySem <- struct{}{}
-		defer func() { <-destroySem }()
-		killCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-		defer cancel()
-		if err := s.manager.Kill(killCtx, id); err != nil {
-			log.Printf("grpc: background destroy %s: %v (orphan reaper will collect)", id, err)
+	// Emit terminal lifecycle event BEFORE removing the per-sandbox SQLite.
+	// The SandboxDBManager's OnRemove hook synchronously flushes any unsynced
+	// events to Redis, so this event makes it upstream to events-ingest, which
+	// updates D1 sandboxes_index. Without this, terminations leak as phantoms
+	// in the global view.
+	if s.sandboxDBs != nil {
+		if sdb, dbErr := s.sandboxDBs.Get(req.SandboxId); dbErr == nil {
+			_ = sdb.LogEvent("stopped", map[string]string{"sandbox_id": req.SandboxId})
 		}
-		// Emit terminal lifecycle event BEFORE removing the per-sandbox SQLite.
-		// The SandboxDBManager's OnRemove hook synchronously flushes any unsynced
-		// events to Redis, so this event makes it upstream to events-ingest, which
-		// updates D1 sandboxes_index. Without this, terminations leak as phantoms
-		// in the global view.
-		if s.sandboxDBs != nil {
-			if sdb, dbErr := s.sandboxDBs.Get(id); dbErr == nil {
-				_ = sdb.LogEvent("stopped", map[string]string{"sandbox_id": id})
-			}
-			_ = s.sandboxDBs.Remove(id)
-		}
-	}(req.SandboxId)
+		_ = s.sandboxDBs.Remove(req.SandboxId)
+	}
 
 	return &pb.DestroySandboxResponse{}, nil
 }


### PR DESCRIPTION
Two parts. (1) Rolls back the #597 changes that read worse in every battery since (97.5/97.0/94.6 vs 98.0/98.7/96.0): the claim-time /status verify taxed every create ~10–25ms, and queued async destroys let teardown I/O pile into later phases (3-wide imploded burst to 80.5). Claims return to plain shard-pop, DestroySandbox to synchronous. (2) Adds this morning's edge work: cap-tokens memoized 60s (~400 HMACs/battery → ~1/min), create's D1 index insert deferred past the hot read window (D1 single-writer contention), and per-op diagnostic logs gated behind DIAG.