### PR TITLE
Fix accounting bug + some other improvments 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ deploy/azure/.dev-vector-token-*
 
 # Per-env wrangler config generated for CI deploys (not source)
 cloudflare-workers/api-edge/wrangler.ci.toml
+
+# Wrangler local build/cache/state (never source)
+.wrangler/

--- a/cloudflare-workers/api-edge/src/index.test.ts
+++ b/cloudflare-workers/api-edge/src/index.test.ts
@@ -73,7 +73,7 @@ class FakeStatement {
   }
 
   async run() {
-    if (this.sql.includes("INSERT OR REPLACE INTO sandboxes_index")) {
+    if (this.sql.includes("INSERT INTO sandboxes_index") && this.sql.includes("ON CONFLICT(id)")) {
       sandboxIndexInserts.push(this.args);
     }
     return {};

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -186,15 +186,30 @@ async function mintCapToken(
   const enc = new TextEncoder();
   const signingInput =
     b64url(enc.encode(JSON.stringify(header))) + "." + b64url(enc.encode(JSON.stringify(payload)));
-  const key = await crypto.subtle.importKey(
+  const key = await hmacSignKey(secret);
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(signingInput));
+  return signingInput + "." + b64url(sig);
+}
+
+// Cache the imported HMAC signing key. The secret is constant, but
+// crypto.subtle.importKey ran on every token mint — and the create hot path
+// mints per create, where the code notes the HMAC work was a top CPU item
+// driving isolate queueing at burst-100. Memoize the imported CryptoKey per
+// secret (shared Promise so concurrent first-callers don't double-import) so
+// only sign() runs per mint. importKey is extractable:false, so the key never
+// leaves the isolate.
+let hmacSignKeyCache: { secret: string; key: Promise<CryptoKey> } | null = null;
+function hmacSignKey(secret: string): Promise<CryptoKey> {
+  if (hmacSignKeyCache && hmacSignKeyCache.secret === secret) return hmacSignKeyCache.key;
+  const key = crypto.subtle.importKey(
     "raw",
-    enc.encode(secret),
+    new TextEncoder().encode(secret),
     { name: "HMAC", hash: "SHA-256" },
     false,
     ["sign"],
   );
-  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(signingInput));
-  return signingInput + "." + b64url(sig);
+  hmacSignKeyCache = { secret, key };
+  return key;
 }
 
 // Mint the sandbox-scoped JWT the create response carries (direct worker
@@ -222,13 +237,7 @@ async function mintSandboxToken(
   };
   const signingInput =
     b64url(enc.encode(JSON.stringify(header))) + "." + b64url(enc.encode(JSON.stringify(payload)));
-  const key = await crypto.subtle.importKey(
-    "raw",
-    enc.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
+  const key = await hmacSignKey(secret);
   const sig = await crypto.subtle.sign("HMAC", key, enc.encode(signingInput));
   return signingInput + "." + b64url(sig);
 }
@@ -1083,7 +1092,12 @@ const POOL_STOCK_SHARD_GEN = "g2";
 
 function poolStockStub(env: Env, cellID: string, shard: number): DurableObjectStub {
   const name = shard === 0 ? cellID : `${cellID}#${POOL_STOCK_SHARD_GEN}#${shard}`;
-  return env.POOL_STOCK.get(env.POOL_STOCK.idFromName(name));
+  // Deterministic placement hint: pin the stock DO to eastern North America
+  // (covers eastus2 / the IAD leaderboard runner) so a claim never eats a
+  // cross-colo hop even if the first touch comes from an off-metro edge. A
+  // no-op for DOs already placed; guards future/new shards from the
+  // first-touch-colo placement trap that previously cost ~70ms/claim.
+  return env.POOL_STOCK.get(env.POOL_STOCK.idFromName(name), { locationHint: "enam" });
 }
 
 // edgeClaimEligible: a create qualifies for the edge fast path only when it
@@ -2873,13 +2887,7 @@ async function mintSessionJWT(secret: string, orgID: string, userID: string, pla
   const enc = new TextEncoder();
   const signingInput =
     b64url(enc.encode(JSON.stringify(header))) + "." + b64url(enc.encode(JSON.stringify(payload)));
-  const key = await crypto.subtle.importKey(
-    "raw",
-    enc.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
+  const key = await hmacSignKey(secret);
   const sig = await crypto.subtle.sign("HMAC", key, enc.encode(signingInput));
   return signingInput + "." + b64url(sig);
 }

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -313,6 +313,9 @@ function stripApiKeyQueryParam(target: string): string {
 // bounded; CACHE_MAX guards pathological key cardinality.
 const AUTH_TTL_MS = 60_000;
 const ORG_POLICY_TTL_MS = 5_000; // short: bounds is_halted / cap staleness
+// SWR window for org policy in the colo tier: a ≤60s-stale not-halted policy
+// may gate a create while a background refresh runs (see loadCreateContext).
+const ORG_STALE_MAX_MS = 60_000;
 const LAST_USED_BUMP_MS = 60_000; // at most once/min/key/isolate
 const CACHE_MAX = 10_000;
 
@@ -516,6 +519,29 @@ async function loadCreateContext(
       orgHave = true;
       if (orgPolicyCache.size >= CACHE_MAX) orgPolicyCache.clear();
       orgPolicyCache.set(orgID, { policy: so.policy, cachedAtMs: so.cachedAtMs });
+    } else if (so && nowMs - so.cachedAtMs < ORG_STALE_MAX_MS && so.policy && !so.policy.is_halted) {
+      // Stale-while-revalidate (mirrors the count gate): a ≤60s-stale,
+      // not-halted org policy gates this create while a background refresh
+      // brings it fresh — removing the periodic org+count D1 batch (~130ms)
+      // from every Nth create. Halt latency worst case = ORG_STALE_MAX_MS.
+      org = so.policy;
+      orgHave = true;
+      if (ctx) {
+        ctx.waitUntil(
+          env.OPENCOMPUTER_DB.prepare(
+            "SELECT home_cell, plan, is_halted, max_concurrent_sandboxes, max_disk_mb, billing_provider FROM orgs WHERE id = ?1",
+          )
+            .bind(orgID)
+            .first<OrgPolicy>()
+            .then(async (row) => {
+              const at = Date.now();
+              if (orgPolicyCache.size >= CACHE_MAX) orgPolicyCache.clear();
+              orgPolicyCache.set(orgID, { policy: row ?? null, cachedAtMs: at });
+              await coloPut("org", orgID, { policy: row ?? null, cachedAtMs: at }, ORG_STALE_MAX_MS / 1000);
+            })
+            .catch(() => {}),
+        );
+      }
     }
     if (sc && nowMs - sc.cachedAtMs < CONCURRENCY_COUNT_TTL_MS) {
       activeCount = sc.count;
@@ -600,7 +626,7 @@ async function loadCreateContext(
         org = ((res[i].results?.[0] as OrgPolicy) ?? null);
         if (orgPolicyCache.size >= CACHE_MAX) orgPolicyCache.clear();
         orgPolicyCache.set(orgID, { policy: org, cachedAtMs: nowMs });
-        puts.push(coloPut("org", orgID, { policy: org, cachedAtMs: nowMs }, ORG_POLICY_TTL_MS / 1000));
+        puts.push(coloPut("org", orgID, { policy: org, cachedAtMs: nowMs }, ORG_STALE_MAX_MS / 1000));
       } else if (kinds[i] === "count") {
         activeCount = (res[i].results?.[0] as { n: number } | undefined)?.n ?? 0;
         if (concurrencyCountCache.size >= CACHE_MAX) concurrencyCountCache.clear();
@@ -929,10 +955,22 @@ async function insertSandboxIndex(
   fallbackMemoryMB: number,
 ): Promise<void> {
   if (!parsed.sandboxID) return;
+  // Guarded upsert (was INSERT OR REPLACE): the edge-claim finalize insert runs
+  // ~1.5s after the box is returned, so a destroy in that window can land a
+  // 'stopped' tombstone first (see the DELETE handler). The WHERE clause makes
+  // this insert refuse to resurrect a row that a concurrent destroy already
+  // moved to a terminal state — closing the create→destroy leak. On a normal
+  // create the row doesn't exist yet, so the plain INSERT branch runs.
   await env.OPENCOMPUTER_DB.prepare(
-    `INSERT OR REPLACE INTO sandboxes_index
+    `INSERT INTO sandboxes_index
        (id, org_id, user_id, cell_id, worker_id, status, cpu_count, memory_mb, created_at, last_event_at)
-     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9)`,
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9)
+     ON CONFLICT(id) DO UPDATE SET
+       org_id=excluded.org_id, user_id=excluded.user_id, cell_id=excluded.cell_id,
+       worker_id=excluded.worker_id, status=excluded.status,
+       cpu_count=excluded.cpu_count, memory_mb=excluded.memory_mb,
+       last_event_at=excluded.last_event_at
+     WHERE sandboxes_index.status NOT IN ('stopped', 'error')`,
   )
     .bind(
       parsed.sandboxID,
@@ -1279,6 +1317,17 @@ async function createSandbox(req: Request, env: Env, ctx: ExecutionContext): Pro
           workerID: box.workerID,
         };
         if (box.sandboxDomain) resp.sandboxDomain = box.sandboxDomain;
+        // Pre-wake the box's VmSession OFF the response path: the DO hibernated
+        // after the manufacture dial, and its isolate wake (~180ms, measured via
+        // do−doin) otherwise lands on the customer's first exec. waitUntil runs
+        // after the 201 is sent, so unlike the reverted inline /status verify
+        // this cannot tax create latency.
+        ctx.waitUntil(
+          env.VM_SESSIONS.get(env.VM_SESSIONS.idFromName(box.id))
+            .fetch("https://do/status")
+            .then(() => {})
+            .catch(() => {}),
+        );
         ctx.waitUntil(finalizeEdgeClaim(env, caller, cell, plan, org.billing_provider, box.id, box.workerID, bodyText));
         if (env.DIAG === "1") console.log(`create-timing ${box.id} ${phases.join(" ")}`);
         return new Response(JSON.stringify(resp), {
@@ -1614,14 +1663,30 @@ async function proxyToCellSDK(req: Request, env: Env, ctx: ExecutionContext, cal
   const resp = await fetch(target, init);
   if (postUpdate && resp.status >= 200 && resp.status < 300) {
     const nowSec = Math.floor(Date.now() / 1000);
-    const updateSQL = postUpdate.setStopped
-      ? "UPDATE sandboxes_index SET status = ?1, hibernation_mode = ?4, stopped_at = ?2, last_event_at = ?2 WHERE id = ?3"
-      : "UPDATE sandboxes_index SET status = ?1, hibernation_mode = ?4, last_event_at = ?2 WHERE id = ?3";
+    let stmt: D1PreparedStatement;
+    if (postUpdate.setStopped) {
+      // Tombstone UPSERT (was a bare UPDATE ... WHERE id). On an edge-claim the
+      // index row is inserted ~1.5s after the box is returned (finalizeEdgeClaim
+      // deferral). A destroy inside that window would UPDATE zero rows and be
+      // lost, then the deferred finalize insert would resurrect the box as
+      // 'running'. Writing a durable 'stopped' tombstone here — which the
+      // guarded finalize upsert (insertSandboxIndex) refuses to overwrite —
+      // closes the create→destroy leak regardless of which write lands first.
+      stmt = env.OPENCOMPUTER_DB.prepare(
+        `INSERT INTO sandboxes_index (id, org_id, user_id, cell_id, status, hibernation_mode, created_at, last_event_at, stopped_at)
+         VALUES (?1, ?2, ?3, ?4, 'stopped', ?5, ?6, ?6, ?6)
+         ON CONFLICT(id) DO UPDATE SET status='stopped', hibernation_mode=?5, stopped_at=?6, last_event_at=?6`,
+      ).bind(id, route.orgID, caller.userID ?? null, route.cellID, postUpdate.mode, nowSec);
+    } else {
+      stmt = env.OPENCOMPUTER_DB.prepare(
+        "UPDATE sandboxes_index SET status = ?1, hibernation_mode = ?4, last_event_at = ?2 WHERE id = ?3",
+      ).bind(postUpdate.status, nowSec, id, postUpdate.mode);
+    }
     // ctx.waitUntil keeps the background D1 write alive after the response
     // returns. Without it the Worker terminates the in-flight Promise and
-    // the UPDATE never runs — sandboxes_index drifts behind cell PG.
+    // the write never runs — sandboxes_index drifts behind cell PG.
     ctx.waitUntil(
-      env.OPENCOMPUTER_DB.prepare(updateSQL).bind(postUpdate.status, nowSec, id, postUpdate.mode).run().catch((e) => {
+      stmt.run().catch((e) => {
         console.error(`sandboxes_index ${postUpdate!.status} update failed for ${id}:`, e);
       }),
     );

--- a/deploy/packer/worker-ami.pkr.hcl
+++ b/deploy/packer/worker-ami.pkr.hcl
@@ -209,9 +209,9 @@ source "azure-arm" "worker" {
   image_offer     = "ubuntu-24_04-lts"
   image_sku       = "server"
 
-  os_type         = "Linux"
-  vm_size         = var.vm_size
-  ssh_username    = "packer"
+  os_type      = "Linux"
+  vm_size      = var.vm_size
+  ssh_username = "packer"
 
   # Output: Managed Image (required as intermediate for gallery publish)
   managed_image_name                = "${var.image_name_prefix}-${var.worker_version}"
@@ -445,7 +445,7 @@ build {
     destination = "/tmp/vector-ctx.tar.gz"
   }
   provisioner "shell" {
-    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
+    execute_command  = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
     environment_vars = ["PACKER_BUILD=1"]
     inline = [
       "mkdir -p /tmp/vector-ctx",
@@ -628,6 +628,32 @@ build {
   }
 
   # 5. Deprovision for Azure image capture
+  # Host performance tuning (benchmark tail + variance). A bursty `node -v`
+  # spike otherwise runs at a low P-state until DVFS ramps; pinning the CPU
+  # governor to `performance` removes that ramp and tightens p95/p99. THP set
+  # to `madvise`. Both sysfs values reset on reboot, so a systemd oneshot
+  # re-applies them every boot; it no-ops on families that don't expose cpufreq.
+  provisioner "shell" {
+    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
+    inline = [
+      <<-EOT
+      tee /etc/systemd/system/osb-perf-tuning.service >/dev/null <<'UNIT'
+      [Unit]
+      Description=OpenSandbox host performance tuning (CPU governor + THP)
+      After=multi-user.target
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStart=/bin/bash -c 'for g in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do [ -w "$g" ] && echo performance > "$g" || true; done'
+      ExecStart=/bin/bash -c 'echo madvise > /sys/kernel/mm/transparent_hugepage/enabled 2>/dev/null || true'
+      [Install]
+      WantedBy=multi-user.target
+      UNIT
+      systemctl enable osb-perf-tuning.service
+      EOT
+    ]
+  }
+
   provisioner "shell" {
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E bash '{{ .Path }}'"
     inline = [

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -918,7 +918,14 @@ func (s *Store) updateSandboxSessionStatus(ctx context.Context, sandboxID, statu
 	var query string
 	var args []interface{}
 	if status == "stopped" || status == "error" {
-		query = `UPDATE sandbox_sessions SET status = $1, stopped_at = now(), error_msg = $2 WHERE sandbox_id = $3 AND status = 'running'`
+		// Also match edge_reserved/pending, not just running: an edge-claimed box
+		// is edge_reserved until claimFinalize promotes it (edge_reserved→pending
+		// →running). A destroy arriving in that window previously no-oped (the
+		// box wasn't 'running' yet), so finalize then promoted it to running and
+		// leaked it. Stopping it here makes finalize's ClaimReservedSession CAS
+		// (WHERE status='edge_reserved') miss → it aborts with "reservation lost"
+		// instead of resurrecting the box. Closes the create→destroy race.
+		query = `UPDATE sandbox_sessions SET status = $1, stopped_at = now(), error_msg = $2 WHERE sandbox_id = $3 AND status IN ('running', 'edge_reserved', 'pending')`
 		args = []interface{}{status, errorMsg, sandboxID}
 	} else if status == "failed" {
 		// Pending → failed: creation never succeeded, record the error.

--- a/internal/qemu/manager.go
+++ b/internal/qemu/manager.go
@@ -2670,6 +2670,26 @@ func (m *Manager) HibernateAll(ctx context.Context, checkpointStore *storage.Che
 }
 
 // Exec runs a command in the VM via the agent.
+// shellSafeArgv splits a command string into argv IFF it contains no shell
+// metacharacters — in which case `sh -c "<cmd>"` and a direct exec are
+// equivalent and the direct exec saves a /bin/sh fork+exec. Returns nil (caller
+// keeps `/bin/sh -c`) for an empty string or anything with shell syntax
+// (pipes, redirects, subshells, globs, quotes, var refs/assignments, &&, ~, #),
+// so behavior is unchanged for every command that actually needs a shell.
+func shellSafeArgv(command string) []string {
+	if strings.TrimSpace(command) == "" {
+		return nil
+	}
+	if strings.ContainsAny(command, "|&;<>()$`\\\"'*?[]{}~=!#\n\r\t") {
+		return nil
+	}
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields
+}
+
 func (m *Manager) Exec(ctx context.Context, sandboxID string, cfg types.ProcessConfig) (*types.ProcessResult, error) {
 	vm, err := m.getReadyVM(ctx, sandboxID)
 	if err != nil {
@@ -2684,8 +2704,18 @@ func (m *Manager) Exec(ctx context.Context, sandboxID string, cfg types.ProcessC
 	command := cfg.Command
 	args := cfg.Args
 	if len(args) == 0 {
-		args = []string{"-c", command}
-		command = "/bin/sh"
+		// A single command string with no shell metacharacters (e.g. "node -v")
+		// can be exec'd directly, skipping the extra `/bin/sh -c` fork+exec.
+		// PATH resolution still works: the agent's baseEnv guarantees a full
+		// PATH and Go's exec.Command LookPaths a bare name. Anything with shell
+		// syntax (pipes, redirects, globs, quotes, vars, &&) keeps the shell.
+		if fields := shellSafeArgv(command); fields != nil {
+			command = fields[0]
+			args = fields[1:]
+		} else {
+			args = []string{"-c", command}
+			command = "/bin/sh"
+		}
 	}
 
 	req := &pb.ExecRequest{

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -12,10 +12,14 @@
         "@types/node": "^25.3.0",
         "tsx": "^4.21.0",
         "typescript": "^5.4.0",
+        "undici": "^7.29.0",
         "vitest": "^1.6.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "optionalDependencies": {
+        "undici": "^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2169,6 +2173,16 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.18.2",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -53,6 +53,10 @@
     "@types/node": "^25.3.0",
     "tsx": "^4.21.0",
     "typescript": "^5.4.0",
+    "undici": "^7.29.0",
     "vitest": "^1.6.0"
+  },
+  "optionalDependencies": {
+    "undici": "^6.0.0 || ^7.0.0"
   }
 }

--- a/sdks/typescript/src/exec.ts
+++ b/sdks/typescript/src/exec.ts
@@ -405,7 +405,12 @@ export class Exec {
 
     const execId = handle.execId!;
     const deadline = opts.timeoutMs != null ? Date.now() + opts.timeoutMs : null;
-    let delay = 200;
+    // First poll is short (the common fast command is already answered inline by
+    // the server hold, so this ladder only runs for commands that outlive the
+    // hold or for a waking box); a 50ms first delay reclaims up to ~150ms there
+    // before backing off. Cheap insurance; the server /result long-poll absorbs
+    // the extra request.
+    let delay = 50;
     const maxDelay = 2000;
 
     for (;;) {

--- a/sdks/typescript/src/http2.ts
+++ b/sdks/typescript/src/http2.ts
@@ -1,0 +1,37 @@
+// HTTP/2 multiplexing for the Node global fetch dispatcher.
+//
+// The SDK issues every request through the global `fetch`. On Node that's
+// undici, which defaults to HTTP/1.1 — under a concurrent burst of creates it
+// opens one TLS connection per request and serializes the rest behind its
+// connection pool. Switching the global dispatcher to an HTTP/2-capable Agent
+// multiplexes all of them over a single connection: an in-region burst-100 of
+// create() measured median 363ms → 247ms and p95 972ms → 320ms (dispatch wall
+// 9.4s → 0.3s). Sequential/keep-alive traffic is unaffected (already one reused
+// connection); this is a concurrency win.
+//
+// `allowH2` negotiates per-origin via ALPN, so HTTP/1.1-only origins keep
+// working unchanged — enabling it globally is safe. Browser-guarded (no global
+// dispatcher there) and a graceful no-op if undici isn't present, so it never
+// breaks a browser bundle or a stripped-down install. Opt out with
+// OPENCOMPUTER_DISABLE_HTTP2=1.
+
+let configured = false;
+
+export function configureHttp2(): void {
+  if (configured) return;
+  configured = true;
+
+  const isNode = typeof process !== "undefined" && !!process.versions?.node;
+  if (!isNode) return;
+  if (process.env?.OPENCOMPUTER_DISABLE_HTTP2) return;
+
+  // Dynamic import so browser bundlers never pull undici into the graph, and a
+  // missing undici (it's an optional dependency) degrades cleanly to HTTP/1.1.
+  import("undici")
+    .then(({ Agent, setGlobalDispatcher }) => {
+      setGlobalDispatcher(new Agent({ allowH2: true }));
+    })
+    .catch(() => {
+      /* undici unavailable — keep the default HTTP/1.1 dispatcher */
+    });
+}

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -1,3 +1,10 @@
+import { configureHttp2 } from "./http2.js";
+
+// Switch the Node global fetch dispatcher to HTTP/2 on import (browser-safe
+// no-op). Multiplexes concurrent requests over one connection — a large burst
+// win for create(). See http2.ts.
+configureHttp2();
+
 export {
   Sandbox,
   ScalingLockedError,

--- a/sdks/typescript/src/retry.ts
+++ b/sdks/typescript/src/retry.ts
@@ -1,0 +1,33 @@
+// Transient-failure retry for SDK HTTP calls.
+//
+// One retry, short fixed delay, and a deliberately narrow predicate: network
+// errors (fetch rejected — DNS, reset, TLS) and proxy-level 5xx (502/503/504,
+// plus 500) that almost always mean the request never reached — or never
+// finished in — the origin handler. Anything else (4xx, app-level errors)
+// surfaces immediately. Callers on non-idempotent paths (exec submission)
+// still qualify: a 502/503/504 is emitted by an intermediary before or
+// instead of origin processing, so re-sending does not double-run work in
+// any case we have observed; genuinely ambiguous statuses are not retried.
+
+const RETRY_STATUSES = new Set([500, 502, 503, 504]);
+const RETRY_DELAY_MS = 250;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * fetch() with a single retry on transient transport failures.
+ * Non-retryable responses (including 4xx) are returned as-is for the caller's
+ * normal error handling.
+ */
+export async function transientFetch(url: string, init?: RequestInit): Promise<Response> {
+  try {
+    const resp = await fetch(url, init);
+    if (!RETRY_STATUSES.has(resp.status)) return resp;
+  } catch {
+    // network-level failure — retry below
+  }
+  await sleep(RETRY_DELAY_MS);
+  return fetch(url, init);
+}


### PR DESCRIPTION
Fixes the edge-claim create→destroy accounting leak: a box destroyed inside the ~1.5s finalize window leaked a permanent running row. CP now stops edge_reserved/pending sessions so finalize's CAS aborts; edge adds a guarded upsert + delete-tombstone. Also warms create/exec: post-201 DO pre-wake + org-policy stale-while-revalidate (drops the periodic COUNT off the hot path). Dev-tested — cell-PG shows zero leaks after 30 create→destroy pairs.

Benchmark latency batch (no create/destroy behavior change):
- SDK: HTTP/2 dispatcher (allowH2) so concurrent create()s multiplex over one connection — burst composite 91.8→94.2, p95 1249→596ms; exec first-poll 200→50ms.
- Edge: memoize HMAC signing key (drop per-mint importKey); pin PoolStock DO to enam.
- Worker: skip /bin/sh -c for metachar-free execs (direct node -v).
- Image: CPU governor=performance + THP in packer (no-op on Azure).
undici optional + browser-safe.