### PR TITLE
Clarify cloud development setup command

### DIFF
--- a/web/src/managed-agents/Home.tsx
+++ b/web/src/managed-agents/Home.tsx
@@ -160,13 +160,20 @@ export default function ProjectsHome() {
       <Panel>
         <PanelContent className="flex items-start gap-3">
           <Bot className="text-muted-foreground mt-0.5 size-4" />
-          <div>
+          <div className="min-w-0 flex-1">
             <p className="text-sm font-medium">Cloud development</p>
             <p className="text-muted-foreground mt-1 text-sm">
-              <code>npm create @opencomputer/start@latest</code> creates an{' '}
+              Create a new app in a <code>my-agent/</code> folder. No global
+              OpenComputer CLI installation is required.
+            </p>
+            <pre className="bg-muted mt-3 overflow-x-auto rounded-md border px-3 py-2 text-xs leading-5">
+              <code>npm create @opencomputer/start@latest my-agent</code>
+            </pre>
+            <p className="text-muted-foreground mt-2 text-xs leading-5">
+              Then run <code>cd my-agent</code>, <code>npm install</code>, and{' '}
+              <code>npm run dev</code>. The project contains an{' '}
               <code>opencomputer/</code> agent backend and a <code>src/</code>{' '}
-              React app. Agent code syncs to the development environment while
-              the React app hot reloads locally in a second terminal.
+              React app.
             </p>
           </div>
         </PanelContent>


### PR DESCRIPTION
## Summary
- show the complete npm create command with the my-agent destination
- explain that no global OpenComputer CLI installation is required
- list the immediate cd, npm install, and npm run dev steps

## Validation
- Prettier check passed
- dashboard TypeScript check passed