### PR TITLE
Fix agent package npm provenance

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -18,5 +18,10 @@
   },
   "engines": { "node": ">=22.0.0" },
   "publishConfig": { "access": "public" },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/diggerhq/opencomputer.git",
+    "directory": "agent"
+  },
   "devDependencies": { "typescript": "^5.9.0" }
 }


### PR DESCRIPTION
## Summary
- add the missing repository metadata to `@opencomputer/agent`
- match npm provenance to `https://github.com/diggerhq/opencomputer`
- retain version `0.3.1` because the failed publish never created that version

## Validation
- confirmed npm still reports agent `0.2.0`, CLI `0.4.7`, and starter `0.1.2`
- agent build passes
- `npm pack --dry-run --json` succeeds for `@opencomputer/agent@0.3.1`

## Failure addressed
Run 31459594839 failed with npm E422 because `agent/package.json` had no `repository.url`, so npm could not validate the GitHub Actions provenance bundle. Merging this PR reruns the ordered publisher; no manual package publication is required.
