### PR TITLE
feat(cli): add project link command

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -8,6 +8,7 @@ npm create @opencomputer/start@latest my-agent
 cd my-agent
 npm install
 npx opencomputer login
+npx opencomputer link
 ```
 
 The npm initializer delegates to `opencomputer init` and creates the same
@@ -24,8 +25,9 @@ npm run dev
 npm run dev:web
 ```
 
-The first `npm run dev` asks whether to create a project or select an existing
-project from the authenticated account. Later runs reuse that local binding.
+`opencomputer link` asks whether to create a project or select an existing
+project from the authenticated account. Later commands reuse that local binding.
+If you skip this step, the first project-scoped command prompts you to link.
 Use `opencomputer dev --project <id|slug>` for non-interactive selection or
 `opencomputer dev --create-project <name>` to create one explicitly.
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/cli",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "@opencode-ai/sdk": "1.18.4",
         "ai": "^7.0.45",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Build, test, connect, deploy, and share OpenComputer agents as code.",
   "type": "module",
   "bin": {

--- a/cli/src/binding.test.ts
+++ b/cli/src/binding.test.ts
@@ -71,7 +71,7 @@ test("first dev can select an existing project and later reuses its binding", as
   }
 });
 
-test("non-interactive dev requires an explicit project choice", async () => {
+test("non-interactive commands direct an unlinked app to link", async () => {
   const root = await mkdtemp(resolve(tmpdir(), "opencomputer-binding-"));
   try {
     const initialized = await initializeAgentProject(root);
@@ -89,7 +89,7 @@ test("non-interactive dev requires an explicit project choice", async () => {
         initialized.agentRoot,
         { interactive: false },
       ),
-      /--project <id\|slug>/,
+      /opencomputer link/,
     );
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/cli/src/binding.ts
+++ b/cli/src/binding.ts
@@ -20,6 +20,7 @@ export interface ProjectBindingOptions {
   project?: string;
   createProjectName?: string;
   interactive?: boolean;
+  select?: boolean;
 }
 
 async function exists(path: string): Promise<boolean> {
@@ -131,7 +132,7 @@ export async function ensureProjectBinding(
   }
   const projectRoot = await findOpenComputerProjectRoot(agentRoot);
   const projects = await client.projects();
-  if (!options.project && !options.createProjectName) {
+  if (!options.project && !options.createProjectName && !options.select) {
     const existing = await readBinding(projectRoot, config.apiUrl);
     if (
       existing &&
@@ -158,7 +159,7 @@ export async function ensureProjectBinding(
   if (!project && !createName) {
     if (options.interactive === false || !process.stdin.isTTY || !process.stdout.isTTY) {
       throw new Error(
-        "This app is not connected to a cloud project. Run `opencomputer dev --project <id|slug>` or `opencomputer dev --create-project <name>`.",
+        "This app is not connected to a cloud project. Run `opencomputer link`.",
       );
     }
     const choice = await chooseProject(projects, basename(projectRoot));

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -120,6 +120,7 @@ async function selectedProject(
   client: OpenComputerClient,
   config: Awaited<ReturnType<typeof resolveConfig>>,
   reference?: string,
+  interactive = true,
 ): Promise<{ projectId: string; agentId: string }> {
   if (reference) {
     const project = (await client.projects()).find(
@@ -132,7 +133,7 @@ async function selectedProject(
   }
   const root = await findOpenComputerProjectRoot(process.cwd());
   const binding = await ensureProjectBinding(client, config, root, {
-    interactive: false,
+    interactive,
   });
   return { projectId: binding.projectId, agentId: binding.agentId };
 }
@@ -557,6 +558,22 @@ export async function runCommand(
     return;
   }
 
+  if (command === "link") {
+    if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+    const root = await findOpenComputerProjectRoot(process.cwd());
+    const binding = await ensureProjectBinding(client, config, root, {
+      interactive: !globals.json,
+      select: true,
+    });
+    if (globals.json) printJSON(binding);
+    else {
+      process.stdout.write(
+        `Linked this app to ${binding.projectName} (${binding.projectId}).\n`,
+      );
+    }
+    return;
+  }
+
   if (command === "deploy") {
     const alias = option(args, "--alias") ?? "production";
     if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
@@ -623,7 +640,12 @@ export async function runCommand(
     const projectReference = option(args, "--project");
     const agentOption = option(args, "--agent");
     const environment = environmentOption(option(args, "--environment"));
-    const project = await selectedProject(client, config, projectReference);
+    const project = await selectedProject(
+      client,
+      config,
+      projectReference,
+      !globals.json,
+    );
     const agentId = agentOption
       ? agentOption === "current"
         ? project.agentId
@@ -722,10 +744,16 @@ export async function runCommand(
     }
     if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
     if (!agentId && !sessionId) {
+      let insideProject = true;
       try {
-        agentId = (await selectedProject(client, config)).agentId;
+        await findOpenComputerProjectRoot(process.cwd());
       } catch {
-        // Outside an initialized app, unfiltered logs cover the account.
+        insideProject = false;
+      }
+      if (insideProject) {
+        agentId = (
+          await selectedProject(client, config, undefined, !globals.json)
+        ).agentId;
       }
     }
     let cursor = "";

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -48,6 +48,7 @@ Usage:
   opencomputer whoami
   opencomputer agents
   opencomputer init <directory|.>
+  opencomputer link
   opencomputer dev [--project <id|slug> | --create-project <name>]
   opencomputer session [prompt]
   opencomputer session create <prompt> [--local]

--- a/docs/agents/projects.mdx
+++ b/docs/agents/projects.mdx
@@ -39,7 +39,14 @@ placeholder capability directories.
 ## Create or select the cloud project
 
 The source scaffold and cloud project are separate. `npm create` writes local
-source; the first `npm run dev` asks where to sync it.
+source. Link it to a cloud project with:
+
+```bash
+npx opencomputer link
+```
+
+The command asks whether to create a project or select an existing one. If you
+skip it, the first project-scoped command shows the same prompt.
 
 For non-interactive use:
 
@@ -48,8 +55,8 @@ npx opencomputer dev --project <project-id-or-slug>
 npx opencomputer dev --create-project "Support agents"
 ```
 
-Later runs reuse `.opencomputer/project.json`. Delete or change that binding
-only when you intentionally want this source directory to target another
+Later commands reuse `.opencomputer/project.json`. Run `opencomputer link`
+again when you intentionally want this source directory to target another
 project.
 
 ## Add another agent

--- a/docs/agents/quickstart.mdx
+++ b/docs/agents/quickstart.mdx
@@ -27,7 +27,17 @@ npx opencomputer login
 The CLI opens the OpenComputer device-login flow and stores the login locally.
 The production API at `https://app.opencomputer.dev` is used by default.
 
-## 3. Start cloud development
+## 3. Link a cloud project
+
+```bash
+npx opencomputer link
+```
+
+Choose an existing project or create a new one. OpenComputer stores this local
+binding for subsequent development, secrets, and logs commands. You can skip
+this step: the first project-scoped command will show the same prompt.
+
+## 4. Start cloud development
 
 In the first terminal:
 
@@ -35,10 +45,10 @@ In the first terminal:
 npm run dev
 ```
 
-On the first run, choose an existing project or create a new one. The process
-stays open, watches `opencomputer/`, and syncs changes to `development`.
+The process stays open, watches `opencomputer/`, and syncs changes to
+`development`.
 
-## 4. Start React
+## 5. Start React
 
 In a second terminal:
 
@@ -56,7 +66,7 @@ bridge details from `.opencomputer/dev.json`; those details are intentionally
 not bundled into browser code.
 </Warning>
 
-## 5. Change the agent
+## 6. Change the agent
 
 Edit `opencomputer/agents/hello-world/agent.ts`:
 
@@ -74,7 +84,7 @@ export default function Agent() {
 Saving the file publishes a new development deployment. Refreshing or
 restarting the React app is not required for agent-only changes.
 
-## 6. Deploy to production
+## 7. Deploy to production
 
 ```bash
 npm run deploy -- --alias production

--- a/docs/agents/secrets.mdx
+++ b/docs/agents/secrets.mdx
@@ -50,6 +50,9 @@ outbound gateway.
 
 ## Set a project secret
 
+Secrets belong to a cloud project. If the app is not linked yet, this command
+first asks you to select or create one, then continues setting the secret.
+
 ```bash
 npx opencomputer secrets set GITHUB_TOKEN
 ```
@@ -85,4 +88,3 @@ local supervisor. The supervisor authenticates the runtime request to the
 OpenComputer gateway. The gateway resolves the scoped secret, injects it for
 that single upstream request, and streams the response back. The sandbox never
 receives the provider credential.
-


### PR DESCRIPTION
## Summary
- add an interactive `opencomputer link` command for selecting or creating a cloud project
- prompt project-scoped commands to link when no local binding exists
- document the link-first and automatic-link flows
- bump `@opencomputer/cli` to 0.4.9 for publication

## Validation
- `cd cli && npm test` (22 tests pass)