### PR TITLE
docs: organize serverless agent concepts

### DIFF
--- a/docs/agents/capabilities.mdx
+++ b/docs/agents/capabilities.mdx
@@ -1,0 +1,50 @@
+---
+title: "Agent capabilities"
+description: "Choose between tools, MCP servers, skills, subagents, and outbound connections"
+---
+
+Capabilities give an agent something beyond its instructions and model. Choose
+the narrowest capability that fits the job.
+
+| Capability | Use it for | Where the work happens | How it is attached |
+| --- | --- | --- | --- |
+| Code-defined tool | One typed operation you implement | Your TypeScript `run()` function | `useTool(tool)` |
+| MCP server | A service that already publishes a collection of tools | The remote MCP server | `useMcpServer(server)` |
+| Skill | A reusable procedure, checklist, or supporting files | The agent follows the loaded instructions | Place it under `skills/` |
+| Subagent | Delegating a focused task to another project agent | The delegated agent | `useSubagent(agentId)` |
+| HTTP connection | A constrained authenticated outbound request | OpenComputer sends the declared request | Call `defineConnection().fetch()` inside a tool |
+
+`useModel()` selects the model for a render, but it does not add an executable
+capability.
+
+## Tool or MCP server?
+
+Use a [code-defined tool](/agents/tools) when you own the operation, want a
+small schema, or need application-specific validation. Use an
+[MCP server](/agents/mcp) when another service already hosts the tools.
+
+Both ultimately give the model callable tools. A code-defined tool exposes the
+single operation you register; an MCP server exposes the tools it advertises.
+
+## Tool or skill?
+
+A tool performs an operation and returns structured data. A
+[skill](/agents/skills) teaches the agent how to approach a category of work.
+Many agents use both: the skill describes the workflow while tools perform the
+individual actions.
+
+## Tool or subagent?
+
+Use a tool for a bounded operation such as fetching an order. Use a
+[subagent](/agents/subagents) when the task benefits from its own instructions,
+model selection, capabilities, and working context.
+
+## Connections are not managed accounts
+
+`defineConnection()` declares a secret-backed HTTP destination. It is not an
+OAuth account selector and does not itself give the model a tool. Call it from
+a code-defined tool, or attach it to an MCP definition when that server accepts
+the corresponding header-based authorization.
+
+See [Secrets and outbound requests](/agents/secrets) for the complete security
+model.

--- a/docs/agents/deployments.mdx
+++ b/docs/agents/deployments.mdx
@@ -1,0 +1,47 @@
+---
+title: "Deployments and environments"
+description: "Understand development, production, immutable deployments, and aliases"
+---
+
+A deployment is an immutable build of one agent. An alias gives a stable name
+to the deployment clients should run.
+
+Every project starts with two working environments:
+
+| Environment | Alias | How it changes |
+| --- | --- | --- |
+| Development | `development` | `npm run dev` publishes source changes |
+| Production | `production` | An explicit deploy advances it |
+
+Sessions keep the deployment they started with. Publishing another version
+does not change the code underneath an existing session.
+
+## Deploy to production
+
+From the project directory:
+
+```bash
+npm run deploy -- --alias production
+```
+
+The CLI builds the current source, creates an immutable deployment, and moves
+the `production` alias to it. Development remains available for further work.
+
+## Select an agent and environment
+
+Clients identify an agent with `agent-id@alias`:
+
+```text
+support@development
+support@production
+```
+
+The project dashboard's environment selector changes which deployment you are
+inspecting. The playground has a separate agent selector when a project
+contains more than one agent.
+
+## Review history
+
+Open the project's **Deployments** page to inspect immutable versions, their
+aliases, and creation times. Use the deployment ID when correlating a session
+with [logs](/agents/logs) or the [debug inspector](/agents/playground).

--- a/docs/agents/development.mdx
+++ b/docs/agents/development.mdx
@@ -1,0 +1,67 @@
+---
+title: "Cloud development"
+description: "Sync agent code to Development while your application runs locally"
+---
+
+OpenComputer's development loop keeps agent execution in the cloud while your
+source files and optional React application stay on your machine.
+
+```bash
+npm run dev
+```
+
+The command performs four jobs:
+
+1. Links the source directory to a cloud project.
+2. Builds and publishes every configured agent to `development`.
+3. Watches `opencomputer/` and publishes changes automatically.
+4. Starts Vite when the project includes the React application.
+
+It also prints the project dashboard URL so you can test the same development
+deployment in the [agent playground](/agents/playground).
+
+## Select a project
+
+On the first run, select an existing project or create one. The choice is saved
+locally and reused by later commands.
+
+```bash
+npx opencomputer link
+```
+
+Use an explicit project in scripts or other non-interactive environments:
+
+```bash
+npx opencomputer dev --project <project-id-or-slug>
+npx opencomputer dev --create-project "Support agents"
+```
+
+## Work with the React application
+
+When a React application is present, the same `npm run dev` process starts both
+cloud synchronization and Vite. Keep it running while using the application;
+the development bridge exists only for the lifetime of that process.
+
+New sessions use the latest synchronized development deployment. Existing
+sessions keep the deployment they started with, so create a new session when
+testing a source change.
+
+## Synchronize development secrets
+
+Put agent credentials in `opencomputer/.env.local`. OpenComputer considers only
+names referenced by `useSecret()` and infers their allowed destinations from
+`defineConnection()` declarations.
+
+```dotenv
+GITHUB_TOKEN=github_pat_...
+```
+
+The CLI asks before the first upload and then watches for changes. Unreferenced
+variables are skipped, and removing a local value does not delete its cloud
+counterpart. See [Secrets and outbound requests](/agents/secrets).
+
+## Development and production stay separate
+
+Saving source advances only `development`. Production remains on its current
+immutable deployment until you explicitly deploy it. See
+[Deployments and environments](/agents/deployments).

--- a/docs/agents/examples/exa-research-session.mdx
+++ b/docs/agents/examples/exa-research-session.mdx
@@ -16,13 +16,13 @@ conversation and can refine an earlier answer without starting over.
 1. The React application sends a question to an OpenComputer session.
 2. The agent uses its `exa_search` tool when the question needs current web
    research.
-3. OpenComputer sends the search through a managed Exa connection and injects
-   the write-only `EXA_API_KEY` without exposing it to the agent or browser.
+3. The declared Exa connection sends the request with the write-only
+   `EXA_API_KEY` without adding it to agent source or browser code.
 4. The agent reads the results and streams an answer with clickable source
    URLs back to the application.
 
 The starter also includes an agent-specific skill that guides the research
-workflow and a reusable React hook for streaming messages and continuing the
+workflow and uses `@opencomputer/react` to stream messages and continue the
 same session.
 
 ## Start with the example
@@ -36,4 +36,5 @@ same session.
 </Card>
 
 The repository README covers installation, setting the Exa secret, running the
-agent and React development processes, and deploying the finished application.
+combined cloud-agent and React development process, and deploying the finished
+application.

--- a/docs/agents/inputs.mdx
+++ b/docs/agents/inputs.mdx
@@ -24,12 +24,7 @@ export default function Agent() {
 
 ```ts
 interface AgentInput {
-  readonly source:
-    | "user"
-    | "schedule"
-    | "webhook"
-    | "subagent"
-    | "system";
+  readonly source: InputSource;
   readonly text?: string;
   readonly payload?: DataValue;
 }
@@ -47,8 +42,7 @@ before use.
 
 ## Adapt to the source
 
-One agent can handle direct user messages, schedules, webhooks, and
-subagent calls without separate definitions:
+The current direct and delegated flows can share one agent definition:
 
 ```tsx
 import { useInput } from "@opencomputer/agent";
@@ -56,16 +50,9 @@ import { useInput } from "@opencomputer/agent";
 export default function Agent() {
   const input = useInput();
 
-  switch (input.source) {
-    case "schedule":
-      return "Run the scheduled review and summarize anything that changed.";
-    case "webhook":
-      return `Process this event: ${JSON.stringify(input.payload)}`;
-    case "subagent":
-      return "Complete the delegated task and return a concise result.";
-    default:
-      return `Help with: ${input.text ?? "the current request"}`;
-  }
+  return input.source === "subagent"
+    ? "Complete the delegated task and return a concise result."
+    : `Help with: ${input.text ?? "the current request"}`;
 }
 ```
 
@@ -76,25 +63,24 @@ Narrow or validate a payload before reading application-specific fields:
 ```tsx
 import { useInput } from "@opencomputer/agent";
 
-type IssueEvent = {
-  action?: string;
-  issue?: { number?: number; title?: string };
+type ResearchRequest = {
+  topic?: string;
+  depth?: "brief" | "deep";
 };
 
 export default function Agent() {
   const input = useInput();
-  const event = (input.payload ?? {}) as IssueEvent;
+  const request = (input.payload ?? {}) as ResearchRequest;
 
-  if (input.source === "webhook" && event.issue?.number) {
-    return `Triage issue #${event.issue.number}: ${event.issue.title ?? "Untitled"}`;
+  if (request.topic) {
+    return `Research ${request.topic} at ${request.depth ?? "brief"} depth.`;
   }
 
-  return "Ask for an issue number before starting triage.";
+  return "Ask for a research topic before starting.";
 }
 ```
 
-For untrusted webhook payloads, validate the value in a tool before performing
-side effects.
+Validate untrusted payloads in a tool before performing side effects.
 
 ## Input is not a prompt UI
 

--- a/docs/agents/logs.mdx
+++ b/docs/agents/logs.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Logs"
-description: "Inspect runtime output and managed-egress activity from the OpenComputer CLI"
+description: "Inspect agent output and outbound-request activity from the OpenComputer CLI"
 ---
 
-OpenComputer collects runtime stdout and stderr together with managed-egress
-events. Logs are indexed by project, environment, agent, and session so you can
-inspect failures without opening the agent sandbox.
+OpenComputer collects agent output together with outbound-request events. Logs
+are indexed by project, environment, agent, and session so you can
+inspect failures from the project or CLI.
 
 ## Read the current agent's logs
 
@@ -41,8 +41,7 @@ the applicable agent or session identifiers.
 
 ## Secret safety
 
-Managed-egress logs describe the connection, method, destination path, status,
+Outbound-request logs describe the connection, method, destination path, status,
 and timing. They do not contain injected secret values or secret-bearing
-headers. Runtime request headers that could override managed credentials are
-discarded by the gateway.
-
+headers. Request headers that could override managed credentials are discarded
+before the outbound request is sent.

--- a/docs/agents/mcp.mdx
+++ b/docs/agents/mcp.mdx
@@ -77,7 +77,7 @@ export default function Agent() {
 
 The declaration contains only a secret reference. Set the secret with
 `opencomputer secrets set GITHUB_PAT`; its value is injected only into requests
-to the declared origin. See [Secrets and managed egress](/agents/secrets).
+to the declared origin. See [Secrets and outbound requests](/agents/secrets).
 
 ## Attach MCP conditionally
 

--- a/docs/agents/models.mdx
+++ b/docs/agents/models.mdx
@@ -4,8 +4,7 @@ description: "Select a managed model with useModel"
 ---
 
 `useModel()` selects the model that powers the next agent step. OpenComputer
-owns the provider connection, authentication, streaming, and managed model
-gateway.
+handles provider authentication and response streaming.
 
 ```tsx
 import { useModel } from "@opencomputer/agent";
@@ -37,8 +36,8 @@ useModel({
 ```
 
 Keep model selection in agent code so development and immutable deployments
-record the behavior together. Provider credentials are resolved by the
-managed gateway and are not added to source bundles or client applications.
+record the behavior together. Provider credentials are not added to source
+bundles or client applications.
 
 ## Select a model conditionally
 
@@ -70,8 +69,8 @@ changes affect cost, latency, context limits, and output behavior.
 ## Keep credentials out of agent code
 
 Do not place provider API keys in `agent.ts`, tools, prompts, or the React
-application. OpenComputer's model gateway resolves the credential for the
-selected provider without exposing it to the agent.
+application. OpenComputer authenticates the selected provider without adding
+the credential to agent code.
 
 For credentials used by your own HTTP tools instead of model inference, use
-[Secrets and managed egress](/agents/secrets).
+[Secrets and outbound requests](/agents/secrets).

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -39,11 +39,14 @@ subagents needed for that render.
   <Card title="Sessions" icon="comments" href="/agents/sessions">
     Stream responses and inspect durable conversations.
   </Card>
+  <Card title="Capabilities" icon="shapes" href="/agents/capabilities">
+    Choose between tools, MCP servers, skills, and subagents.
+  </Card>
   <Card title="Secrets" icon="key" href="/agents/secrets">
     Declare secret-backed connections without exposing credentials to agents.
   </Card>
   <Card title="Logs" icon="terminal" href="/agents/logs">
-    Follow runtime and managed-egress activity from the CLI.
+    Follow agent and outbound-request activity from the CLI.
   </Card>
 </CardGroup>
 
@@ -77,9 +80,9 @@ same command also starts it locally.
   multi-turn session reuse
 - dashboard and CLI playground sessions
 - immutable deployments promoted through aliases such as `production`
-- project-level secrets with optional agent overrides and managed egress
+- project-level secrets with optional agent overrides and constrained outbound requests
 - indexed runtime and egress logs available from the CLI
 
-The dashboard is primarily an inspection and testing surface. Agent behavior
-belongs in the repository under `opencomputer/`; credentials remain managed by
-OpenComputer.
+Agent behavior belongs in the repository under `opencomputer/`. The dashboard
+is primarily for selecting environments, testing agents, and inspecting what
+was deployed.

--- a/docs/agents/playground.mdx
+++ b/docs/agents/playground.mdx
@@ -1,0 +1,42 @@
+---
+title: "Playground and debugging"
+description: "Test deployments and inspect what the agent received for each turn"
+---
+
+The agent playground is the fastest way to test a cloud deployment without
+building a client. Open a project, choose an environment and agent, then create
+a session.
+
+## Select the correct target
+
+The project header selects `development` or `production`. Projects with
+multiple agents have a separate agent selector in the playground. A session
+keeps the deployment selected when it starts.
+
+Create a new session after changing the target when you want an isolated test.
+Resume an existing session when you want to verify multi-turn behavior.
+
+## Use the debug inspector
+
+The inspector shows the information needed to explain a turn:
+
+- deployment and session identifiers
+- rendered agent instructions
+- selected model
+- tools and MCP capabilities available to that render
+- tool activity and errors
+
+OpenComputer's private platform instructions and credentials are intentionally
+not shown. The inspector describes your deployed agent configuration, not the
+internal execution implementation.
+
+## Follow runtime logs
+
+Use the CLI when a failure needs more detail:
+
+```bash
+npx opencomputer logs --follow
+npx opencomputer logs --session <session-id>
+```
+
+See [Logs](/agents/logs) for filters and JSON output.

--- a/docs/agents/projects.mdx
+++ b/docs/agents/projects.mdx
@@ -14,6 +14,7 @@ The starter is intentionally small:
 ```text
 my-agent/
 ├── opencomputer/
+│   ├── .env.example
 │   ├── project.ts
 │   └── agents/
 │       └── hello-world/
@@ -22,14 +23,14 @@ my-agent/
 │           └── skills/      # optional
 ├── src/
 │   ├── App.tsx
-│   ├── main.tsx
-│   └── use-agent.ts
+│   └── main.tsx
 ├── package.json
 └── vite.config.ts
 ```
 
 - `opencomputer/project.ts` declares project metadata and agent IDs.
 - `opencomputer/agents/<id>/agent.ts` defines one agent.
+- `opencomputer/.env.local` optionally holds ignored development secrets.
 - `src/` is a normal React application.
 - `.opencomputer/` is ignored local state created by the CLI.
 
@@ -96,7 +97,8 @@ The current project dashboard provides:
 - **Agent playground** for creating and resuming test sessions
 - **Deployments** for immutable version history and active aliases
 - **Sessions** created through the dashboard, React client, or API
-- **Channels** connected to a deployed agent alias
+- **Secrets** for write-only project and agent credentials
 
 Project and agent behavior remains code-owned. The dashboard is for selection,
-inspection, testing, and credential-backed setup flows.
+inspection, and testing. Use `opencomputer logs` to diagnose agent and
+outbound-request failures.

--- a/docs/agents/quickstart.mdx
+++ b/docs/agents/quickstart.mdx
@@ -40,9 +40,8 @@ changes to `development`. If you included the SPA, the same command starts
 Vite; open its URL and send a message.
 
 <Warning>
-  Keep `npm run dev` running while using the React app. Vite reads temporary
-  bridge details from `.opencomputer/dev.json`; they are intentionally not
-  bundled into browser code.
+  Keep `npm run dev` running while using the React app. The authenticated
+  development bridge exists only for the lifetime of that process.
 </Warning>
 
 ## 4. Change the agent
@@ -60,8 +59,12 @@ export default function Agent() {
 }
 ```
 
-Saving the file publishes a new development deployment. Refreshing or
-restarting the React app is not required for agent-only changes.
+Saving the file publishes a new development deployment. Start a new playground
+or client session to test it; an existing session keeps the deployment it
+started with.
+
+See [Cloud development](/agents/development) for project selection, automatic
+secret synchronization, and the full development lifecycle.
 
 ## 5. Deploy to production
 
@@ -71,6 +74,9 @@ npm run deploy -- --alias production
 
 The command builds an immutable deployment and advances the `production`
 alias. Development remains available for subsequent edits.
+
+See [Deployments and environments](/agents/deployments) for aliases and
+version history.
 
 <CardGroup cols={2}>
   <Card title="Projects" icon="folder" href="/agents/projects">

--- a/docs/agents/react.mdx
+++ b/docs/agents/react.mdx
@@ -1,0 +1,72 @@
+---
+title: "React integration"
+description: "Stream agent sessions from a React application with useAgent"
+---
+
+Projects created with the React option use `@opencomputer/react`. The package
+owns session creation, multi-turn reuse, and streamed assistant messages.
+
+```tsx
+import { useAgent } from "@opencomputer/react";
+
+export default function Chat() {
+  const { messages, send, sessionId, isRunning, error } = useAgent(
+    "hello-world@development",
+  );
+
+  return (
+    <main>
+      {messages.map((message) => (
+        <p key={message.id}>
+          <strong>{message.role}:</strong> {message.text}
+        </p>
+      ))}
+      <button
+        disabled={isRunning}
+        onClick={() => void send("Hello")}
+      >
+        Send
+      </button>
+      {sessionId ? <small>Session: {sessionId}</small> : null}
+      {error ? <p role="alert">{error}</p> : null}
+    </main>
+  );
+}
+```
+
+## Hook result
+
+| Value | Purpose |
+| --- | --- |
+| `messages` | User and assistant messages accumulated by this hook instance |
+| `send(text)` | Starts or continues the session and streams the response |
+| `sessionId` | Current cloud session after the first message |
+| `isRunning` | Whether a turn is active |
+| `error` | Most recent request error |
+
+## Select the target
+
+Pass `agent-id@alias` to choose the agent and environment:
+
+```tsx
+useAgent("support@development");
+useAgent("support@production");
+```
+
+An options object can also set the input source, API base path, or fetch
+implementation:
+
+```tsx
+useAgent({
+  agent: "support@development",
+  source: "customer-portal",
+});
+```
+
+## Development
+
+Keep `npm run dev` running while using the local application. It starts Vite
+and provides the authenticated development bridge; credentials are not bundled
+into browser code.
+
+For the durable conversation model, see [Sessions and turns](/agents/sessions).

--- a/docs/agents/reactive-agents.mdx
+++ b/docs/agents/reactive-agents.mdx
@@ -31,8 +31,8 @@ needs it.
 | `useSessionData(key)` | Reads a value previously stored in the current session |
 
 `useInput()` is not a human-in-the-loop prompt. It describes the input that
-caused the current render. Its `source` can be `user`, `schedule`,
-`webhook`, `subagent`, or `system`.
+caused the current render. See [Inputs](/agents/inputs) for its text, payload,
+and source metadata.
 
 ## Conditional configuration
 
@@ -105,8 +105,8 @@ runs in the managed agent runtime, not in the browser.
 
 ## Skills
 
-Skills are reusable instruction bundles for the coding-agent harness. Add a
-skill only when an agent needs one:
+Skills are reusable instruction bundles. Add a skill only when an agent needs
+one:
 
 ```text
 opencomputer/agents/hello-world/skills/code-review/SKILL.md
@@ -131,8 +131,8 @@ An object form is also supported:
 useModel({ provider: "anthropic", model: "claude-sonnet-4.6" });
 ```
 
-Provider credentials are resolved by the managed model gateway and are not
-placed in the agent sandbox or React application.
+Provider credentials are managed by OpenComputer and are not placed in agent
+source or the React application.
 
 Continue with [Agent hooks](/agents/hooks), then use the focused guides for
 [inputs](/agents/inputs), [models](/agents/models), [tools](/agents/tools),

--- a/docs/agents/secrets.mdx
+++ b/docs/agents/secrets.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Secrets and managed egress"
+title: "Secrets and outbound requests"
 description: "Use project and agent secrets without exposing values to agent runtimes"
 ---
 
@@ -43,8 +43,8 @@ const repository = await response.json();
 ```
 
 Only a relative path is accepted. OpenComputer checks the declared origin,
-path prefix, method, agent, and environment before injecting the secret at the
-outbound gateway.
+path prefix, method, agent, and environment before sending the outbound
+request.
 
 ## Synchronize development secrets
 
@@ -99,10 +99,9 @@ npx opencomputer secrets remove GITHUB_TOKEN --environment development
 List output contains metadata such as the name, scope, environment, and
 allowed origins. Secret values are never returned.
 
-## Request path
+## Security guarantees
 
-The agent runtime sends a declared connection ID and relative request to its
-local supervisor. The supervisor authenticates the runtime request to the
-OpenComputer gateway. The gateway resolves the scoped secret, injects it for
-that single upstream request, and streams the response back. The sandbox never
-receives the provider credential.
+OpenComputer resolves the declared connection and scoped secret for each
+request. The credential is attached only after the destination, method, path,
+agent, project, and environment have been validated. The value is never added
+to the agent's source bundle, prompt, browser application, or logs.

--- a/docs/agents/session-data.mdx
+++ b/docs/agents/session-data.mdx
@@ -75,6 +75,6 @@ The current `@opencomputer/agent` API exposes session data as a read-only
 snapshot. It does not yet include a hook for setting or updating a value from
 agent code. Code should treat the returned value as immutable.
 
-See [Sessions and playground](/agents/sessions) for the durable conversation
+See [Sessions and turns](/agents/sessions) for the durable conversation
 lifecycle and [Exa research session](/agents/examples/exa-research-session)
 for a starter that continues follow-up questions in one session.

--- a/docs/agents/sessions.mdx
+++ b/docs/agents/sessions.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Sessions and playground"
-description: "Create durable conversations from React, the dashboard, or the CLI"
+title: "Sessions and turns"
+description: "Understand durable conversations and multi-turn agent work"
 ---
 
 A session is a durable conversation with a deployed agent. Each turn appends
@@ -30,6 +30,9 @@ Playground sessions stay in the playground list. Sessions started through an
 API appear under **Sessions**, where their durable turn history can be
 inspected.
 
+See [Playground and debugging](/agents/playground) for target selection and the
+debug inspector.
+
 ## CLI
 
 Start an interactive session against the development agent:
@@ -56,5 +59,5 @@ the command exits.
 ## Input sources
 
 Inside an agent, `useInput().source` identifies how the current work arrived.
-This lets the same agent adapt to React, playground, API, schedule, webhook,
-subagent, and system inputs without separate agent definitions.
+This lets the same agent distinguish direct work from delegated subagent work
+without defining another session type.

--- a/docs/agents/skills.mdx
+++ b/docs/agents/skills.mdx
@@ -5,7 +5,7 @@ description: "Package reusable instructions and supporting resources with an age
 
 A skill is a reusable instruction bundle that teaches an agent how to perform
 a task. A tool executes code; a skill provides a procedure, checklist, or
-domain playbook the managed coding-agent harness can load when relevant.
+domain playbook the agent can load when relevant.
 
 ## Create a skill
 
@@ -38,14 +38,13 @@ description: Create a sourced campaign brief. Use when planning a new campaign o
 5. Read `CHECKLIST.md` before returning the final brief.
 ```
 
-The description should say both what the skill does and when it applies. It is
-the information the harness uses to decide whether to load the instructions.
+The description should say both what the skill does and when it applies. The
+agent uses it to decide whether to load the instructions.
 
 ## Use the skill
 
-Skills do not need a hook in the current authoring API. OpenComputer packages
-the entire `skills/` directory with that agent, and the managed harness can
-load a matching skill during the session.
+Skills do not need a hook. OpenComputer packages the entire `skills/` directory
+with that agent, which can load a matching skill during the session.
 
 Tell the agent when the skill should guide its work:
 

--- a/docs/agents/tools.mdx
+++ b/docs/agents/tools.mdx
@@ -122,8 +122,8 @@ runtime already provides that tool.
 
 Do not embed API keys in a tool or read them from the runtime environment.
 Declare an HTTP connection, store the value as an OpenComputer secret, and
-call the connection's managed `fetch()` method. See [Secrets and managed
-egress](/agents/secrets) for a complete example.
+call the connection's `fetch()` method. See
+[Secrets and outbound requests](/agents/secrets) for a complete example.
 
 ## Tools versus skills and MCP
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -27,12 +27,27 @@
         "tab": "Serverless Agents",
         "groups": [
           {
-            "group": "Serverless Agents",
+            "group": "Getting started",
             "pages": [
               "agents/overview",
               "agents/quickstart",
               "agents/projects",
+              "agents/development",
+              "agents/deployments"
+            ]
+          },
+          {
+            "group": "Concepts",
+            "pages": [
               "agents/reactive-agents",
+              "agents/sessions",
+              "agents/capabilities",
+              "agents/secrets"
+            ]
+          },
+          {
+            "group": "Agent API",
+            "pages": [
               "agents/hooks",
               "agents/inputs",
               "agents/models",
@@ -41,8 +56,13 @@
               "agents/skills",
               "agents/subagents",
               "agents/session-data",
-              "agents/sessions",
-              "agents/secrets",
+              "agents/react"
+            ]
+          },
+          {
+            "group": "Test and operate",
+            "pages": [
+              "agents/playground",
               "agents/logs"
             ]
           },

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7,7 +7,12 @@
 - [Overview](https://docs.opencomputer.dev/agents/overview.md): Build, test, and deploy agents as code.
 - [Quickstart](https://docs.opencomputer.dev/agents/quickstart.md): Create a project and sync its first agent to Development (Cloud).
 - [Projects and agents](https://docs.opencomputer.dev/agents/projects.md): Organize multiple agents and a React application.
+- [Cloud development](https://docs.opencomputer.dev/agents/development.md): Sync agent code to Development while your application runs locally.
+- [Deployments and environments](https://docs.opencomputer.dev/agents/deployments.md): Understand development, production, immutable deployments, and aliases.
 - [Reactive agents](https://docs.opencomputer.dev/agents/reactive-agents.md): Render instructions, models, tools, subagents, and MCP servers from code.
+- [Sessions and turns](https://docs.opencomputer.dev/agents/sessions.md): Create and inspect durable conversations.
+- [Agent capabilities](https://docs.opencomputer.dev/agents/capabilities.md): Choose between tools, MCP servers, skills, subagents, and outbound connections.
+- [Secrets and outbound requests](https://docs.opencomputer.dev/agents/secrets.md): Store scoped secrets and inject them only into declared outbound requests.
 - [Agent hooks](https://docs.opencomputer.dev/agents/hooks.md): Compose agent capabilities with reactive hooks.
 - [Inputs](https://docs.opencomputer.dev/agents/inputs.md): Read text, structured payloads, and input sources with `useInput()`.
 - [Models](https://docs.opencomputer.dev/agents/models.md): Select a managed model with `useModel()`.
@@ -16,9 +21,9 @@
 - [Skills](https://docs.opencomputer.dev/agents/skills.md): Package reusable instructions and supporting resources with an agent.
 - [Subagents](https://docs.opencomputer.dev/agents/subagents.md): Let an agent delegate focused work with `useSubagent()`.
 - [Session data](https://docs.opencomputer.dev/agents/session-data.md): Read durable per-session values with `useSessionData()`.
-- [Sessions and playground](https://docs.opencomputer.dev/agents/sessions.md): Create and inspect durable conversations.
-- [Secrets and managed egress](https://docs.opencomputer.dev/agents/secrets.md): Store scoped secrets and inject them only into declared outbound requests.
-- [Logs](https://docs.opencomputer.dev/agents/logs.md): Inspect and follow runtime and managed-egress logs.
+- [React integration](https://docs.opencomputer.dev/agents/react.md): Stream agent sessions from a React application with `useAgent()`.
+- [Playground and debugging](https://docs.opencomputer.dev/agents/playground.md): Test deployments and inspect each agent turn.
+- [Logs](https://docs.opencomputer.dev/agents/logs.md): Inspect and follow agent and outbound-request logs.
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- reorganize the Serverless Agents navigation into getting started, concepts, API, operations, and examples
- add focused guides for cloud development, deployments, capabilities, React integration, and playground debugging
- clarify projects, sessions, inputs, models, tools, MCP, skills, secrets, and logs around the current public contract
- remove stale internal implementation language and update the LLM docs index

## Validation
- parsed docs/docs.json and verified all 21 Serverless Agents navigation entries exist
- verified internal /agents links across all 21 pages
- verified MDX frontmatter and git diff formatting
- scanned the Serverless Agents docs for private service hostnames, historical branding, infrastructure topology, model-routing details, bridge-state filenames, and hidden prompt references

## Scope
Documentation only. Unrelated local runtime and CLI changes were intentionally left out.