### PR TITLE
Keep active managed-agent turns attached

### DIFF
--- a/web/src/managed-agents/api.test.ts
+++ b/web/src/managed-agents/api.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import { displayManagedAgentName, managedAgentRenderDebug } from './api'
+import {
+  displayManagedAgentName,
+  managedAgentRenderDebug,
+  nextAgentEventDeadline,
+} from './api'
+
+describe('nextAgentEventDeadline', () => {
+  it('refreshes the inactivity deadline only when progress arrives', () => {
+    expect(nextAgentEventDeadline(10_000, 3_000, 0, 9_000)).toBe(10_000)
+    expect(nextAgentEventDeadline(10_000, 3_000, 1, 9_000)).toBe(12_000)
+  })
+})
 
 describe('displayManagedAgentName', () => {
   it('hides UUID-shaped legacy names without hiding readable stable names', () => {

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -431,6 +431,15 @@ async function sleep(milliseconds: number) {
   await new Promise((resolve) => setTimeout(resolve, milliseconds))
 }
 
+export function nextAgentEventDeadline(
+  deadline: number,
+  timeoutMs: number,
+  receivedEvents: number,
+  now = Date.now(),
+) {
+  return receivedEvents > 0 ? now + timeoutMs : deadline
+}
+
 async function waitForAgentEvent(
   sessionId: string,
   after: number,
@@ -439,7 +448,7 @@ async function waitForAgentEvent(
   timeoutMs: number,
   signal?: AbortSignal,
 ) {
-  const deadline = Date.now() + timeoutMs
+  let deadline = Date.now() + timeoutMs
   let cursor = after
   while (Date.now() < deadline) {
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
@@ -465,6 +474,9 @@ async function waitForAgentEvent(
       }
       if (terminal(event)) return { event, cursor }
     }
+    // Treat timeoutMs as an inactivity deadline. Multi-step agents can run for
+    // longer than one fixed window while continuing to stream useful progress.
+    deadline = nextAgentEventDeadline(deadline, timeoutMs, events.length)
     await sleep(600)
   }
   throw new Error('Timed out waiting for the agent.')


### PR DESCRIPTION
## Summary
- treat the playground's 180-second agent deadline as an inactivity timeout
- refresh the deadline whenever the session emits progress
- retain timeout behavior for genuinely stalled turns

## Evidence
Session fc486e63-c4bb-4c7f-b00d-26bccb1bb96a streamed successful GitHub and Unleash activity for over three minutes, then the old absolute deadline suspended it mid-turn.

## Verification
- focused managed-agent API tests pass
- web TypeScript check passes
- Prettier check passes