### PR TITLE
fix: publish agent redirect support

### DIFF
--- a/agent/package-lock.json
+++ b/agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/agent",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/agent",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
         "typescript": "^5.9.0"
       },

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/agent",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Reactive agent authoring API for OpenComputer.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- bump `@opencomputer/agent` from 0.4.0 to 0.4.1
- publish the `redirectOrigins` connection support already merged in #627
- keep the agent package lockfile in sync

## Verification

- `npm ci`
- `npm run build`
- `npm pack --dry-run`
- runtime assertion that `defineConnection` preserves redirect origin and path-prefix policies
- `node scripts/check-opencomputer-package-contract.mjs`
- `git diff --check`