### PR TITLE
fix: publish redirect-aware CLI

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/cli",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@opencode-ai/sdk": "1.18.4",
         "ai": "^7.0.45",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Build, test, deploy, and share OpenComputer agents as code.",
   "type": "module",
   "bin": {

--- a/create-start/package.json
+++ b/create-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/create-start",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Create a hello-world OpenComputer agent application.",
   "type": "module",
   "bin": {
@@ -18,7 +18,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@opencomputer/cli": "0.5.0"
+    "@opencomputer/cli": "0.5.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

- bump `@opencomputer/cli` to 0.5.1 so development sync includes connection `redirectOrigins`
- bump `@opencomputer/create-start` to the matching 0.5.1 version
- keep the CLI lockfile and starter's exact CLI dependency in sync

The compiler support was merged in #627 but was absent from the published CLI 0.5.0, causing development manifests to omit `codeload.github.com` and GitHub archive clones to fail with `egress_redirect_blocked`.

## Verification

- `cd cli && npm ci && npm test` (24 passed)
- `OPENCOMPUTER_CREATE_START_MODULE_PATH=... npm test` in `create-start` (2 passed)
- `node scripts/check-opencomputer-package-contract.mjs`
- `git diff --check`