### PR TITLE
Document channels and outboxes

### DIFF
--- a/docs/agents/channels.mdx
+++ b/docs/agents/channels.mdx
@@ -1,0 +1,118 @@
+---
+title: "Slack channels"
+description: "Declare Slack capabilities in code and connect them per environment"
+---
+
+Channels connect a project to a messaging provider. The channel definition is
+code-owned; provider credentials and Slack conversation IDs are configured in
+the dashboard for each environment.
+
+The current channel provider is Slack.
+
+## Define a Slack channel
+
+Create a project-level channel under `opencomputer/channels/`:
+
+```tsx opencomputer/channels/team-slack.ts
+import { defineChannel } from "@opencomputer/agent";
+
+export default defineChannel({
+  id: "team-slack",
+  type: "slack",
+  displayName: "Engineering Slack",
+  scopes: {
+    bot: ["app_mentions:read", "channels:read", "chat:write"],
+  },
+  events: ["app_mention"],
+  destinations: {
+    "pull-request-reviews": {
+      type: "conversation",
+      visibility: "public",
+    },
+  },
+  routing: {
+    whenAmbiguous: "ask",
+  },
+});
+```
+
+The filename must match the channel `id`. A channel owns:
+
+- the Slack bot scopes requested by its generated app manifest;
+- the Slack events the app subscribes to;
+- stable destination names used by outboxes; and
+- the routing policy used when several agents can receive the same event.
+
+Slack workspace IDs, conversation IDs, bot tokens, and signing secrets do not
+belong in source.
+
+## Register an agent for inbound messages
+
+A channel does not name an agent. An agent opts into inbound events with a
+registration under its own directory:
+
+```tsx opencomputer/agents/reviewer/channels/team-slack.ts
+import { registerChannel } from "@opencomputer/agent";
+import teamSlack from "../../../channels/team-slack.js";
+
+export default registerChannel(teamSlack, {
+  on: ["mention"],
+});
+```
+
+`mention` requires the channel to declare the `app_mention` event and the
+`app_mentions:read` scope. `direct-message` requires `message.im` and
+`im:history`.
+
+Several agents may register the same channel. An existing Slack thread stays
+with its selected agent. If a new thread has several eligible agents,
+OpenComputer asks the user which agent should handle it instead of guessing.
+
+## Connect Slack
+
+After the deployment is synchronized:
+
+1. Open the project in the dashboard.
+2. Select **Development** or **Production**.
+3. Open **Channels** and choose **Connect Slack**.
+4. Create or update the Slack app from the generated manifest.
+5. Install the app to the intended Slack workspace.
+6. Enter the installed app credentials when prompted.
+7. Invite the app to each Slack conversation it will use.
+8. Bind each code-defined destination to that conversation's Slack ID and
+   verify it.
+
+For a public destination, include `channels:read` and `chat:write`. For a
+private destination, include `groups:read` and `chat:write`. The app must be a
+member of the selected conversation. OpenComputer does not request
+`chat:write.public` automatically.
+
+Adding a scope in code changes the generated manifest. Update and reinstall
+the Slack app so its granted scopes satisfy the current deployment.
+
+## Environment isolation
+
+Development and Production never share Slack credentials, destination
+bindings, thread routing, or delivery history. Connecting a Slack app in one
+environment does not connect it in the other.
+
+The same stable destination name can therefore map independently:
+
+```text
+Development: pull-request-reviews -> #agent-tests
+Production:  pull-request-reviews -> #pull-request-reviews
+```
+
+Slack delivery uses the stored conversation ID. Renaming the conversation does
+not change the route, although its display label may refresh later.
+
+## Current limits
+
+- Slack is the only channel provider.
+- Destination binding currently uses a Slack conversation ID.
+- Direct Slack user mapping and outbound DMs are not available.
+- A registration can receive mentions or direct messages only when the
+  corresponding event and scope are declared.
+
+Use an [outbox](/agents/outboxes) when an agent needs to publish a proactive
+message to a configured Slack destination.

--- a/docs/agents/outboxes.mdx
+++ b/docs/agents/outboxes.mdx
@@ -1,0 +1,103 @@
+---
+title: "Outboxes"
+description: "Publish durable notifications from agents to Slack"
+---
+
+An outbox is a code-defined, durable route for proactive notifications. The
+agent publishes provider-neutral content; OpenComputer stores it first and
+delivers it asynchronously through the configured channel destination.
+
+## Define an outbox
+
+Create a project-level outbox under `opencomputer/outboxes/`:
+
+```tsx opencomputer/outboxes/review-requests.ts
+import { defineOutbox } from "@opencomputer/agent";
+import teamSlack from "../channels/team-slack.js";
+
+export default defineOutbox({
+  id: "review-requests",
+  delivery: {
+    channel: teamSlack,
+    destination: "pull-request-reviews",
+  },
+});
+```
+
+The referenced destination must exist on the channel. The filename must match
+the outbox `id`.
+
+An outbox currently has one exact route: one channel resource and one named
+destination. It does not select a fallback destination or fan a publication
+out to several providers.
+
+## Authorize an agent
+
+Register the outbox under every agent that may publish through it:
+
+```tsx opencomputer/agents/reviewer/outboxes/review-requests.ts
+import { registerOutbox } from "@opencomputer/agent";
+import reviewRequests from "../../../outboxes/review-requests.js";
+
+export default registerOutbox(reviewRequests);
+```
+
+Inbound channel registration and outbound outbox registration are independent.
+For example, a scheduled agent can publish to Slack without receiving Slack
+mentions.
+
+## Publish a notification
+
+Publish from a code-defined tool or another effectful agent operation:
+
+```tsx
+import { defineTool, publishOutbox } from "@opencomputer/agent";
+
+export const notifyReviewer = defineTool({
+  name: "notify_reviewer",
+  description: "Notify the team that a pull request is ready",
+  async run() {
+    return publishOutbox("review-requests", {
+      type: "pull-request.review-requested",
+      content: {
+        title: "Pull request ready for review",
+        body: "A reviewer was requested on GitHub.",
+        url: "https://github.com/acme/widgets/pull/42",
+      },
+      idempotencyKey: "acme/widgets#42:review-requested",
+    });
+  },
+});
+```
+
+`type` is a lowercase dot-notation event name. `content` must be
+JSON-compatible. `idempotencyKey` identifies this publication within the
+project environment and outbox; reuse it when retrying the same logical event.
+
+Publishing returns after the item is durably stored. Slack delivery continues
+outside the agent runtime, so a transient Slack failure does not extend or
+repeat the producing turn.
+
+## Inspect delivery
+
+Select an environment and open **Outboxes** in the project dashboard. The list
+shows each declared outbox, its exact channel and destination, binding
+readiness, recent items, delivery status, source session when recorded, and
+redacted errors.
+
+Delivery records are isolated by environment. A Development publication cannot
+use Production credentials or appear in Production history.
+
+## Current limits
+
+- An outbox delivers to one Slack conversation.
+- One publish does not fan out to Slack, Discord, SMS, or several Slack
+  conversations. Define and publish to separate outboxes when you need separate
+  routes.
+- Outboxes do not resolve GitHub users to Slack users and cannot send a direct
+  message to a reviewer.
+- The initial Slack renderer supports provider-neutral text-oriented content;
+  Slack-specific Block Kit definitions are not part of the authoring API.
+
+See [Slack channels](/agents/channels) for app installation, scopes, and
+destination binding.

--- a/docs/agents/projects.mdx
+++ b/docs/agents/projects.mdx
@@ -16,9 +16,13 @@ my-agent/
 ├── opencomputer/
 │   ├── .env.example
 │   ├── project.ts
+│   ├── channels/        # optional project messaging channels
+│   ├── outboxes/        # optional durable notification routes
 │   └── agents/
 │       └── hello-world/
 │           ├── agent.ts
+│           ├── channels/    # optional inbound registrations
+│           ├── outboxes/    # optional publish registrations
 │           ├── tools/       # optional
 │           └── skills/      # optional
 ├── src/
@@ -30,6 +34,8 @@ my-agent/
 
 - `opencomputer/project.ts` declares project metadata and agent IDs.
 - `opencomputer/agents/<id>/agent.ts` defines one agent.
+- `opencomputer/channels/` and `opencomputer/outboxes/` define shared project
+  resources; registrations under an agent authorize that agent to use them.
 - `opencomputer/.env.local` optionally holds ignored development secrets.
 - `src/` is a normal React application.
 - `.opencomputer/` is ignored local state created by the CLI.
@@ -97,6 +103,9 @@ The current project dashboard provides:
 - **Agent playground** for creating and resuming test sessions
 - **Deployments** for immutable version history and active aliases
 - **Sessions** created through the dashboard, React client, or API
+- **Channels** for environment-specific Slack installation and destination
+  binding
+- **Outboxes** for inspecting proactive notification delivery
 - **Secrets** for write-only project and agent credentials
 
 Project and agent behavior remains code-owned. The dashboard is for selection,

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -42,6 +42,8 @@
               "agents/reactive-agents",
               "agents/sessions",
               "agents/capabilities",
+              "agents/channels",
+              "agents/outboxes",
               "agents/secrets"
             ]
           },


### PR DESCRIPTION
Documents code-defined Slack channels, generated manifests and scopes, environment-specific connections, destination mappings, outbox publication and delivery, deduplication, and current limitations.\n\nAlso links both guides from project documentation and navigation.