### PR TITLE
Show schedule run outcome notifications

### DIFF
--- a/web/src/managed-agents/Schedules.tsx
+++ b/web/src/managed-agents/Schedules.tsx
@@ -20,7 +20,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { notifyError } from '@/lib/errors'
+import { notifyError, notifySuccess } from '@/lib/errors'
 import {
   getManagedAgentScheduleRuns,
   getManagedAgentSchedules,
@@ -61,7 +61,18 @@ export function ManagedAgentSchedules({
   const runNow = useMutation({
     mutationFn: (scheduleId: string) =>
       runManagedAgentSchedule(projectId, agentId, environment, scheduleId),
-    onSuccess: async () => {
+    onSuccess: async (run) => {
+      if (run.outcome === 'enacted') {
+        notifySuccess(
+          'Schedule run started.',
+          run.sessionId ? `Session ${run.sessionId}` : undefined,
+        )
+      } else {
+        notifyError(
+          `Schedule run ${run.outcome}.`,
+          run.error ? new Error(run.error) : undefined,
+        )
+      }
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: [


### PR DESCRIPTION
## What changed
- show a success toast when a manual schedule run starts
- include the created session ID when available
- surface skipped and failed outcomes instead of silently treating them as success

## Verification
- `npm run typecheck`
- `npx eslint src/managed-agents/Schedules.tsx`
- `npx prettier --check src/managed-agents/Schedules.tsx`
- `npm run build`