### PR TITLE
Fix OpenComputer package version contract

### DIFF
--- a/create-start/package.json
+++ b/create-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/create-start",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Create a hello-world OpenComputer agent application.",
   "type": "module",
   "bin": {
@@ -18,7 +18,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@opencomputer/cli": "0.5.4"
+    "@opencomputer/cli": "0.5.5"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

- bump `@opencomputer/create-start` to `0.5.5`
- align its `@opencomputer/cli` dependency with CLI `0.5.5`
- restore the package-version contract required by the publish workflow

## Verification

- `node scripts/check-opencomputer-package-contract.mjs`
- `npm run build --prefix cli`
- `npm test --prefix create-start`