### PR TITLE
githubApp() connections: authoring, CLI, dashboard Repositories tab, api-edge

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -68,9 +68,21 @@ export interface SecretHeaderReference {
   readonly suffix?: string;
 }
 
+export type GithubAppPermission = "read" | "write";
+
+export interface GithubAppHeaderReference {
+  readonly kind: "github-app-header";
+  readonly permissions: Readonly<Record<string, GithubAppPermission>>;
+}
+
+export type ConnectionHeaderValue =
+  | string
+  | SecretHeaderReference
+  | GithubAppHeaderReference;
+
 export interface HttpConnectionDefinition extends ConnectionReference {
   readonly origin: string;
-  readonly headers: Readonly<Record<string, string | SecretHeaderReference>>;
+  readonly headers: Readonly<Record<string, ConnectionHeaderValue>>;
   readonly methods?: readonly string[];
   readonly pathPrefix?: string;
   readonly redirectOrigins?: readonly HttpConnectionRedirectOrigin[];
@@ -286,10 +298,53 @@ export function bearer(secret: SecretReference): SecretHeaderReference {
   return secretHeader(secret, { prefix: "Bearer " });
 }
 
+const GITHUB_APP_PERMISSION_KEYS = new Set([
+  "contents",
+  "pull_requests",
+  "issues",
+  "metadata",
+  "checks",
+]);
+
+const GITHUB_APP_ORIGINS = new Set([
+  "https://api.github.com",
+  "https://api.githubcopilot.com",
+]);
+
+export function githubApp(options: {
+  permissions: Readonly<Record<string, GithubAppPermission>>;
+}): GithubAppHeaderReference {
+  const entries = Object.entries(options?.permissions ?? {});
+  if (entries.length === 0) {
+    throw new Error(
+      "githubApp() requires at least one permission, e.g. githubApp({ permissions: { contents: \"read\" } })",
+    );
+  }
+  const permissions: Record<string, GithubAppPermission> = {};
+  for (const [key, value] of entries) {
+    if (!GITHUB_APP_PERMISSION_KEYS.has(key)) {
+      throw new Error(
+        `githubApp() does not support the ${key} permission; supported keys are ${[...GITHUB_APP_PERMISSION_KEYS].join(", ")}`,
+      );
+    }
+    if (value !== "read" && value !== "write") {
+      throw new Error(`githubApp() permissions must be read or write, got ${String(value)}`);
+    }
+    if ((key === "metadata" || key === "checks") && value === "write") {
+      throw new Error(`The ${key} permission is read-only`);
+    }
+    permissions[key] = value;
+  }
+  return Object.freeze({
+    kind: "github-app-header",
+    permissions: Object.freeze(permissions),
+  });
+}
+
 export function defineConnection(input: {
   id: string;
   origin: string;
-  headers?: Readonly<Record<string, string | SecretHeaderReference>>;
+  headers?: Readonly<Record<string, ConnectionHeaderValue>>;
   methods?: readonly string[];
   pathPrefix?: string;
   redirectOrigins?: readonly HttpConnectionRedirectOrigin[];
@@ -298,6 +353,17 @@ export function defineConnection(input: {
   const origin = new URL(input.origin);
   if (origin.protocol !== "https:" || origin.pathname !== "/") {
     throw new Error("Connection origins must be HTTPS origins without a path");
+  }
+  for (const [, value] of Object.entries(input.headers ?? {})) {
+    if (
+      typeof value === "object" &&
+      value.kind === "github-app-header" &&
+      !GITHUB_APP_ORIGINS.has(origin.origin)
+    ) {
+      throw new Error(
+        "githubApp() headers are only valid on GitHub API origins (https://api.github.com, https://api.githubcopilot.com)",
+      );
+    }
   }
   for (const [name, value] of Object.entries(input.headers ?? {})) {
     if (

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -271,6 +271,35 @@ export class OpenComputerClient {
     );
   }
 
+  githubStatus(input: { projectId: string }) {
+    return this.request<{
+      environments: Array<{
+        environment: "development" | "production";
+        state: string;
+        app?: { mode: string; slug: string };
+        installation?: { accountLogin: string };
+        scopeMode?: "all" | "selected";
+        selectedRepositoryCount?: number;
+      }>;
+      ocAppAvailable: boolean;
+    }>(
+      `/api/managed-agents/projects/${encodeURIComponent(input.projectId)}/github`,
+    );
+  }
+
+  githubConnect(input: {
+    projectId: string;
+    environments: Array<"development" | "production">;
+  }) {
+    return this.request<{ installUrl?: string }>(
+      `/api/managed-agents/projects/${encodeURIComponent(input.projectId)}/github/connect`,
+      {
+        method: "POST",
+        body: JSON.stringify({ environments: input.environments }),
+      },
+    );
+  }
+
   deleteSecret(input: {
     projectId: string;
     name: string;
@@ -437,6 +466,10 @@ export class OpenComputerClient {
             name: string;
             prefix?: string;
             suffix?: string;
+          }
+        | {
+            kind: "github_app";
+            permissions: Record<string, "read" | "write">;
           }
       >;
       methods?: string[];

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -676,7 +676,10 @@ export async function runCommand(
         allowedOrigins = built.httpConnections
           .filter((connection) =>
             Object.values(connection.headers).some(
-              (value) => typeof value !== "string" && value.name === name,
+              (value) =>
+                typeof value !== "string" &&
+                value.kind === "secret" &&
+                value.name === name,
             ),
           )
           .flatMap((connection) => [
@@ -796,6 +799,75 @@ export async function runCommand(
       return;
     }
     throw new Error("Use `opencomputer env set|list|remove <name>`.");
+  }
+
+  if (command === "github") {
+    const action = args.shift();
+    const projectReference = option(args, "--project");
+    const project = await selectedProject(
+      client,
+      config,
+      projectReference,
+      !globals.json,
+    );
+    if (action === "status" || action === undefined) {
+      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+      const status = await client.githubStatus({
+        projectId: project.projectId,
+      });
+      if (globals.json) printJSON(status);
+      else {
+        for (const entry of status.environments) {
+          const app = entry.app
+            ? `${entry.app.slug} (${entry.app.mode === "oc_app" ? "shared" : "dedicated"})`
+            : "—";
+          const scope =
+            entry.scopeMode === "selected"
+              ? `${entry.selectedRepositoryCount ?? 0} selected repositories`
+              : entry.scopeMode === "all"
+                ? "all granted repositories"
+                : "";
+          process.stdout.write(
+            `${entry.environment.padEnd(12)} ${entry.state.padEnd(14)} ${app}` +
+              (entry.installation ? `  @${entry.installation.accountLogin}` : "") +
+              (scope ? `  ${scope}` : "") +
+              "\n",
+          );
+        }
+        if (
+          status.environments.every((entry) => entry.state === "not_connected")
+        ) {
+          process.stdout.write(
+            "Connect with `opencomputer github connect` or from the dashboard Repositories tab.\n",
+          );
+        }
+      }
+      return;
+    }
+    if (action === "connect") {
+      const environmentValue = option(args, "--environment");
+      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+      const result = await client.githubConnect({
+        projectId: project.projectId,
+        environments: environmentValue
+          ? [environmentOption(environmentValue)]
+          : ["development", "production"],
+      });
+      if (globals.json) printJSON(result);
+      else if (result.installUrl) {
+        process.stdout.write(
+          "Open this URL to install the OpenComputer GitHub app:\n" +
+            `  ${result.installUrl}\n` +
+            "Pick repositories on GitHub, then manage scope from the dashboard Repositories tab.\n",
+        );
+      } else {
+        process.stdout.write("GitHub is connected for this project.\n");
+      }
+      return;
+    }
+    throw new Error(
+      "Use `opencomputer github status` or `opencomputer github connect`.",
+    );
   }
 
   if (command === "webhooks") {

--- a/cli/src/dev.ts
+++ b/cli/src/dev.ts
@@ -75,7 +75,7 @@ function secretOrigins(results: DevelopmentResults): Map<string, string[]> {
   for (const { built } of results) {
     for (const connection of built.httpConnections) {
       for (const header of Object.values(connection.headers)) {
-        if (typeof header === "string") continue;
+        if (typeof header === "string" || header.kind !== "secret") continue;
         const current = origins.get(header.name) ?? new Set<string>();
         current.add(connection.origin);
         for (const redirect of connection.redirectOrigins ?? []) {
@@ -516,6 +516,33 @@ export async function runCloudDevelopment(
           ? `React:      starting local Vite app\n`
           : `React:      not included\n`),
     );
+    const usesGithubApp = initial.some(({ built }) =>
+      built.httpConnections.some((connection) =>
+        Object.values(connection.headers).some(
+          (header) => typeof header !== "string" && header.kind === "github_app",
+        ),
+      ),
+    );
+    if (usesGithubApp) {
+      try {
+        const github = await client.githubStatus({
+          projectId: binding.projectId,
+        });
+        const development = github.environments.find(
+          (entry) => entry.environment === "development",
+        );
+        if (development && development.state !== "connected") {
+          process.stdout.write(
+            `GitHub:     not connected for development — githubApp() calls will fail
+` +
+              `            Run \`opencomputer github connect\` or open the dashboard Repositories tab
+`,
+          );
+        }
+      } catch {
+        // Connection status is advisory; never block the dev loop on it.
+      }
+    }
     if (spa) web = await startReactDevServer(projectRoot);
     watcher = watch(
       resolve(projectRoot, "opencomputer"),

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -63,6 +63,8 @@ Usage:
   opencomputer env set <name> [--environment development|production] [--agent <agent>|current]
   opencomputer env list [--environment development|production] [--agent <agent>|current]
   opencomputer env remove <name> [--environment development|production] [--agent <agent>|current]
+  opencomputer github status [--project <id|slug>]
+  opencomputer github connect [--environment development|production] [--project <id|slug>]
   opencomputer webhooks list [--environment development|production] [--agent <agent>|current]
   opencomputer webhooks create <name> [--environment development|production] [--agent <agent>|current]
   opencomputer webhooks enable <webhook-id> [--project <id|slug>]

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -454,6 +454,81 @@ export default function Agent() {
   }
 });
 
+test("the compiler records app-minted GitHub connections with literal permissions", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-github-app-"));
+  const root = resolve(parent, "app");
+  try {
+    const initialized = await initializeAgentProject(root);
+    await writeFile(
+      resolve(initialized.agentRoot, "agent.ts"),
+      `import { defineConnection, githubApp } from "@opencomputer/agent";
+
+export const github = defineConnection({
+  id: "github",
+  origin: "https://api.github.com",
+  headers: {
+    Authorization: githubApp({
+      permissions: { contents: "read", pull_requests: "write" },
+    }),
+  },
+});
+export default function Agent() {
+  return "Use GitHub.";
+}
+`,
+    );
+    const built = await buildAgentArtifact(initialized.agentRoot);
+    await assert.doesNotReject(
+      import(
+        `${pathToFileURL(resolve(initialized.agentRoot, ".opencomputer", "runtime", "opencomputer-agent.js")).href}?test=${crypto.randomUUID()}`
+      ),
+    );
+    assert.deepEqual(built.httpConnections, [
+      {
+        id: "github",
+        origin: "https://api.github.com",
+        headers: {
+          Authorization: {
+            kind: "github_app",
+            permissions: { contents: "read", pull_requests: "write" },
+          },
+        },
+      },
+    ]);
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+test("the compiler rejects githubApp permissions that are not literal", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-github-bad-"));
+  const root = resolve(parent, "app");
+  try {
+    const initialized = await initializeAgentProject(root);
+    await writeFile(
+      resolve(initialized.agentRoot, "agent.ts"),
+      `import { defineConnection, githubApp } from "@opencomputer/agent";
+
+const shared = { contents: "read" } as const;
+export const github = defineConnection({
+  id: "github",
+  origin: "https://api.github.com",
+  headers: { Authorization: githubApp({ permissions: shared }) },
+});
+export default function Agent() {
+  return "Use GitHub.";
+}
+`,
+    );
+    await assert.rejects(
+      buildAgentArtifact(initialized.agentRoot),
+      /githubApp\(\) permissions must be an inline object literal/,
+    );
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
 test("the compiler records managed MCP server definitions", async () => {
   const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-mcp-"));
   const root = resolve(parent, "app");

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -34,7 +34,9 @@ export interface HttpConnectionManifest {
   origin: string;
   headers: Record<
     string,
-    string | { kind: "secret"; name: string; prefix?: string; suffix?: string }
+    | string
+    | { kind: "secret"; name: string; prefix?: string; suffix?: string }
+    | { kind: "github_app"; permissions: Record<string, "read" | "write"> }
   >;
   methods?: string[];
   pathPrefix?: string;
@@ -1371,10 +1373,63 @@ function connectionHeaderValue(
     !ts.isIdentifier(expression.expression)
   ) {
     throw new Error(
-      "Connection headers must be string literals, bearer(useSecret()), or secretHeader(useSecret())",
+      "Connection headers must be string literals, bearer(useSecret()), secretHeader(useSecret()), or githubApp()",
     );
   }
   const helper = expression.expression.text;
+  if (helper === "githubApp") {
+    const options = expression.arguments[0];
+    if (!options || !ts.isObjectLiteralExpression(options)) {
+      throw new Error(
+        "githubApp() requires an object literal, e.g. githubApp({ permissions: { contents: \"read\" } })",
+      );
+    }
+    const permissionsProperty = objectProperty(options, "permissions");
+    if (
+      !permissionsProperty ||
+      !ts.isObjectLiteralExpression(permissionsProperty)
+    ) {
+      throw new Error(
+        "githubApp() permissions must be an inline object literal with literal values",
+      );
+    }
+    const permissions: Record<string, "read" | "write"> = {};
+    for (const property of permissionsProperty.properties) {
+      if (
+        !ts.isPropertyAssignment(property) ||
+        (!ts.isIdentifier(property.name) &&
+          !ts.isStringLiteralLike(property.name))
+      ) {
+        throw new Error(
+          "githubApp() permissions must use literal keys and literal values",
+        );
+      }
+      const key = ts.isIdentifier(property.name)
+        ? property.name.text
+        : property.name.text;
+      const value = literalStringValue(
+        property.initializer,
+        `githubApp permission ${key}`,
+      );
+      if (value !== "read" && value !== "write") {
+        throw new Error(
+          `githubApp() permission ${key} must be "read" or "write"`,
+        );
+      }
+      if (
+        !["contents", "pull_requests", "issues", "metadata", "checks"].includes(
+          key,
+        )
+      ) {
+        throw new Error(`githubApp() does not support the ${key} permission`);
+      }
+      permissions[key] = value;
+    }
+    if (Object.keys(permissions).length === 0) {
+      throw new Error("githubApp() requires at least one permission");
+    }
+    return { kind: "github_app", permissions };
+  }
   if (helper === "bearer") {
     const secret = expression.arguments[0];
     if (!secret) throw new Error("bearer() requires useSecret()");
@@ -1593,6 +1648,18 @@ export const useSecret = (value) => {
 };
 export const secretHeader = (secret, options = {}) => Object.freeze({ kind: "secret-header", secret, ...options });
 export const bearer = (secret) => secretHeader(secret, { prefix: "Bearer " });
+export const githubApp = (options) => {
+  const entries = Object.entries(options?.permissions || {});
+  if (!entries.length) throw new Error("githubApp() requires at least one permission");
+  const permissions = {};
+  for (const [key, value] of entries) {
+    if (!["contents", "pull_requests", "issues", "metadata", "checks"].includes(key)) throw new Error("githubApp() does not support the " + key + " permission");
+    if (value !== "read" && value !== "write") throw new Error("githubApp() permissions must be read or write");
+    if ((key === "metadata" || key === "checks") && value === "write") throw new Error("The " + key + " permission is read-only");
+    permissions[key] = value;
+  }
+  return Object.freeze({ kind: "github-app-header", permissions: Object.freeze(permissions) });
+};
 export const defineConnection = (input) => {
   const connectionId = id(input.id, "defineConnection");
   const origin = new URL(input.origin);

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -52,6 +52,7 @@ import { createAPIKey, hashAPIKey } from "./api_keys";
 import {
   handleAgentWebhookInvocation,
   handleManagedAgentChannelConnection,
+  handleManagedAgentGithubPublic,
   proxyManagedAgents,
 } from "./managed_agents";
 
@@ -3632,6 +3633,12 @@ export default {
     }
     if (path.startsWith("/api/agent-webhooks/")) {
       return handleAgentWebhookInvocation(req, env);
+    }
+    // GitHub App browser callbacks and webhook ingress. Unauthenticated by
+    // design: the callbacks are authorized by a one-time state consumed at the
+    // private edge, the webhook by its HMAC signature there.
+    if (path.startsWith("/api/managed-agents/github/")) {
+      return handleManagedAgentGithubPublic(req, env);
     }
     if (
       path === "/api/managed-agents" ||

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -834,6 +834,38 @@ function isAllowedManagedAgentsRoute(method: string, suffix: string): boolean {
   ) {
     return true;
   }
+  if (
+    (method === "GET" || method === "DELETE") &&
+    /^\/projects\/[^/]+\/github$/.test(suffix)
+  ) {
+    return true;
+  }
+  if (
+    method === "POST" &&
+    /^\/projects\/[^/]+\/github\/(connect|manifest)$/.test(suffix)
+  ) {
+    return true;
+  }
+  if (
+    (method === "GET" || method === "PUT") &&
+    /^\/projects\/[^/]+\/github\/repositories$/.test(suffix)
+  ) {
+    return true;
+  }
+  if (
+    method === "POST" &&
+    /^\/projects\/[^/]+\/github\/apps\/[^/]+\/(webhook-secret|private-key)$/.test(
+      suffix,
+    )
+  ) {
+    return true;
+  }
+  if (
+    method === "DELETE" &&
+    /^\/projects\/[^/]+\/github\/apps\/[^/]+$/.test(suffix)
+  ) {
+    return true;
+  }
   if (method === "GET" && suffix === "/logs") return true;
   if (method === "POST" && suffix === "/deployments") return true;
   if (method === "POST" && suffix === "/benchmarks/warm-pool") return true;
@@ -991,6 +1023,84 @@ export async function handleManagedAgentChannelConnection(
       "x-content-type-options": "nosniff",
     },
   });
+}
+
+// GitHub App public surface: two browser-facing callbacks (setup after an
+// installation, manifest conversion after app creation) and the App webhook
+// ingress. No API-key auth — the private edge authorizes the callbacks with
+// their one-time state and the webhook with its HMAC signature. This public
+// origin is what gets baked into GitHub app manifests, never the private
+// hostname.
+export async function handleManagedAgentGithubPublic(
+  request: Request,
+  env: ManagedAgentsEnv,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const base = (
+    env.MANAGED_AGENTS_API_URL ?? DEFAULT_MANAGED_AGENTS_API_URL
+  ).replace(/\/+$/, "");
+  let target: URL | null = null;
+  if (
+    request.method === "GET" &&
+    url.pathname === "/api/managed-agents/github/setup"
+  ) {
+    target = new URL(`${base}/v1/github/setup${url.search}`);
+  } else if (
+    request.method === "GET" &&
+    url.pathname === "/api/managed-agents/github/manifest/callback"
+  ) {
+    target = new URL(`${base}/v1/github/manifest/callback${url.search}`);
+  } else if (
+    request.method === "POST" &&
+    url.pathname === "/api/managed-agents/github/webhooks"
+  ) {
+    target = new URL(`${base}/v1/webhooks/github`);
+  }
+  if (!target || (target.protocol !== "https:" && target.hostname !== "localhost")) {
+    return Response.json(
+      { error: { code: "not_found", message: "Route not found." } },
+      { status: 404 },
+    );
+  }
+  const headers = new Headers({ "x-request-id": crypto.randomUUID() });
+  for (const name of [
+    "content-type",
+    "x-github-event",
+    "x-github-delivery",
+    "x-github-hook-installation-target-id",
+    "x-github-hook-installation-target-type",
+    "x-hub-signature-256",
+  ]) {
+    const value = request.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  try {
+    const upstream = await fetch(target, {
+      method: request.method,
+      headers,
+      body: request.method === "POST" ? request.body : undefined,
+      redirect: "manual",
+    });
+    // Redirects (e.g. manifest conversion -> GitHub install) and HTML
+    // callback pages pass through verbatim.
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: upstream.headers,
+    });
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "managed_agents.github_public_failed",
+        path: url.pathname,
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    );
+    return Response.json(
+      { error: { code: "unavailable", message: "GitHub service is unavailable." } },
+      { status: 503 },
+    );
+  }
 }
 
 export async function handleAgentWebhookInvocation(

--- a/web/src/components/app-shell-nav.ts
+++ b/web/src/components/app-shell-nav.ts
@@ -3,6 +3,7 @@ import {
   Bot,
   Boxes,
   CalendarClock,
+  FolderGit2,
   KeySquare,
   Layers,
   MessagesSquare,
@@ -85,6 +86,11 @@ export function managedAgentsNav(options: {
             to: `${projectPath}/secrets`,
             label: 'Secrets',
             icon: KeySquare,
+          },
+          {
+            to: `${projectPath}/repositories`,
+            label: 'Repositories',
+            icon: FolderGit2,
           },
           {
             to: projectPath,

--- a/web/src/components/app-shell.test.ts
+++ b/web/src/components/app-shell.test.ts
@@ -25,6 +25,7 @@ describe('managed agents navigation', () => {
       'Schedules',
       'Webhooks',
       'Secrets',
+      'Repositories',
       'Debug playground',
     ])
     expect(nav[1]?.items[nav[1].items.length - 1]?.to).toBe(

--- a/web/src/managed-agents/Detail.tsx
+++ b/web/src/managed-agents/Detail.tsx
@@ -63,6 +63,7 @@ import {
   sessionsForEnvironment,
 } from './session-history'
 import { ManagedProjectSecrets } from './Secrets'
+import { ManagedProjectRepositories } from './Repositories'
 import { ManagedSlackWizard } from './SlackWizard'
 import { ManagedAgentOutboxes } from './Outboxes'
 import { ManagedAgentSchedules } from './Schedules'
@@ -78,6 +79,7 @@ type DetailTab =
   | 'schedules'
   | 'webhooks'
   | 'secrets'
+  | 'repositories'
 
 function formatDate(value: string) {
   return new Date(value).toLocaleString()
@@ -483,6 +485,7 @@ export default function ManagedAgentDetail({
     'schedules',
     'webhooks',
     'secrets',
+    'repositories',
   ])
   const activeTab = project
     ? routeTab && projectTabs.has(routeTab)
@@ -652,6 +655,9 @@ export default function ManagedAgentDetail({
     ...(project ? ([{ id: 'schedules', label: 'Schedules' }] as const) : []),
     ...(project ? ([{ id: 'webhooks', label: 'Webhooks' }] as const) : []),
     ...(project ? ([{ id: 'secrets', label: 'Secrets' }] as const) : []),
+    ...(project
+      ? ([{ id: 'repositories', label: 'Repositories' }] as const)
+      : []),
   ]
 
   return (
@@ -1042,6 +1048,13 @@ export default function ManagedAgentDetail({
         <ManagedProjectSecrets
           projectId={project.project.id}
           agents={project.project.agents}
+          environment={environment}
+        />
+      ) : null}
+
+      {activeTab === 'repositories' && project ? (
+        <ManagedProjectRepositories
+          projectId={project.project.id}
           environment={environment}
         />
       ) : null}

--- a/web/src/managed-agents/Repositories.tsx
+++ b/web/src/managed-agents/Repositories.tsx
@@ -1,0 +1,1326 @@
+import { useState, type FormEvent } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  Check,
+  ExternalLink,
+  FolderGit2,
+  Loader2,
+  RefreshCw,
+  Trash2,
+  TriangleAlert,
+} from 'lucide-react'
+import { ApiError } from '@/api/client'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+import { EmptyState } from '@/components/empty-state'
+import { GithubMark } from '@/components/github-mark'
+import {
+  Panel,
+  PanelContent,
+  PanelDescription,
+  PanelHeader,
+  PanelTitle,
+} from '@/components/panel'
+import { StatusBadge } from '@/components/status-badge'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Field, Input, Select, Textarea } from '@/components/form'
+import { notifyError, notifySuccess } from '@/lib/errors'
+import { cn } from '@/lib/utils'
+import {
+  connectProjectGithub,
+  createProjectGithubManifest,
+  deleteProjectGithubApp,
+  detachProjectGithub,
+  getProjectGithub,
+  getProjectGithubRepositories,
+  putProjectGithubRepositories,
+  setProjectGithubAppPrivateKey,
+  setProjectGithubAppWebhookSecret,
+  type ProjectGithubEnvironment,
+  type ProjectGithubRepositories,
+  type ProjectGithubSelectedRepository,
+  type ProjectGithubStatus,
+} from './api'
+import {
+  defaultProjectGithubScopeMode,
+  isNarrowingProjectGithubScope,
+  projectGithubQueryKey,
+  projectGithubRepositoriesQueryKey,
+  projectGithubScopeCandidates,
+  sameProjectGithubScopePolicy,
+  selectedProjectGithubRepoIds,
+  toggleProjectGithubScopeRepository,
+  type ProjectGithubScopePolicy,
+} from './github-scope'
+
+type Environment = 'development' | 'production'
+
+const BOTH_ENVIRONMENTS: Environment[] = ['development', 'production']
+const NEW_INSTALLATION = '__new__'
+
+function githubErrorCode(error: unknown): string | undefined {
+  if (!(error instanceof ApiError)) return undefined
+  const code = error.details?.code
+  return typeof code === 'string' ? code : error.type
+}
+
+/** GitHub's app-manifest flow requires a browser form POST with a single
+ * `manifest` field; submit it into a new tab without leaving this page. */
+function postManifestToGithub(
+  action: string,
+  manifest: Record<string, unknown>,
+) {
+  const form = document.createElement('form')
+  form.method = 'post'
+  form.action = action
+  form.target = '_blank'
+  const field = document.createElement('input')
+  field.type = 'hidden'
+  field.name = 'manifest'
+  field.value = JSON.stringify(manifest)
+  form.appendChild(field)
+  document.body.appendChild(form)
+  form.submit()
+  form.remove()
+}
+
+function GithubWizardSteps({
+  current,
+  steps,
+}: {
+  current: number
+  steps: string[]
+}) {
+  return (
+    <ol className="flex items-center gap-2 pt-2">
+      {steps.map((label, index) => (
+        <li key={label} className="flex min-w-0 items-center gap-2">
+          <span
+            className={cn(
+              'flex size-5 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold',
+              index <= current
+                ? 'bg-foreground text-background'
+                : 'bg-secondary text-muted-foreground',
+            )}
+          >
+            {index < current ? <Check className="size-3" /> : index + 1}
+          </span>
+          <span
+            className={cn(
+              'truncate text-xs',
+              index === current
+                ? 'text-foreground font-medium'
+                : 'text-muted-foreground',
+            )}
+          >
+            {label}
+          </span>
+          {index < steps.length - 1 ? (
+            <span className="bg-border h-px w-4 shrink-0" />
+          ) : null}
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+/** The tradeoffs of the shared OpenComputer app, stated instead of enforced. */
+function SharedAppNotice() {
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2.5 text-xs leading-5 text-amber-900 dark:border-amber-700/50 dark:bg-amber-950/40 dark:text-amber-200">
+      <TriangleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+      <p>
+        The shared OpenComputer app uses one bot identity across every attached
+        project, GitHub shows a single grant with no per-project breakdown, and
+        a single project's access cannot be revoked from GitHub's side — only
+        narrowed here. Create a dedicated app for production.
+      </p>
+    </div>
+  )
+}
+
+function GithubWaiting({ message }: { message: string }) {
+  return (
+    <div className="flex items-start gap-3">
+      <Loader2 className="mt-0.5 size-5 animate-spin" aria-hidden />
+      <div>
+        <p className="text-sm font-medium">Waiting for GitHub…</p>
+        <p className="text-muted-foreground text-sm">{message}</p>
+      </div>
+    </div>
+  )
+}
+
+function EnvironmentLimitCheckbox({
+  environment,
+  onlyCurrent,
+  onChange,
+}: {
+  environment: Environment
+  onlyCurrent: boolean
+  onChange: (onlyCurrent: boolean) => void
+}) {
+  return (
+    <div className="space-y-1">
+      <label className="flex cursor-pointer items-center gap-2 text-sm">
+        <Checkbox
+          checked={onlyCurrent}
+          onCheckedChange={(next) => onChange(next === true)}
+        />
+        Only connect the {environment} environment
+      </label>
+      <p className="text-muted-foreground text-xs">
+        By default both development and production are connected. Each
+        environment keeps its own attachment and can be switched or disconnected
+        independently.
+      </p>
+    </div>
+  )
+}
+
+function GithubConnected({ environment }: { environment: Environment }) {
+  return (
+    <div className="flex items-start gap-3">
+      <Check className="mt-0.5 size-5 text-emerald-600" aria-hidden />
+      <div>
+        <p className="text-sm font-medium">GitHub connected</p>
+        <p className="text-muted-foreground text-sm">
+          The installation landed for {environment}. Review the repository scope
+          to control what agents can reach.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function GithubConnectDialog({
+  projectId,
+  environment,
+  status,
+  connected,
+  onOpenChange,
+  onAwaitGithub,
+  onCreateDedicated,
+}: {
+  projectId: string
+  environment: Environment
+  status: ProjectGithubStatus
+  connected: boolean
+  onOpenChange: (open: boolean) => void
+  onAwaitGithub: () => void
+  onCreateDedicated: () => void
+}) {
+  const queryClient = useQueryClient()
+  const installations = status.installations
+  const [installationId, setInstallationId] = useState(
+    installations[0]?.id ?? NEW_INSTALLATION,
+  )
+  const [onlyCurrentEnv, setOnlyCurrentEnv] = useState(false)
+  const [waiting, setWaiting] = useState(false)
+  const chosen = installations.find(
+    (installation) => installation.id === installationId,
+  )
+  const chosenAppMode = chosen ? (chosen.app?.mode ?? 'oc_app') : 'oc_app'
+  const sharedPath = chosenAppMode === 'oc_app'
+  const newInstallBlocked = !chosen && !status.ocAppAvailable
+
+  const connect = useMutation({
+    mutationFn: () =>
+      connectProjectGithub({
+        projectId,
+        environments: onlyCurrentEnv ? [environment] : BOTH_ENVIRONMENTS,
+        ...(chosen ? { installationId: chosen.id } : {}),
+        scopeMode: defaultProjectGithubScopeMode(chosenAppMode),
+      }),
+    onSuccess: async (result) => {
+      if ('installUrl' in result) {
+        window.open(result.installUrl, '_blank', 'noopener')
+        setWaiting(true)
+        onAwaitGithub()
+        return
+      }
+      await queryClient.invalidateQueries({
+        queryKey: projectGithubQueryKey(projectId),
+      })
+      await queryClient.invalidateQueries({
+        queryKey: projectGithubRepositoriesQueryKey(projectId, environment),
+      })
+      notifySuccess(
+        'GitHub connected.',
+        'Review the repository scope below to control what agents can reach.',
+      )
+      onOpenChange(false)
+    },
+    onError: (error) => notifyError("Couldn't connect GitHub.", error),
+  })
+
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Connect GitHub</DialogTitle>
+          <DialogDescription>
+            Agents reach GitHub through short-lived installation tokens scoped
+            to this project's repository selection — no personal access tokens.
+          </DialogDescription>
+        </DialogHeader>
+        {waiting ? (
+          <div className="space-y-4">
+            {connected ? (
+              <GithubConnected environment={environment} />
+            ) : (
+              <GithubWaiting message="Pick the repositories to grant in the GitHub tab. This page updates automatically once the installation lands." />
+            )}
+            <DialogFooter>
+              <Button
+                variant={connected ? 'default' : 'outline'}
+                onClick={() => onOpenChange(false)}
+              >
+                {connected ? 'Done' : 'Close'}
+              </Button>
+            </DialogFooter>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {installations.length ? (
+              <Field
+                label="Installation"
+                htmlFor="github-connect-installation"
+                description="Use an installation this account already has, or start a fresh install of the shared OpenComputer app."
+              >
+                <Select
+                  id="github-connect-installation"
+                  value={installationId}
+                  onValueChange={setInstallationId}
+                  options={[
+                    ...installations.map((installation) => ({
+                      value: installation.id,
+                      label: `${installation.accountLogin} · ${installation.app?.name ?? 'GitHub app'}`,
+                      hint: installation.accountType,
+                    })),
+                    ...(status.ocAppAvailable
+                      ? [
+                          {
+                            value: NEW_INSTALLATION,
+                            label: 'Install the OpenComputer app…',
+                          },
+                        ]
+                      : []),
+                  ]}
+                />
+              </Field>
+            ) : null}
+            {newInstallBlocked ? (
+              <p className="text-muted-foreground text-sm">
+                The shared OpenComputer app is not available here. Create a
+                dedicated GitHub app for this project instead.
+              </p>
+            ) : null}
+            {sharedPath && !newInstallBlocked ? <SharedAppNotice /> : null}
+            <EnvironmentLimitCheckbox
+              environment={environment}
+              onlyCurrent={onlyCurrentEnv}
+              onChange={setOnlyCurrentEnv}
+            />
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              {newInstallBlocked ? (
+                <Button onClick={onCreateDedicated}>
+                  Create a dedicated app
+                </Button>
+              ) : (
+                <Button
+                  disabled={connect.isPending}
+                  onClick={() => connect.mutate()}
+                >
+                  {connect.isPending ? (
+                    <Loader2 className="animate-spin" />
+                  ) : (
+                    <GithubMark className="size-4" />
+                  )}
+                  {chosen ? 'Attach installation' : 'Continue on GitHub'}
+                </Button>
+              )}
+            </DialogFooter>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const WIZARD_STEPS = ['Account', 'Create app', 'Install']
+
+function GithubDedicatedAppWizard({
+  projectId,
+  environment,
+  connected,
+  onOpenChange,
+  onAwaitGithub,
+}: {
+  projectId: string
+  environment: Environment
+  connected: boolean
+  onOpenChange: (open: boolean) => void
+  onAwaitGithub: () => void
+}) {
+  const [step, setStep] = useState<'target' | 'create' | 'install'>('target')
+  const [organization, setOrganization] = useState('')
+  const [onlyCurrentEnv, setOnlyCurrentEnv] = useState(false)
+
+  const manifest = useMutation({
+    mutationFn: () =>
+      createProjectGithubManifest({
+        projectId,
+        environments: onlyCurrentEnv ? [environment] : BOTH_ENVIRONMENTS,
+        ...(organization.trim() ? { organization: organization.trim() } : {}),
+        scopeMode: 'all',
+      }),
+    onSuccess: () => setStep('create'),
+    onError: (error) =>
+      notifyError("Couldn't prepare the GitHub app manifest.", error),
+  })
+
+  const stepIndex = step === 'target' ? 0 : step === 'create' ? 1 : 2
+
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Create a dedicated GitHub app</DialogTitle>
+          <DialogDescription>
+            A dedicated app gives this project its own bot identity, its own
+            GitHub-side grant, and GitHub-side revocability. No credential is
+            ever pasted — GitHub hands the app back to OpenComputer directly.
+          </DialogDescription>
+          <GithubWizardSteps current={stepIndex} steps={WIZARD_STEPS} />
+        </DialogHeader>
+
+        {step === 'target' ? (
+          <form
+            className="space-y-4"
+            onSubmit={(event: FormEvent) => {
+              event.preventDefault()
+              manifest.mutate()
+            }}
+          >
+            <Field
+              label="GitHub organization (optional)"
+              htmlFor="github-app-organization"
+              description="Leave blank to create the app under your personal GitHub account. Creating an org-owned app requires organization owner rights."
+            >
+              <Input
+                id="github-app-organization"
+                value={organization}
+                onChange={(event) => setOrganization(event.target.value)}
+                placeholder="my-org"
+                autoComplete="off"
+              />
+            </Field>
+            <EnvironmentLimitCheckbox
+              environment={environment}
+              onlyCurrent={onlyCurrentEnv}
+              onChange={setOnlyCurrentEnv}
+            />
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={manifest.isPending}>
+                {manifest.isPending ? (
+                  <Loader2 className="animate-spin" />
+                ) : null}
+                Next: create app
+              </Button>
+            </DialogFooter>
+          </form>
+        ) : step === 'create' ? (
+          <div className="space-y-4">
+            <p className="text-muted-foreground text-sm">
+              GitHub will show a pre-filled app manifest. The suggested name
+              comes from this project, but GitHub requires a globally unique
+              name and lets you edit it — whatever name you land on is accepted
+              here. The app stays private to its owner account.
+            </p>
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => setStep('target')}>
+                Back
+              </Button>
+              <Button
+                disabled={!manifest.data}
+                onClick={() => {
+                  if (!manifest.data) return
+                  postManifestToGithub(
+                    manifest.data.action,
+                    manifest.data.manifest,
+                  )
+                  onAwaitGithub()
+                  setStep('install')
+                }}
+              >
+                <ExternalLink /> Create app on GitHub
+              </Button>
+            </DialogFooter>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {connected ? (
+              <GithubConnected environment={environment} />
+            ) : (
+              <GithubWaiting message="Finish in the GitHub tab: confirm the app, then install it on the account and pick the repositories to grant. This page updates automatically once the installation lands." />
+            )}
+            <DialogFooter>
+              <Button
+                variant={connected ? 'default' : 'outline'}
+                onClick={() => onOpenChange(false)}
+              >
+                {connected ? 'Done' : 'Close'}
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function DormantRepositoryLabel({
+  repository,
+  unknownGrant,
+}: {
+  repository: { granted: boolean; repoId: number }
+  unknownGrant: Set<number>
+}) {
+  if (unknownGrant.has(repository.repoId)) {
+    return (
+      <span className="text-muted-foreground block text-xs">
+        Beyond the enumerated repositories — selection kept.
+      </span>
+    )
+  }
+  if (!repository.granted) {
+    return (
+      <span className="block text-xs text-amber-700 dark:text-amber-400">
+        No longer granted on GitHub — kept, so access resumes if it is granted
+        again.
+      </span>
+    )
+  }
+  return null
+}
+
+function GithubScopeEditor({
+  projectId,
+  environment,
+}: {
+  projectId: string
+  environment: Environment
+}) {
+  const queryClient = useQueryClient()
+  const queryKey = projectGithubRepositoriesQueryKey(projectId, environment)
+  const repositories = useQuery({
+    queryKey,
+    queryFn: () => getProjectGithubRepositories(projectId, environment),
+  })
+  const [draft, setDraft] = useState<ProjectGithubScopePolicy>()
+  const save = useMutation({
+    mutationFn: (policy: ProjectGithubScopePolicy) =>
+      putProjectGithubRepositories({
+        projectId,
+        environment,
+        mode: policy.mode,
+        ...(policy.mode === 'selected'
+          ? { repositories: policy.repositories }
+          : {}),
+      }),
+    onSuccess: async () => {
+      setDraft(undefined)
+      await queryClient.invalidateQueries({ queryKey })
+      await queryClient.invalidateQueries({
+        queryKey: projectGithubQueryKey(projectId),
+      })
+      notifySuccess(
+        'Repository access updated.',
+        'The next minted token uses this scope.',
+      )
+    },
+    onError: (error) => {
+      if (githubErrorCode(error) === 'repository_not_granted') {
+        notifyError(
+          'A selected repository is no longer granted to the installation.',
+          error,
+        )
+        return
+      }
+      notifyError("Couldn't update repository access.", error)
+    },
+  })
+
+  const renderRetainedSelection = (
+    selected: ProjectGithubSelectedRepository[],
+  ) =>
+    selected.length ? (
+      <div className="divide-y rounded-md border">
+        {selected.map((repository) => (
+          <div
+            key={repository.repoId}
+            className="flex min-w-0 items-center gap-3 px-3 py-2.5"
+          >
+            <GithubMark className="text-muted-foreground size-3.5 shrink-0" />
+            <span className="min-w-0 flex-1 truncate font-mono text-xs">
+              {repository.fullName}
+            </span>
+            {!repository.granted ? (
+              <span className="shrink-0 text-xs text-amber-700 dark:text-amber-400">
+                No longer granted
+              </span>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    ) : null
+
+  return (
+    <Panel>
+      <PanelHeader>
+        <div>
+          <PanelTitle>Repository access</PanelTitle>
+          <PanelDescription className="mt-1 max-w-3xl">
+            What agents in {environment} can reach through githubApp()
+            connections. Scope changes apply to the next minted token;
+            already-issued tokens can stay valid for up to an hour.
+          </PanelDescription>
+        </div>
+        <span className="bg-muted rounded-md px-2 py-1 text-xs capitalize">
+          {environment}
+        </span>
+      </PanelHeader>
+      {repositories.isLoading ? (
+        <PanelContent className="text-muted-foreground flex items-center gap-2 text-sm">
+          <Loader2 className="size-4 animate-spin" /> Enumerating granted
+          repositories…
+        </PanelContent>
+      ) : repositories.isError || repositories.data?.state === 'unavailable' ? (
+        <PanelContent className="space-y-4">
+          <div className="flex items-start gap-3">
+            <TriangleAlert
+              className="mt-0.5 size-5 text-amber-600"
+              aria-hidden
+            />
+            <div>
+              <p className="text-sm font-medium">
+                GitHub can't be reached right now
+              </p>
+              <p className="text-muted-foreground text-sm">
+                This is a temporary GitHub failure. The connection and the saved
+                scope below are unchanged — nothing needs to be reconnected.
+              </p>
+            </div>
+          </div>
+          {repositories.data?.state === 'unavailable'
+            ? renderRetainedSelection(repositories.data.selected)
+            : null}
+          <Button
+            variant="outline"
+            disabled={repositories.isFetching}
+            onClick={() => void repositories.refetch()}
+          >
+            <RefreshCw
+              className={cn(repositories.isFetching && 'animate-spin')}
+            />
+            Retry
+          </Button>
+        </PanelContent>
+      ) : repositories.data?.state === 'connected' ? (
+        <GithubScopeForm
+          data={repositories.data}
+          draft={draft}
+          setDraft={setDraft}
+          pending={save.isPending}
+          onSave={(policy) => save.mutate(policy)}
+        />
+      ) : (
+        <PanelContent className="text-muted-foreground text-sm">
+          GitHub is not connected for {environment}.
+        </PanelContent>
+      )}
+    </Panel>
+  )
+}
+
+function GithubScopeForm({
+  data,
+  draft,
+  setDraft,
+  pending,
+  onSave,
+}: {
+  data: Extract<ProjectGithubRepositories, { state: 'connected' }>
+  draft: ProjectGithubScopePolicy | undefined
+  setDraft: (policy: ProjectGithubScopePolicy | undefined) => void
+  pending: boolean
+  onSave: (policy: ProjectGithubScopePolicy) => void
+}) {
+  const serverPolicy: ProjectGithubScopePolicy =
+    data.scopeMode === 'all'
+      ? { mode: 'all' }
+      : {
+          mode: 'selected',
+          repositories: data.selected.map(({ repoId, fullName }) => ({
+            repoId,
+            fullName,
+          })),
+        }
+  const policy = draft ?? serverPolicy
+  const candidates = projectGithubScopeCandidates(data.grant, data.selected)
+  const selectedIds = new Set(selectedProjectGithubRepoIds(policy))
+  const unknownGrant = new Set(data.unavailableSelected)
+  const dirty = !sameProjectGithubScopePolicy(policy, serverPolicy)
+  const narrowing = isNarrowingProjectGithubScope(serverPolicy, policy)
+
+  return (
+    <PanelContent className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <button
+          type="button"
+          onClick={() => setDraft({ mode: 'all' })}
+          className={cn(
+            'rounded-md border p-3 text-left transition-colors',
+            policy.mode === 'all'
+              ? 'border-foreground'
+              : 'hover:border-muted-foreground/40',
+          )}
+        >
+          <p className="text-sm font-medium">All repositories</p>
+          <p className="text-muted-foreground mt-1 text-xs leading-5">
+            Everything the installation is granted, including repositories added
+            on GitHub later. Tokens are install-wide — the boundary is the
+            GitHub grant itself, and OpenComputer adds nothing beyond it.
+          </p>
+        </button>
+        <button
+          type="button"
+          // Stored selections survive an `all` interlude — switching back
+          // restores them instead of starting empty.
+          onClick={() =>
+            setDraft({
+              mode: 'selected',
+              repositories: data.selected.map(({ repoId, fullName }) => ({
+                repoId,
+                fullName,
+              })),
+            })
+          }
+          className={cn(
+            'rounded-md border p-3 text-left transition-colors',
+            policy.mode === 'selected'
+              ? 'border-foreground'
+              : 'hover:border-muted-foreground/40',
+          )}
+        >
+          <p className="text-sm font-medium">Selected repositories</p>
+          <p className="text-muted-foreground mt-1 text-xs leading-5">
+            Every minted token carries exactly these repository ids, so GitHub
+            itself enforces the boundary on each call — renames included.
+          </p>
+        </button>
+      </div>
+
+      {policy.mode === 'selected' ? (
+        <div className="space-y-2">
+          {data.truncated ? (
+            <p className="text-xs text-amber-700 dark:text-amber-400">
+              Showing the first 500 repositories from GitHub. Repositories
+              beyond this limit are not listed, and selections among them are
+              kept — never treated as revoked.
+            </p>
+          ) : null}
+          <div className="max-h-72 overflow-y-auto rounded-md border">
+            {candidates.length ? (
+              candidates.map((repository) => (
+                <label
+                  key={repository.repoId}
+                  className="hover:bg-muted/40 flex min-w-0 cursor-pointer items-center gap-3 border-b px-3 py-2.5 last:border-b-0"
+                >
+                  <Checkbox
+                    checked={selectedIds.has(repository.repoId)}
+                    onCheckedChange={(next) =>
+                      setDraft(
+                        toggleProjectGithubScopeRepository(
+                          policy,
+                          {
+                            repoId: repository.repoId,
+                            fullName: repository.fullName,
+                          },
+                          next === true,
+                        ),
+                      )
+                    }
+                  />
+                  <GithubMark className="text-muted-foreground size-3.5 shrink-0" />
+                  <span className="min-w-0 flex-1">
+                    <span
+                      className="block truncate font-mono text-xs"
+                      title={repository.fullName}
+                    >
+                      {repository.fullName}
+                    </span>
+                    <DormantRepositoryLabel
+                      repository={repository}
+                      unknownGrant={unknownGrant}
+                    />
+                  </span>
+                  {repository.private ? (
+                    <span className="text-muted-foreground shrink-0 text-[10px] font-medium uppercase">
+                      Private
+                    </span>
+                  ) : null}
+                </label>
+              ))
+            ) : (
+              <p className="text-muted-foreground px-3 py-4 text-sm">
+                The installation has no granted repositories yet. Grant some on
+                GitHub, then retry.
+              </p>
+            )}
+          </div>
+          {selectedIds.size === 0 ? (
+            <p className="text-muted-foreground text-xs">
+              No repositories selected — GitHub access is off for this
+              environment while everything else keeps working.
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button disabled={!dirty || pending} onClick={() => onSave(policy)}>
+          {pending ? <Loader2 className="animate-spin" /> : null}
+          Save scope
+        </Button>
+        {dirty ? (
+          <Button variant="ghost" onClick={() => setDraft(undefined)}>
+            Reset
+          </Button>
+        ) : null}
+        {dirty && narrowing ? (
+          <p className="text-xs text-amber-700 dark:text-amber-400">
+            Narrowing applies to the next minted token; tokens already issued
+            can stay valid for up to an hour.
+          </p>
+        ) : null}
+      </div>
+    </PanelContent>
+  )
+}
+
+function GithubConnectionCard({
+  projectId,
+  environment,
+  envState,
+  status,
+  onSwitch,
+  onCreateDedicated,
+}: {
+  projectId: string
+  environment: Environment
+  envState: ProjectGithubEnvironment
+  status: ProjectGithubStatus
+  onSwitch: () => void
+  onCreateDedicated: () => void
+}) {
+  const queryClient = useQueryClient()
+  const app = envState.app
+  const installation = envState.installation
+  const fullApp = status.apps.find((candidate) => candidate.id === app?.id)
+  const htmlUrl = fullApp?.htmlUrl
+  const dedicated = app?.mode === 'dedicated'
+  const [confirmDetach, setConfirmDetach] = useState(false)
+  const [confirmDeleteApp, setConfirmDeleteApp] = useState(false)
+  const [secretOpen, setSecretOpen] = useState(false)
+  const [keyOpen, setKeyOpen] = useState(false)
+  const [webhookSecret, setWebhookSecret] = useState('')
+  const [privateKey, setPrivateKey] = useState('')
+
+  const invalidate = async () => {
+    await queryClient.invalidateQueries({
+      queryKey: projectGithubQueryKey(projectId),
+    })
+    await queryClient.invalidateQueries({
+      queryKey: projectGithubRepositoriesQueryKey(projectId, environment),
+    })
+  }
+  const detach = useMutation({
+    mutationFn: () => detachProjectGithub(projectId, environment),
+    onSuccess: async () => {
+      setConfirmDetach(false)
+      notifySuccess(
+        `GitHub disconnected from ${environment}.`,
+        'Other environments and the GitHub installation are unaffected.',
+      )
+      await invalidate()
+    },
+    onError: (error) => notifyError("Couldn't disconnect GitHub.", error),
+  })
+  const removeApp = useMutation({
+    mutationFn: () => deleteProjectGithubApp(projectId, app!.id),
+    onSuccess: async () => {
+      setConfirmDeleteApp(false)
+      notifySuccess('GitHub app removed.')
+      await invalidate()
+    },
+    onError: (error) => notifyError("Couldn't remove the GitHub app.", error),
+  })
+  const saveWebhookSecret = useMutation({
+    mutationFn: () =>
+      setProjectGithubAppWebhookSecret(projectId, app!.id, webhookSecret),
+    onSuccess: async () => {
+      setSecretOpen(false)
+      setWebhookSecret('')
+      notifySuccess(
+        'Webhook secret saved.',
+        'Deliveries verify against the new secret from now on.',
+      )
+      await invalidate()
+    },
+    onError: (error) => notifyError("Couldn't save the webhook secret.", error),
+  })
+  const savePrivateKey = useMutation({
+    mutationFn: () =>
+      setProjectGithubAppPrivateKey(projectId, app!.id, privateKey),
+    onSuccess: async () => {
+      setKeyOpen(false)
+      setPrivateKey('')
+      notifySuccess(
+        'Private key saved.',
+        'App authentication uses the new key from now on.',
+      )
+      await invalidate()
+    },
+    onError: (error) => notifyError("Couldn't save the private key.", error),
+  })
+
+  return (
+    <Panel>
+      <PanelHeader>
+        <div>
+          <PanelTitle>GitHub connection</PanelTitle>
+          <PanelDescription className="mt-1">
+            The app and installation this environment mints repository-scoped
+            tokens against.
+          </PanelDescription>
+        </div>
+        <span className="bg-muted rounded-md px-2 py-1 text-xs capitalize">
+          {environment}
+        </span>
+      </PanelHeader>
+      <PanelContent className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="bg-muted flex size-9 shrink-0 items-center justify-center rounded-md">
+              <GithubMark className="size-4" />
+            </span>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium">
+                {app?.name ?? 'GitHub app'}
+              </p>
+              <p className="text-muted-foreground truncate text-xs">
+                {app?.mode === 'oc_app'
+                  ? 'Shared OpenComputer app'
+                  : 'Dedicated app'}
+                {app ? ` · @${app.slug}` : ''}
+                {installation
+                  ? ` · installed on ${installation.accountLogin} (${installation.accountType})`
+                  : ''}
+              </p>
+              <p className="text-muted-foreground mt-0.5 text-xs">
+                {envState.scopeMode === 'all'
+                  ? 'Scope: all granted repositories (install-wide tokens)'
+                  : `Scope: ${envState.selectedRepositoryCount ?? 0} selected ${
+                      (envState.selectedRepositoryCount ?? 0) === 1
+                        ? 'repository'
+                        : 'repositories'
+                    }`}
+              </p>
+            </div>
+          </div>
+          {envState.state === 'connected' ? (
+            <StatusBadge status="connected" />
+          ) : envState.state === 'auth_required' ? (
+            <StatusBadge status="auth_required" />
+          ) : envState.state === 'app_suspended' ? (
+            <StatusBadge status="error" label="Suspended" />
+          ) : (
+            <StatusBadge status="error" label="App deleted" />
+          )}
+        </div>
+
+        {envState.state === 'auth_required' ? (
+          <div className="flex items-start gap-2 rounded-md border px-3 py-2.5 text-xs leading-5">
+            <TriangleAlert
+              className="text-destructive mt-0.5 size-3.5 shrink-0"
+              aria-hidden
+            />
+            <p>
+              GitHub authorization needs attention: the app's private key is
+              invalid, or newly requested permissions have not been accepted on
+              GitHub yet. Review the app on GitHub
+              {dedicated ? ' or re-enter its private key below' : ''}; access
+              resumes automatically once GitHub accepts.
+            </p>
+          </div>
+        ) : envState.state === 'app_suspended' ? (
+          <div className="flex items-start gap-2 rounded-md border px-3 py-2.5 text-xs leading-5">
+            <TriangleAlert
+              className="text-destructive mt-0.5 size-3.5 shrink-0"
+              aria-hidden
+            />
+            <p>
+              This installation is suspended on GitHub, so no tokens can be
+              minted. Unsuspend it in the GitHub account's installed-apps
+              settings — nothing needs to change here, and access resumes
+              automatically.
+            </p>
+          </div>
+        ) : envState.state === 'app_deleted' ? (
+          <div className="flex items-start gap-2 rounded-md border px-3 py-2.5 text-xs leading-5">
+            <TriangleAlert
+              className="text-destructive mt-0.5 size-3.5 shrink-0"
+              aria-hidden
+            />
+            <p>
+              This dedicated app was deleted on GitHub, so its stored key can no
+              longer authenticate — this is different from uninstalling. Remove
+              the app here, then create a new dedicated app.
+            </p>
+          </div>
+        ) : null}
+
+        {app?.mode === 'oc_app' ? <SharedAppNotice /> : null}
+
+        <div className="flex flex-wrap items-center gap-2">
+          {htmlUrl ? (
+            <Button asChild variant="outline" size="sm">
+              <a href={htmlUrl} target="_blank" rel="noreferrer">
+                Configure on GitHub <ExternalLink />
+              </a>
+            </Button>
+          ) : null}
+          <Button variant="outline" size="sm" onClick={onSwitch}>
+            Switch installation
+          </Button>
+          {envState.state === 'app_deleted' ? (
+            <Button variant="outline" size="sm" onClick={onCreateDedicated}>
+              Create a dedicated app
+            </Button>
+          ) : null}
+          {dedicated ? (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setSecretOpen(true)}
+              >
+                Re-enter webhook secret
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setKeyOpen(true)}
+              >
+                Re-enter private key
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setConfirmDeleteApp(true)}
+              >
+                <Trash2 /> Delete app
+              </Button>
+            </>
+          ) : null}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setConfirmDetach(true)}
+          >
+            Disconnect
+          </Button>
+        </div>
+      </PanelContent>
+
+      <Dialog open={secretOpen} onOpenChange={setSecretOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Re-enter webhook secret</DialogTitle>
+            <DialogDescription>
+              GitHub offers no API to read or rotate a webhook secret. If you
+              changed it on GitHub, paste the new value so event deliveries
+              verify again.
+            </DialogDescription>
+          </DialogHeader>
+          <Field label="Webhook secret" htmlFor="github-webhook-secret">
+            <Input
+              id="github-webhook-secret"
+              type="password"
+              value={webhookSecret}
+              onChange={(event) => setWebhookSecret(event.target.value)}
+              placeholder="••••••••"
+              autoComplete="new-password"
+            />
+          </Field>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setSecretOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={!webhookSecret.trim() || saveWebhookSecret.isPending}
+              onClick={() => saveWebhookSecret.mutate()}
+            >
+              {saveWebhookSecret.isPending ? (
+                <Loader2 className="animate-spin" />
+              ) : null}
+              Save secret
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={keyOpen} onOpenChange={setKeyOpen}>
+        <DialogContent className="sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Re-enter private key</DialogTitle>
+            <DialogDescription>
+              Generate a new private key in the app's GitHub settings, then
+              paste the PEM here. The key is stored encrypted and never shown
+              again.
+            </DialogDescription>
+          </DialogHeader>
+          <Field label="Private key (PEM)" htmlFor="github-private-key">
+            <Textarea
+              id="github-private-key"
+              value={privateKey}
+              onChange={(event) => setPrivateKey(event.target.value)}
+              placeholder={'-----BEGIN RSA PRIVATE KEY-----'}
+              className="min-h-40 font-mono text-xs"
+              autoComplete="off"
+            />
+          </Field>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setKeyOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={!privateKey.trim() || savePrivateKey.isPending}
+              onClick={() => savePrivateKey.mutate()}
+            >
+              {savePrivateKey.isPending ? (
+                <Loader2 className="animate-spin" />
+              ) : null}
+              Save key
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={confirmDetach}
+        onOpenChange={setConfirmDetach}
+        title={`Disconnect GitHub from ${environment}?`}
+        description="Agents in this environment will fail GitHub calls with github_not_connected. Only this environment is detached — the other environment and the GitHub installation keep working."
+        confirmLabel="Disconnect"
+        destructive
+        pending={detach.isPending}
+        onConfirm={() => detach.mutate()}
+      />
+
+      <ConfirmDialog
+        open={confirmDeleteApp}
+        onOpenChange={setConfirmDeleteApp}
+        title="Delete this GitHub app?"
+        description="Its stored private key and webhook secret are removed, its installations are forgotten, and every environment attached through it is disconnected. Agent GitHub calls fail with github_not_connected until a new connection exists. The app itself remains on GitHub until you also delete it there."
+        confirmLabel="Delete app"
+        destructive
+        pending={removeApp.isPending}
+        onConfirm={() => removeApp.mutate()}
+      />
+    </Panel>
+  )
+}
+
+export function ManagedProjectRepositories({
+  projectId,
+  environment,
+}: {
+  projectId: string
+  environment: Environment
+}) {
+  const queryClient = useQueryClient()
+  // Snapshot of the environment's attachment when a GitHub tab was opened
+  // (undefined = no flow in flight). Success is a *transition* away from it —
+  // an already-connected environment starting a fresh install must not read
+  // its old attachment as the new one landing.
+  const [awaitBaseline, setAwaitBaseline] = useState<string>()
+  const [connectOpen, setConnectOpen] = useState(false)
+  const [wizardOpen, setWizardOpen] = useState(false)
+  const attachmentKey = (data: ProjectGithubStatus | undefined) => {
+    const row = data?.environments.find(
+      (candidate) => candidate.environment === environment,
+    )
+    return `${row?.state ?? 'none'}:${row?.installation?.id ?? ''}`
+  }
+  const flowSettled = (data: ProjectGithubStatus | undefined) => {
+    if (awaitBaseline === undefined) return false
+    const key = attachmentKey(data)
+    return key !== awaitBaseline && key.startsWith('connected:')
+  }
+  const status = useQuery({
+    queryKey: projectGithubQueryKey(projectId),
+    queryFn: () => getProjectGithub(projectId),
+    // The install/manifest flows finish in a GitHub tab; refresh eagerly when
+    // the user comes back, and poll while a flow is in flight.
+    refetchOnWindowFocus: 'always',
+    refetchInterval: (query) =>
+      awaitBaseline !== undefined && !flowSettled(query.state.data)
+        ? 3_000
+        : false,
+  })
+  const envState = status.data?.environments.find(
+    (candidate) => candidate.environment === environment,
+  )
+  const beginAwaitGithub = () => setAwaitBaseline(attachmentKey(status.data))
+  // Closing either flow (Done, Cancel, or Escape) settles it: stop polling and
+  // refresh the grant enumeration so a just-landed installation shows fresh.
+  const closeGithubFlows = () => {
+    setConnectOpen(false)
+    setWizardOpen(false)
+    setAwaitBaseline(undefined)
+    void queryClient.invalidateQueries({
+      queryKey: projectGithubRepositoriesQueryKey(projectId, environment),
+    })
+  }
+
+  if (status.isLoading) {
+    return (
+      <Panel>
+        <PanelContent className="text-muted-foreground flex items-center gap-2 text-sm">
+          <Loader2 className="size-4 animate-spin" /> Loading GitHub status…
+        </PanelContent>
+      </Panel>
+    )
+  }
+  if (status.isError || !status.data) {
+    return (
+      <Panel>
+        <PanelContent className="space-y-3">
+          <p className="text-muted-foreground text-sm">
+            The GitHub status is temporarily unavailable. Any existing
+            connection is unchanged.
+          </p>
+          <Button variant="outline" onClick={() => void status.refetch()}>
+            <RefreshCw /> Retry
+          </Button>
+        </PanelContent>
+      </Panel>
+    )
+  }
+
+  const sharedPathAvailable =
+    status.data.ocAppAvailable || status.data.installations.length > 0
+
+  return (
+    <div className="space-y-8">
+      {!envState || envState.state === 'not_connected' ? (
+        <Panel>
+          <EmptyState
+            icon={FolderGit2}
+            title={`GitHub is not connected for ${environment}`}
+            description="Install a GitHub App so agents reach repositories through short-lived, repository-scoped tokens minted per call — never a personal access token."
+            action={
+              <div className="flex flex-col items-center gap-3">
+                <div className="flex flex-wrap items-center justify-center gap-2">
+                  {sharedPathAvailable ? (
+                    <Button onClick={() => setConnectOpen(true)}>
+                      <GithubMark className="size-4" /> Connect GitHub
+                    </Button>
+                  ) : null}
+                  <Button
+                    variant={sharedPathAvailable ? 'outline' : 'default'}
+                    onClick={() => setWizardOpen(true)}
+                  >
+                    Create a dedicated app
+                  </Button>
+                </div>
+                {!sharedPathAvailable ? (
+                  <p className="text-muted-foreground max-w-sm text-xs">
+                    The shared OpenComputer app is not available here, so this
+                    project needs its own dedicated GitHub app.
+                  </p>
+                ) : null}
+              </div>
+            }
+          />
+        </Panel>
+      ) : (
+        <>
+          <GithubConnectionCard
+            projectId={projectId}
+            environment={environment}
+            envState={envState}
+            status={status.data}
+            onSwitch={() => setConnectOpen(true)}
+            onCreateDedicated={() => setWizardOpen(true)}
+          />
+          {envState.state === 'connected' ? (
+            <GithubScopeEditor
+              projectId={projectId}
+              environment={environment}
+            />
+          ) : null}
+        </>
+      )}
+
+      {connectOpen ? (
+        <GithubConnectDialog
+          projectId={projectId}
+          environment={environment}
+          status={status.data}
+          connected={flowSettled(status.data)}
+          onOpenChange={(open) => {
+            if (!open) closeGithubFlows()
+          }}
+          onAwaitGithub={beginAwaitGithub}
+          onCreateDedicated={() => {
+            setConnectOpen(false)
+            setWizardOpen(true)
+          }}
+        />
+      ) : null}
+      {wizardOpen ? (
+        <GithubDedicatedAppWizard
+          projectId={projectId}
+          environment={environment}
+          connected={flowSettled(status.data)}
+          onOpenChange={(open) => {
+            if (!open) closeGithubFlows()
+          }}
+          onAwaitGithub={beginAwaitGithub}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -268,6 +268,125 @@ const webhookSchema = z.object({
 const webhooksResponseSchema = z.object({ webhooks: z.array(webhookSchema) })
 const webhookResponseSchema = z.object({ webhook: webhookSchema })
 
+const githubEnvironmentNameSchema = z.enum(['development', 'production'])
+const githubScopeModeSchema = z.enum(['all', 'selected'])
+const githubAppModeSchema = z.enum(['oc_app', 'dedicated'])
+
+const githubAttachedAppSchema = z.object({
+  id: z.string(),
+  mode: githubAppModeSchema,
+  slug: z.string(),
+  name: z.string(),
+  githubAppId: z.number(),
+  webhookConfigured: z.boolean(),
+  status: z.string(),
+})
+
+const githubAppSchema = z.object({
+  id: z.string(),
+  mode: githubAppModeSchema,
+  slug: z.string(),
+  name: z.string(),
+  htmlUrl: z.string().optional(),
+  permissions: z.record(z.string(), z.string()),
+  events: z.array(z.string()),
+  webhookConfigured: z.boolean(),
+  status: z.string(),
+})
+
+const githubAttachedInstallationSchema = z.object({
+  id: z.string(),
+  githubInstallationId: z.number(),
+  accountLogin: z.string(),
+  accountType: z.string(),
+  repositorySelection: z.string(),
+  status: z.string(),
+})
+
+const githubInstallationSchema = z.object({
+  id: z.string(),
+  accountLogin: z.string(),
+  accountType: z.string(),
+  repositorySelection: z.string(),
+  status: z.string(),
+  app: z
+    .object({
+      id: z.string(),
+      mode: githubAppModeSchema,
+      slug: z.string(),
+      name: z.string(),
+    })
+    .nullish(),
+})
+
+const githubEnvironmentSchema = z.object({
+  environment: githubEnvironmentNameSchema,
+  state: z.enum([
+    'not_connected',
+    'connected',
+    'auth_required',
+    'app_suspended',
+    'app_deleted',
+  ]),
+  app: githubAttachedAppSchema.optional(),
+  installation: githubAttachedInstallationSchema.optional(),
+  scopeMode: githubScopeModeSchema.optional(),
+  selectedRepositoryCount: z.number().optional(),
+})
+
+const githubStatusSchema = z.object({
+  environments: z.array(githubEnvironmentSchema),
+  installations: z.array(githubInstallationSchema),
+  apps: z.array(githubAppSchema),
+  ocAppAvailable: z.boolean(),
+})
+
+// Attaching an existing installation resolves immediately (fresh environment
+// states); a new OC-app install hands back the GitHub URL to finish in.
+const githubConnectResponseSchema = z.union([
+  z.object({ installUrl: z.string() }),
+  z.object({ environments: z.array(githubEnvironmentSchema) }),
+])
+
+const githubEnvironmentsResponseSchema = z.object({
+  environments: z.array(githubEnvironmentSchema),
+})
+
+const githubManifestResponseSchema = z.object({
+  action: z.string(),
+  manifest: z.record(z.string(), z.unknown()),
+})
+
+const githubSelectedRepositorySchema = z.object({
+  repoId: z.number(),
+  fullName: z.string(),
+  granted: z.boolean(),
+})
+
+const githubGrantRepositorySchema = z.object({
+  repoId: z.number(),
+  fullName: z.string(),
+  private: z.boolean(),
+  defaultBranch: z.string().optional(),
+})
+
+const githubRepositoriesSchema = z.discriminatedUnion('state', [
+  z.object({ state: z.literal('not_connected') }),
+  z.object({
+    state: z.literal('unavailable'),
+    scopeMode: githubScopeModeSchema,
+    selected: z.array(githubSelectedRepositorySchema),
+  }),
+  z.object({
+    state: z.literal('connected'),
+    scopeMode: githubScopeModeSchema,
+    truncated: z.boolean(),
+    grant: z.array(githubGrantRepositorySchema),
+    selected: z.array(githubSelectedRepositorySchema),
+    unavailableSelected: z.array(z.number()),
+  }),
+])
+
 const slackManifestResponseSchema = z.object({
   connection: channelSchema,
   manifest: z.record(z.string(), z.unknown()),
@@ -377,6 +496,19 @@ export type ManagedAgentScheduleRun = z.infer<typeof scheduleRunSchema>
 export type ManagedAgentWebhook = z.infer<typeof webhookSchema>
 export type ManagedSlackManifest = z.infer<typeof slackManifestResponseSchema>
 export type ManagedProjectSecret = z.infer<typeof secretSchema>
+export type ProjectGithubStatus = z.infer<typeof githubStatusSchema>
+export type ProjectGithubEnvironment = z.infer<typeof githubEnvironmentSchema>
+export type ProjectGithubApp = z.infer<typeof githubAppSchema>
+export type ProjectGithubAttachedApp = z.infer<typeof githubAttachedAppSchema>
+export type ProjectGithubInstallation = z.infer<typeof githubInstallationSchema>
+export type ProjectGithubManifest = z.infer<typeof githubManifestResponseSchema>
+export type ProjectGithubRepositories = z.infer<typeof githubRepositoriesSchema>
+export type ProjectGithubGrantRepository = z.infer<
+  typeof githubGrantRepositorySchema
+>
+export type ProjectGithubSelectedRepository = z.infer<
+  typeof githubSelectedRepositorySchema
+>
 
 const UUID_NAME =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
@@ -691,6 +823,128 @@ export async function deleteManagedAgentWebhook(
 ) {
   return apiFetch<void>(
     `/managed-agents/projects/${encodeURIComponent(projectId)}/webhooks/${encodeURIComponent(webhookId)}`,
+    { method: 'DELETE' },
+  )
+}
+
+export async function getProjectGithub(projectId: string) {
+  return apiFetch(
+    `/managed-agents/projects/${encodeURIComponent(projectId)}/github`,
+    undefined,
+    githubStatusSchema,
+  )
+}
+
+export async function connectProjectGithub(input: {
+  projectId: string
+  environments: Array<'development' | 'production'>
+  installationId?: string
+  scopeMode?: 'all' | 'selected'
+}) {
+  return apiFetch(
+    `/managed-agents/projects/${encodeURIComponent(input.projectId)}/github/connect`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        environments: input.environments,
+        ...(input.installationId
+          ? { installationId: input.installationId }
+          : {}),
+        ...(input.scopeMode ? { scopeMode: input.scopeMode } : {}),
+      }),
+    },
+    githubConnectResponseSchema,
+  )
+}
+
+export async function createProjectGithubManifest(input: {
+  projectId: string
+  environments: Array<'development' | 'production'>
+  organization?: string
+  scopeMode?: 'all' | 'selected'
+}) {
+  return apiFetch(
+    `/managed-agents/projects/${encodeURIComponent(input.projectId)}/github/manifest`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        environments: input.environments,
+        ...(input.organization ? { organization: input.organization } : {}),
+        ...(input.scopeMode ? { scopeMode: input.scopeMode } : {}),
+      }),
+    },
+    githubManifestResponseSchema,
+  )
+}
+
+export async function getProjectGithubRepositories(
+  projectId: string,
+  environment: 'development' | 'production',
+) {
+  return apiFetch(
+    `/managed-agents/projects/${encodeURIComponent(projectId)}/github/repositories?environment=${encodeURIComponent(environment)}`,
+    undefined,
+    githubRepositoriesSchema,
+  )
+}
+
+export async function putProjectGithubRepositories(input: {
+  projectId: string
+  environment: 'development' | 'production'
+  mode: 'all' | 'selected'
+  repositories?: Array<{ repoId: number; fullName: string }>
+}) {
+  return apiFetch(
+    `/managed-agents/projects/${encodeURIComponent(input.projectId)}/github/repositories?environment=${encodeURIComponent(input.environment)}`,
+    {
+      method: 'PUT',
+      body: JSON.stringify({
+        mode: input.mode,
+        ...(input.repositories ? { repositories: input.repositories } : {}),
+      }),
+    },
+    githubEnvironmentsResponseSchema,
+  )
+}
+
+export async function detachProjectGithub(
+  projectId: string,
+  environment: 'development' | 'production',
+) {
+  return apiFetch<void>(
+    `/managed-agents/projects/${encodeURIComponent(projectId)}/github?environment=${encodeURIComponent(environment)}`,
+    { method: 'DELETE' },
+  )
+}
+
+export async function setProjectGithubAppWebhookSecret(
+  projectId: string,
+  appRef: string,
+  secret: string,
+) {
+  return apiFetch<void>(
+    `/managed-agents/projects/${encodeURIComponent(projectId)}/github/apps/${encodeURIComponent(appRef)}/webhook-secret`,
+    { method: 'POST', body: JSON.stringify({ secret }) },
+  )
+}
+
+export async function setProjectGithubAppPrivateKey(
+  projectId: string,
+  appRef: string,
+  pem: string,
+) {
+  return apiFetch<void>(
+    `/managed-agents/projects/${encodeURIComponent(projectId)}/github/apps/${encodeURIComponent(appRef)}/private-key`,
+    { method: 'POST', body: JSON.stringify({ pem }) },
+  )
+}
+
+export async function deleteProjectGithubApp(
+  projectId: string,
+  appRef: string,
+) {
+  return apiFetch<void>(
+    `/managed-agents/projects/${encodeURIComponent(projectId)}/github/apps/${encodeURIComponent(appRef)}`,
     { method: 'DELETE' },
   )
 }

--- a/web/src/managed-agents/github-scope.test.ts
+++ b/web/src/managed-agents/github-scope.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+import {
+  defaultProjectGithubScopeMode,
+  isNarrowingProjectGithubScope,
+  projectGithubQueryKey,
+  projectGithubRepositoriesQueryKey,
+  projectGithubScopeCandidates,
+  sameProjectGithubScopePolicy,
+  toggleProjectGithubScopeRepository,
+} from './github-scope'
+
+describe('project github scope helpers', () => {
+  it('uses project-namespaced query keys', () => {
+    expect(projectGithubQueryKey('prj_1')).toEqual(['project-github', 'prj_1'])
+    expect(projectGithubRepositoriesQueryKey('prj_1', 'production')).toEqual([
+      'project-github-repositories',
+      'prj_1',
+      'production',
+    ])
+  })
+
+  it('defaults the shared app to selected and dedicated apps to all', () => {
+    expect(defaultProjectGithubScopeMode('oc_app')).toBe('selected')
+    expect(defaultProjectGithubScopeMode('dedicated')).toBe('all')
+  })
+
+  it('detects narrowing without treating expansion as narrowing', () => {
+    expect(
+      isNarrowingProjectGithubScope(
+        { mode: 'all' },
+        { mode: 'selected', repositories: [{ repoId: 1, fullName: 'o/a' }] },
+      ),
+    ).toBe(true)
+    expect(
+      isNarrowingProjectGithubScope(
+        { mode: 'selected', repositories: [{ repoId: 1, fullName: 'o/a' }] },
+        { mode: 'all' },
+      ),
+    ).toBe(false)
+    expect(
+      isNarrowingProjectGithubScope(
+        {
+          mode: 'selected',
+          repositories: [
+            { repoId: 1, fullName: 'o/a' },
+            { repoId: 2, fullName: 'o/dormant' },
+          ],
+        },
+        { mode: 'selected', repositories: [{ repoId: 1, fullName: 'o/a' }] },
+      ),
+    ).toBe(true)
+  })
+
+  it('compares policies by repository id, ignoring order and names', () => {
+    expect(
+      sameProjectGithubScopePolicy(
+        {
+          mode: 'selected',
+          repositories: [
+            { repoId: 2, fullName: 'o/b' },
+            { repoId: 1, fullName: 'o/a' },
+          ],
+        },
+        {
+          mode: 'selected',
+          repositories: [
+            { repoId: 1, fullName: 'o/a-renamed' },
+            { repoId: 2, fullName: 'o/b' },
+          ],
+        },
+      ),
+    ).toBe(true)
+    expect(
+      sameProjectGithubScopePolicy(
+        { mode: 'all' },
+        { mode: 'selected', repositories: [] },
+      ),
+    ).toBe(false)
+  })
+
+  it('keeps dormant selected entries visible next to the live grant', () => {
+    const candidates = projectGithubScopeCandidates(
+      [{ repoId: 1, fullName: 'o/granted', private: true }],
+      [
+        { repoId: 1, fullName: 'o/granted', granted: true },
+        { repoId: 2, fullName: 'o/dormant', granted: false },
+      ],
+    )
+    expect(candidates).toEqual([
+      { repoId: 2, fullName: 'o/dormant', granted: false },
+      {
+        repoId: 1,
+        fullName: 'o/granted',
+        granted: true,
+        private: true,
+        defaultBranch: undefined,
+      },
+    ])
+  })
+
+  it('never classifies a truncation omission as revoked', () => {
+    // Selected id absent from the (truncated) grant but flagged granted by the
+    // server stays granted in the merged view.
+    const candidates = projectGithubScopeCandidates(
+      [],
+      [{ repoId: 9, fullName: 'o/beyond-500', granted: true }],
+    )
+    expect(candidates).toEqual([
+      { repoId: 9, fullName: 'o/beyond-500', granted: true },
+    ])
+  })
+
+  it('preserves a dormant selection when toggling another repository', () => {
+    expect(
+      toggleProjectGithubScopeRepository(
+        {
+          mode: 'selected',
+          repositories: [{ repoId: 2, fullName: 'o/dormant' }],
+        },
+        { repoId: 1, fullName: 'o/a' },
+        true,
+      ),
+    ).toEqual({
+      mode: 'selected',
+      repositories: [
+        { repoId: 1, fullName: 'o/a' },
+        { repoId: 2, fullName: 'o/dormant' },
+      ],
+    })
+    expect(
+      toggleProjectGithubScopeRepository(
+        { mode: 'all' },
+        { repoId: 1, fullName: 'o/a' },
+        true,
+      ),
+    ).toEqual({
+      mode: 'selected',
+      repositories: [{ repoId: 1, fullName: 'o/a' }],
+    })
+  })
+})

--- a/web/src/managed-agents/github-scope.ts
+++ b/web/src/managed-agents/github-scope.ts
@@ -1,0 +1,122 @@
+import type {
+  ProjectGithubGrantRepository,
+  ProjectGithubSelectedRepository,
+} from './api'
+
+export const projectGithubQueryKey = (projectId: string) =>
+  ['project-github', projectId] as const
+
+export const projectGithubRepositoriesQueryKey = (
+  projectId: string,
+  environment: 'development' | 'production',
+) => ['project-github-repositories', projectId, environment] as const
+
+/** A repository pinned by `selected` scope. Identity is the numeric GitHub
+ * repo id; the name rides along only because the PUT contract wants it. */
+export type ProjectGithubScopeRepository = {
+  repoId: number
+  fullName: string
+}
+
+export type ProjectGithubScopePolicy =
+  | { mode: 'all' }
+  | { mode: 'selected'; repositories: ProjectGithubScopeRepository[] }
+
+/** A row in the selected-mode editor: the live grant plus dormant retained
+ * selections (`granted: false` — still stored, no longer reachable). */
+export type ProjectGithubScopeCandidate = {
+  repoId: number
+  fullName: string
+  granted: boolean
+  private?: boolean
+  defaultBranch?: string
+}
+
+/** Shared OC app → breadth must be a visible choice (`selected`); a dedicated
+ * app is the project's own and the install screen already picked repos (`all`). */
+export function defaultProjectGithubScopeMode(
+  appMode: 'oc_app' | 'dedicated',
+): 'all' | 'selected' {
+  return appMode === 'oc_app' ? 'selected' : 'all'
+}
+
+export function selectedProjectGithubRepoIds(
+  policy: ProjectGithubScopePolicy,
+): number[] {
+  return policy.mode === 'selected'
+    ? policy.repositories.map((repository) => repository.repoId)
+    : []
+}
+
+export function isNarrowingProjectGithubScope(
+  previous: ProjectGithubScopePolicy,
+  next: ProjectGithubScopePolicy,
+): boolean {
+  if (previous.mode === 'all') return next.mode === 'selected'
+  if (next.mode === 'all') return false
+  const nextIds = new Set(selectedProjectGithubRepoIds(next))
+  return selectedProjectGithubRepoIds(previous).some((id) => !nextIds.has(id))
+}
+
+export function sameProjectGithubScopePolicy(
+  left: ProjectGithubScopePolicy,
+  right: ProjectGithubScopePolicy,
+): boolean {
+  if (left.mode !== right.mode) return false
+  if (left.mode === 'all' || right.mode === 'all') return true
+  const leftIds = selectedProjectGithubRepoIds(left)
+  const rightIds = new Set(selectedProjectGithubRepoIds(right))
+  return (
+    leftIds.length === rightIds.size && leftIds.every((id) => rightIds.has(id))
+  )
+}
+
+/**
+ * Merge the live grant enumeration with every stored selected entry so dormant
+ * selections stay visible instead of being silently dropped. The server's
+ * `granted` flag is authoritative for dormancy — a selected repository omitted
+ * from a truncated grant view is never classified as revoked here.
+ */
+export function projectGithubScopeCandidates(
+  grant: ProjectGithubGrantRepository[],
+  selected: ProjectGithubSelectedRepository[],
+): ProjectGithubScopeCandidate[] {
+  const byId = new Map<number, ProjectGithubScopeCandidate>()
+  for (const repository of grant) {
+    byId.set(repository.repoId, {
+      repoId: repository.repoId,
+      fullName: repository.fullName,
+      granted: true,
+      private: repository.private,
+      defaultBranch: repository.defaultBranch,
+    })
+  }
+  for (const repository of selected) {
+    if (!byId.has(repository.repoId)) {
+      byId.set(repository.repoId, {
+        repoId: repository.repoId,
+        fullName: repository.fullName,
+        granted: repository.granted,
+      })
+    }
+  }
+  return [...byId.values()].sort((a, b) => a.fullName.localeCompare(b.fullName))
+}
+
+export function toggleProjectGithubScopeRepository(
+  policy: ProjectGithubScopePolicy,
+  repository: ProjectGithubScopeRepository,
+  checked: boolean,
+): ProjectGithubScopePolicy {
+  const byId = new Map(
+    (policy.mode === 'selected' ? policy.repositories : []).map(
+      (entry) => [entry.repoId, entry] as const,
+    ),
+  )
+  if (checked) byId.set(repository.repoId, repository)
+  else byId.delete(repository.repoId)
+  return {
+    mode: 'selected',
+    repositories: [...byId.values()].sort((a, b) => a.repoId - b.repoId),
+  }
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -14,6 +14,24 @@ const target = process.env.OC_API_TARGET || 'http://localhost:8080'
 // org-token; this shortcut is local-only.
 const v3Key = process.env.OC_V3_KEY
 const v3Target = process.env.OC_V3_TARGET || 'https://api.opencomputer.dev'
+
+// Dev-only managed-agents bypass. With OC_MANAGED_TARGET set (e.g. a local
+// `wrangler dev` of the private edge on http://localhost:8787), Vite forwards
+// /api/managed-agents/* straight to it as /v1/* — skipping the public api-edge
+// adapter. The private edge in development mode accepts unauthenticated
+// requests as the local account, so the dashboard works with no key. GitHub
+// browser callbacks (/api/managed-agents/github/setup, .../manifest/callback)
+// ride the same rewrite.
+const managedTarget = process.env.OC_MANAGED_TARGET
+const managedProxy: Record<string, ProxyOptions> = managedTarget
+  ? {
+      '/api/managed-agents': {
+        target: managedTarget,
+        changeOrigin: true,
+        rewrite: (p) => p.replace(/^\/api\/managed-agents/, '/v1'),
+      },
+    }
+  : {}
 const injectKey: ProxyOptions['configure'] = (proxy) => {
   proxy.on('proxyReq', (proxyReq) => {
     if (v3Key) proxyReq.setHeader('x-api-key', v3Key)
@@ -52,6 +70,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       ...v3Proxy,
+      ...managedProxy,
       '/auth': target,
       // Trailing slash so the SPA route `/api-keys` isn't proxied to the
       // backend; all real API paths live under `/api/dashboard/`.

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -32,6 +32,26 @@ const managedProxy: Record<string, ProxyOptions> = managedTarget
       },
     }
   : {}
+
+// Dev-only prod-shell bypass. Cookie auth can't bridge localhost -> the prod
+// edge (the WorkOS callback lands on the prod domain), but the vite proxy can
+// attach an existing prod session server-side: set OC_SESSION_COOKIE to the
+// value of your `oc_session` cookie from app.opencomputer.dev (devtools ->
+// Application -> Cookies) and point OC_API_TARGET at https://app.opencomputer.dev.
+// The cookie lives only in the Node dev server, never in the browser bundle.
+const sessionCookie = process.env.OC_SESSION_COOKIE
+const shellProxyOptions: ProxyOptions = sessionCookie
+  ? {
+      target,
+      ws: true,
+      changeOrigin: true,
+      configure: (proxy) => {
+        proxy.on('proxyReq', (proxyReq) => {
+          proxyReq.setHeader('cookie', `oc_session=${sessionCookie}`)
+        })
+      },
+    }
+  : { target, ws: true }
 const injectKey: ProxyOptions['configure'] = (proxy) => {
   proxy.on('proxyReq', (proxyReq) => {
     if (v3Key) proxyReq.setHeader('x-api-key', v3Key)
@@ -74,7 +94,7 @@ export default defineConfig({
       '/auth': target,
       // Trailing slash so the SPA route `/api-keys` isn't proxied to the
       // backend; all real API paths live under `/api/dashboard/`.
-      '/api/': { target, ws: true },
+      '/api/': shellProxyOptions,
       '/webhooks': target,
     },
   },


### PR DESCRIPTION
Public half of the GitHub App integration (serverless-agents-ws `.agents/work/010-github-app-integration.md`). Companion to diggerhq/blue#32 (private edge: mint, attachments, routes) and diggerhq/blue#31 (independent proxy fix).

## What ships

- **`@opencomputer/agent`**: `githubApp({ permissions })` — a credential reference for `defineConnection` headers. Permissions are a required argument validated against the supported set (`contents`, `pull_requests`, `issues`, `metadata`, `checks`; read-only keys enforced); valid only on GitHub API origins. Replaces PAT-in-secret for GitHub: the platform mints a ~1h installation token scoped to the project's repositories and the declared permissions, attached at managed egress — agent code never sees a credential, and there is no token to create, paste, or rotate.
- **CLI**: static parser + bundled shim support (permissions must be an inline object literal — enforced with a targeted error), manifest emits `{kind: "github_app", permissions}`, `opencomputer github status|connect`, and a `dev`-loop warning when code uses `githubApp()` but development has no GitHub connection. Secrets origin-inference now skips non-secret header kinds.
- **Dashboard**: project-level **Repositories** tab (per-environment, like Secrets): connect the shared OpenComputer app or create a **dedicated per-project GitHub App** via the manifest wizard; `all`/`selected` repository scope with dormant selections visibly retained and truncation honesty; the full connection state model including `unavailable` → Retry (a GitHub outage never renders as disconnected); app management (webhook-secret/private-key re-entry, delete). Scope logic lives namespaced in `managed-agents/github-scope.ts` — deliberately not shared with the legacy repository-access module.
- **api-edge**: explicit allowlist entries for the project GitHub routes, plus an unauthenticated public surface for the two GitHub browser callbacks and the App webhook ingress (authorized at the private edge by one-time state / HMAC). The public origin is what gets baked into GitHub app manifests.
- **Local dev**: `OC_MANAGED_TARGET` Vite proxy bypass (mirrors `OC_V3_KEY`) — point the dashboard at a local `wrangler dev` of the private edge; the dedicated-app flow round-trips real GitHub against localhost.

## Verification

- agent/, cli/, api-edge: tsc clean; CLI 38 tests, api-edge 95 tests green. New compiler tests: literal-permissions manifest output + non-literal rejection.
- web: typecheck + build clean; 189 tests green incl. new scope-logic units (dormant retention, truncation-omission never classified as revoked).

## Not in this PR

Public docs (repo rule: only after the slice is verified on default branches); OC shared-app registration per environment (ops); repo checkout/publish (explicitly deferred to its own design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)