### PR TITLE
Give prod the deep MicroVM pool; stop dev's orphan reaper terminating it

### DIFF
--- a/cloudflare-workers/api-edge/wrangler.prod.toml
+++ b/cloudflare-workers/api-edge/wrangler.prod.toml
@@ -145,6 +145,17 @@ crons = ["*/5 * * * *"]
 
 [vars]
 WORKER_ENV = "prod"
+# PoolStock sizing. SHARDS × TARGET must stay ≤ the cell's MicroVM pool
+# (OPENSANDBOX_MICROVM_POOL_TARGET on the CP) or every shard sits permanently
+# below low-water, restocks on every claim, and competes for a supply that can
+# never satisfy it — creates then fall through to the ~10× slower CP path.
+#
+# 8 × 18 = 144 against prod's pool of 150. These were unset until 2026-08-20,
+# which meant the DO defaults (38 per shard = 304 fleet) applied against a pool
+# of 5 — every shard starved and edge-claim effectively never hit. Raise the CP
+# pool target FIRST, then this. See the SIZING INVARIANT in src/pool_stock.ts.
+POOL_STOCK_TARGET = "18"
+POOL_STOCK_LOW_WATER = "9"
 # Cells eligible for new-org home assignment live in the D1 `cells` table
 # (`accepts_new_orgs` column), not an env list — toggle a row to onboard a cell,
 # no deploy. See pickHomeCell in src/index.ts.

--- a/cloudflare-workers/api-edge/wrangler.toml
+++ b/cloudflare-workers/api-edge/wrangler.toml
@@ -210,8 +210,14 @@ PAUSED_CAP = "10"
 # more than the pool maintains starves every shard. Raise the pool first, then
 # this. Measured before the change: burst-30 returned exactly 24 fast (90ms
 # median) and dropped the remaining 6 to the CP.
-POOL_STOCK_TARGET = "18"
-POOL_STOCK_LOW_WATER = "9"
+#
+# 2026-08-20: dev's MicroVM pool dropped 150 → 30 so prod could hold the deep
+# pool instead (both cells draw on the SAME us-east-1 account, so depth here is
+# depth prod cannot have). 8 × 3 = 24 against 30, restoring the ratio this file
+# used to carry. The tuning above is kept because it is the reasoning that will
+# be needed again if dev ever takes the deep pool back.
+POOL_STOCK_TARGET = "3"
+POOL_STOCK_LOW_WATER = "2"
 # Cells eligible for new-org home assignment are NOT configured here anymore —
 # it's the `accepts_new_orgs` column on the D1 `cells` table (single source of
 # truth, toggled per-row without a deploy). See pickHomeCell in src/index.ts.


### PR DESCRIPTION
Prod's MicroVM pool target was **5** while dev's was **150** — against the same `us-east-1` account. The environment with no customers held all the depth, so prod's edge-claim essentially never hit and creates fell through to the ~10× slower control-plane path.

## The reason prod couldn't hold a pool

Sizing wasn't the whole story. Dev had `OPENSANDBOX_MICROVM_ORPHAN_REAP=1`, and the sweep's only ownership test is the image identifier — which cannot discriminate here, because both control planes launch the identical `opensandbox-agent-dev` ARN in the same account.

```
Aug 20 19:11:40  microvm: orphan sweep reclaimed 5 of 5 unowned box(es)
                 (dev CP — prod's pool target is exactly 5)
```

Every sweep line reads `0 foreign-image`. Dev was terminating prod's pool as fast as prod rebuilt it. This is precisely what `sweepOrphans`' own comment warns about: the image guard isn't enough discrimination for a shared account, and boxes need real tagging before it's armed anywhere.

## Applied directly to the control planes (not in this repo)

| | prod `oc-controlplane-2` | dev `osb-controlplane-2` |
|---|---|---|
| `MICROVM_POOL_TARGET` | 5 → **150** | 150 → **30** |
| `MICROVM_MAX_TOTAL_BOXES` | unset → **230** | 230 |
| `MICROVM_ORPHAN_REAP` | **not armed** | 1 → **0** |

The reaper is deliberately left unarmed on prod — mirroring it would just aim the same undiscriminating sweep at dev's boxes.

## In this PR

Keeping the invariant `SHARDS × TARGET ≤ the cell's pool`:

- **prod**: `POOL_STOCK_TARGET=18`, `LOW_WATER=9` → 8×18 = 144 ≤ 150. These were unset, so the DO defaults (38/shard = **304**) were applying against a pool of 5.
- **dev**: `POOL_STOCK_TARGET=3`, `LOW_WATER=2` → 8×3 = 24 ≤ 30.

Net AWS footprint is roughly unchanged (~180 vs ~155); the depth just moves to where customers are.

## Follow-up

Per-environment images or real box tagging, so the orphan sweep can be armed safely again. Filed separately — until then it stays off in both environments.