### PR TITLE
Re-place PoolStock shards to IAD (g4) — g3 split MIA/IAD

### DIFF
--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -1158,8 +1158,17 @@ function indexSandboxFromSSE(
 // pre-sharding DO would drain as a first-class shard, but that cutover is long
 // done, and the bare name was permanently unplaceable — a guaranteed 1-in-8
 // cross-country claim no gen bump could ever fix.
+// g4: g3 fixed the hemisphere but not the metro. Measured on prod 2026-08-20
+// from an IAD runner, the g3 shards split MIA/IAD — `doin=0` on both, so the
+// gap is pure network: IAD shards answered a claim in 10-18ms, MIA shards in
+// 35-49ms, dragging the claim median to 35ms and create to 50ms.
+//
+// locationHint is doing its job: Miami IS eastern North America. The hint picks
+// a region, not a metro, so within enam the placement still falls out of which
+// colo touches the object first. That is the part only the arming run controls
+// — see the note above about first-touching from the cell's own metro.
 const POOL_STOCK_SHARDS = 8;
-const POOL_STOCK_SHARD_GEN = "g3";
+const POOL_STOCK_SHARD_GEN = "g4";
 
 function poolStockStub(env: Env, cellID: string, shard: number): DurableObjectStub {
   const name = `${cellID}#${POOL_STOCK_SHARD_GEN}#${shard}`;


### PR DESCRIPTION
`g3` fixed the hemisphere but not the metro.

Measured on prod from an IAD runner (16 creates), the `g3` shards answered from **both MIA and IAD**, with `doin=0` on every claim — so the entire difference is network:

```
do@IAD   claim 10-18ms
do@MIA   claim 35-49ms
```

That pulls the claim median to 35ms and create to 50ms, against the 10-18ms the correctly-placed shards already deliver.

`locationHint: "enam"` isn't at fault — Miami *is* eastern North America. The hint selects a region, not a metro; within `enam` the placement still falls out of whichever colo first touches the object. Bumping the generation is the only way to re-place a Durable Object, because placement is fixed at creation and permanent.

## Required after deploy

**First-touch the `g4` shards from the cell's own metro** — the IAD bastion, or a sandbox in-region — before customer traffic arrives. A create from a laptop pins them to that laptop's colo and reintroduces this exact problem; that's how `g1`, `g2` and `g3` each ended up mis-placed.

Old-gen shards release their stock through the idle self-decommission path (`IDLE_DECOMMISSION_MS`), so `g3`'s reservations drain on their own.

## Context

Prod's edge-claim only started firing at all today — `EDGE_CLAIM` was set as a **secret** on the prod Worker (invisible to the toml and to `--dry-run` binding output), so the fast path had been skipped entirely. With it cleared, prod went TTI median 334ms → 215ms and `reach` 17ms → 6ms. This PR is the remaining metro-placement cleanup on top of that.