### PR TITLE
perf(edge): instrument the unattributed create time (pre/hdl marks)

### DIFF
--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -1350,6 +1350,21 @@ async function createSandbox(req: Request, env: Env, ctx: ExecutionContext): Pro
   // in Workers, so deltas attribute I/O waits; pure CPU shows ~0).
   const phases: string[] = [];
   let tPrev = Date.now();
+  const tEntry = tPrev;
+  // `pre` is everything before this handler ran: client send -> CF -> routing ->
+  // handler entry. Every other mark starts at tPrev, i.e. AFTER this point, so
+  // without it the biggest term on the burst create path is invisible. Measured
+  // 2026-08-20 from IAD: create median scaled 334->551->853ms at concurrency
+  // 10/25/100 while the marks stayed flat (claim 20->21->32ms), leaving ~700ms
+  // unattributed even after cutting the waitUntil fan-out. This says whether
+  // that time is spent getting to the handler or after the response is built.
+  //
+  // Client-supplied clock, so it carries the client's skew — fine against a
+  // ~700ms signal, useless for anything small. Absent header => no mark.
+  const clientSentMs = Number(req.headers.get("x-client-sent") ?? "");
+  if (Number.isFinite(clientSentMs) && clientSentMs > 0) {
+    phases.push(`pre;dur=${tEntry - clientSentMs}`);
+  }
   const mark = (name: string): void => {
     const t = Date.now();
     phases.push(`${name};dur=${t - tPrev}`);
@@ -1560,6 +1575,11 @@ async function createSandbox(req: Request, env: Env, ctx: ExecutionContext): Pro
         } else {
           ctx.waitUntil(finalizeEdgeClaim(env, caller, cell, plan, org.billing_provider, org.runtime ?? "", box.id, box.workerID, bodyText));
         }
+        // Total in-handler wall time. With `pre`, the client's own measurement
+        // splits three ways: pre (getting here) + hdl (this handler) + the rest
+        // (response back over the wire, or time this Worker spent after the
+        // return that no mark can reach).
+        phases.push(`hdl;dur=${Date.now() - tEntry}`);
         if (env.DIAG === "1") console.log(`create-timing ${box.id} ${phases.join(" ")}`);
         return new Response(JSON.stringify(resp), {
           status: 201,


### PR DESCRIPTION
## Why

#655 cut the create path's held connections from 6 to 3 and moved burst create from **853ms → 727ms** at concurrency 100. Real, but small — subtract the claim and **~700ms is still unattributed**. So connection contention is not the driver, and further guessing is wasted effort.

The reason it's invisible is structural: every mark measures from `tPrev`, which is set at handler entry. Anything before the handler runs cannot appear in `server-timing` no matter how many phases get added inside it.

## What

Two marks that close the gap:

- **`pre;dur`** — client send → handler entry, computed from an `x-client-sent` stamp the caller supplies. Uses the client's clock, so it carries skew: fine against a ~700ms signal, useless for anything small. Absent header means no mark, so normal traffic is unaffected.
- **`hdl;dur`** — total wall time inside the handler.

The client's own create measurement then splits three ways:

```
create = pre + hdl + remainder
         │     │     └─ response back over the wire, or post-return Worker time
         │     └─ inside the handler (what today's marks already cover)
         └─ getting to the handler at all
```

Whichever term holds the 700ms says what to fix, and rules out the other two.

## Verification

`tsc --noEmit` clean, 101/101 edge tests pass. Telemetry only — no behaviour change on any request that doesn't send the header.