### PR TITLE
perf(edge): label the exec path and split its client-transit from handler time

### DIFF
--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -4326,6 +4326,27 @@ export default {
     if (m) {
       const id = m[1];
       const rest = m[2]; // undefined for /api/sandboxes/:id, "/exec/run" etc otherwise
+      const tSubEntry = Date.now();
+      // Uniform client→handler / in-handler split for /:id/* responses, whichever
+      // sub-path served them. Each exec path emits its own disjoint mark set
+      // (microvm-direct: reach/exec/up/ready; VM-DO: do/doin/agent; tunnel:
+      // origin), so a harness that knows one set reads the others as absent and
+      // silently drops those requests from its breakdown — while the client's
+      // total minus the in-handler marks stays an unattributable lump. That is
+      // exactly the blind spot that made create's burst regression unreadable
+      // until `pre`/`hdl` landed (see createSandbox). `path` names the winner so
+      // a fallback is counted rather than inferred.
+      const stampSub = (resp: Response, servedBy: string): Response => {
+        // A WebSocket upgrade (pty) can't be reconstructed — pass it through.
+        if (resp.status === 101 || (resp as unknown as { webSocket?: unknown }).webSocket) return resp;
+        const extra = [`path;desc=${servedBy}`, `hdl;dur=${Date.now() - tSubEntry}`];
+        const clientSentMs = Number(req.headers.get("x-client-sent") ?? "");
+        if (Number.isFinite(clientSentMs) && clientSentMs > 0) extra.unshift(`pre;dur=${tSubEntry - clientSentMs}`);
+        const out = new Response(resp.body, resp);
+        const prev = out.headers.get("server-timing");
+        out.headers.set("server-timing", prev ? `${prev}, ${extra.join(", ")}` : extra.join(", "));
+        return out;
+      };
       if (!rest) {
         if (req.method === "GET") return getSandbox(req, env, id);
         if (req.method === "DELETE") {
@@ -4353,11 +4374,16 @@ export default {
         const tVmdo = Date.now();
         const doResp = await tryVmDoExec(req, env, ctx, caller, id, authMs);
         vmdoMs = Date.now() - tVmdo;
-        if (doResp) return doResp;
+        // Name the winner from the marks it emitted rather than plumbing a label
+        // back out of two functions that already disagree about their shape.
+        if (doResp) {
+          const st = doResp.headers.get("server-timing") ?? "";
+          return stampSub(doResp, st.includes("reach;") ? "mvm-direct" : st.includes("do;") ? "vmdo" : "fast");
+        }
       }
       // vmdo = time spent deciding NOT to use the VM-DO path. For MicroVM orgs
       // that decision needs an org-policy lookup, so it is not free.
-      return proxyToCellSDK(req, env, ctx, caller, id, authMs, vmdoMs);
+      return stampSub(await proxyToCellSDK(req, env, ctx, caller, id, authMs, vmdoMs), "tunnel");
     }
 
     // Generic /api/* fallback for SDK/CLI routes without a dedicated D1-native


### PR DESCRIPTION
## Why

The previous commit added `pre`/`hdl` marks to **create**, which is what finally made its burst numbers readable: at C=100, `pre` (client send → handler entry) was 256ms against 83ms at C=25, and it was the *only* term that scaled. Every in-handler mark stayed flat.

**Exec never got the same treatment.** So an exec's client-measured total minus its in-handler marks is still an unattributable lump, and we have no way to tell whether the exec regression we saw (102 → 232ms, concentrated in `execleg`) is real work or the same client-transit term showing up again.

There's a second, quieter problem. The three exec paths emit **disjoint** mark sets:

| path | marks |
|---|---|
| microvm-direct | `reach`, `exec`, `up`, `ready` |
| VM-DO | `do`, `doin`, `agent` |
| tunnel (fallback) | `origin` |

A harness that knows one set reads the others as *absent* rather than as a different path — so a request that quietly fell back to the tunnel is dropped from the breakdown instead of being counted as a fallback. Fallback rate is precisely what we need to see under burst.

## What

Stamp both at the single `/:id/*` dispatch point rather than in each of the three functions:

- **`pre`** — client send → handler entry (needs the client to send `x-client-sent`; omitted when it doesn't).
- **`hdl`** — total in-handler wall time.
- **`path`** — which of the three actually served it (`mvm-direct` / `vmdo` / `tunnel`).

The label is read back off the marks the winner already emitted, so the inner functions keep their current shapes and there's no label to thread out through two layers that already disagree about their response shape.

WebSocket upgrades (pty) pass through untouched — a 101 can't be reconstructed via `new Response(body, init)`.

## Risk

Response-header-only; no routing, auth, or timing behaviour changes. `tsc --noEmit` clean, 101/101 vitest pass.

## Note

Unrelated to this diff, but found while chasing the prod pool: **133 leaked MicroVM sandboxes** from earlier benchmark runs had pinned the cell at its `MAX_TOTAL_BOXES=230` budget (`141 in use + 89 committed`), which pauses pool refill in 1-minute increments and holds pool depth near zero. The cause was a fire-and-forget `DELETE` in the bench harness. Cleaned up (in-use 144 → 9, refill resumed immediately); the harness now awaits its deletes in a separate phase and reports any that don't return 204.