### PR TITLE
fix(edge,sdk): restore exec output on microvm-direct; stop prewarming 100 sockets by default

### DIFF
--- a/cloudflare-workers/api-edge/src/exec_shape.test.ts
+++ b/cloudflare-workers/api-edge/src/exec_shape.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentExecRequest } from "./index";
+
+// Regression cover for a bug that produced no error signal at all: the
+// microvm-direct exec path read only `cmd` and dropped `args`, so the SDK's
+// {cmd:"sh", args:["-c", ...]} became `/bin/sh -lc sh` — a shell with no script,
+// which exits 0 having printed nothing. Every SDK exec on a MicroVM box returned
+// {exitCode: 0, stdout: ""} and looked like a command that produced no output.
+describe("buildAgentExecRequest", () => {
+  it("runs the argv form verbatim (the shape the SDK sends)", () => {
+    const req = buildAgentExecRequest({ cmd: "sh", args: ["-c", "echo hi"] }, "sh");
+    expect(req.command).toBe("/bin/sh");
+    expect(req.args).toEqual(["-c", "echo hi"]);
+    // The bug: the script was replaced by the program name.
+    expect(req.args).not.toEqual(["-lc", "sh"]);
+  });
+
+  it("treats the string form as a shell line", () => {
+    const req = buildAgentExecRequest({ cmd: "echo hi" }, "echo hi");
+    expect(req.command).toBe("/bin/sh");
+    expect(req.args).toEqual(["-lc", "echo hi"]);
+  });
+
+  it("keeps a non-shell program as the program", () => {
+    const req = buildAgentExecRequest({ cmd: "node", args: ["-e", "console.log(1)"] }, "node");
+    expect(req.command).toBe("node");
+    expect(req.args).toEqual(["-e", "console.log(1)"]);
+  });
+
+  it("ignores a non-string entry rather than shipping it to the guest", () => {
+    const req = buildAgentExecRequest({ cmd: "sh", args: ["-c", 42, "echo hi"] as unknown[] }, "sh");
+    expect(req.args).toEqual(["-c", "echo hi"]);
+  });
+
+  it("falls back to the shell line when args is present but empty", () => {
+    const req = buildAgentExecRequest({ cmd: "echo hi", args: [] }, "echo hi");
+    expect(req.args).toEqual(["-lc", "echo hi"]);
+  });
+
+  it("passes cwd, env and timeout through, omitting what was not sent", () => {
+    const req = buildAgentExecRequest(
+      { cmd: "sh", args: ["-c", "pwd"], cwd: "/tmp", env: { A: "1" }, timeoutSeconds: 5 },
+      "sh",
+    );
+    expect(req.cwd).toBe("/tmp");
+    expect(req.env).toEqual({ A: "1" });
+    expect(req.timeoutSeconds).toBe(5);
+    expect(buildAgentExecRequest({ cmd: "x" }, "x").cwd).toBeUndefined();
+  });
+});

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -1933,13 +1933,18 @@ async function tryMicrovmDirectExec(req: Request, env: Env, ctx: ExecutionContex
   // here, where quoting and redirection would be silently mangled.
   const cmd = typeof body.cmd === "string" ? body.cmd : typeof body.command === "string" ? body.command : "";
   if (!cmd) return null;
-  const execReq = {
-    command: "/bin/sh",
-    args: ["-lc", cmd],
-    cwd: typeof body.cwd === "string" ? body.cwd : undefined,
-    env: (body.env as Record<string, string> | undefined) ?? undefined,
-    timeoutSeconds: typeof body.timeoutSeconds === "number" ? body.timeoutSeconds : undefined,
-  };
+  // Two request shapes reach this endpoint and only one used to be handled.
+  //
+  //   string form: {cmd: "echo hi"}                  — cmd IS the shell line
+  //   argv form:   {cmd: "sh", args: ["-c","echo hi"]} — cmd is the program
+  //
+  // The SDK sends the argv form (see Exec.run). Reading only `cmd` turned that
+  // into `/bin/sh -lc sh` — a shell with no script, which reads stdin, gets EOF,
+  // and exits 0 having printed nothing. So every SDK exec against a MicroVM box
+  // came back {exitCode: 0, stdout: ""}: silent, total output loss that looks
+  // like a command which simply produced nothing. Verified on prod — the string
+  // form returned "hi-string\n" while the argv form returned "" on the same box.
+  const execReq = buildAgentExecRequest(body, cmd);
 
   const tReach = Date.now();
   // Create now folds reach into the "route" entry (one colo write instead of
@@ -2668,6 +2673,38 @@ type IdentitySelection = "browser" | "cli";
 // the 1000-char prompt limit (web/src/lib/deferred-actions.ts) through the
 // WorkOS `state` round-trip — keep the two limits in sync. WorkOS documents no
 // `state` maximum, so we bound it here rather than rely on a large round-trip.
+// buildAgentExecRequest shapes an SDK exec body into the agent's argv contract.
+//
+// Two request shapes reach this endpoint and only one used to be handled:
+//
+//   string form: {cmd: "echo hi"}                    — cmd IS the shell line
+//   argv form:   {cmd: "sh", args: ["-c", "echo hi"]} — cmd is the program
+//
+// The SDK sends the argv form (see Exec.run). Reading only `cmd` turned that
+// into `/bin/sh -lc sh` — a shell with no script, which reads stdin, gets EOF,
+// and exits 0 having printed nothing. So every SDK exec against a MicroVM box
+// came back {exitCode: 0, stdout: ""}: silent, total output loss that reads as
+// a command which simply produced nothing. Verified on prod — the string form
+// returned "hi-string\n" while the argv form returned "" on the same box.
+//
+// Exported purely so that contract has a test; the wire format is invisible in
+// every signal except the output being empty.
+export function buildAgentExecRequest(
+  body: Record<string, unknown>,
+  cmd: string,
+): { command: string; args: string[]; cwd?: string; env?: Record<string, string>; timeoutSeconds?: number } {
+  const argv = Array.isArray(body.args) ? (body.args as unknown[]).filter((a): a is string => typeof a === "string") : [];
+  return {
+    // Honour argv verbatim when present; "sh" means the guest's shell, which is
+    // what /bin/sh resolves to and what the string form already assumed.
+    command: argv.length > 0 ? (cmd === "sh" ? "/bin/sh" : cmd) : "/bin/sh",
+    args: argv.length > 0 ? argv : ["-lc", cmd],
+    cwd: typeof body.cwd === "string" ? body.cwd : undefined,
+    env: (body.env as Record<string, string> | undefined) ?? undefined,
+    timeoutSeconds: typeof body.timeoutSeconds === "number" ? body.timeoutSeconds : undefined,
+  };
+}
+
 export function safeReturnTo(raw: string | null | undefined): string | null {
   if (!raw || raw.length > 4096) return null;
   if (!raw.startsWith("/") || raw.startsWith("//")) return null;

--- a/cloudflare-workers/api-edge/src/pool_stock.ts
+++ b/cloudflare-workers/api-edge/src/pool_stock.ts
@@ -115,7 +115,8 @@ const IDLE_WARM_INTERVAL_MS = 20_000;
 // it is out of service, and warming it is pure cost.
 const WARM_MAX_IDLE_MS = 6 * 3600_000;
 // Warmed before traffic teaches a shard who to warm. Overridden by WARM_ORG_IDS.
-const DEFAULT_WARM_ORG_IDS = "1f92e6ca-fe5d-4cf4-ab3e-00fa7bedef4f";
+const DEFAULT_WARM_ORG_IDS =
+  "1f92e6ca-fe5d-4cf4-ab3e-00fa7bedef4f,b0e1d424-b592-44c5-b8a1-cd022e04f4a5";
 
 // Synthetic org that owns parked pool boxes (db.PoolOrgID). Used as the cap
 // token subject for reserve/release calls — those endpoints are org-agnostic,

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/sdk",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "TypeScript SDK for OpenComputer - cloud sandbox platform",
   "type": "module",
   "main": "dist/index.js",

--- a/sdks/typescript/src/http2.ts
+++ b/sdks/typescript/src/http2.ts
@@ -31,10 +31,21 @@
 
 let configurePromise: Promise<void> | null = null;
 
-// How many connections to hold open, and how often to keep them alive. The
-// default matches the concurrency of a 100-way burst; a smaller pool simply
-// warms fewer of them, and anything beyond the burst width is wasted sockets.
-const DEFAULT_PREWARM = 100;
+// How many connections to hold open, and how often to keep them alive.
+//
+// OFF by default. The original default was 100 — sized to a 100-way burst on
+// the theory that anything less just warms fewer connections. Measured against
+// prod from an IAD runner (4 vCPU), the opposite is true: opening 100 TLS
+// connections while 100 creates are already in flight starves the event loop
+// and every request unblocks together at the end.
+//
+//   prewarm=100   wall 24,040ms   create p50 994ms   exec p50 22,991ms   TTI p50 23,990ms
+//   prewarm=0     wall  1,203ms   create p50 573ms   exec p50    107ms   TTI p50    709ms
+//
+// A 34x regression in exactly the shape it was written to help, so it does not
+// get to be the default. Opt in with OPENCOMPUTER_PREWARM_CONNECTIONS=N once a
+// value has been measured to beat 0 on the workload in question.
+const DEFAULT_PREWARM = 0;
 const KEEPALIVE_INTERVAL_MS = 30_000;
 // Above undici's 4s default so an idle connection survives between phases of a
 // workload; still far below any sane server-side idle close.


### PR DESCRIPTION
Two independent bugs, both found while running a burst-100 against prod from an IAD bastion.

## 1. `exec.run()` silently returns empty output on MicroVM boxes

The edge's microvm-direct exec path read only `body.cmd` and never looked at `body.args`. The SDK sends the argv form:

```js
{ cmd: "sh", args: ["-c", "node -v"] }
```

so the edge took `cmd` = `"sh"`, discarded the args, and ran `/bin/sh -lc sh` — a shell with no script, which reads stdin, gets EOF and exits 0 having printed nothing. Every SDK exec against a MicroVM box came back `{exitCode: 0, stdout: ""}`.

This fails **silently**: no error, exit code 0, output simply gone — indistinguishable from a command that legitimately printed nothing.

Verified on prod, same box, back to back:

| request | stdout |
|---|---|
| `{cmd:"echo hi-string"}` | `"hi-string\n"` |
| `{cmd:"sh", args:["-c","echo hi-argv"]}` | `""` |

Shaping now honours argv when present, and still treats the bare string form as a shell line. Pulled out into `buildAgentExecRequest` with 6 regression tests, because the only signal this bug ever produced was empty output.

## 2. SDK pre-warming 100 sockets makes a burst 34x slower

`DEFAULT_PREWARM` was 100, sized to a 100-way burst on the reasoning that a smaller pool just warms fewer connections. Measured from an IAD runner (4 vCPU) against prod, the opposite is true — opening 100 TLS connections while 100 creates are already in flight starves the event loop, and every request unblocks together at the end.

Identical SDK build, only `OPENCOMPUTER_DISABLE_PREWARM` differs:

| | prewarm=100 | prewarm=0 |
|---|---|---|
| wall | 24,040ms | **1,203ms** |
| create p50 | 994ms | **573ms** |
| exec p50 | 22,991ms | **107ms** |
| TTI p50 | 23,990ms | **709ms** |
| success | 100/100 | 100/100 |

Default is now 0. HTTP/2 is **not** affected — `configureHttp2()` runs at module import, not from the prewarm path, so both arms above were HTTP/2. Opt back in with `OPENCOMPUTER_PREWARM_CONNECTIONS=N` once a value has been measured to beat 0.

SDK bumped to 0.15.3 so this actually publishes; 0.15.2 is on npm now carrying the regression.

## Also

Pins our own org alongside the leaderboard org in the shard warm list, so our own burst measurements see the same warm create-context the pinned org gets.

## Testing

- edge: `tsc --noEmit` clean, 107/107 vitest (6 new)
- sdk: build clean, 44/44 vitest
- edge deployed to dev; the argv fix could **not** be verified end-to-end there — dev never takes the microvm-direct path (it routes `vmdo` → tunnel, and dev's tunnel is currently erroring). That path is prod-only, so it wants the prod A/B after merge:

```
curl -X POST .../exec/run-async -d '{"cmd":"sh","args":["-c","echo hi-argv"]}'   # expect "hi-argv\n"
```