### PR TITLE
perf(edge): route microvm exec through the session DO so the agent tunnel survives between requests

### DIFF
--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -1999,6 +1999,55 @@ async function tryMicrovmDirectExec(req: Request, env: Env, ctx: ExecutionContex
   // form returned "hi-string\n" while the argv form returned "" on the same box.
   const execReq = buildAgentExecRequest(body, cmd);
 
+  // Session-DO first, direct dial as the fallback.
+  //
+  // A Durable Object can hold the agent tunnel across requests; a Worker
+  // isolate provably cannot — #663 held connections in a module map and got
+  // hit=0 out of 100 twice, with 40-53% found dead on arrival, because the
+  // socket dies with the request context that opened it. That is what task #167
+  // meant by "shared dialer DO", and the object already exists: pool_stock
+  // attaches AND dials it at stock-prep (warmMicrovmBox), so a pooled box
+  // should reach its customer with a live channel already open.
+  //
+  // Tried BEFORE resolving reach: the DO holds its own credentials from attach,
+  // so a hit skips that lookup entirely. 409 (channel unavailable, for any
+  // reason) falls through to the dial below, which is exactly today's path.
+  if (env.MICROVM_SESSIONS) {
+    const tDo = Date.now();
+    try {
+      const ns = env.MICROVM_SESSIONS;
+      const dr = await ns.get(ns.idFromName(id), { locationHint: "enam" }).fetch("https://do/exec", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ...execReq, timeoutMs: MVM_EXEC_TIMEOUT_MS }),
+      });
+      const doMs = Date.now() - tDo;
+      if (dr.status === 200) {
+        // Split the DO's own timing back out. `dlive` is the one that matters:
+        // 1 means the channel survived from a previous request or the
+        // keepalive, which is the entire point of routing through here.
+        const t = Object.fromEntries(
+          (dr.headers.get("x-mvm-timing") ?? "")
+            .split(",")
+            .map((kv) => kv.split("="))
+            .filter((kv) => kv.length === 2),
+        ) as Record<string, string>;
+        return new Response(dr.body, {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "server-timing":
+              `auth;dur=${authMs}, pol;dur=${polMs}, mvmdo;dur=${doMs}, ` +
+              `dlive;dur=${t.live ?? -1}, dcold;dur=${t.cold ?? -1}, ddial;dur=${t.dial ?? -1}, ` +
+              `dunary;dur=${t.unary ?? -1}, dinside;dur=${t.inside ?? -1}`,
+          },
+        });
+      }
+    } catch {
+      /* DO unreachable — the direct dial below is the fallback */
+    }
+  }
+
   const tReach = Date.now();
   // Create now folds reach into the "route" entry (one colo write instead of
   // two — see createSandbox). Fall back to the standalone "mvmreach" key, which


### PR DESCRIPTION
Targets the ~20% unpaid first touch, which is the entire p99.

## The problem, measured three times

| run | slow boxes | exec#1 med | exec#2 med | fast group |
|---|---|---|---|---|
| prewarm 64 | 24/100 | 299ms | 64ms | 35 → 36 |
| prewarm 48 | 19/100 | 354ms | 50ms | 37 → 36 |
| #663 | 23/100 | 292ms | 71ms | 36 → 35 |

TTI p99 736ms is almost entirely exec p99 575ms, and inside that the `exec` mark is 484ms. Create p99 is only 285ms.

The cost is bound to **the edge's own connection**, not the box: the CP pings all 144 reserved boxes over its own gRPC channels every cycle with 0 failures, and a fifth are still slow when the edge first talks to them.

## Why a DO and not a map

#663 held connections in a module-level map. It shipped a `held;desc` mark to check, and the answer was unambiguous:

```
held (exec#1):  miss=60  stale=40  hit=0
held (exec#2):  miss=47  stale=53  hit=0
```

Zero hits, twice, with 40-53% **dead on arrival**. A WebSocket dies with the request context that opened it. Only a Durable Object can hold one across requests — which is what #167 said originally.

## The wiring

The object already exists (`vm-do/src/microvm_session.ts`), already serves `/exec`, and `pool_stock.warmMicrovmBox` already attaches **and dials** it at stock-prep. A pooled box should therefore reach its customer with a live channel. The exec path just never used it.

- tried **before** resolving reach — the DO carries its own credentials from attach, so a hit skips that lookup
- **409 → falls through to the existing direct dial**, so the worst case is exactly today's path
- any throw falls through the same way

## Falsifier

Emits `dlive/dcold/ddial/dunary/dinside` from the DO's `x-mvm-timing`.

**`dlive=1` is the number that matters** — the channel survived from a previous request or the keepalive. If `dlive` is mostly 1 and the slow-box fraction collapses, this is the p99 fix. If `dlive` is mostly 0 or we mostly 409, the stock-prep warm isn't reaching these boxes and the problem is in `warmMicrovmBox`, not the exec path.

Note: `stampSub` will label these `vmdo` (its check is `st.includes("do;")`, and `mvmdo;` matches). Distinguish by the presence of `dlive`.

## Testing

`tsc` clean, 107/107 vitest. **Prod-only** — dev never takes the microvm-direct path.