### PR TITLE
diag(edge,vm-do): report MicrovmSession colo so DO placement can be proved before it is rebuilt

### DIFF
--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -2039,7 +2039,8 @@ async function tryMicrovmDirectExec(req: Request, env: Env, ctx: ExecutionContex
             "server-timing":
               `auth;dur=${authMs}, pol;dur=${polMs}, mvmdo;dur=${doMs}, ` +
               `dlive;dur=${t.live ?? -1}, dcold;dur=${t.cold ?? -1}, ddial;dur=${t.dial ?? -1}, ` +
-              `dunary;dur=${t.unary ?? -1}, dinside;dur=${t.inside ?? -1}`,
+              `dunary;dur=${t.unary ?? -1}, dinside;dur=${t.inside ?? -1}, ` +
+              `dcolo;desc=${dr.headers.get("x-mvm-colo") ?? "?"}`,
           },
         });
       }

--- a/cloudflare-workers/vm-do/src/microvm_session.ts
+++ b/cloudflare-workers/vm-do/src/microvm_session.ts
@@ -274,6 +274,27 @@ export class MicrovmSession {
     return this.dial(creds);
   }
 
+  // Colo self-identification, resolved once per isolate and reported on every
+  // exec. Placement is decided at FIRST TOUCH and is permanent, and the first
+  // touch for these objects is warmMicrovmBox running inside a PoolStock shard
+  // — so they inherit the shards' placement, which was measured scattered
+  // across ATL/IAD/EWR/MIA/ORD. locationHint cannot fix this: it is
+  // jurisdiction-level ("enam" covers all of those) and only consulted at
+  // creation. This number is here to prove or kill that theory: if mvmdo
+  // latency tracks colo, placement is the remaining tail.
+  private colo = "?";
+  private coloResolved = false;
+
+  private resolveColo(): void {
+    if (this.coloResolved) return;
+    this.coloResolved = true;
+    void fetch("https://www.cloudflare.com/cdn-cgi/trace")
+      .then(async (r) => {
+        this.colo = ((await r.text()).match(/^colo=(\w+)/m) ?? [])[1] ?? "?";
+      })
+      .catch(() => {});
+  }
+
   private async exec(req: Request): Promise<Response> {
     // Everything the caller cannot see from outside. do;dur on the edge is one
     // opaque number covering the hop to this object, this object's cold start,
@@ -281,6 +302,7 @@ export class MicrovmSession {
     // completely different fixes. Measured here and handed back so the edge can
     // publish the split.
     const tEnter = Date.now();
+    this.resolveColo();
     this.lastDialMs = 0;
     const wasLive = this.live();
     const coldStart = this.served === 1;
@@ -320,6 +342,7 @@ export class MicrovmSession {
         // live=1 means the channel survived from the last request or the
         // keepalive — the state this whole design is trying to be in.
         "x-mvm-timing": `live=${wasLive ? 1 : 0},cold=${coldStart ? 1 : 0},dial=${this.lastDialMs},unary=${unaryMs},inside=${Date.now() - tEnter}`,
+        "x-mvm-colo": this.colo,
       });
     } catch (e) {
       // The channel is suspect once a call fails on it: drop it so the next


### PR DESCRIPTION
Diagnostic only — no routing or lifecycle change.

## Why

Routing exec through the session DO (#665) removed the unpaid first touch outright:

```
dlive = 1 on 100/100     ddial = 0 p50→max     TTI p99 736 → 564
```

What remains is the hop to the object: **`mvmdo` p99 317ms while `dunary` (the DO's own work) is 39ms.**

## The theory

Placement is decided at **first touch** and is permanent. The first touch for these objects is `warmMicrovmBox`, which runs **inside a PoolStock shard DO** — so MicrovmSessions inherit the shards' placement. Measured this session:

```
PoolStock DO colo: ATL=29  IAD=25  EWR=21  MIA=17  ORD=8
edge colo:         IAD=100
```

`locationHint` cannot fix this. It is jurisdiction-level — `"enam"` covers ATL, MIA, ORD, EWR *and* IAD — and is only consulted at creation. That is very likely why previous re-placement attempts didn't produce the expected result.

## Why measure instead of just fixing it

Re-placing DOs has been tried several times without the expected outcome, and this area has surprised us repeatedly tonight. So the DO now resolves its own colo once per isolate and returns it as `x-mvm-colo`; the edge publishes it as `dcolo`.

- **`mvmdo` tracks `dcolo`** (in-IAD cheap, out-of-metro expensive) → placement is the remaining tail, worth rebuilding for, and the prize is sized exactly
- **no correlation** → the hop is something else and rebuilding placement would have been wasted work

`tsc` clean both packages, 107/107 vitest.