### PR TITLE
perf(edge): place the session DO from the create request so it lands in the traffic's colo

### DIFF
--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -1630,7 +1630,7 @@ async function createSandbox(req: Request, env: Env, ctx: ExecutionContext): Pro
         // Net for the benchmark, which scores create+exec together, this is a
         // win. It stays in waitUntil and swallows its errors, so the worst case
         // is the first exec dialling cold exactly as it does today.
-        if (routeEntry.reach) ctx.waitUntil(warmEdgeTunnel(routeEntry.reach));
+        if (routeEntry.reach) ctx.waitUntil(placeAndDialMicrovmSession(env, box.id, routeEntry.reach));
         //
         // NOTE: the MicroVM exec channel is deliberately NOT warmed here. It is
         // warmed at stock-prep in pool_stock.ts, where the box sits idle for
@@ -2126,6 +2126,36 @@ const MVM_EXEC_TIMEOUT_MS = 10_000;
  * path, and a box that refuses now simply means the first exec pays what it
  * would have paid anyway.
  */
+// attachMicrovmSession hands a freshly-claimed box's reach-info to its session
+// DO and has it dial, from the CREATE request rather than from a PoolStock
+// shard.
+//
+// Placement is the point. A DO lives next to whatever first touches it, forever,
+// and locationHint only names a jurisdiction ("enam" covers IAD, EWR, ATL, ORD
+// and MIA alike). Stock-prep touched these first, from a shard, so they
+// inherited the shards' scatter — and the edge->DO hop tracks that precisely:
+// IAD 57ms, EWR 88, ATL 95, ORD 177, MIA 201, with only ~25% in IAD against
+// 100% of requests served there. Creates run in the request's colo, so touching
+// here places the object with the traffic that will use it.
+//
+// The cost is that the dial now races the customer's first exec instead of
+// happening minutes ahead while the box sits in stock. The race looks winnable
+// (ddial p90 39ms against a create->exec gap of ~200ms) but that is a
+// prediction, which is what the dlive mark exists to check.
+async function placeAndDialMicrovmSession(env: Env, id: string, r: MvmReach): Promise<void> {
+  const ns = env.MICROVM_SESSIONS;
+  if (!ns) return;
+  try {
+    await ns.get(ns.idFromName(id)).fetch("https://do/attach", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ endpoint: r.endpoint, token: r.token, port: r.port, dial: true }),
+    });
+  } catch {
+    /* first exec dials through the DO itself, exactly as it would have */
+  }
+}
+
 async function warmEdgeTunnel(r: MvmReach): Promise<void> {
   try {
     const conn = await dialAgent(r);

--- a/cloudflare-workers/api-edge/src/pool_stock.ts
+++ b/cloudflare-workers/api-edge/src/pool_stock.ts
@@ -679,7 +679,17 @@ export class PoolStock {
         added++;
         // Open and guest-attach this box's agent tunnel NOW, while it is still
         // stock and nobody is waiting on it.
-        this.warmMicrovmBox(b);
+        // NOT warming the MicrovmSession here any more, and the reason is
+        // placement, not warmth. A Durable Object is placed next to whatever
+        // FIRST touches it, permanently, and locationHint is jurisdiction-level
+        // ("enam" spans IAD, EWR, ATL, ORD and MIA) so it cannot pin a colo.
+        // Touching from this shard therefore made every session DO inherit the
+        // shards' own scatter. Measured on prod, the edge->DO hop tracks that
+        // exactly — IAD 57ms, EWR 88, ATL 95, ORD 177, MIA 201 — while only
+        // ~25% of objects landed in IAD, where 100% of requests are served.
+        //
+        // The create handler does the attach instead: it runs in the request's
+        // colo, so the object is placed with the traffic. See attachMicrovmSession.
         // Pre-wake the box's VmSession DO now (stock-prep), off any hot path, so
         // the create burst doesn't fan out ~100 prewake subrequests from the
         // create isolate. The alarm (prewakeStock) keeps it warm while it sits.
@@ -696,7 +706,11 @@ export class PoolStock {
   private async release(entries: StockEntry[]): Promise<void> {
     // Tear down any agent tunnel first — this box is about to be reissued under
     // a different sandbox id. See coolMicrovmBox.
-    for (const e of entries) if (e.endpoint) this.coolMicrovmBox(e.id);
+    // Deliberately NOT detaching here. These boxes were never handed to a
+    // customer, so their session DO was never created — and asking for one by
+    // id CREATES it, from this shard, which is precisely the first touch that
+    // would pin it to the wrong colo. The id stops resolving in D1 either way.
+    void entries;
     // Group by cell (entries could straddle a base_url change).
     const byCell = new Map<string, { cellID: string; ids: string[] }>();
     for (const e of entries) {


### PR DESCRIPTION
## The measurement

The `dcolo` diagnostic (#666) came back with a textbook correlation — the edge→DO hop tracks where the object lives:

| DO colo | n | `mvmdo` med |
|---|---|---|
| **IAD** | 21 | **57ms** |
| EWR | 29 | 88ms |
| ATL | 18 | 95ms |
| ORD | 13 | 177ms |
| MIA | 17 | 201ms |

**144ms of spread from placement alone**, and only ~25% of objects are in IAD while 100% of requests are served there.

## Why re-hinting never worked

Placement is decided by **first touch** and is permanent. `locationHint` cannot override it, and it is jurisdiction-level anyway — `"enam"` spans IAD, EWR, ATL, ORD *and* MIA, every colo in that table.

Stock-prep touched these first, from inside a PoolStock shard. So session DOs inherited the shards' own scatter (ATL 29, IAD 25, EWR 21, MIA 17, ORD 8). Nothing was ever wrong with the hint — the toucher was wrong.

## The change

- **create handler does the attach.** Creates run in the request's colo (`edge colo: IAD=100` in every run this session), and the create already holds reach-info, so this is cheaper than the existing cell round trip too.
- **stock-prep no longer touches the DO.**
- **released boxes are no longer detached from the shard** — asking for a DO by id *creates* it, so detaching an unclaimed box from a shard is itself the mispinning first touch. Those boxes never reached a customer and never had a session; the id stops resolving in D1 regardless.

## The tradeoff, stated plainly

The dial now races the customer's first exec instead of happening minutes ahead while the box sits in stock. `ddial` p90 is 39ms against a create→exec gap of ~200ms, so it should win — but that is a prediction.

This also re-litigates a deliberate decision: `warmMicrovmBox`'s comment says warming at create "loses the race." That was written when the DO did not hold the channel across requests, so the premise has changed — but it is a flag, not a green light.

**`dlive` settles it.** If `dlive=1` stays dominant and `dcolo` goes mostly IAD, this is the win. If `dlive` collapses, the race is lost and stock-prep warming has to come back — in which case the fix is to place from create and *also* warm from the shard afterwards.

`tsc` clean, 107/107 vitest. Prod-only, as ever.