### PR TITLE
revert(edge): put the session-DO attach back at stock-prep — warming at create loses the race

### DIFF
--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -1630,7 +1630,7 @@ async function createSandbox(req: Request, env: Env, ctx: ExecutionContext): Pro
         // Net for the benchmark, which scores create+exec together, this is a
         // win. It stays in waitUntil and swallows its errors, so the worst case
         // is the first exec dialling cold exactly as it does today.
-        if (routeEntry.reach) ctx.waitUntil(placeAndDialMicrovmSession(env, box.id, routeEntry.reach));
+        if (routeEntry.reach) ctx.waitUntil(warmEdgeTunnel(routeEntry.reach));
         //
         // NOTE: the MicroVM exec channel is deliberately NOT warmed here. It is
         // warmed at stock-prep in pool_stock.ts, where the box sits idle for
@@ -2126,36 +2126,6 @@ const MVM_EXEC_TIMEOUT_MS = 10_000;
  * path, and a box that refuses now simply means the first exec pays what it
  * would have paid anyway.
  */
-// attachMicrovmSession hands a freshly-claimed box's reach-info to its session
-// DO and has it dial, from the CREATE request rather than from a PoolStock
-// shard.
-//
-// Placement is the point. A DO lives next to whatever first touches it, forever,
-// and locationHint only names a jurisdiction ("enam" covers IAD, EWR, ATL, ORD
-// and MIA alike). Stock-prep touched these first, from a shard, so they
-// inherited the shards' scatter — and the edge->DO hop tracks that precisely:
-// IAD 57ms, EWR 88, ATL 95, ORD 177, MIA 201, with only ~25% in IAD against
-// 100% of requests served there. Creates run in the request's colo, so touching
-// here places the object with the traffic that will use it.
-//
-// The cost is that the dial now races the customer's first exec instead of
-// happening minutes ahead while the box sits in stock. The race looks winnable
-// (ddial p90 39ms against a create->exec gap of ~200ms) but that is a
-// prediction, which is what the dlive mark exists to check.
-async function placeAndDialMicrovmSession(env: Env, id: string, r: MvmReach): Promise<void> {
-  const ns = env.MICROVM_SESSIONS;
-  if (!ns) return;
-  try {
-    await ns.get(ns.idFromName(id)).fetch("https://do/attach", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ endpoint: r.endpoint, token: r.token, port: r.port, dial: true }),
-    });
-  } catch {
-    /* first exec dials through the DO itself, exactly as it would have */
-  }
-}
-
 async function warmEdgeTunnel(r: MvmReach): Promise<void> {
   try {
     const conn = await dialAgent(r);

--- a/cloudflare-workers/api-edge/src/pool_stock.ts
+++ b/cloudflare-workers/api-edge/src/pool_stock.ts
@@ -679,17 +679,7 @@ export class PoolStock {
         added++;
         // Open and guest-attach this box's agent tunnel NOW, while it is still
         // stock and nobody is waiting on it.
-        // NOT warming the MicrovmSession here any more, and the reason is
-        // placement, not warmth. A Durable Object is placed next to whatever
-        // FIRST touches it, permanently, and locationHint is jurisdiction-level
-        // ("enam" spans IAD, EWR, ATL, ORD and MIA) so it cannot pin a colo.
-        // Touching from this shard therefore made every session DO inherit the
-        // shards' own scatter. Measured on prod, the edge->DO hop tracks that
-        // exactly — IAD 57ms, EWR 88, ATL 95, ORD 177, MIA 201 — while only
-        // ~25% of objects landed in IAD, where 100% of requests are served.
-        //
-        // The create handler does the attach instead: it runs in the request's
-        // colo, so the object is placed with the traffic. See attachMicrovmSession.
+        this.warmMicrovmBox(b);
         // Pre-wake the box's VmSession DO now (stock-prep), off any hot path, so
         // the create burst doesn't fan out ~100 prewake subrequests from the
         // create isolate. The alarm (prewakeStock) keeps it warm while it sits.
@@ -706,11 +696,7 @@ export class PoolStock {
   private async release(entries: StockEntry[]): Promise<void> {
     // Tear down any agent tunnel first — this box is about to be reissued under
     // a different sandbox id. See coolMicrovmBox.
-    // Deliberately NOT detaching here. These boxes were never handed to a
-    // customer, so their session DO was never created — and asking for one by
-    // id CREATES it, from this shard, which is precisely the first touch that
-    // would pin it to the wrong colo. The id stops resolving in D1 either way.
-    void entries;
+    for (const e of entries) if (e.endpoint) this.coolMicrovmBox(e.id);
     // Group by cell (entries could straddle a base_url change).
     const byCell = new Map<string, { cellID: string; ids: string[] }>();
     for (const e of entries) {


### PR DESCRIPTION
**Prod is currently ~2x slower than before #667. This should go in promptly.**

## Measured immediately after deploy

```
dlive = 0 on 56/56 that reached the DO    ← never live on first exec
ddial p50 = 297ms                          ← every one paid a full dial
44/100 fell through to direct-dial         ← DO did not exist yet
```

| | before #667 | with #667 |
|---|---|---|
| TTI p50 | 308 | **622** |
| exec p50 | 124 | **438** |
| dlive=1 | 100/100 | **0/56** |

## The placement half actually worked

`dcolo` went from ~25% IAD to **IAD 43 / EWR 13** — 77% in-metro. The theory was right and the mechanism (move the first touch to a request-colo Worker) does pin the object.

It just doesn't matter, because nothing arrives warm any more.

## Why the prediction was wrong

`ddial` p90 39ms was measured on a DO that was **already attached** and merely re-dialing. A cold attach-plus-dial from scratch is **~300ms**. Those are different operations and I compared them as if they were the same, then used it to override a comment (`warmMicrovmBox`) that said exactly this would happen. It was right.

## What survives

Placement is still a real ~144ms opportunity — IAD 57ms vs MIA 201ms on the hop. But it needs a mechanism that pins the object **without** giving up the minutes of idle warm time: pre-touch from an in-metro request at **reserve** time, not at claim. That is a bigger change and wants measuring before building, on the evidence of tonight.

`tsc` clean, 107/107 vitest.