### PR TITLE
perf(edge): pin the pool shards to the eight that measured IAD

### DIFF
--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -1277,13 +1277,16 @@ function indexSandboxFromSSE(
 // POOL_STOCK_SHARD_IDS is therefore a MEASUREMENT, not a configuration. Re-run
 // the probe and re-pick if the shard set is ever regenerated; do not hand-edit
 // it to indices nobody has verified.
-// STILL g4 with the identity list — i.e. exactly today's behaviour. The gen
-// flips only once the probe below has run against prod and named the winning
-// indices; shipping a fresh generation before then would empty the live shards
-// (every create falling through to a cold CP launch) to land on placements
-// nobody has looked at yet.
-const POOL_STOCK_SHARD_GEN = "g4";
-const POOL_STOCK_SHARD_IDS = [0, 1, 2, 3, 4, 5, 6, 7];
+// Probed on prod 2026-08-21 from the control plane (IAD ingress), 64 g5
+// candidates: IAD 27, EWR 17, ATL 9, MIA 7, ORD 4. Confirms the diagnosis —
+// every candidate was first-touched by the same request, from one colo, and
+// they still scattered five ways. Placement inside enam is not ours to aim.
+//
+// The eight below are the first eight that answered IAD. There is nothing
+// special about these indices; they are simply the ones that landed where we
+// want, which is the entire idea.
+const POOL_STOCK_SHARD_GEN = "g5";
+const POOL_STOCK_SHARD_IDS = [1, 4, 6, 12, 13, 14, 16, 17];
 const POOL_STOCK_SHARDS = POOL_STOCK_SHARD_IDS.length;
 // How many candidate names the probe route sweeps. Only the ones that report
 // the target colo get promoted into POOL_STOCK_SHARD_IDS above.

--- a/cloudflare-workers/api-edge/src/pool_stock.ts
+++ b/cloudflare-workers/api-edge/src/pool_stock.ts
@@ -292,6 +292,14 @@ export class PoolStock {
     // IT landed. That is the load-bearing question for stock-prep warming: if a
     // child inherits its parent's colo, pinning the shards pins every session
     // DO with them; if it does not, session placement needs its own lever.
+    //
+    // ANSWERED, on prod 2026-08-21 over 64 parent/child pairs: it does not.
+    // A child matches its parent's colo 34/64 of the time, and parent-IAD
+    // yields child-IAD only 12/27 (44%) against a 30% background rate. So
+    // parentage biases placement without deciding it. Pinning the shards is
+    // still worth doing — deterministic for the claim hop, and it lifts the
+    // session DOs from 21% IAD to ~44% for free — but the other half of them
+    // need a lever this has now ruled out.
     if (req.method === "GET" && url.pathname === "/colo") {
       const self = await this.coloNow();
       const child = url.searchParams.get("child");


### PR DESCRIPTION
Follow-up to the placement probe merged in #669.

## What the probe found

Ran against prod from the control plane (IAD ingress), 64 `g5` candidates:

| colo | candidates |
|---|---|
| IAD | **27** |
| EWR | 17 |
| ATL | 9 |
| MIA | 7 |
| ORD | 4 |

That spread *is* the confirmation. Every candidate was first-touched by the same
request, from the same colo, in the same instant — and they still scattered five
ways. Placement inside `enam` is not ours to aim, which is why four generations
of arming runs kept missing.

Selecting works where aiming did not, so the shard set becomes the first eight
indices that answered IAD: `[1, 4, 6, 12, 13, 14, 16, 17]`. Nothing distinguishes
those indices except where they landed, which is the point.

## It also settles the child-inheritance question — the answer is no

The probe was built to decide whether pinning shards would drag the
`MicrovmSession` DOs along with them, since those are warmed at stock-prep by
the shard that parents them. Over 64 parent/child pairs:

- child matched parent's colo **34/64**
- parent-IAD produced child-IAD **12/27 (44%)**, against a **30%** background rate

So parentage *biases* placement without deciding it. This change is still worth
shipping on its own terms — the claim hop becomes deterministic, and the session
DOs come along from 21% IAD to roughly 44% — but **it is not the fix for session
placement**, and the next attempt should not assume it is.

What remains is a lever that does not exist yet. Shards can be selected because
we choose their names; session DOs are named by sandbox id, so they can only be
inherited into a colo or first-touched into one. #667/#668 already established
that first-touching at create trades the warm channel away for the good colo.

## Cutover cost — deliberately not hidden

A new generation starts empty. The g4 shards strand their reservations for up to
`ENTRY_TTL` plus the cell's 15-minute reaper, and until the g5 alarms restock,
creates fall through to a cold control-plane launch (9-17s).

**Merge when a few minutes of slow creates is acceptable**, then let the pool
refill to 144 before measuring anything.

## Verification

- `tsc --noEmit` clean; 107/107 vitest.
- The eight selected DOs already exist and are already placed — the probe placed
  them. They hold no cell and no alarm, so they are inert until the first claim
  arms them.