### PR TITLE
fix(vm-do): re-attach must not tear down a live channel

### DIFF
--- a/cloudflare-workers/vm-do/src/microvm_session.ts
+++ b/cloudflare-workers/vm-do/src/microvm_session.ts
@@ -159,7 +159,19 @@ export class MicrovmSession {
     // Opening the tunnel costs ~30-45ms. Doing it here, off the create path,
     // means the first exec — the one time-to-first-command actually measures —
     // finds a live channel instead of paying for it.
-    if (c.dial) {
+    // Only dial when there is nothing live to reuse. dial() unconditionally
+    // opens a new socket and overwrites this.ws/this.conn — it has no
+    // live-channel guard of its own (it only dedupes CONCURRENT dials) — so
+    // calling it on a healthy channel destroys that channel and replaces it with
+    // an unproven one.
+    //
+    // That was harmless while attach ran exactly once per box, at restock. It
+    // stopped being harmless when PoolStock started re-attaching sitting stock
+    // on a rotation: every box would have its working tunnel torn down and
+    // rebuilt every ~45s, and any exec in flight at that moment would have the
+    // channel swapped underneath it. Re-attaching must be a no-op refresh of the
+    // credentials and the idle clock, not a reconnect.
+    if (c.dial && !this.live()) {
       try {
         await this.dial(this.creds);
       } catch (e) {


### PR DESCRIPTION
dial() opens a new socket unconditionally and overwrites this.ws/this.conn. Its only guard dedupes CONCURRENT dials; it has none for a channel that is already up. attach() called it whenever dial was requested, without checking live().

That was harmless while attach ran exactly once per box, at restock. The rotating re-warm added in the previous commit made it destructive: every box in stock would have its working tunnel torn down and rebuilt roughly every 45s, and an exec in flight when that landed would have its channel swapped underneath it — turning a fix for "never re-attached" into "re-attached destructively, on a timer". Re-attaching is meant to refresh credentials and the idle clock, not to reconnect.

Note this is not the cause of the slow execs measured on the #668 state, which predate the re-warm entirely; that was the attach-once plus keepalive-give-up bug. This only prevents the repair from introducing a new fault of its own.