### PR TITLE
feat: make deploy watch the agent development flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,26 @@
 # OpenComputer
 
 Build, steer, and deploy serverless agents as code. An OpenComputer project
-contains one or more agents plus the React app used to interact with them.
+contains one or more agents that run in the cloud.
 
 ```bash
-npm create @opencomputer/start@latest my-agent
+npx @opencomputer/cli init my-agent
 cd my-agent
 npm install
 npx --package @opencomputer/cli opencomputer login
 ```
 
-Sync agent code to Development (Cloud) in one terminal:
+Watch agent code and deploy changes to Development (Cloud):
 
 ```bash
-npm run dev
-```
-
-Start the React app in another:
-
-```bash
-npm run dev:web
+npm run deploy -- --watch
 ```
 
 [Documentation](https://docs.opencomputer.dev/agents/overview) · [Quickstart](https://docs.opencomputer.dev/agents/quickstart) · [Dashboard](https://app.opencomputer.dev)
 
 ## Project structure
 
-`npm create @opencomputer/start@latest <directory|.>` creates a complete
-hello-world project:
+`npx @opencomputer/cli init <directory|.>` creates a hello-world agent project:
 
 ```text
 my-agent/
@@ -36,27 +29,22 @@ my-agent/
 │   └── agents/
 │       └── hello-world/
 │           └── agent.ts
-└── src/
-    ├── App.tsx
-    └── use-agent.ts
+└── package.json
 ```
 
-The `opencomputer/` tree is the backend definition. It is designed to grow to
-multiple agents in one project. The `src/` tree is a normal Vite + React app;
-its generated `useAgent` hook talks to the remote development agent through a
-small authenticated local bridge without exposing the server token to browser
-code.
+The `opencomputer/` tree contains the cloud agent definitions and is designed
+to grow to multiple agents in one project. A browser application can live in
+the same repository, but it has its own development and deployment lifecycle.
 
 ## Develop and deploy
 
-On the first `npm run dev`, choose an existing project from your account or
+On the first `npm run deploy -- --watch`, choose an existing project from your account or
 create a new one. That binding is reused on later runs. The CLI uses
 `https://app.opencomputer.dev` by default; pass `--api-url` or set
 `OPENCOMPUTER_API_URL` only when intentionally targeting another service.
 
-Edit the agent function, tools, connections, and routing while cloud sync
-is running. The React app streams turns and keeps the durable session ID for
-follow-up messages.
+Edit the agent function, tools, connections, and routing while watched cloud
+deployment is running. Test it from the dashboard or CLI.
 
 When the project is ready, publish an immutable deployment:
 
@@ -78,6 +66,7 @@ opencomputer whoami
 opencomputer init my-agent
 opencomputer agents
 opencomputer session "Say hello"
+opencomputer deploy --watch
 opencomputer deploy --alias production
 opencomputer run hello-world "Say hello"
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,38 +1,37 @@
 # @opencomputer/cli
 
-The agent-focused OpenComputer CLI creates, develops, and deploys agent
-projects with an optional React application.
+The agent-focused OpenComputer CLI creates and deploys cloud agent projects.
 
 ```bash
-npm create @opencomputer/start@latest my-agent
+npx @opencomputer/cli init my-agent
 cd my-agent
 npm install
 npx --package @opencomputer/cli opencomputer login
 npx --package @opencomputer/cli opencomputer link
 ```
 
-The npm initializer asks whether to include a React SPA, then delegates to
-`opencomputer init`. Agent definitions live under `opencomputer/agents/`; the
-optional React app lives under `src/`.
+Agent definitions live under `opencomputer/agents/`. The default initializer
+creates one hello-world agent and no browser application.
 
-Start cloud sync and the optional React app together:
+Watch source and deploy changes to Development (Cloud):
 
 ```bash
-npm run dev
+npm run deploy -- --watch
 ```
 
 `opencomputer link` asks whether to create a project or select an existing
 project from the authenticated account. Later commands reuse that local binding.
 If you skip this step, the first project-scoped command prompts you to link.
-Use `opencomputer dev --project <id|slug>` for non-interactive selection or
-`opencomputer dev --create-project <name>` to create one explicitly.
+Use `opencomputer deploy --watch --project <id|slug>` for non-interactive
+selection or `opencomputer deploy --watch --create-project <name>` to create
+one explicitly.
 
 The production cloud API (`https://app.opencomputer.dev`) is the default.
 Override it only with `--api-url` or `OPENCOMPUTER_API_URL`.
 
-The command prints the cloud dashboard URL. A React app imports `useAgent`
-from `@opencomputer/react`; Vite proxies requests through the CLI's
-authenticated bridge, while agent execution remains in the cloud.
+The command prints the cloud dashboard URL. It does not start a local agent
+server or a browser application. A colocated web application can use a
+separate command such as `npm run dev:web` and be deployed independently.
 
 Deploy the same agent source when it is ready:
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/cli",
-      "version": "0.5.6",
+      "version": "0.6.0",
       "dependencies": {
         "@opencode-ai/sdk": "1.18.4",
         "ai": "^7.0.45",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "Build, test, deploy, and share OpenComputer agents as code.",
   "type": "module",
   "bin": {

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -6,7 +6,11 @@ import {
 } from "./api.js";
 import { login, logout } from "./auth.js";
 import { resolveConfig } from "./config.js";
-import { publishProjectDeployment, runCloudDevelopment } from "./dev.js";
+import {
+  publishProjectDeployment,
+  runCloudDevelopment,
+  runDeploymentWatch,
+} from "./dev.js";
 import {
   ensureProjectBinding,
   findOpenComputerProjectRoot,
@@ -497,7 +501,7 @@ export async function runCommand(
     if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
     await assertStarterTarget(directory);
     const initialized = await initializeAgentProject(directory, undefined, {
-      spa: !agentOnly,
+      spa,
     });
     if (globals.json) printJSON(initialized);
     else {
@@ -505,13 +509,14 @@ export async function runCommand(
       process.stdout.write(
         `Created the ${initialized.manifest.name} OpenComputer app\n` +
           `Directory: ${initialized.root}\n` +
-          `Project:   choose or create one on the first npm run dev\n` +
+          `Project:   choose or create one on the first watched deployment\n` +
           `Agents:    opencomputer/\n` +
-          (agentOnly ? `App:       agent only\n\n` : `React:     src/\n\n`) +
+          (spa ? `Web app:   src/ (separate lifecycle)\n\n` : `App:       agent only\n\n`) +
           `Next:\n` +
           enterDirectory +
           `  npm install\n` +
-          `  npm run dev       # cloud sync${agentOnly ? "" : " + React app"}\n`,
+          `  npm run deploy -- --watch  # deploy changes to Development\n` +
+          (spa ? `  npm run dev:web             # optional local web app\n` : ""),
       );
     }
     return;
@@ -555,7 +560,10 @@ export async function runCommand(
   }
 
   if (command === "deploy") {
-    const alias = option(args, "--alias") ?? "production";
+    const watch = flag(args, "--watch");
+    const requestedAlias = option(args, "--alias");
+    const project = option(args, "--project");
+    const createProjectName = option(args, "--create-project");
     if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
     const root = await findOpenComputerProjectRoot(process.cwd());
     if (!root) {
@@ -563,6 +571,23 @@ export async function runCommand(
         "No OpenComputer project found. Run `opencomputer init <directory>` first.",
       );
     }
+    if (watch) {
+      if (requestedAlias && requestedAlias !== "development") {
+        throw new Error(
+          "--watch deploys only to development; omit --alias or use --alias development",
+        );
+      }
+      await runDeploymentWatch(client, config, root, {
+        project,
+        createProjectName,
+        interactive: !globals.json,
+      });
+      return;
+    }
+    if (project || createProjectName) {
+      throw new Error("--project and --create-project require --watch");
+    }
+    const alias = requestedAlias ?? "production";
     const binding = await ensureProjectBinding(client, config, root, {
       interactive: !globals.json,
       select: true,
@@ -614,6 +639,9 @@ export async function runCommand(
     const project = option(args, "--project");
     const createProjectName = option(args, "--create-project");
     if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+    process.stderr.write(
+      "`opencomputer dev` is deprecated. Use `opencomputer deploy --watch`; start any web app separately.\n",
+    );
     await runCloudDevelopment(
       client,
       config,

--- a/cli/src/create-start.test.ts
+++ b/cli/src/create-start.test.ts
@@ -10,11 +10,22 @@ test("CLI-owned create-start generates agent-only projects", async () => {
   const root = await mkdtemp(resolve(tmpdir(), "opencomputer-create-start-"));
   const app = resolve(root, "agent-only");
   try {
-    await runCreateStart([app, "--agent-only"]);
+    await runCreateStart([app]);
     await stat(
       resolve(app, "opencomputer", "agents", "hello-world", "agent.ts"),
     );
     await assert.rejects(stat(resolve(app, "src")));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("CLI-owned create-start keeps the legacy SPA opt-in explicit", async () => {
+  const root = await mkdtemp(resolve(tmpdir(), "opencomputer-create-start-"));
+  const app = resolve(root, "with-spa");
+  try {
+    await runCreateStart([app, "--spa"]);
+    await stat(resolve(app, "src", "App.tsx"));
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/cli/src/create-start.ts
+++ b/cli/src/create-start.ts
@@ -1,12 +1,10 @@
-import { createInterface } from "node:readline/promises";
-
 import { runCommand } from "./commands.js";
 
 function usage(): void {
   process.stdout.write(`Create a hello-world OpenComputer application.
 
 Usage:
-  npm create @opencomputer/start@latest [directory|.] [--spa|--agent-only]
+  npm create @opencomputer/start@latest [directory|.]
 `);
 }
 
@@ -29,28 +27,11 @@ export async function runCreateStart(rawArgs: string[]): Promise<void> {
   }
 
   const directory = args[0] ?? ".";
-  let includeSpa = spaFlag >= 0;
-  if (spaFlag < 0 && agentOnlyFlag < 0 && process.stdin.isTTY) {
-    const prompt = createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    });
-    try {
-      process.stdout.write(
-        "\nWhat would you like to create?\n\n" +
-          "  1) Agent only\n" +
-          "  2) Agent + React SPA\n\n",
-      );
-      const answer = await prompt.question("Select [1]: ");
-      includeSpa = ["2", "y", "yes", "spa"].includes(
-        answer.trim().toLowerCase(),
-      );
-    } finally {
-      prompt.close();
-    }
-  }
+  const includeSpa = spaFlag >= 0;
 
-  await runCommand("init", [directory, includeSpa ? "--spa" : "--agent-only"], {
-    json: false,
-  });
+  await runCommand(
+    "init",
+    includeSpa ? [directory, "--spa"] : [directory],
+    { json: false },
+  );
 }

--- a/cli/src/dev.test.ts
+++ b/cli/src/dev.test.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 import {
+  developmentWatchReadyMessage,
   hasReactSpa,
   projectDashboardURL,
   publishDevelopment,
@@ -12,6 +13,21 @@ import {
   syncDevelopmentSecrets,
 } from "./dev.js";
 import { initializeAgentProject } from "./project.js";
+
+test("development watch explains the live deployment loop", () => {
+  const output = developmentWatchReadyMessage({
+    projectName: "Support agents",
+    projectId: "prj_support",
+    dashboardUrl: "https://mo-oc-dev.com/projects/prj_support",
+    agents: ["support@development"],
+    deployments: ["support:abc123"],
+    watchedDirectory: "/workspace/opencomputer",
+  });
+  assert.match(output, /✓ Deployment ready/);
+  assert.match(output, /Watching \/workspace\/opencomputer for changes\./);
+  assert.match(output, /Changes deploy automatically\. Press Ctrl\+C to stop\./);
+  assert.doesNotMatch(output, /web app|Vite/i);
+});
 
 test("development derives the cloud dashboard project URL", () => {
   assert.equal(

--- a/cli/src/dev.test.ts
+++ b/cli/src/dev.test.ts
@@ -23,7 +23,11 @@ test("development derives the cloud dashboard project URL", () => {
 test("development detects whether the starter includes a React SPA", async () => {
   const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-dev-shape-"));
   try {
-    const withSpa = await initializeAgentProject(resolve(parent, "with-spa"));
+    const withSpa = await initializeAgentProject(
+      resolve(parent, "with-spa"),
+      undefined,
+      { spa: true },
+    );
     const agentOnly = await initializeAgentProject(
       resolve(parent, "agent-only"),
       undefined,

--- a/cli/src/dev.ts
+++ b/cli/src/dev.ts
@@ -371,6 +371,28 @@ export function projectDashboardURL(apiUrl: string, projectId: string): string {
   return `${apiUrl.replace(/\/+$/, "")}/projects/${encodeURIComponent(projectId)}`;
 }
 
+export function developmentWatchReadyMessage(input: {
+  projectName: string;
+  projectId: string;
+  dashboardUrl: string;
+  agents: string[];
+  deployments: string[];
+  watchedDirectory: string;
+  startWebApp?: boolean;
+}): string {
+  return (
+    `\nOpenComputer Development\n\n` +
+    `✓ Deployment ready\n` +
+    `  Project      ${input.projectName} (${input.projectId})\n` +
+    `  Agents       ${input.agents.join(", ")}\n` +
+    `  Deployments  ${input.deployments.join("\n               ")}\n` +
+    `  Dashboard    ${input.dashboardUrl}\n\n` +
+    `Watching ${input.watchedDirectory} for changes.\n` +
+    `Changes deploy automatically. Press Ctrl+C to stop.\n` +
+    (input.startWebApp ? `Starting legacy local web app with Vite.\n` : "")
+  );
+}
+
 export async function hasReactSpa(projectRoot: string): Promise<boolean> {
   try {
     await Promise.all([
@@ -466,26 +488,34 @@ export async function runDeploymentWatch(
       do {
         pending = false;
         try {
+          process.stdout.write("\nChange detected. Deploying to Development...\n");
           const results = await publishProjectDevelopment(
             client,
             projectRoot,
             binding,
           );
           latestResults = results;
+          let changed = false;
           for (const result of results) {
             if (
               result.built.digest !== lastDigests.get(result.deployment.agentId)
             ) {
+              changed = true;
               lastDigests.set(result.deployment.agentId, result.built.digest);
               process.stdout.write(
-                `Synced ${result.deployment.agentId}@development  ${result.deployment.id}\n`,
+                `✓ Deployed ${result.deployment.agentId}@development\n` +
+                  `  Deployment  ${result.deployment.id}\n`,
               );
             }
+          }
+          if (!changed) {
+            process.stdout.write("✓ Development is already up to date.\n");
           }
           await syncSecrets();
         } catch (error) {
           process.stderr.write(
-            `Sync failed: ${error instanceof Error ? error.message : String(error)}\n`,
+            `✗ Deployment failed: ${error instanceof Error ? error.message : String(error)}\n` +
+              `Watching for the next change.\n`,
           );
         }
       } while (pending);
@@ -508,13 +538,17 @@ export async function runDeploymentWatch(
     const spa = await hasReactSpa(projectRoot);
     const startWebApp = behavior.startWebApp === true && spa;
     process.stdout.write(
-      `Watching Development deployments\n` +
-        `Project:    ${binding.projectName} (${binding.projectId})\n` +
-        `Dashboard:  ${projectDashboardURL(config.apiUrl, binding.projectId)}\n` +
-        `Agents:     ${initial.map((result) => `${result.deployment.agentId}@development`).join(", ")}\n` +
-        `Deployments:${initial.map((result) => ` ${result.deployment.id}`).join("\n            ")}\n` +
-        `Watching:   ${projectRoot}\n` +
-        (startWebApp ? `Web app:    starting legacy local Vite app\n` : ""),
+      developmentWatchReadyMessage({
+        projectName: binding.projectName,
+        projectId: binding.projectId,
+        dashboardUrl: projectDashboardURL(config.apiUrl, binding.projectId),
+        agents: initial.map(
+          (result) => `${result.deployment.agentId}@development`,
+        ),
+        deployments: initial.map((result) => result.deployment.id),
+        watchedDirectory: resolve(projectRoot, "opencomputer"),
+        startWebApp,
+      }),
     );
     if (startWebApp) web = await startReactDevServer(projectRoot);
     watcher = watch(

--- a/cli/src/dev.ts
+++ b/cli/src/dev.ts
@@ -177,7 +177,7 @@ export async function syncDevelopmentSecrets(
     const confirmed = await (options.confirm ?? confirmNewSecrets)(newSecrets);
     if (!confirmed) {
       process.stderr.write(
-        "Development secret sync skipped. Use `opencomputer secrets set` or restart dev to approve it.\n",
+        "Development secret sync skipped. Use `opencomputer secrets set` or restart `opencomputer deploy --watch` to approve it.\n",
       );
       return [];
     }
@@ -398,11 +398,12 @@ async function startReactDevServer(projectRoot: string): Promise<ChildProcess> {
   });
 }
 
-export async function runCloudDevelopment(
+export async function runDeploymentWatch(
   client: OpenComputerClient,
   config: ResolvedConfig,
   root: string,
   options: ProjectBindingOptions = {},
+  behavior: { startWebApp?: boolean } = {},
 ): Promise<void> {
   const projectRoot = await findOpenComputerProjectRoot(root);
   const binding = await ensureProjectBinding(
@@ -505,18 +506,17 @@ export async function runCloudDevelopment(
     }
     await syncSecrets();
     const spa = await hasReactSpa(projectRoot);
+    const startWebApp = behavior.startWebApp === true && spa;
     process.stdout.write(
-      `Development (Cloud)\n` +
+      `Watching Development deployments\n` +
         `Project:    ${binding.projectName} (${binding.projectId})\n` +
         `Dashboard:  ${projectDashboardURL(config.apiUrl, binding.projectId)}\n` +
         `Agents:     ${initial.map((result) => `${result.deployment.agentId}@development`).join(", ")}\n` +
         `Deployments:${initial.map((result) => ` ${result.deployment.id}`).join("\n            ")}\n` +
         `Watching:   ${projectRoot}\n` +
-        (spa
-          ? `React:      starting local Vite app\n`
-          : `React:      not included\n`),
+        (startWebApp ? `Web app:    starting legacy local Vite app\n` : ""),
     );
-    if (spa) web = await startReactDevServer(projectRoot);
+    if (startWebApp) web = await startReactDevServer(projectRoot);
     watcher = watch(
       resolve(projectRoot, "opencomputer"),
       { recursive: true },
@@ -539,4 +539,15 @@ export async function runCloudDevelopment(
     await rm(stateFile, { force: true });
     await gateway.close();
   }
+}
+
+export async function runCloudDevelopment(
+  client: OpenComputerClient,
+  config: ResolvedConfig,
+  root: string,
+  options: ProjectBindingOptions = {},
+): Promise<void> {
+  return runDeploymentWatch(client, config, root, options, {
+    startWebApp: true,
+  });
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -47,9 +47,10 @@ Usage:
   opencomputer logout [--local]
   opencomputer whoami
   opencomputer agents
-  opencomputer init <directory|.> [--spa|--agent-only]
+  opencomputer init <directory|.>
   opencomputer link
-  opencomputer dev [--project <id|slug> | --create-project <name>]
+  opencomputer deploy --watch [--project <id|slug> | --create-project <name>]
+  opencomputer dev [--project <id|slug> | --create-project <name>]  (legacy alias)
   opencomputer session [prompt] [--agent <project-agent>] [--keep]
   opencomputer session create [prompt] [--agent <project-agent>] [--keep]
   opencomputer session list
@@ -70,7 +71,7 @@ Usage:
   opencomputer webhooks rotate-token <webhook-id> [--project <id|slug>]
   opencomputer webhooks remove <webhook-id> [--project <id|slug>]
   opencomputer logs [--agent <agent>] [--session <session-id>] [--environment development|production] [--follow]
-  opencomputer deploy [--alias <alias>]
+  opencomputer deploy [--alias <alias>] [--watch]
   opencomputer run <agent> <prompt> [--keep]
 
 Global options:

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -19,7 +19,7 @@ import {
   readProjectResources,
 } from "./project.js";
 
-test("init creates a multi-agent-ready project and React hello world app", async () => {
+test("init creates a multi-agent-ready hello-world agent by default", async () => {
   const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-project-"));
   const root = resolve(parent, "hello-app");
   try {
@@ -42,11 +42,8 @@ test("init creates a multi-agent-ready project and React hello world app", async
       await readFile(resolve(root, "opencomputer", "project.ts"), "utf8"),
       /id:/,
     );
-    await assert.rejects(stat(resolve(root, "src", "use-agent.ts")));
-    assert.match(
-      await readFile(resolve(root, "src", "App.tsx"), "utf8"),
-      /import \{ useAgent \} from "@opencomputer\/react"[\s\S]*useAgent\(__OPENCOMPUTER_AGENT__\)/,
-    );
+    await assert.rejects(stat(resolve(root, "src")));
+    await assert.rejects(stat(resolve(root, "vite.config.ts")));
     const packageJSON = JSON.parse(
       await readFile(resolve(root, "package.json"), "utf8"),
     ) as {
@@ -54,22 +51,16 @@ test("init creates a multi-agent-ready project and React hello world app", async
       dependencies: Record<string, string>;
       devDependencies: Record<string, string>;
     };
-    assert.equal(packageJSON.scripts.dev, "opencomputer dev");
+    assert.equal(packageJSON.scripts.dev, undefined);
     assert.equal(packageJSON.scripts["dev:web"], undefined);
+    assert.equal(packageJSON.scripts.deploy, "opencomputer deploy");
     assert.equal(packageJSON.dependencies["@opencomputer/agent"], "^0.5.0");
-    assert.equal(packageJSON.dependencies["@opencomputer/react"], "^0.1.0");
-    assert.equal(packageJSON.devDependencies["@opencomputer/cli"], "^0.5.0");
-    assert.ok(packageJSON.devDependencies["@types/node"]);
-    const viteConfig = await readFile(resolve(root, "vite.config.ts"), "utf8");
-    assert.match(viteConfig, /command === "serve"/);
-    assert.match(viteConfig, /resolve\("\.opencomputer\/dev\.json"\)/);
-    assert.doesNotMatch(
-      viteConfig,
-      /opencomputer\/agents\/hello-world\/\.opencomputer\/dev\.json/,
-    );
+    assert.equal(packageJSON.dependencies["@opencomputer/react"], undefined);
+    assert.equal(packageJSON.devDependencies["@opencomputer/cli"], "^0.6.0");
+    assert.equal(packageJSON.devDependencies["@types/node"], undefined);
     assert.match(
       await readFile(resolve(root, "README.md"), "utf8"),
-      /Sync agent code to Development \(Cloud\)[\s\S]*opencomputer\/\.env\.local/,
+      /Deploy agent changes to Development \(Cloud\)[\s\S]*npm run deploy -- --watch[\s\S]*opencomputer\/\.env\.local/,
     );
     assert.match(
       await readFile(resolve(root, "opencomputer", ".env.example"), "utf8"),
@@ -104,14 +95,8 @@ test("init creates a multi-agent-ready project and React hello world app", async
       "opencomputer/.env.example",
       "opencomputer/agents/hello-world/agent.ts",
       "package.json",
-      "vite.config.ts",
-      "tsconfig.json",
-      "index.html",
       "README.md",
       ".gitignore",
-      "src/App.tsx",
-      "src/main.tsx",
-      "src/styles.css",
     ]);
   } finally {
     await rm(parent, { recursive: true, force: true });
@@ -261,18 +246,18 @@ export default defineSchedule({
   }
 });
 
-test("init can create an agent-only project", async () => {
-  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-agent-only-"));
-  const root = resolve(parent, "hello-agent");
+test("init can explicitly include a separately-run React app", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-with-spa-"));
+  const root = resolve(parent, "hello-app");
   try {
     const initialized = await initializeAgentProject(root, undefined, {
-      spa: false,
+      spa: true,
     });
     await stat(
       resolve(root, "opencomputer", "agents", "hello-world", "agent.ts"),
     );
-    await assert.rejects(stat(resolve(root, "src")));
-    await assert.rejects(stat(resolve(root, "vite.config.ts")));
+    await stat(resolve(root, "src", "App.tsx"));
+    await stat(resolve(root, "vite.config.ts"));
     const packageJSON = JSON.parse(
       await readFile(resolve(root, "package.json"), "utf8"),
     ) as {
@@ -281,20 +266,30 @@ test("init can create an agent-only project", async () => {
       devDependencies: Record<string, string>;
     };
     assert.deepEqual(packageJSON.scripts, {
-      dev: "opencomputer dev",
+      "dev:web": "vite",
+      build: "tsc -b && vite build",
       session: "opencomputer session",
       deploy: "opencomputer deploy",
     });
-    assert.equal(packageJSON.dependencies["@opencomputer/react"], undefined);
-    assert.equal(packageJSON.dependencies.react, undefined);
-    assert.equal(packageJSON.devDependencies.vite, undefined);
+    assert.equal(packageJSON.dependencies["@opencomputer/react"], "^0.1.0");
+    assert.equal(packageJSON.dependencies.react, "^19.2.0");
+    assert.equal(packageJSON.devDependencies.vite, "^8.0.0");
+    assert.equal(packageJSON.devDependencies["@opencomputer/cli"], "^0.6.0");
+    const viteConfig = await readFile(resolve(root, "vite.config.ts"), "utf8");
+    assert.match(viteConfig, /npm run deploy -- --watch/);
     assert.deepEqual(initialized.files, [
       "opencomputer/project.ts",
       "opencomputer/.env.example",
       "opencomputer/agents/hello-world/agent.ts",
       "package.json",
+      "vite.config.ts",
+      "tsconfig.json",
+      "index.html",
       "README.md",
       ".gitignore",
+      "src/App.tsx",
+      "src/main.tsx",
+      "src/styles.css",
     ]);
   } finally {
     await rm(parent, { recursive: true, force: true });

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -355,7 +355,7 @@ export async function initializeAgentProject(
   files: string[];
 }> {
   const root = resolve(directory);
-  const spa = options.spa ?? true;
+  const spa = options.spa ?? false;
   const agentRoot = resolve(root, "opencomputer", "agents", "hello-world");
   await assertStarterTarget(root);
   await mkdir(agentRoot, { recursive: true });
@@ -421,8 +421,9 @@ export default function Agent() {
         private: true,
         type: "module",
         scripts: {
-          dev: "opencomputer dev",
-          ...(spa ? { build: "tsc -b && vite build" } : {}),
+          ...(spa
+            ? { "dev:web": "vite", build: "tsc -b && vite build" }
+            : {}),
           session: "opencomputer session",
           deploy: "opencomputer deploy",
         },
@@ -437,7 +438,7 @@ export default function Agent() {
             : {}),
         },
         devDependencies: {
-          "@opencomputer/cli": "^0.5.0",
+          "@opencomputer/cli": "^0.6.0",
           ...(spa
             ? {
                 "@types/node": "^24.0.0",
@@ -469,7 +470,7 @@ function openComputerDev() {
     ) as { url: string; token: string; agent: string };
   } catch {
     throw new Error(
-      "OpenComputer is not running. Start npm run dev first.",
+      "OpenComputer is not running. Start npm run deploy -- --watch first.",
     );
   }
 }
@@ -484,7 +485,7 @@ function openComputerAgent() {
     // The production build below reports the actionable binding error.
   }
   throw new Error(
-    "This app is not connected to an OpenComputer project. Run npm run dev first.",
+    "This app is not connected to an OpenComputer project. Run npm run deploy -- --watch first.",
   );
 }
 
@@ -671,14 +672,20 @@ form button:disabled { cursor: default; opacity: .45; }
 This project keeps agent definitions in \`opencomputer/\` and the React app in
 \`src/\`.
 
-Sync agent code to Development (Cloud) and start the React app:
+Deploy agent changes to Development (Cloud):
 
 \`\`\`bash
-npm run dev
+npm run deploy -- --watch
+\`\`\`
+
+Start the web app separately:
+
+\`\`\`bash
+npm run dev:web
 \`\`\`
 
 The first run asks you to create a cloud project or select an existing one.
-That choice is saved for later development runs.
+That choice is saved for later watched deployments.
 
 Development secrets can be placed in \`opencomputer/.env.local\`. Only values
 referenced by \`useSecret()\` are synchronized, and their allowed origins are
@@ -688,14 +695,14 @@ inferred from \`defineConnection()\` declarations.
 
 This project keeps agent definitions in \`opencomputer/\`.
 
-Sync agent code to Development (Cloud):
+Deploy agent changes to Development (Cloud):
 
 \`\`\`bash
-npm run dev
+npm run deploy -- --watch
 \`\`\`
 
 The first run asks you to create a cloud project or select an existing one.
-That choice is saved for later development runs.
+That choice is saved for later watched deployments.
 
 Development secrets can be placed in \`opencomputer/.env.local\`. Only values
 referenced by \`useSecret()\` are synchronized, and their allowed origins are

--- a/cli/ui/main.tsx
+++ b/cli/ui/main.tsx
@@ -417,7 +417,7 @@ function App() {
   useEffect(() => {
     if (!token) {
       setError(
-        "Missing dev token. Open the complete URL printed by opencomputer dev.",
+        "Missing dev token. Open the complete URL printed by opencomputer deploy --watch.",
       );
       return;
     }

--- a/create-start/README.md
+++ b/create-start/README.md
@@ -1,23 +1,22 @@
 # @opencomputer/create-start
 
-Create a hello-world OpenComputer application:
+This package is a compatibility shim for the former npm initializer. New
+projects should use the CLI directly:
 
 ```bash
-npm create @opencomputer/start@latest my-agent
+npx @opencomputer/cli init my-agent
 cd my-agent
 npm install
 npx --package @opencomputer/cli opencomputer login
-npm run dev
+npm run deploy -- --watch
 ```
 
-This package is the naming shim npm resolves for the command above. The
-interactive initializer is shipped by the same-version `@opencomputer/cli`
-package. It asks whether to create agent code only or include a React SPA. A
-single `npm run dev` syncs agents to Development (Cloud), prints the dashboard
-URL, and starts Vite when the SPA is included.
+The initializer creates a hello-world agent without a browser application.
+`npm run deploy -- --watch` watches agent source, publishes changes to
+Development (Cloud), and prints the dashboard URL.
 
 Use `.` to initialize the current directory:
 
 ```bash
-npm create @opencomputer/start@latest .
+npx @opencomputer/cli init .
 ```

--- a/create-start/package.json
+++ b/create-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/create-start",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "Create a hello-world OpenComputer agent application.",
   "type": "module",
   "bin": {
@@ -18,7 +18,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@opencomputer/cli": "0.5.6"
+    "@opencomputer/cli": "0.6.0"
   },
   "publishConfig": {
     "access": "public"

--- a/create-start/test/create-start.test.js
+++ b/create-start/test/create-start.test.js
@@ -20,7 +20,7 @@ export async function runCreateStart(args) {
     );
     const result = spawnSync(
       process.execPath,
-      [resolve("index.js"), "my-agent", "--spa"],
+      [resolve("index.js"), "my-agent"],
       {
         cwd: resolve(import.meta.dirname, ".."),
         env: {
@@ -33,7 +33,6 @@ export async function runCreateStart(args) {
     assert.equal(result.status, 0, result.stderr.toString());
     assert.deepEqual(JSON.parse(await readFile(capture, "utf8")), [
       "my-agent",
-      "--spa",
     ]);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -54,7 +53,7 @@ test("creates an app through the local CLI module", async () => {
   try {
     const result = spawnSync(
       process.execPath,
-      [resolve("index.js"), app, "--spa"],
+      [resolve("index.js"), app],
       {
         cwd: resolve(import.meta.dirname, ".."),
         env: {
@@ -72,7 +71,7 @@ test("creates an app through the local CLI module", async () => {
       ).isFile(),
       true,
     );
-    assert.equal((await stat(resolve(app, "src", "App.tsx"))).isFile(), true);
+    await assert.rejects(stat(resolve(app, "src", "App.tsx")));
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/docs/agents/deployments.mdx
+++ b/docs/agents/deployments.mdx
@@ -10,7 +10,7 @@ Every project starts with two working environments:
 
 | Environment | Alias | How it changes |
 | --- | --- | --- |
-| Development | `development` | `npm run dev` publishes source changes |
+| Development | `development` | `npm run deploy -- --watch` publishes source changes |
 | Production | `production` | An explicit deploy advances it |
 
 Sessions keep the deployment they started with. Publishing another version

--- a/docs/agents/examples/feature-flag-hygiene.mdx
+++ b/docs/agents/examples/feature-flag-hygiene.mdx
@@ -147,7 +147,7 @@ development secrets:
 
 ```bash
 npm install
-npm run dev
+npm run deploy -- --watch
 ```
 
 Start with the included fixture and a dry run:

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -4,8 +4,7 @@ description: "Define reactive agents in TypeScript and run them in the OpenCompu
 ---
 
 OpenComputer is a managed runtime for agents defined as code. A project can
-contain several agents and optionally a React application that talks to them. You write
-the behavior; OpenComputer manages development deployments, model execution,
+contain several agents. You write the behavior; OpenComputer manages development deployments, model execution,
 tools, durable sessions, streaming, and production versions.
 
 ```tsx
@@ -28,7 +27,7 @@ subagents needed for that render.
 
 <CardGroup cols={2}>
   <Card title="Projects" icon="folder" href="/agents/projects">
-    Group multiple agents and a client application in one repository.
+    Group multiple agents in one repository.
   </Card>
   <Card title="Reactive agents" icon="code" href="/agents/reactive-agents">
     Build agent behavior with a function and conditional hooks.
@@ -53,21 +52,20 @@ subagents needed for that render.
 ## Start a project
 
 ```bash
-npm create @opencomputer/start@latest my-agent
+npx @opencomputer/cli init my-agent
 cd my-agent
 npm install
 npx --package @opencomputer/cli opencomputer login
-npm run dev
+npm run deploy -- --watch
 ```
 
-The initializer asks whether to include a React SPA. The first `npm run dev`
+The initializer creates one hello-world agent. The first watched deployment
 lets you create a cloud project or select an existing one, prints its dashboard
-URL, and syncs every configured agent to `development`. When a SPA exists, the
-same command also starts it locally.
+URL, and syncs every configured agent to `development`.
 
 <Note>
-  There is no local agent server. An optional React app runs locally, while
-  agent code runs in OpenComputer's managed development cloud.
+  There is no local agent server. Agent code runs in OpenComputer's managed
+  development cloud.
 </Note>
 
 ## What is available today
@@ -76,8 +74,6 @@ same command also starts it locally.
 - reactive instructions, model selection, tools, subagents, MCP
   servers, input metadata, and session data reads
 - cloud development with file watching and automatic synchronization
-- an optional React client using `@opencomputer/react` for streaming and
-  multi-turn session reuse
 - dashboard and CLI playground sessions
 - immutable deployments promoted through aliases such as `production`
 - project-level secrets with optional agent overrides and constrained outbound requests

--- a/docs/agents/projects.mdx
+++ b/docs/agents/projects.mdx
@@ -1,11 +1,10 @@
 ---
 title: "Projects and agents"
-description: "Organize multiple cloud agents and a React application"
+description: "Organize multiple cloud agents in one project"
 ---
 
 A project is the cloud boundary for related agents, environments, deployments,
-and sessions. A source repository contains the project's agent definitions and
-the application that interacts with them.
+and sessions. A source repository contains the project's agent definitions.
 
 ## Project structure
 
@@ -26,11 +25,7 @@ my-agent/
 │           ├── tools/       # optional
 │           ├── skills/      # optional
 │           └── schedules/   # optional
-├── src/
-│   ├── App.tsx
-│   └── main.tsx
-├── package.json
-└── vite.config.ts
+└── package.json
 ```
 
 - `opencomputer/project.ts` declares project metadata and agent IDs.
@@ -38,7 +33,6 @@ my-agent/
 - `opencomputer/channels/` and `opencomputer/outboxes/` define shared project
   resources; registrations under an agent authorize that agent to use them.
 - `opencomputer/.env.local` optionally holds ignored development secrets.
-- `src/` is a normal React application.
 - `.opencomputer/` is ignored local state created by the CLI.
 
 Add source files only when the project uses them. The starter does not generate
@@ -46,8 +40,8 @@ placeholder capability directories.
 
 ## Create or select the cloud project
 
-The source scaffold and cloud project are separate. `npm create` writes local
-source. Link it to a cloud project with:
+The source scaffold and cloud project are separate. `opencomputer init` writes
+local source. Link it to a cloud project with:
 
 ```bash
 npx --package @opencomputer/cli opencomputer link
@@ -59,8 +53,8 @@ skip it, the first project-scoped command shows the same prompt.
 For non-interactive use:
 
 ```bash
-npx --package @opencomputer/cli opencomputer dev --project <project-id-or-slug>
-npx --package @opencomputer/cli opencomputer dev --create-project "Support agents"
+npx --package @opencomputer/cli opencomputer deploy --watch --project <project-id-or-slug>
+npx --package @opencomputer/cli opencomputer deploy --watch --create-project "Support agents"
 ```
 
 Later commands reuse `.opencomputer/project.json`. Run `opencomputer link`

--- a/docs/agents/quickstart.mdx
+++ b/docs/agents/quickstart.mdx
@@ -8,16 +8,16 @@ description: "Create an agent project and sync it to Development (Cloud)"
 - Node.js 22 or newer
 - an OpenComputer account
 
-## 1. Create the app
+## 1. Create the agent
 
 ```bash
-npm create @opencomputer/start@latest my-agent
+npx @opencomputer/cli init my-agent
 cd my-agent
 npm install
 ```
 
-Use `.` instead of `my-agent` to initialize an empty current directory.
-The initializer asks whether to create agent code only or include a React SPA.
+Use `.` instead of `my-agent` to initialize an empty current directory. The
+initializer creates one hello-world agent.
 
 ## 2. Log in
 
@@ -28,21 +28,20 @@ npx --package @opencomputer/cli opencomputer login
 The CLI opens the OpenComputer device-login flow and stores the login locally.
 The production API at `https://app.opencomputer.dev` is used by default.
 
-## 3. Start cloud development
+## 3. Watch development deployments
 
 ```bash
-npm run dev
+npm run deploy -- --watch
 ```
 
 On the first run, choose an existing cloud project or create a new one. The
-process prints the project dashboard URL, watches `opencomputer/`, and syncs
-changes to `development`. If you included the SPA, the same command starts
-Vite; open its URL and send a message.
+process prints the project dashboard URL, watches `opencomputer/`, and deploys
+changes to `development`. Open the dashboard playground or use the CLI to send
+a message.
 
-<Warning>
-  Keep `npm run dev` running while using the React app. The authenticated
-  development bridge exists only for the lifetime of that process.
-</Warning>
+<Note>
+  This command does not start a local agent server or a browser application.
+</Note>
 
 ## 4. Change the agent
 

--- a/docs/agents/quickstart.mdx
+++ b/docs/agents/quickstart.mdx
@@ -39,6 +39,20 @@ process prints the project dashboard URL, watches `opencomputer/`, and deploys
 changes to `development`. Open the dashboard playground or use the CLI to send
 a message.
 
+The watcher stays open like a live-reload development process:
+
+```text
+OpenComputer Development
+
+✓ Deployment ready
+  Project      my-agent (prj_...)
+  Agents       hello-world@development
+  Dashboard    https://app.opencomputer.dev/projects/prj_...
+
+Watching /path/to/my-agent/opencomputer for changes.
+Changes deploy automatically. Press Ctrl+C to stop.
+```
+
 <Note>
   This command does not start a local agent server or a browser application.
 </Note>

--- a/docs/agents/react.mdx
+++ b/docs/agents/react.mdx
@@ -3,8 +3,9 @@ title: "React integration"
 description: "Stream agent sessions from a React application with useAgent"
 ---
 
-Projects created with the React option use `@opencomputer/react`. The package
-owns session creation, multi-turn reuse, and streamed assistant messages.
+An independently developed React application can use `@opencomputer/react`.
+The package owns session creation, multi-turn reuse, and streamed assistant
+messages. React is not part of the default agent scaffold.
 
 ```tsx
 import { useAgent } from "@opencomputer/react";
@@ -65,8 +66,16 @@ useAgent({
 
 ## Development
 
-Keep `npm run dev` running while using the local application. It starts Vite
-and provides the authenticated development bridge; credentials are not bundled
+Run the watched agent deployment and the web application separately:
+
+```bash
+npm run deploy -- --watch
+npm run dev:web
+```
+
+The first command deploys agent changes and provides the authenticated
+development bridge. The second starts only the web application. The web app
+can also be deployed through its own lifecycle; credentials are not bundled
 into browser code.
 
 For the durable conversation model, see [Sessions and turns](/agents/sessions).

--- a/docs/agents/secrets.mdx
+++ b/docs/agents/secrets.mdx
@@ -50,7 +50,7 @@ Place development-only values in `opencomputer/.env.local`:
 GITHUB_TOKEN=github_pat_...
 ```
 
-When `npm run dev` starts, the CLI considers only names referenced by
+When `npm run deploy -- --watch` starts, the CLI considers only names referenced by
 `useSecret()` in a `defineConnection()` declaration. It infers the allowed
 origins from those declarations and asks before uploading each newly discovered
 secret. Changed values are synchronized while the development process is

--- a/docs/agents/sessions.mdx
+++ b/docs/agents/sessions.mdx
@@ -7,19 +7,6 @@ A session is a durable conversation with a deployed agent. Each turn appends
 input and streamed runtime events to the session, allowing clients to resume a
 conversation without rebuilding its history locally.
 
-## React
-
-When you select the React SPA, the starter imports `useAgent()` from
-`@opencomputer/react`. The hook exposes:
-
-- `messages` — accumulated user and assistant messages
-- `send(text)` — create a session if necessary and stream the next turn
-- `isRunning` — whether a turn is active
-- `error` — the latest request error
-
-The hook accepts an agent selector such as `hello-world@development`. Build
-additional UI and application hooks around its session state as needed.
-
 ## Agent playground
 
 Open a project in the dashboard and choose **Agent playground**. Select the

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -59,8 +59,7 @@
               "agents/mcp",
               "agents/skills",
               "agents/subagents",
-              "agents/session-data",
-              "agents/react"
+              "agents/session-data"
             ]
           },
           {

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,7 +6,7 @@
 
 - [Overview](https://docs.opencomputer.dev/agents/overview.md): Build, test, and deploy agents as code.
 - [Quickstart](https://docs.opencomputer.dev/agents/quickstart.md): Create a project and sync its first agent to Development (Cloud).
-- [Projects and agents](https://docs.opencomputer.dev/agents/projects.md): Organize multiple agents and a React application.
+- [Projects and agents](https://docs.opencomputer.dev/agents/projects.md): Organize multiple cloud agents in one project.
 - [Cloud development](https://docs.opencomputer.dev/agents/development.md): Sync agent code to Development while your application runs locally.
 - [Deployments and environments](https://docs.opencomputer.dev/agents/deployments.md): Understand development, production, immutable deployments, and aliases.
 - [Reactive agents](https://docs.opencomputer.dev/agents/reactive-agents.md): Render instructions, models, tools, subagents, and MCP servers from code.
@@ -21,7 +21,6 @@
 - [Skills](https://docs.opencomputer.dev/agents/skills.md): Package reusable instructions and supporting resources with an agent.
 - [Subagents](https://docs.opencomputer.dev/agents/subagents.md): Let an agent delegate focused work with `useSubagent()`.
 - [Session data](https://docs.opencomputer.dev/agents/session-data.md): Read durable per-session values with `useSessionData()`.
-- [React integration](https://docs.opencomputer.dev/agents/react.md): Stream agent sessions from a React application with `useAgent()`.
 - [Playground and debugging](https://docs.opencomputer.dev/agents/playground.md): Test deployments and inspect each agent turn.
 - [Logs](https://docs.opencomputer.dev/agents/logs.md): Inspect and follow agent and outbound-request logs.
 

--- a/react/README.md
+++ b/react/README.md
@@ -8,5 +8,6 @@ import { useAgent } from "@opencomputer/react";
 const agent = useAgent("support@development");
 ```
 
-The generated OpenComputer starter configures the local authenticated bridge
-automatically during `npm run dev`.
+Run `npm run deploy -- --watch` for the agent project to configure the local
+authenticated bridge, then start the React application separately with its own
+development command, such as `npm run dev:web`.

--- a/web/src/managed-agents/Home.tsx
+++ b/web/src/managed-agents/Home.tsx
@@ -107,8 +107,8 @@ export default function ProjectsHome() {
               Create your first project
             </h2>
             <p className="text-muted-foreground mt-3 max-w-xl text-sm leading-6">
-              Start with one hello-world agent, with an optional React SPA. Your
-              OpenComputer project is ready for more agents as it grows.
+              Start with one hello-world agent. Your OpenComputer project is
+              ready for more agents as it grows.
             </p>
             <pre className="bg-foreground text-background mt-5 overflow-x-auto rounded-lg px-4 py-3 text-sm leading-7">
               <code>{starterCommands('hello-world').join('\n')}</code>
@@ -161,19 +161,18 @@ export default function ProjectsHome() {
         <PanelContent className="flex items-start gap-3">
           <Bot className="text-muted-foreground mt-0.5 size-4" />
           <div className="min-w-0 flex-1">
-            <p className="text-sm font-medium">Cloud development</p>
+            <p className="text-sm font-medium">Deploy your first agent</p>
             <p className="text-muted-foreground mt-1 text-sm">
               Create a new app in a <code>my-agent/</code> folder. No global
               OpenComputer CLI installation is required.
             </p>
             <pre className="bg-muted mt-3 overflow-x-auto rounded-md border px-3 py-2 text-xs leading-5">
-              <code>npm create @opencomputer/start@latest my-agent</code>
+              <code>npx @opencomputer/cli init my-agent</code>
             </pre>
             <p className="text-muted-foreground mt-2 text-xs leading-5">
               Then run <code>cd my-agent</code>, <code>npm install</code>, and{' '}
-              <code>npm run dev</code>. The project contains an{' '}
-              <code>opencomputer/</code> agent backend and can include a{' '}
-              <code>src/</code> React app.
+              <code>npm run deploy -- --watch</code>. The project contains an{' '}
+              <code>opencomputer/</code> cloud agent definition.
             </p>
           </div>
         </PanelContent>

--- a/web/src/managed-agents/onboarding.test.ts
+++ b/web/src/managed-agents/onboarding.test.ts
@@ -2,22 +2,24 @@ import { describe, expect, it } from 'vitest'
 import { createStartCommand, starterCommands } from './onboarding'
 
 describe('managed-agent onboarding commands', () => {
-  it('uses the scoped npm initializer for a new account', () => {
+  it('uses the CLI initializer and watched cloud deployment for a new account', () => {
     expect(createStartCommand('hello-world')).toBe(
-      'npm create @opencomputer/start@latest hello-world',
+      'npx @opencomputer/cli init hello-world',
     )
     expect(starterCommands('hello-world')).toEqual([
-      'npm create @opencomputer/start@latest hello-world',
-      'npm i',
-      'npm run dev',
+      'npx @opencomputer/cli init hello-world',
+      'cd hello-world',
+      'npm install',
+      'npm run deploy -- --watch',
     ])
   })
 
   it('quotes a directory that contains spaces', () => {
     expect(starterCommands('support agent')).toEqual([
-      "npm create @opencomputer/start@latest 'support agent'",
-      'npm i',
-      'npm run dev',
+      "npx @opencomputer/cli init 'support agent'",
+      "cd 'support agent'",
+      'npm install',
+      'npm run deploy -- --watch',
     ])
   })
 })

--- a/web/src/managed-agents/onboarding.ts
+++ b/web/src/managed-agents/onboarding.ts
@@ -5,9 +5,14 @@ function shellArgument(value: string) {
 }
 
 export function createStartCommand(directory: string) {
-  return `npm create @opencomputer/start@latest ${shellArgument(directory)}`
+  return `npx @opencomputer/cli init ${shellArgument(directory)}`
 }
 
 export function starterCommands(directory: string) {
-  return [createStartCommand(directory), 'npm i', 'npm run dev']
+  return [
+    createStartCommand(directory),
+    `cd ${shellArgument(directory)}`,
+    'npm install',
+    'npm run deploy -- --watch',
+  ]
 }


### PR DESCRIPTION
## Summary
- make npx @opencomputer/cli init create a hello-world agent without a React application
- add deploy --watch as the cloud Development live-deployment loop without starting Vite
- keep web applications on a separate dev:web and deployment lifecycle
- update signup onboarding, generated projects, package versions, and public docs
- improve watcher output with explicit ready, deploying, success, and failure states

## Review map
- cli/src/project.ts and create-start: default scaffold and package scripts
- cli/src/commands.ts and cli/src/dev.ts: command routing and watched deployments
- web/src/managed-agents: first-project onboarding commands
- docs/agents and package READMEs: revised public journey

## Verification
- CLI: 38 tests passed, including build
- create-start: 2 tests passed
- dashboard: 182 tests passed and production build completed
- mo-oc-dev smoke: initial deployment reached the watch loop and did not start a web app

## Rollout
Publish @opencomputer/cli 0.6.0 and @opencomputer/create-start 0.6.0 after merge.