### PR TITLE
fix: make agent onboarding commands copyable

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/cli",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@opencode-ai/sdk": "1.18.4",
         "ai": "^7.0.45",
@@ -16,6 +16,7 @@
         "typescript": "^5.9.0"
       },
       "bin": {
+        "cli": "dist/index.js",
         "opencomputer": "dist/index.js",
         "opencomputer-create": "dist/create-start-bin.js"
       },

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Build, test, deploy, and share OpenComputer agents as code.",
   "type": "module",
   "bin": {
+    "cli": "dist/index.js",
     "opencomputer": "dist/index.js",
     "opencomputer-create": "dist/create-start-bin.js"
   },

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -56,7 +56,7 @@ test("init creates a multi-agent-ready hello-world agent by default", async () =
     assert.equal(packageJSON.scripts.deploy, "opencomputer deploy");
     assert.equal(packageJSON.dependencies["@opencomputer/agent"], "^0.5.0");
     assert.equal(packageJSON.dependencies["@opencomputer/react"], undefined);
-    assert.equal(packageJSON.devDependencies["@opencomputer/cli"], "^0.6.0");
+    assert.equal(packageJSON.devDependencies["@opencomputer/cli"], "^0.6.1");
     assert.equal(packageJSON.devDependencies["@types/node"], undefined);
     assert.match(
       await readFile(resolve(root, "README.md"), "utf8"),
@@ -274,7 +274,7 @@ test("init can explicitly include a separately-run React app", async () => {
     assert.equal(packageJSON.dependencies["@opencomputer/react"], "^0.1.0");
     assert.equal(packageJSON.dependencies.react, "^19.2.0");
     assert.equal(packageJSON.devDependencies.vite, "^8.0.0");
-    assert.equal(packageJSON.devDependencies["@opencomputer/cli"], "^0.6.0");
+    assert.equal(packageJSON.devDependencies["@opencomputer/cli"], "^0.6.1");
     const viteConfig = await readFile(resolve(root, "vite.config.ts"), "utf8");
     assert.match(viteConfig, /npm run deploy -- --watch/);
     assert.deepEqual(initialized.files, [

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -438,7 +438,7 @@ export default function Agent() {
             : {}),
         },
         devDependencies: {
-          "@opencomputer/cli": "^0.6.0",
+          "@opencomputer/cli": "^0.6.1",
           ...(spa
             ? {
                 "@types/node": "^24.0.0",

--- a/create-start/package.json
+++ b/create-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/create-start",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Create a hello-world OpenComputer agent application.",
   "type": "module",
   "bin": {
@@ -18,7 +18,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@opencomputer/cli": "0.6.0"
+    "@opencomputer/cli": "0.6.1"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/check-opencomputer-package-contract.mjs
+++ b/scripts/check-opencomputer-package-contract.mjs
@@ -6,6 +6,12 @@ const cli = await load("cli/package.json");
 const starter = await load("create-start/package.json");
 
 assert.equal(
+  cli.bin?.cli,
+  cli.bin?.opencomputer,
+  "@opencomputer/cli must expose a package-name bin so `npx @opencomputer/cli` is unambiguous",
+);
+
+assert.equal(
   starter.version,
   cli.version,
   "@opencomputer/create-start and @opencomputer/cli must share a version",

--- a/web/src/managed-agents/Home.tsx
+++ b/web/src/managed-agents/Home.tsx
@@ -2,7 +2,6 @@ import { FormEvent, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link, useNavigate } from 'react-router-dom'
 import {
-  Bot,
   Check,
   ChevronRight,
   Clipboard,
@@ -26,7 +25,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { notifyError } from '@/lib/errors'
 import { createManagedProject, getManagedProjects } from './api'
-import { createStartCommand, starterCommands } from './onboarding'
+import { starterCommandBlock, starterCopyCommand } from './onboarding'
 
 export default function ProjectsHome() {
   const navigate = useNavigate()
@@ -58,7 +57,7 @@ export default function ProjectsHome() {
 
   async function copyCommand() {
     try {
-      await navigator.clipboard.writeText(createStartCommand('hello-world'))
+      await navigator.clipboard.writeText(starterCopyCommand('hello-world'))
       setCopied(true)
       toast.success('Command copied')
     } catch (error) {
@@ -111,7 +110,7 @@ export default function ProjectsHome() {
               ready for more agents as it grows.
             </p>
             <pre className="bg-foreground text-background mt-5 overflow-x-auto rounded-lg px-4 py-3 text-sm leading-7">
-              <code>{starterCommands('hello-world').join('\n')}</code>
+              <code>{starterCommandBlock('hello-world')}</code>
             </pre>
             <div className="mt-6 flex flex-wrap gap-3">
               <Button onClick={() => setDialogOpen(true)}>
@@ -156,27 +155,6 @@ export default function ProjectsHome() {
           </div>
         </section>
       )}
-
-      <Panel>
-        <PanelContent className="flex items-start gap-3">
-          <Bot className="text-muted-foreground mt-0.5 size-4" />
-          <div className="min-w-0 flex-1">
-            <p className="text-sm font-medium">Deploy your first agent</p>
-            <p className="text-muted-foreground mt-1 text-sm">
-              Create a new app in a <code>my-agent/</code> folder. No global
-              OpenComputer CLI installation is required.
-            </p>
-            <pre className="bg-muted mt-3 overflow-x-auto rounded-md border px-3 py-2 text-xs leading-5">
-              <code>npx @opencomputer/cli init my-agent</code>
-            </pre>
-            <p className="text-muted-foreground mt-2 text-xs leading-5">
-              Then run <code>cd my-agent</code>, <code>npm install</code>, and{' '}
-              <code>npm run deploy -- --watch</code>. The project contains an{' '}
-              <code>opencomputer/</code> cloud agent definition.
-            </p>
-          </div>
-        </PanelContent>
-      </Panel>
 
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent className="sm:max-w-md">

--- a/web/src/managed-agents/onboarding.test.ts
+++ b/web/src/managed-agents/onboarding.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { createStartCommand, starterCommands } from './onboarding'
+import {
+  createStartCommand,
+  starterCommandBlock,
+  starterCopyCommand,
+  starterCommands,
+} from './onboarding'
 
 describe('managed-agent onboarding commands', () => {
   it('uses the CLI initializer and watched cloud deployment for a new account', () => {
@@ -21,5 +26,22 @@ describe('managed-agent onboarding commands', () => {
       'npm install',
       'npm run deploy -- --watch',
     ])
+  })
+
+  it('renders the complete onboarding flow shown to the user', () => {
+    expect(starterCommandBlock('hello-world')).toBe(
+      [
+        'npx @opencomputer/cli init hello-world',
+        'cd hello-world',
+        'npm install',
+        'npm run deploy -- --watch',
+      ].join('\n'),
+    )
+  })
+
+  it('copies the complete onboarding flow as one guarded shell command', () => {
+    expect(starterCopyCommand('hello-world')).toBe(
+      'npx @opencomputer/cli init hello-world && cd hello-world && npm install && npm run deploy -- --watch',
+    )
   })
 })

--- a/web/src/managed-agents/onboarding.ts
+++ b/web/src/managed-agents/onboarding.ts
@@ -16,3 +16,11 @@ export function starterCommands(directory: string) {
     'npm run deploy -- --watch',
   ]
 }
+
+export function starterCommandBlock(directory: string) {
+  return starterCommands(directory).join('\n')
+}
+
+export function starterCopyCommand(directory: string) {
+  return starterCommands(directory).join(' && ')
+}


### PR DESCRIPTION
Fixes the published initializer command and first-project onboarding flow.

- exposes a cli bin alias so npx can resolve @opencomputer/cli directly
- bumps the CLI and legacy starter packages to 0.6.1
- copies the full guarded init/install/deploy command chain
- removes the redundant deployment panel
- adds package-contract and onboarding regression coverage

Verification:
- CLI test suite (38 tests)
- create-start test suite (2 tests)
- onboarding tests (4 tests)
- dashboard production build