### PR TITLE
Bill serverless agent model and runtime usage

### DIFF
--- a/.github/workflows/deploy-api-edge.yml
+++ b/.github/workflows/deploy-api-edge.yml
@@ -99,9 +99,23 @@ jobs:
         working-directory: cloudflare-workers/api-edge
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          OC_MANAGED_CRED_HMAC_SECRET: ${{ secrets.OC_MANAGED_CRED_HMAC_SECRET }}
+          AGENT_RUNTIME_USAGE_HMAC_SECRET: ${{ secrets.AGENT_RUNTIME_USAGE_HMAC_SECRET }}
         run: |
           if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
             echo "CLOUDFLARE_API_TOKEN GitHub secret is required for Wrangler deploys" >&2
             exit 1
           fi
-          npx wrangler deploy -c wrangler.ci.toml
+          : "${OC_MANAGED_CRED_HMAC_SECRET:?missing OC_MANAGED_CRED_HMAC_SECRET}"
+          : "${AGENT_RUNTIME_USAGE_HMAC_SECRET:?missing AGENT_RUNTIME_USAGE_HMAC_SECRET}"
+          umask 077
+          jq -n \
+            --arg managedCredential "$OC_MANAGED_CRED_HMAC_SECRET" \
+            --arg runtimeUsage "$AGENT_RUNTIME_USAGE_HMAC_SECRET" \
+            '{OC_MANAGED_CRED_HMAC_SECRET: $managedCredential, AGENT_RUNTIME_USAGE_HMAC_SECRET: $runtimeUsage}' \
+            > "$RUNNER_TEMP/api-edge-secrets.json"
+          npx wrangler deploy \
+            -c wrangler.ci.toml \
+            --keep-vars \
+            --strict \
+            --secrets-file "$RUNNER_TEMP/api-edge-secrets.json"

--- a/cloudflare-workers/api-edge/src/agent_runtime_usage.test.ts
+++ b/cloudflare-workers/api-edge/src/agent_runtime_usage.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { agentRuntimeUsageInternal, type AutumnEnv } from "./autumn_webhook";
+
+async function hmacHex(secret: string, data: string) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(data));
+  return [...new Uint8Array(sig)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function env(): AutumnEnv {
+  return {
+    AUTUMN_SECRET_KEY: "autumn-secret",
+    AUTUMN_BASE_URL: "https://autumn.test/v1",
+    AUTUMN_WEBHOOK_SECRET: "whsec_test",
+    EVENT_SECRET: "event-secret",
+    AGENT_RUNTIME_USAGE_HMAC_SECRET: "agent-runtime-secret",
+    CF_ADMIN_SECRET: "admin-secret",
+    OPENCOMPUTER_DB: {} as D1Database,
+  };
+}
+
+describe("managed-agent runtime usage billing", () => {
+  it("tracks a finalized resource segment with its stable idempotency key", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json({ balance: { remaining: 9.7 } }));
+    const body = JSON.stringify({
+      org_id: "org_1",
+      deployment_id: "dep_1",
+      agent_id: "agent_1",
+      session_id: "session_1",
+      microvm_id: "vm_1",
+      resource_tier: "2gb_1vcpu",
+      quantity_seconds: 60,
+      idempotency_key: "lease_1:final",
+    });
+    const ts = String(Math.floor(Date.now() / 1000));
+    const path = "/internal/agent-runtime-usage";
+    const sig = await hmacHex("agent-runtime-secret", `${ts}.${path}.${body}`);
+
+    const response = await agentRuntimeUsageInternal(
+      new Request(`https://api.test${path}`, {
+        method: "POST",
+        headers: { "X-Timestamp": ts, "X-Signature": sig },
+        body,
+      }),
+      env(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      billed: true,
+      org_id: "org_1",
+      session_id: "session_1",
+      remaining: 9.7,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://autumn.test/v1/track",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Idempotency-Key": "lease_1:final",
+        }),
+        body: JSON.stringify({
+          customer_id: "org_1",
+          feature_id: "agent_runtime_2gb_1vcpu",
+          value: 60,
+          idempotency_key: "lease_1:final",
+        }),
+      }),
+    );
+  });
+});

--- a/cloudflare-workers/api-edge/src/autumn_webhook.test.ts
+++ b/cloudflare-workers/api-edge/src/autumn_webhook.test.ts
@@ -3,8 +3,95 @@ import {
   autumnPurchase,
   autumnSetAutoTopup,
   autumnUsagePlanPurchase,
+  summarizeAutumnCreditBalance,
   type AutumnApiEnv,
 } from "./autumn_webhook";
+
+describe("Autumn credit balance summary", () => {
+  it("separates monthly plan credits from persistent top-ups", () => {
+    expect(
+      summarizeAutumnCreditBalance(
+        {
+          id: "org_1",
+          balances: {
+            credits: {
+              remaining: 225,
+              breakdown: [
+                {
+                  plan_id: "pro",
+                  remaining: 200,
+                  reset: {
+                    interval: "month",
+                    resets_at: 1_787_472_000_000,
+                  },
+                },
+                { plan_id: "top_up", remaining: 25, reset: null },
+              ],
+            },
+          },
+        },
+        "pro",
+      ),
+    ).toEqual({
+      available: true,
+      planRemaining: 200,
+      topupRemaining: 25,
+      otherRemaining: 0,
+      planResetsAt: 1_787_472_000_000,
+    });
+  });
+
+  it("keeps carried credits separate even when Autumn folds them into the plan row", () => {
+    const summary = summarizeAutumnCreditBalance(
+      {
+        id: "org_1",
+        balances: {
+          credits: {
+            remaining: 229.9,
+            rollovers: [{ balance: 4.9, expires_at: 1_787_472_000_000 }],
+            breakdown: [
+              {
+                plan_id: "pro",
+                remaining: 204.9,
+                reset: {
+                  interval: "month",
+                  resets_at: 1_787_472_000_000,
+                },
+              },
+              { plan_id: "top_up", remaining: 25 },
+            ],
+          },
+        },
+      },
+      "pro",
+    );
+
+    expect(summary).toMatchObject({
+      available: true,
+      planRemaining: 200,
+      topupRemaining: 25,
+    });
+    expect(summary.otherRemaining).toBeCloseTo(4.9);
+  });
+
+  it("does not invent a split when Autumn omits its balance breakdown", () => {
+    expect(
+      summarizeAutumnCreditBalance(
+        {
+          id: "org_1",
+          balances: { credits: { remaining: 12.5 } },
+        },
+        "base",
+      ),
+    ).toEqual({
+      available: false,
+      planRemaining: 0,
+      topupRemaining: 0,
+      otherRemaining: 12.5,
+      planResetsAt: null,
+    });
+  });
+});
 
 const env: AutumnApiEnv = {
   AUTUMN_SECRET_KEY: "autumn-secret",

--- a/cloudflare-workers/api-edge/src/autumn_webhook.test.ts
+++ b/cloudflare-workers/api-edge/src/autumn_webhook.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { autumnPurchase, autumnSetAutoTopup, type AutumnApiEnv } from "./autumn_webhook";
+import {
+  autumnPurchase,
+  autumnSetAutoTopup,
+  autumnUsagePlanPurchase,
+  type AutumnApiEnv,
+} from "./autumn_webhook";
 
 const env: AutumnApiEnv = {
   AUTUMN_SECRET_KEY: "autumn-secret",
@@ -102,6 +107,72 @@ describe("Autumn recurring plan purchases", () => {
           customer_id: "org_1",
           product_id: "pro",
           success_url: "https://example.test/billing",
+        }),
+      }),
+    );
+  });
+});
+
+describe("Autumn shared-credit plan purchases", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("carries the remaining signup balance into the first paid plan", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json({
+        id: "org_1",
+        subscriptions: [{ plan_id: "base", add_on: false, status: "active" }],
+        purchases: [],
+      }))
+      .mockResolvedValueOnce(Response.json({ payment_url: "https://checkout.stripe.test/session" }));
+
+    await expect(autumnUsagePlanPurchase(env, {
+      customerId: "org_1",
+      planId: "pro",
+      successUrl: "https://example.test/billing?usage-plan=pro",
+    })).resolves.toEqual({ url: "https://checkout.stripe.test/session" });
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://autumn.test/v1/billing.attach",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          customer_id: "org_1",
+          plan_id: "pro",
+          success_url: "https://example.test/billing?usage-plan=pro",
+          plan_schedule: "immediate",
+          carry_over_balances: {
+            enabled: true,
+            feature_ids: ["credits"],
+          },
+        }),
+      }),
+    );
+  });
+
+  it("does not roll paid monthly grants into another paid plan", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json({
+        id: "org_1",
+        subscriptions: [{ plan_id: "pro", add_on: false, status: "active" }],
+        purchases: [],
+      }))
+      .mockResolvedValueOnce(Response.json({ payment_url: null }));
+
+    await expect(autumnUsagePlanPurchase(env, {
+      customerId: "org_1",
+      planId: "max",
+      successUrl: "https://example.test/billing?usage-plan=max",
+    })).resolves.toEqual({ url: null });
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://autumn.test/v1/billing.attach",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          customer_id: "org_1",
+          plan_id: "max",
+          success_url: "https://example.test/billing?usage-plan=max",
+          plan_schedule: "immediate",
         }),
       }),
     );

--- a/cloudflare-workers/api-edge/src/autumn_webhook.test.ts
+++ b/cloudflare-workers/api-edge/src/autumn_webhook.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { autumnSetAutoTopup, type AutumnApiEnv } from "./autumn_webhook";
+import { autumnPurchase, autumnSetAutoTopup, type AutumnApiEnv } from "./autumn_webhook";
 
 const env: AutumnApiEnv = {
   AUTUMN_SECRET_KEY: "autumn-secret",
@@ -53,5 +53,57 @@ describe("Autumn auto top-up", () => {
         budget: 90,
       }),
     ).rejects.toThrow("monthly budget divisible by quantity");
+  });
+});
+
+describe("Autumn recurring plan purchases", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("switches an existing paid subscriber directly through attach", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json({
+        id: "org_1",
+        subscriptions: [{ plan_id: "pro", add_on: false, status: "active" }],
+        purchases: [],
+      }))
+      .mockResolvedValueOnce(Response.json({}));
+
+    await expect(autumnPurchase(env, {
+      customerId: "org_1",
+      productId: "max",
+      successUrl: "https://example.test/billing",
+    })).resolves.toEqual({ url: null });
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://autumn.test/v1/attach",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ customer_id: "org_1", product_id: "max" }),
+      }),
+    );
+  });
+
+  it("starts hosted checkout when the customer has no payment history", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json({ id: "org_1", subscriptions: [], purchases: [] }))
+      .mockResolvedValueOnce(Response.json({ url: "https://checkout.stripe.test/session" }));
+
+    await expect(autumnPurchase(env, {
+      customerId: "org_1",
+      productId: "pro",
+      successUrl: "https://example.test/billing",
+    })).resolves.toEqual({ url: "https://checkout.stripe.test/session" });
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://autumn.test/v1/checkout",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          customer_id: "org_1",
+          product_id: "pro",
+          success_url: "https://example.test/billing",
+        }),
+      }),
+    );
   });
 });

--- a/cloudflare-workers/api-edge/src/autumn_webhook.test.ts
+++ b/cloudflare-workers/api-edge/src/autumn_webhook.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { autumnSetAutoTopup, type AutumnApiEnv } from "./autumn_webhook";
+
+const env: AutumnApiEnv = {
+  AUTUMN_SECRET_KEY: "autumn-secret",
+  AUTUMN_BASE_URL: "https://autumn.test/v1",
+};
+
+describe("Autumn auto top-up", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("converts the dollar budget to an exact monthly purchase limit", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(Response.json({}));
+
+    await autumnSetAutoTopup(env, "org_1", {
+      enabled: true,
+      threshold: 10,
+      quantity: 25,
+      budget: 100,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://autumn.test/v1/customers/org_1",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          billing_controls: {
+            auto_topups: [
+              {
+                feature_id: "credits",
+                enabled: true,
+                threshold: 10,
+                quantity: 25,
+                purchase_limit: {
+                  interval: "month",
+                  interval_count: 1,
+                  limit: 4,
+                },
+              },
+            ],
+          },
+        }),
+      }),
+    );
+  });
+
+  it("rejects a budget that cannot be represented as a hard purchase limit", async () => {
+    await expect(
+      autumnSetAutoTopup(env, "org_1", {
+        enabled: true,
+        threshold: 10,
+        quantity: 25,
+        budget: 90,
+      }),
+    ).rejects.toThrow("monthly budget divisible by quantity");
+  });
+});

--- a/cloudflare-workers/api-edge/src/autumn_webhook.ts
+++ b/cloudflare-workers/api-edge/src/autumn_webhook.ts
@@ -82,8 +82,97 @@ export interface AutumnCustomer {
   // (autumnTopUpCharge), that's also when auto-recharge becomes armed. So it's our
   // "auto-recharge will fire" signal (Autumn exposes no payment-method field).
   purchases?: Array<{ plan_id: string }>;
-  balances?: Record<string, { remaining?: number }>;
+  balances?: Record<string, AutumnBalance>;
   billing_controls?: { auto_topups?: AutumnAutoTopup[] };
+}
+
+export interface AutumnBalanceBreakdown {
+  plan_id?: string | null;
+  remaining?: number;
+  reset?: {
+    interval?: string;
+    resets_at?: number | null;
+  } | null;
+}
+
+export interface AutumnBalance {
+  remaining?: number;
+  next_reset_at?: number | null;
+  breakdown?: AutumnBalanceBreakdown[];
+  rollovers?: Array<{
+    balance?: number;
+    expires_at?: number | null;
+  }>;
+}
+
+export interface AutumnCreditBalanceSummary {
+  available: boolean;
+  planRemaining: number;
+  topupRemaining: number;
+  otherRemaining: number;
+  planResetsAt: number | null;
+}
+
+const PLAN_CREDIT_GRANTS: Record<string, number> = {
+  base: 5,
+  pro: 200,
+  max: 2_000,
+};
+
+export function summarizeAutumnCreditBalance(
+  customer: AutumnCustomer,
+  usagePlan: string,
+): AutumnCreditBalanceSummary {
+  const balance = customer.balances?.[CREDITS_FEATURE_ID];
+  const totalRemaining = Math.max(0, balance?.remaining ?? 0);
+  const breakdown = balance?.breakdown;
+
+  if (!breakdown?.length) {
+    return {
+      available: false,
+      planRemaining: 0,
+      topupRemaining: 0,
+      otherRemaining: totalRemaining,
+      planResetsAt: null,
+    };
+  }
+
+  const planRows = breakdown.filter((row) => row.plan_id === usagePlan);
+  const planGrant = PLAN_CREDIT_GRANTS[usagePlan] ?? 0;
+  const rawPlanRemaining = planRows.reduce(
+    (sum, row) => sum + Math.max(0, row.remaining ?? 0),
+    0,
+  );
+  const rolloverRemaining = (balance?.rollovers ?? []).reduce(
+    (sum, rollover) => sum + Math.max(0, rollover.balance ?? 0),
+    0,
+  );
+  // Autumn includes rollover balances in the active entitlement's remaining
+  // amount. Remove those explicit rollovers before labeling the monthly bucket.
+  const planRemaining = Math.min(
+    Math.max(0, rawPlanRemaining - rolloverRemaining),
+    planGrant,
+  );
+  const topupRemaining = breakdown
+    .filter((row) => row.plan_id === "top_up")
+    .reduce((sum, row) => sum + Math.max(0, row.remaining ?? 0), 0);
+  const resetCandidates = planRows
+    .map((row) => row.reset?.resets_at)
+    .filter(
+      (value): value is number =>
+        typeof value === "number" && Number.isFinite(value),
+    );
+
+  return {
+    available: true,
+    planRemaining,
+    topupRemaining,
+    otherRemaining: Math.max(0, totalRemaining - planRemaining - topupRemaining),
+    planResetsAt:
+      resetCandidates.length > 0
+        ? Math.min(...resetCandidates)
+        : balance?.next_reset_at ?? null,
+  };
 }
 
 function json(body: unknown, status = 200): Response {

--- a/cloudflare-workers/api-edge/src/autumn_webhook.ts
+++ b/cloudflare-workers/api-edge/src/autumn_webhook.ts
@@ -615,6 +615,49 @@ export async function autumnPurchase(
   return { url: co.url };
 }
 
+// autumnUsagePlanPurchase uses Autumn's current billing.attach API for the
+// mutually-exclusive Usage / Pro / Max plan group. When a customer leaves the
+// free Usage plan, preserve only the remaining shared-credit balance from that
+// plan. Purchased top-ups are already independent balances and continue to
+// stack; paid-plan switches keep Autumn's normal replacement/proration rules.
+export async function autumnUsagePlanPurchase(
+  env: AutumnApiEnv,
+  params: { customerId: string; planId: "pro" | "max"; successUrl: string },
+): Promise<{ url: string | null }> {
+  const customer = await getAutumnCustomer(env, params.customerId);
+  const upgradingFromUsage = (customer?.subscriptions ?? []).some(
+    (subscription) =>
+      subscription.plan_id === "base" &&
+      (!subscription.status || subscription.status === "active"),
+  );
+  const body: Record<string, unknown> = {
+    customer_id: params.customerId,
+    plan_id: params.planId,
+    success_url: params.successUrl,
+    plan_schedule: "immediate",
+  };
+  if (upgradingFromUsage) {
+    body.carry_over_balances = {
+      enabled: true,
+      feature_ids: [CREDITS_FEATURE_ID],
+    };
+  }
+
+  const base = env.AUTUMN_BASE_URL || DEFAULT_BASE_URL;
+  const resp = await fetch(`${base}/billing.attach`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.AUTUMN_SECRET_KEY}`,
+      "content-type": "application/json",
+      "x-api-version": "2.3.0",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) throw new Error(`autumn billing.attach ${resp.status}: ${await resp.text()}`);
+  const result = (await resp.json()) as { payment_url?: string | null };
+  return { url: result.payment_url ?? null };
+}
+
 // autumnSetupPayment creates a Stripe SETUP session that saves a card for future
 // OFF-SESSION use — POST /v1/billing.setup_payment. It does NOT charge (setup
 // mode), so arming auto-recharge takes a follow-up /attach once the card is on

--- a/cloudflare-workers/api-edge/src/autumn_webhook.ts
+++ b/cloudflare-workers/api-edge/src/autumn_webhook.ts
@@ -583,9 +583,10 @@ export async function autumnAttach(
   }
 }
 
-// autumnPurchase buys a product (concurrency tier), handling both Autumn flows.
-// It gates the direct /attach on hasToppedUp — a real prior charge means a card
-// is RELIABLY on file. We deliberately do NOT use the /checkout `url` probe to
+// autumnPurchase buys a recurring plan or concurrency add-on, handling both
+// Autumn flows. It gates direct /attach on a prior top-up or paid subscription —
+// either is reliable evidence that a card is on file. We deliberately do NOT
+// use the /checkout `url` probe to
 // detect a card: it can spuriously return null for a CARDLESS org, which then
 // takes the attach path → Autumn returns checkout_created → autumnAttach throws
 // → 502 (the same failure we fixed for top-up via autumnTopUpCharge). So:
@@ -597,7 +598,16 @@ export async function autumnPurchase(
   env: AutumnApiEnv,
   params: { customerId: string; productId: string; options?: AutumnCheckoutOption[]; successUrl: string },
 ): Promise<{ url: string | null }> {
-  if (await autumnHasToppedUp(env, params.customerId)) {
+  const customer = await getAutumnCustomer(env, params.customerId);
+  const hasPaidSubscription = (customer?.subscriptions ?? []).some(
+    (subscription) =>
+      (subscription.plan_id === "pro" || subscription.plan_id === "max") &&
+      (!subscription.status || subscription.status === "active"),
+  );
+  const hasToppedUp = (customer?.purchases ?? []).some(
+    (purchase) => purchase.plan_id === "top_up",
+  );
+  if (hasToppedUp || hasPaidSubscription) {
     await autumnAttach(env, { customerId: params.customerId, productId: params.productId, options: params.options });
     return { url: null };
   }

--- a/cloudflare-workers/api-edge/src/autumn_webhook.ts
+++ b/cloudflare-workers/api-edge/src/autumn_webhook.ts
@@ -67,6 +67,11 @@ export interface AutumnAutoTopup {
   enabled: boolean;
   threshold: number;
   quantity: number;
+  purchase_limit?: {
+    interval: "hour" | "day" | "week" | "month";
+    interval_count: number;
+    limit: number;
+  };
 }
 export interface AutumnCustomer {
   id: string;
@@ -411,7 +416,11 @@ export async function trackAutumnUsage(
   const base = env.AUTUMN_BASE_URL || DEFAULT_BASE_URL;
   const resp = await fetch(`${base}/track`, {
     method: "POST",
-    headers: { Authorization: `Bearer ${env.AUTUMN_SECRET_KEY}`, "content-type": "application/json" },
+    headers: {
+      Authorization: `Bearer ${env.AUTUMN_SECRET_KEY}`,
+      "content-type": "application/json",
+      "Idempotency-Key": p.idempotencyKey,
+    },
     body: JSON.stringify({
       customer_id: p.customerID,
       feature_id: p.featureID,
@@ -604,17 +613,40 @@ export async function autumnHasToppedUp(env: AutumnApiEnv, customerId: string): 
 export async function autumnSetAutoTopup(
   env: AutumnApiEnv,
   customerID: string,
-  cfg: { enabled: boolean; threshold: number; quantity: number },
+  cfg: { enabled: boolean; threshold: number; quantity: number; budget: number },
 ): Promise<void> {
+  if (
+    cfg.enabled &&
+    (!Number.isInteger(cfg.threshold) ||
+      cfg.threshold < 0 ||
+      !Number.isInteger(cfg.quantity) ||
+      cfg.quantity < 1 ||
+      !Number.isInteger(cfg.budget) ||
+      cfg.budget < cfg.quantity ||
+      cfg.budget % cfg.quantity !== 0)
+  ) {
+    throw new Error("auto-topup requires integer threshold, quantity, and a monthly budget divisible by quantity");
+  }
   const base = env.AUTUMN_BASE_URL || DEFAULT_BASE_URL;
+  const autoTopup: Record<string, unknown> = {
+    feature_id: CREDITS_FEATURE_ID,
+    enabled: cfg.enabled,
+    threshold: cfg.threshold,
+    quantity: cfg.quantity,
+  };
+  if (cfg.enabled) {
+    autoTopup.purchase_limit = {
+      interval: "month",
+      interval_count: 1,
+      limit: cfg.budget / cfg.quantity,
+    };
+  }
   const resp = await fetch(`${base}/customers/${encodeURIComponent(customerID)}`, {
     method: "POST",
     headers: { Authorization: `Bearer ${env.AUTUMN_SECRET_KEY}`, "content-type": "application/json" },
     body: JSON.stringify({
       billing_controls: {
-        auto_topups: [
-          { feature_id: CREDITS_FEATURE_ID, enabled: cfg.enabled, threshold: cfg.threshold, quantity: cfg.quantity },
-        ],
+        auto_topups: [autoTopup],
       },
     }),
   });

--- a/cloudflare-workers/api-edge/src/autumn_webhook.ts
+++ b/cloudflare-workers/api-edge/src/autumn_webhook.ts
@@ -35,6 +35,7 @@ export interface AutumnEnv extends AutumnSyncEnv {
   EVENT_SECRET: string;
   AUTUMN_WEBHOOK_SECRET: string;
   BROWSER_USAGE_HMAC_SECRET?: string;
+  AGENT_RUNTIME_USAGE_HMAC_SECRET?: string;
 }
 
 const DEFAULT_BASE_URL = "https://api.useautumn.com/v1";
@@ -220,6 +221,82 @@ export async function browserUsageInternal(req: Request, env: AutumnEnv): Promis
   } catch (err) {
     console.error(`browser-usage: track failed org=${p.org_id} browser=${p.browser_id}`, err);
     return json({ error: "browser usage billing failed" }, 502);
+  }
+}
+
+// Managed-agent runtime usage arrives only after the session Durable Object
+// has finalized a bounded lease segment. The segment ID is the financial
+// idempotency key; authenticated organization and session attribution travel
+// with it, but only the fixed resource tier controls the Autumn feature.
+export async function agentRuntimeUsageInternal(
+  req: Request,
+  env: AutumnEnv,
+): Promise<Response> {
+  const rawBody = await req.text();
+  const ts = req.headers.get("X-Timestamp") ?? "";
+  const sig = req.headers.get("X-Signature") ?? "";
+  if (!ts || !sig) return json({ error: "missing signature headers" }, 400);
+  const tsNum = parseInt(ts, 10);
+  if (!Number.isFinite(tsNum) || Math.abs(Date.now() / 1000 - tsNum) > SVIX_TOLERANCE_SEC) {
+    return json({ error: "timestamp out of window" }, 401);
+  }
+  const secret = env.AGENT_RUNTIME_USAGE_HMAC_SECRET;
+  if (!secret) return json({ error: "agent runtime usage billing is not configured" }, 503);
+  const url = new URL(req.url);
+  const expected = await hmacHex(secret, `${ts}.${url.pathname}.${rawBody}`);
+  if (!timingSafeEqual(expected, sig)) return json({ error: "signature mismatch" }, 401);
+
+  let p: {
+    org_id?: string;
+    project_id?: string;
+    environment?: string;
+    deployment_id?: string;
+    agent_id?: string;
+    session_id?: string;
+    microvm_id?: string;
+    resource_tier?: string;
+    quantity_seconds?: number;
+    idempotency_key?: string;
+  };
+  try {
+    p = JSON.parse(rawBody);
+  } catch {
+    return json({ error: "bad json" }, 400);
+  }
+  if (!p.org_id || !p.session_id || !p.deployment_id || !p.agent_id || !p.idempotency_key) {
+    return json(
+      { error: "org_id, session_id, deployment_id, agent_id, and idempotency_key required" },
+      400,
+    );
+  }
+  if (p.resource_tier !== "2gb_1vcpu") {
+    return json({ error: "unsupported resource_tier" }, 400);
+  }
+  if (!Number.isInteger(p.quantity_seconds) || Number(p.quantity_seconds) <= 0) {
+    return json({ error: "quantity_seconds must be a positive integer" }, 400);
+  }
+
+  try {
+    const remaining = await trackAutumnUsage(env, {
+      customerID: p.org_id,
+      featureID: "agent_runtime_2gb_1vcpu",
+      value: Number(p.quantity_seconds),
+      idempotencyKey: p.idempotency_key,
+    });
+    if (remaining !== null && remaining <= 0) await projectOrg(env, p.org_id);
+    return json({
+      ok: true,
+      billed: true,
+      org_id: p.org_id,
+      session_id: p.session_id,
+      remaining,
+    });
+  } catch (err) {
+    console.error(
+      `agent-runtime-usage: track failed org=${p.org_id} session=${p.session_id}`,
+      err,
+    );
+    return json({ error: "agent runtime usage billing failed" }, 502);
   }
 }
 

--- a/cloudflare-workers/api-edge/src/browser_usage.test.ts
+++ b/cloudflare-workers/api-edge/src/browser_usage.test.ts
@@ -77,6 +77,7 @@ describe("browser usage billing", () => {
         headers: {
           Authorization: "Bearer autumn-secret",
           "content-type": "application/json",
+          "Idempotency-Key": "browser_runtime:br_1",
         },
         body: JSON.stringify({
           customer_id: "org_1",

--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -19,6 +19,7 @@
 
 import {
   autumnPurchase,
+  autumnUsagePlanPurchase,
   autumnTopUpCharge,
   autumnAttach,
   autumnHasToppedUp,
@@ -1650,10 +1651,10 @@ async function handleAutumnUsagePlan(req: Request, env: DashboardEnv, caller: { 
   }
   const origin = new URL(req.url).origin;
   try {
-    const co = await autumnPurchase(env, {
+    const co = await autumnUsagePlanPurchase(env, {
       customerId: caller.orgID,
-      productId: plan,
-      successUrl: `${origin}/dashboard/billing?usage-plan=success`,
+      planId: plan,
+      successUrl: `${origin}/billing?usage-plan=${plan}`,
     });
     return json({ url: co.url });
   } catch (e) {

--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -1567,7 +1567,17 @@ async function handleAutumnBilling(_req: Request, env: DashboardEnv, caller: { o
     concurrencyPlan,
     isHalted: r.halted,
     hasToppedUp,
-    autoTopup: at ? { enabled: at.enabled, threshold: at.threshold, quantity: at.quantity } : null,
+    autoTopup: at
+      ? {
+          enabled: at.enabled,
+          threshold: at.threshold,
+          quantity: at.quantity,
+          budget:
+            at.purchase_limit?.interval === "month"
+              ? at.purchase_limit.limit * at.quantity
+              : null,
+        }
+      : null,
     modelUsage: {
       enabled: modelStatus === "active",
       status: modelStatus,
@@ -1579,13 +1589,14 @@ async function handleAutumnBilling(_req: Request, env: DashboardEnv, caller: { o
   });
 }
 
-// POST /api/dashboard/billing/autumn/auto-topup { enabled, threshold, quantity }
-// — configure automatic credit recharge. threshold/quantity are in credits ($1
-// each). A saved payment method is required for the charge to succeed; the
-// config itself persists regardless.
+// POST /api/dashboard/billing/autumn/auto-topup
+// { enabled, threshold, quantity, budget } — configure automatic credit
+// recharge. Monetary values are integer credits ($1 each). Autumn expresses the
+// hard monthly budget as a purchase count, so budget must be a whole multiple of
+// quantity. A saved payment method is required for charges to succeed.
 async function handleAutumnAutoTopup(req: Request, env: DashboardEnv, caller: { orgID: string }): Promise<Response> {
   if (!env.AUTUMN_SECRET_KEY) return json({ error: "autumn billing not configured" }, 503);
-  let body: { enabled?: boolean; threshold?: number; quantity?: number };
+  let body: { enabled?: boolean; threshold?: number; quantity?: number; budget?: number };
   try {
     body = await req.json();
   } catch {
@@ -1594,11 +1605,24 @@ async function handleAutumnAutoTopup(req: Request, env: DashboardEnv, caller: { 
   const enabled = !!body.enabled;
   const threshold = Math.floor(body.threshold ?? 0);
   const quantity = Math.floor(body.quantity ?? 0);
-  if (enabled && (threshold < 0 || quantity < 1)) {
-    return json({ error: "threshold ≥ 0 and quantity ≥ 1 required when enabling" }, 400);
+  const budget = Math.floor(body.budget ?? 0);
+  if (
+    enabled &&
+    (!Number.isFinite(threshold) ||
+      threshold < 0 ||
+      !Number.isFinite(quantity) ||
+      quantity < 1 ||
+      !Number.isFinite(budget) ||
+      budget < quantity ||
+      budget % quantity !== 0)
+  ) {
+    return json(
+      { error: "threshold ≥ 0, quantity ≥ 1, and a monthly budget divisible by quantity are required" },
+      400,
+    );
   }
   try {
-    await autumnSetAutoTopup(env, caller.orgID, { enabled, threshold, quantity });
+    await autumnSetAutoTopup(env, caller.orgID, { enabled, threshold, quantity, budget });
 
     // Auto-recharge is armed once the customer has charged a top-up (a
     // saved-but-never-charged card is unarmed). If they've already topped up, just

--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -24,6 +24,7 @@ import {
   autumnAttach,
   autumnHasToppedUp,
   syncAutumnToD1,
+  summarizeAutumnCreditBalance,
   autumnSetAutoTopup,
   autumnOpenCustomerPortal,
 } from "./autumn_webhook";
@@ -1574,6 +1575,7 @@ async function handleAutumnBilling(_req: Request, env: DashboardEnv, caller: { o
   // recharge or just save. Free — the customer is already loaded above.
   const hasToppedUp = (r.customer.purchases ?? []).some((p) => p.plan_id === "top_up");
   const hasPaidSubscription = usagePlan === "pro" || usagePlan === "max";
+  const creditBreakdown = summarizeAutumnCreditBalance(r.customer, usagePlan);
 
   const model = await env.OPENCOMPUTER_DB.prepare(
     `SELECT
@@ -1599,9 +1601,28 @@ async function handleAutumnBilling(_req: Request, env: DashboardEnv, caller: { o
   const modelMarkupBps = model?.markup_bps ?? 0;
   const modelProviderSpendCents = Math.round((model?.committed_micro ?? 0) / 10_000);
   const modelBilledCreditsCents = Math.round(modelProviderSpendCents * (1 + modelMarkupBps / 10_000));
+  const creditsRemainingCents = Math.max(0, Math.round(r.creditsRemaining * 100));
+  const planRemainingCents = Math.min(
+    creditsRemainingCents,
+    Math.round(creditBreakdown.planRemaining * 100),
+  );
+  const topupRemainingCents = Math.min(
+    creditsRemainingCents - planRemainingCents,
+    Math.round(creditBreakdown.topupRemaining * 100),
+  );
 
   return json({
-    creditsRemainingCents: Math.round(r.creditsRemaining * 100),
+    creditsRemainingCents,
+    creditBreakdown: {
+      available: creditBreakdown.available,
+      planRemainingCents,
+      topupRemainingCents,
+      otherRemainingCents:
+        creditsRemainingCents - planRemainingCents - topupRemainingCents,
+      planResetsAt: creditBreakdown.planResetsAt == null
+        ? null
+        : new Date(creditBreakdown.planResetsAt).toISOString(),
+    },
     maxConcurrentSandboxes: r.maxConcurrent,
     concurrencyPlan,
     usagePlan,

--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -33,6 +33,7 @@ import {
 } from "./agent_security_notifications";
 import { createAPIKey } from "./api_keys";
 import { proxyManagedAgents } from "./managed_agents";
+import { enableManagedBilling } from "./model_billing";
 
 export interface DashboardEnv {
   OPENCOMPUTER_DB: D1Database;
@@ -70,6 +71,10 @@ export interface DashboardEnv {
   // never receives the backend URL or assertion secret.
   MANAGED_AGENTS_API_URL?: string;
   OC_MANAGED_AGENTS_SECRET?: string;
+  OPENROUTER_PROVISIONING_KEY: string;
+  OPENROUTER_BASE_URL?: string;
+  OPENROUTER_MARKUP_BPS?: string;
+  OC_MANAGED_CRED_HMAC_SECRET: string;
 }
 
 const SESSION_COOKIE = "oc_session";
@@ -955,6 +960,20 @@ export async function handleDashboard(
 
   // ── Managed Agents experiment ───────────────────────────────────────────
   if (sub === "/managed-agents" || sub.startsWith("/managed-agents/")) {
+    if (sub === "/managed-agents/sessions" && method === "POST") {
+      try {
+        const billing = await enableManagedBilling(env, caller.orgID);
+        if (billing.status !== "active") {
+          return json({ error: "managed model billing is unavailable" }, 503);
+        }
+      } catch (error) {
+        console.error(
+          `managed-agents: model billing admission failed org=${caller.orgID}`,
+          error,
+        );
+        return json({ error: "managed model billing is unavailable" }, 503);
+      }
+    }
     return proxyManagedAgents(
       req,
       env,
@@ -1543,6 +1562,7 @@ async function handleAutumnBilling(_req: Request, env: DashboardEnv, caller: { o
        o.model_billing_status AS status,
        o.model_markup_bps AS markup_bps,
        COUNT(CASE WHEN k.status = 'active' THEN 1 END) AS active_key_count,
+       MIN(k.created_at) AS billing_started_at,
        COALESCE(SUM(k.committed_micro), 0) AS committed_micro
      FROM orgs o
      LEFT JOIN managed_model_keys k
@@ -1554,6 +1574,7 @@ async function handleAutumnBilling(_req: Request, env: DashboardEnv, caller: { o
     status: string;
     markup_bps: number;
     active_key_count: number;
+    billing_started_at: number | null;
     committed_micro: number;
   }>();
   const modelStatus = model?.status ?? "off";
@@ -1585,6 +1606,10 @@ async function handleAutumnBilling(_req: Request, env: DashboardEnv, caller: { o
       providerSpendCents: modelProviderSpendCents,
       billedCreditsCents: modelBilledCreditsCents,
       activeKeyCount: model?.active_key_count ?? 0,
+      billingStartedAt:
+        model?.billing_started_at != null
+          ? new Date(Number(model.billing_started_at) * 1_000).toISOString()
+          : null,
     },
   });
 }

--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -1257,6 +1257,9 @@ export async function handleDashboard(
   if (sub === "/billing/autumn/topup" && method === "POST") {
     return handleAutumnTopup(req, env, caller);
   }
+  if (sub === "/billing/autumn/plan" && method === "POST") {
+    return handleAutumnUsagePlan(req, env, caller);
+  }
   if (sub === "/billing/autumn/concurrency" && method === "POST") {
     return handleAutumnConcurrency(req, env, caller);
   }
@@ -1524,6 +1527,12 @@ const AUTUMN_CONCURRENCY_PRODUCTS: Record<string, number> = {
   concurrency_pro_plus_plus: 1000,
 };
 
+const AUTUMN_USAGE_PLANS: Record<string, number> = {
+  base: 0,
+  pro: 1,
+  max: 2,
+};
+
 // GET /api/dashboard/billing/autumn — prepaid credit balance + concurrency plan.
 // Re-syncs Autumn → D1 on the way (this is the checkout-return / page-view resume
 // trigger: a just-topped-up user's is_halted clears here even if the webhook lagged).
@@ -1540,13 +1549,20 @@ async function handleAutumnBilling(_req: Request, env: DashboardEnv, caller: { o
 
   // The active concurrency plan = the highest non-base plan the customer holds.
   let concurrencyPlan = "base";
+  let usagePlan = "base";
   let best = 0;
+  let bestUsagePlan = 0;
   for (const s of r.customer.subscriptions ?? []) {
     if (s.status && s.status !== "active") continue;
     const v = AUTUMN_CONCURRENCY_PRODUCTS[s.plan_id];
     if (v !== undefined && v > best) {
       best = v;
       concurrencyPlan = s.plan_id;
+    }
+    const usageRank = AUTUMN_USAGE_PLANS[s.plan_id];
+    if (usageRank !== undefined && usageRank >= bestUsagePlan) {
+      bestUsagePlan = usageRank;
+      usagePlan = s.plan_id;
     }
   }
 
@@ -1556,6 +1572,7 @@ async function handleAutumnBilling(_req: Request, env: DashboardEnv, caller: { o
   // so the UI uses it to tell whether enabling auto-recharge will run a first
   // recharge or just save. Free — the customer is already loaded above.
   const hasToppedUp = (r.customer.purchases ?? []).some((p) => p.plan_id === "top_up");
+  const hasPaidSubscription = usagePlan === "pro" || usagePlan === "max";
 
   const model = await env.OPENCOMPUTER_DB.prepare(
     `SELECT
@@ -1586,8 +1603,10 @@ async function handleAutumnBilling(_req: Request, env: DashboardEnv, caller: { o
     creditsRemainingCents: Math.round(r.creditsRemaining * 100),
     maxConcurrentSandboxes: r.maxConcurrent,
     concurrencyPlan,
+    usagePlan,
     isHalted: r.halted,
     hasToppedUp,
+    hasPaidSubscription,
     autoTopup: at
       ? {
           enabled: at.enabled,
@@ -1612,6 +1631,35 @@ async function handleAutumnBilling(_req: Request, env: DashboardEnv, caller: { o
           : null,
     },
   });
+}
+
+// POST /api/dashboard/billing/autumn/plan { plan } — subscribe to or switch
+// between the recurring Pro and Max shared-credit plans. Usage remains the
+// automatic fallback when a paid subscription is cancelled in Stripe.
+async function handleAutumnUsagePlan(req: Request, env: DashboardEnv, caller: { orgID: string }): Promise<Response> {
+  if (!env.AUTUMN_SECRET_KEY) return json({ error: "autumn billing not configured" }, 503);
+  let body: { plan?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "bad json" }, 400);
+  }
+  const plan = body.plan ?? "";
+  if (plan !== "pro" && plan !== "max") {
+    return json({ error: `unknown usage plan '${plan}'` }, 400);
+  }
+  const origin = new URL(req.url).origin;
+  try {
+    const co = await autumnPurchase(env, {
+      customerId: caller.orgID,
+      productId: plan,
+      successUrl: `${origin}/dashboard/billing?usage-plan=success`,
+    });
+    return json({ url: co.url });
+  } catch (e) {
+    console.error("billing/autumn plan:", e);
+    return json({ error: (e as Error).message }, 502);
+  }
 }
 
 // POST /api/dashboard/billing/autumn/auto-topup

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -61,6 +61,10 @@ import {
 import { runAutumnMeter } from "./autumn_meter";
 import { disableManagedBilling, enableManagedBilling } from "./model_billing";
 import { runModelMeter } from "./model_meter";
+import {
+  enforceManagedAgentCreditGate,
+  insufficientManagedAgentCredits,
+} from "./managed_agent_credit_gate";
 import { runRetentionSweep } from "./retention";
 import * as secretStores from "./secret_stores";
 import * as snapshots from "./snapshots";
@@ -4587,6 +4591,9 @@ export default {
       if (path === "/api/managed-agents/sessions" && req.method === "POST") {
         try {
           const billing = await enableManagedBilling(env, caller.orgID);
+          if (billing.status === "halted") {
+            return insufficientManagedAgentCredits(req);
+          }
           if (billing.status !== "active") {
             return json({ error: "managed model billing is unavailable" }, 503);
           }
@@ -4597,6 +4604,13 @@ export default {
           );
           return json({ error: "managed model billing is unavailable" }, 503);
         }
+      } else {
+        const creditError = await enforceManagedAgentCreditGate(
+          req,
+          env,
+          caller.orgID,
+        );
+        if (creditError) return creditError;
       }
       return proxyManagedAgents(
         req,

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -4584,6 +4584,20 @@ export default {
       }
       const scopeError = provisionScopeGate(caller, path);
       if (scopeError) return scopeError;
+      if (path === "/api/managed-agents/sessions" && req.method === "POST") {
+        try {
+          const billing = await enableManagedBilling(env, caller.orgID);
+          if (billing.status !== "active") {
+            return json({ error: "managed model billing is unavailable" }, 503);
+          }
+        } catch (error) {
+          console.error(
+            `managed-agents: model billing admission failed org=${caller.orgID}`,
+            error,
+          );
+          return json({ error: "managed model billing is unavailable" }, 503);
+        }
+      }
       return proxyManagedAgents(
         req,
         env,

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -53,6 +53,7 @@ import {
   autumnWebhook,
   autumnProjectInternal,
   autumnSetProviderInternal,
+  agentRuntimeUsageInternal,
   browserUsageInternal,
   selfHealHalt,
   createAutumnCustomer,
@@ -94,6 +95,8 @@ export interface Env extends DashboardEnv {
   // HMAC secret used by Browser API to submit runtime usage. Falls back to
   // EVENT_SECRET in the handler when unset for compatibility during rollout.
   BROWSER_USAGE_HMAC_SECRET?: string;
+  // Dedicated HMAC secret for finalized managed-agent runtime segments.
+  AGENT_RUNTIME_USAGE_HMAC_SECRET?: string;
   // Shared with every CP via Infisical /shared/ → per-cell KV/SM. Used for
   // envelope encryption of secret_store_entries.encrypted_value. Matches
   // internal/crypto.Encryptor key format (hex-encoded 32 bytes).
@@ -4227,6 +4230,10 @@ export default {
     if (path === "/internal/browser-usage") {
       if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
       return browserUsageInternal(req, env);
+    }
+    if (path === "/internal/agent-runtime-usage") {
+      if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+      return agentRuntimeUsageInternal(req, env);
     }
     if (path === AGENT_SECURITY_NOTIFICATION_PATH) {
       return receiveAgentSecurityNotification(req, env);

--- a/cloudflare-workers/api-edge/src/managed_agent_credit_gate.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agent_credit_gate.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  enforceManagedAgentCreditGate,
+  insufficientManagedAgentCredits,
+  isManagedAgentBillableRequest,
+  isManagedAgentCreditHalted,
+} from "./managed_agent_credit_gate";
+
+class FakeStatement {
+  private orgID = "";
+
+  constructor(private readonly halted: number | null) {}
+
+  bind(orgID: string): this {
+    this.orgID = orgID;
+    return this;
+  }
+
+  async first<T>(): Promise<T | null> {
+    expect(this.orgID).toBe("org_test");
+    return (this.halted === null
+      ? null
+      : { is_halted: this.halted }) as T | null;
+  }
+}
+
+function env(halted: number | null) {
+  return {
+    OPENCOMPUTER_DB: {
+      prepare(sql: string) {
+        expect(sql).toBe("SELECT is_halted FROM orgs WHERE id = ?1");
+        return new FakeStatement(halted);
+      },
+    } as unknown as D1Database,
+  };
+}
+
+describe("managed-agent credit admission", () => {
+  it.each([
+    "/api/managed-agents/sessions",
+    "/api/managed-agents/sessions/session_1/turns",
+    "/api/managed-agents/sessions/session_1/resume",
+    "/api/managed-agents/schedules/daily-review/run",
+  ])("recognizes billable POST %s", (path) => {
+    expect(isManagedAgentBillableRequest("POST", path)).toBe(true);
+  });
+
+  it.each([
+    ["GET", "/api/managed-agents/sessions"],
+    ["POST", "/api/managed-agents/sessions/session_1/suspend"],
+    ["POST", "/api/managed-agents/sessions/session_1/end"],
+    ["GET", "/api/managed-agents/schedules"],
+  ])("does not gate non-billable %s %s", (method, path) => {
+    expect(isManagedAgentBillableRequest(method, path)).toBe(false);
+  });
+
+  it("reads the D1 halt projection", async () => {
+    await expect(isManagedAgentCreditHalted(env(1), "org_test")).resolves.toBe(
+      true,
+    );
+    await expect(isManagedAgentCreditHalted(env(0), "org_test")).resolves.toBe(
+      false,
+    );
+    await expect(
+      isManagedAgentCreditHalted(env(null), "org_test"),
+    ).resolves.toBe(false);
+  });
+
+  it("returns a typed, actionable 402", async () => {
+    const response = insufficientManagedAgentCredits(
+      new Request("https://mo-oc-dev.com/api/managed-agents/sessions"),
+    );
+    expect(response.status).toBe(402);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "insufficient_credits",
+        message:
+          "Insufficient prepaid credits. Top up or enable automatic top-up: https://mo-oc-dev.com/billing",
+        actionUrl: "https://mo-oc-dev.com/billing",
+      },
+    });
+  });
+
+  it("allows active organizations and fails open when D1 is unavailable", async () => {
+    const request = new Request(
+      "https://mo-oc-dev.com/api/managed-agents/sessions/session_1/turns",
+      { method: "POST" },
+    );
+    await expect(
+      enforceManagedAgentCreditGate(request, env(0), "org_test"),
+    ).resolves.toBeNull();
+
+    const error = new Error("D1 unavailable");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const brokenEnv = {
+      OPENCOMPUTER_DB: {
+        prepare() {
+          throw error;
+        },
+      } as unknown as D1Database,
+    };
+    await expect(
+      enforceManagedAgentCreditGate(request, brokenEnv, "org_test"),
+    ).resolves.toBeNull();
+    expect(consoleError).toHaveBeenCalledWith(
+      "managed-agents: credit admission unavailable org=org_test",
+      error,
+    );
+    consoleError.mockRestore();
+  });
+});

--- a/cloudflare-workers/api-edge/src/managed_agent_credit_gate.ts
+++ b/cloudflare-workers/api-edge/src/managed_agent_credit_gate.ts
@@ -1,0 +1,69 @@
+export interface ManagedAgentCreditGateEnv {
+  OPENCOMPUTER_DB: D1Database;
+}
+
+interface ManagedAgentCreditRow {
+  is_halted: number;
+}
+
+export function isManagedAgentBillableRequest(
+  method: string,
+  path: string,
+): boolean {
+  if (method.toUpperCase() !== "POST") return false;
+  if (path === "/api/managed-agents/sessions") return true;
+  return (
+    /^\/api\/managed-agents\/sessions\/[^/]+\/(turns|resume)$/.test(path) ||
+    /^\/api\/managed-agents\/schedules\/[^/]+\/run$/.test(path)
+  );
+}
+
+export async function isManagedAgentCreditHalted(
+  env: ManagedAgentCreditGateEnv,
+  orgID: string,
+): Promise<boolean> {
+  const row = await env.OPENCOMPUTER_DB.prepare(
+    "SELECT is_halted FROM orgs WHERE id = ?1",
+  )
+    .bind(orgID)
+    .first<ManagedAgentCreditRow>();
+  return row?.is_halted === 1;
+}
+
+export function insufficientManagedAgentCredits(request: Request): Response {
+  const billingURL = new URL("/billing", request.url).toString();
+  return Response.json(
+    {
+      error: {
+        code: "insufficient_credits",
+        message:
+          `Insufficient prepaid credits. Top up or enable automatic top-up: ${billingURL}`,
+        actionUrl: billingURL,
+      },
+    },
+    { status: 402 },
+  );
+}
+
+export async function enforceManagedAgentCreditGate(
+  request: Request,
+  env: ManagedAgentCreditGateEnv,
+  orgID: string,
+): Promise<Response | null> {
+  if (!isManagedAgentBillableRequest(request.method, new URL(request.url).pathname)) {
+    return null;
+  }
+  try {
+    return (await isManagedAgentCreditHalted(env, orgID))
+      ? insufficientManagedAgentCredits(request)
+      : null;
+  } catch (error) {
+    // D1 is the low-latency projection, not the financial authority. Preserve
+    // availability and rely on the provider key limit as the hard backstop.
+    console.error(
+      `managed-agents: credit admission unavailable org=${orgID}`,
+      error,
+    );
+    return null;
+  }
+}

--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -136,7 +136,7 @@ describe("managed agents proxy", () => {
   });
 
   it("claims a channel grant and redirects to the provider", async () => {
-    const fetchSpy = vi.fn(async () =>
+    const fetchSpy = vi.fn(async (_input: RequestInfo | URL) =>
       Response.json({
         authorizationUrl: "https://connect.example.test/authorize",
       }),
@@ -1127,6 +1127,58 @@ describe("managed agents proxy", () => {
       "The agent service is temporarily unavailable.",
     );
     expect(JSON.stringify(body)).not.toMatch(/blue|lambda|microvm/i);
+  });
+
+  it("exposes durable per-session billing attribution", async () => {
+    const fetchSpy = vi.fn(async (_input: RequestInfo | URL) =>
+      Response.json({
+        sessions: [
+          {
+            id: "session-1",
+            agentId: "reviewer",
+            deploymentId: "reviewer:digest",
+            source: "schedule",
+            status: "idle",
+            title: "Review stale flags",
+            createdAt: "2026-08-22T00:00:00.000Z",
+            updatedAt: "2026-08-22T00:01:00.000Z",
+            modelCalls: 2,
+            modelProviderCostUsd: 0.0123,
+            modelUsage: [
+              { timestamp: "2026-08-22T00:00:30.000Z", costUsd: 0.0123 },
+            ],
+            runtimeSecondsByTier: { "2gb_1vcpu": 40 },
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const response = await proxyManagedAgents(
+      new Request(
+        "https://app.opencomputer.dev/api/dashboard/managed-agents/billing/sessions?limit=100",
+      ),
+      {
+        OC_MANAGED_AGENTS_SECRET: "test-secret",
+        MANAGED_AGENTS_API_URL: "https://managedagents.test",
+      },
+      { orgID: "org_test", userID: "user_test" },
+      "/api/dashboard/managed-agents",
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      sessions: [
+        {
+          id: "session-1",
+          modelProviderCostUsd: 0.0123,
+          runtimeSecondsByTier: { "2gb_1vcpu": 40 },
+        },
+      ],
+    });
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toBe(
+      "https://managedagents.test/v1/billing/sessions?limit=100",
+    );
   });
 
   it("forwards explicit running-session input modes", async () => {

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -120,6 +120,11 @@ async function publicErrorResponse(upstream: Response): Promise<Response> {
     }
   } else if (upstream.status === 429) {
     message = "Too many agent requests. Try again shortly.";
+  } else if (upstream.status === 402) {
+    message =
+      backendCode === "insufficient_credits"
+        ? "Insufficient prepaid credits. Top up or enable automatic top-up."
+        : "The agent request requires additional prepaid credits.";
   } else if (upstream.status >= 500) {
     message = "The agent service is temporarily unavailable.";
   }

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -644,6 +644,9 @@ function publicSuccessBody(
       duplicate: body.duplicate,
     };
   }
+  if (method === "GET" && suffix === "/billing/sessions") {
+    return stripPrivateValues(body);
+  }
   if (method === "POST" && /\/suspend$/.test(suffix)) {
     return {
       id: body.id,
@@ -859,6 +862,7 @@ function isAllowedManagedAgentsRoute(method: string, suffix: string): boolean {
   if (suffix.startsWith("/openrouter/")) return true;
   if (method === "POST" && suffix === "/sessions") return true;
   if (method === "GET" && suffix === "/sessions") return true;
+  if (method === "GET" && suffix === "/billing/sessions") return true;
   if (method === "GET" && /^\/sessions\/[^/]+$/.test(suffix)) return true;
   if (method === "GET" && /^\/sessions\/[^/]+\/events$/.test(suffix)) {
     return true;

--- a/cloudflare-workers/api-edge/src/model_billing.test.ts
+++ b/cloudflare-workers/api-edge/src/model_billing.test.ts
@@ -21,6 +21,7 @@ interface OrgRow {
   billing_provider: string;
   model_billing_status: string;
   model_markup_bps: number;
+  is_halted?: number;
 }
 
 class FakeDb {
@@ -228,6 +229,20 @@ describe("openrouter client", () => {
 });
 
 describe("enableManagedBilling state machine", () => {
+  it("returns halted before provisioning or calling a provider", async () => {
+    const db = new FakeDb();
+    const orgId = seedOrg(db, { is_halted: 1 });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(enableManagedBilling(makeEnv(db), orgId)).resolves.toEqual({
+      status: "halted",
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(db.keys).toHaveLength(0);
+    expect(db.orgs.get(orgId)!.model_billing_status).toBe("off");
+  });
+
   it("off → active: mints key, binds credential, flips org", async () => {
     const db = new FakeDb();
     const orgId = seedOrg(db);

--- a/cloudflare-workers/api-edge/src/model_billing.ts
+++ b/cloudflare-workers/api-edge/src/model_billing.ts
@@ -66,6 +66,7 @@ interface OrgBillingRow {
   billing_provider: string;
   model_billing_status: string;
   model_markup_bps: number;
+  is_halted?: number;
 }
 
 // sessions-api owner id for an OC org. MUST match sessions-api's ownerIdForOrg
@@ -96,7 +97,7 @@ function markupBps(env: ModelBillingEnv, org: OrgBillingRow): number {
 
 async function getOrg(env: ModelBillingEnv, orgId: string): Promise<OrgBillingRow | null> {
   return env.OPENCOMPUTER_DB.prepare(
-    "SELECT id, billing_provider, model_billing_status, model_markup_bps FROM orgs WHERE id = ?1",
+    "SELECT id, billing_provider, model_billing_status, model_markup_bps, is_halted FROM orgs WHERE id = ?1",
   )
     .bind(orgId)
     .first<OrgBillingRow>();
@@ -305,7 +306,7 @@ async function revokeManagedCredential(env: ModelBillingEnv, ownerId: string): P
 // ── the state machine ───────────────────────────────────────────────────────
 
 export interface EnableResult {
-  status: "active" | "error";
+  status: "active" | "error" | "halted";
   credentialId?: string;
 }
 
@@ -315,6 +316,10 @@ export interface EnableResult {
 export async function enableManagedBilling(env: ModelBillingEnv, orgId: string): Promise<EnableResult> {
   const org = await getOrg(env, orgId);
   if (!org) throw new Error(`model-billing: org ${orgId} not found`);
+  // Reuse the row this path already reads so session creation pays no extra D1
+  // round trip for credit admission. OpenRouter's per-org key limit remains the
+  // hard backstop if this asynchronously maintained projection briefly lags.
+  if (org.is_halted === 1) return { status: "halted" };
   if (org.model_billing_status === "active") {
     const active = await getActiveKeyRow(env, orgId);
     if (active) {

--- a/cloudflare-workers/api-edge/src/model_billing.ts
+++ b/cloudflare-workers/api-edge/src/model_billing.ts
@@ -1,8 +1,8 @@
-// Token / model-usage billing — provisioning state machine + the edge→sessions-api
+// Token / model-usage billing — provisioning state machine + the edge→managed-agent
 // key hand-off (design: .agents/work/token-billing.md §5.1, §6.7.5). The edge owns
 // the whole OpenRouter lifecycle (Autumn/OR are edge-native); this module drives one
 // managed org from `model_billing_status` off → provisioning → active, minting a
-// per-org OR key and binding it to a sessions-api credential.
+// per-org OR key and binding it to an encrypted managed-agent credential.
 //
 // The metering cron (model_meter, §5.4) is a separate file (step 3); this is step 1:
 // the key lifecycle + per-org state only.
@@ -18,6 +18,9 @@ export interface ModelBillingEnv extends OpenRouterEnv, AutumnApiEnv {
   OPENCOMPUTER_DB: D1Database;
   // sessions-api base URL (shared with the dashboard /v3 proxy). Default = prod.
   SESSIONS_API_URL?: string;
+  // Private managed-agent backend. Preferred for new Serverless Agent key
+  // custody; SESSIONS_API_URL remains a compatibility fallback during rollout.
+  MANAGED_AGENTS_API_URL?: string;
   // DEDICATED HMAC secret for the plaintext-key hand-off (§6.7.5 / P2-f). NOT the
   // generic internal-auth secret — this route carries a live model key. Shared
   // only with sessions-api.
@@ -238,7 +241,11 @@ async function signedHandoff(
   if (!env.OC_MANAGED_CRED_HMAC_SECRET) {
     throw new Error("model-billing: OC_MANAGED_CRED_HMAC_SECRET unset — refusing hand-off");
   }
-  const base = (env.SESSIONS_API_URL ?? DEFAULT_SESSIONS_API).replace(/\/+$/, "");
+  const base = (
+    env.MANAGED_AGENTS_API_URL ??
+    env.SESSIONS_API_URL ??
+    DEFAULT_SESSIONS_API
+  ).replace(/\/+$/, "");
   const ts = Math.floor(Date.now() / 1000).toString();
   const sig = await hmacHex(env.OC_MANAGED_CRED_HMAC_SECRET, `${ts}.${method}.${path}.${body}`);
   const resp = await fetch(`${base}${path}`, {
@@ -308,6 +315,15 @@ export interface EnableResult {
 export async function enableManagedBilling(env: ModelBillingEnv, orgId: string): Promise<EnableResult> {
   const org = await getOrg(env, orgId);
   if (!org) throw new Error(`model-billing: org ${orgId} not found`);
+  if (org.model_billing_status === "active") {
+    const active = await getActiveKeyRow(env, orgId);
+    if (active) {
+      return {
+        status: "active",
+        credentialId: active.managed_credential_id ?? undefined,
+      };
+    }
+  }
   // Managed is available to ANY org (decoupled from billing). Autumn orgs meter
   // against the shared credit pool; non-autumn orgs run on a fixed OR-key budget
   // (see budgetFor). The provider only changes the budget source, never whether

--- a/scripts/autumn/README.md
+++ b/scripts/autumn/README.md
@@ -3,10 +3,12 @@
 This directory defines the Autumn features and plans used to bill serverless
 agent sessions. It contains no environment credentials.
 
-The catalog currently covers the shared credit balance, the fixed 2 GB / 1
-vCPU agent runtime meter, managed model spend, Usage/Pro/Max plans, and one-off
-top-ups. Raw standalone-sandbox products are intentionally outside this
-catalog and have a separate rollout lifecycle.
+The catalog is a complete declaration of the shared Autumn environment. It
+preserves the existing standalone-sandbox compute, browser, disk, concurrency,
+base-credit, model-spend, and top-up resources, and adds the fixed 2 GB / 1 vCPU
+agent runtime meter plus the Pro and Max plans. Even when a rollout changes
+only agent-session billing, existing resources must remain declared so the CLI
+does not propose deleting or archiving them.
 
 To create or reconcile a sandbox catalog:
 
@@ -21,3 +23,17 @@ configuring a development environment.
 
 After pushing the catalog, configure the API edge with the same sandbox key and
 the signing secret for a webhook targeting `/webhooks/autumn`.
+
+To preview and reconcile the production catalog, use an Autumn production key
+and keep the first push interactive:
+
+```sh
+npm ci
+AUTUMN_PROD_SECRET_KEY=<production-key> npm run preview:prod
+AUTUMN_PROD_SECRET_KEY=<production-key> npm run push:prod
+```
+
+The `--prod` flag selects Autumn's production environment. Review the complete
+diff and verify the connected Stripe account before confirming the push. Do not
+use `--yes` for the first production reconciliation. The deployed API edge uses
+the same production key under its runtime secret name `AUTUMN_SECRET_KEY`.

--- a/scripts/autumn/README.md
+++ b/scripts/autumn/README.md
@@ -1,7 +1,12 @@
 # Autumn billing catalog
 
-This directory defines the Autumn features and plans expected by
-OpenComputer's usage-billing code. It contains no environment credentials.
+This directory defines the Autumn features and plans used to bill serverless
+agent sessions. It contains no environment credentials.
+
+The catalog currently covers the shared credit balance, the fixed 2 GB / 1
+vCPU agent runtime meter, managed model spend, Usage/Pro/Max plans, and one-off
+top-ups. Raw standalone-sandbox products are intentionally outside this
+catalog and have a separate rollout lifecycle.
 
 To create or reconcile a sandbox catalog:
 

--- a/scripts/autumn/README.md
+++ b/scripts/autumn/README.md
@@ -1,0 +1,18 @@
+# Autumn billing catalog
+
+This directory defines the Autumn features and plans expected by
+OpenComputer's usage-billing code. It contains no environment credentials.
+
+To create or reconcile a sandbox catalog:
+
+```sh
+npm ci
+AUTUMN_SECRET_KEY=<sandbox-key> npm run push:sandbox
+```
+
+The command targets Autumn's sandbox environment by default. Review the diff
+printed by the CLI before confirming it. Do not add the production flag when
+configuring a development environment.
+
+After pushing the catalog, configure the API edge with the same sandbox key and
+the signing secret for a webhook targeting `/webhooks/autumn`.

--- a/scripts/autumn/autumn.config.ts
+++ b/scripts/autumn/autumn.config.ts
@@ -38,12 +38,43 @@ export const base = plan({
   id: "base",
   name: "Usage",
   description: "Default OpenComputer usage balance.",
+  group: "usage_plan",
   autoEnable: true,
   items: [
     item({
       featureId: credits.id,
       included: 5,
       reset: { interval: "one_off" },
+    }),
+  ],
+});
+
+export const pro = plan({
+  id: "pro",
+  name: "Pro",
+  description: "$20 per month with $200 in shared OpenComputer credits.",
+  group: "usage_plan",
+  price: { amount: 20, interval: "month" },
+  items: [
+    item({
+      featureId: credits.id,
+      included: 200,
+      reset: { interval: "month" },
+    }),
+  ],
+});
+
+export const max = plan({
+  id: "max",
+  name: "Max",
+  description: "$200 per month with $2,000 in shared OpenComputer credits.",
+  group: "usage_plan",
+  price: { amount: 200, interval: "month" },
+  items: [
+    item({
+      featureId: credits.id,
+      included: 2_000,
+      reset: { interval: "month" },
     }),
   ],
 });

--- a/scripts/autumn/autumn.config.ts
+++ b/scripts/autumn/autumn.config.ts
@@ -1,0 +1,55 @@
+import { feature, item, plan } from "atmn";
+
+// Keep these IDs aligned with the feature IDs emitted by the billing paths in
+// cloudflare-workers/api-edge. Credits are denominated in US dollars.
+export const agentRuntime = feature({
+  id: "agent_runtime_2gb_1vcpu",
+  name: "Agent runtime (2 GB / 1 vCPU)",
+  type: "metered",
+  consumable: true,
+});
+
+export const credits = feature({
+  id: "credits",
+  name: "Credits",
+  type: "credit_system",
+  creditSchema: [
+    {
+      meteredFeatureId: agentRuntime.id,
+      // $0.00315 per minute, billed in whole seconds.
+      creditCost: 0.0000525,
+    },
+  ],
+});
+
+export const base = plan({
+  id: "base",
+  name: "Usage",
+  description: "Default OpenComputer usage balance.",
+  autoEnable: true,
+  items: [
+    item({
+      featureId: credits.id,
+      included: 5,
+      reset: { interval: "one_off" },
+    }),
+  ],
+});
+
+export const topUp = plan({
+  id: "top_up",
+  name: "Credit top-up",
+  description: "One-off prepaid OpenComputer credits.",
+  addOn: true,
+  items: [
+    item({
+      featureId: credits.id,
+      price: {
+        amount: 1,
+        billingUnits: 1,
+        billingMethod: "prepaid",
+        interval: "one_off",
+      },
+    }),
+  ],
+});

--- a/scripts/autumn/autumn.config.ts
+++ b/scripts/autumn/autumn.config.ts
@@ -1,7 +1,72 @@
 import { feature, item, plan } from "atmn";
 
-// Keep these IDs aligned with the feature IDs emitted by the billing paths in
-// cloudflare-workers/api-edge. Credits are denominated in US dollars.
+// This is the complete shared OpenComputer catalog. Keep existing production
+// IDs and prices stable: atmn push reconciles the whole target environment, so
+// omitting an existing resource can propose deleting or archiving it.
+
+export const compute1gb = feature({
+  id: "compute_1gb",
+  name: "compute_1gb",
+  type: "metered",
+  consumable: true,
+});
+
+export const compute4gb = feature({
+  id: "compute_4gb",
+  name: "compute_4gb",
+  type: "metered",
+  consumable: true,
+});
+
+export const compute8gb = feature({
+  id: "compute_8gb",
+  name: "compute_8gb",
+  type: "metered",
+  consumable: true,
+});
+
+export const compute16gb = feature({
+  id: "compute_16gb",
+  name: "compute_16gb",
+  type: "metered",
+  consumable: true,
+});
+
+export const compute32gb = feature({
+  id: "compute_32gb",
+  name: "compute_32gb",
+  type: "metered",
+  consumable: true,
+});
+
+export const compute64gb = feature({
+  id: "compute_64gb",
+  name: "compute_64gb",
+  type: "metered",
+  consumable: true,
+});
+
+export const modelSpend = feature({
+  id: "model_spend",
+  name: "model_spend",
+  type: "metered",
+  consumable: true,
+});
+
+export const browserRuntime = feature({
+  id: "browser_runtime",
+  name: "browser_runtime",
+  type: "metered",
+  consumable: true,
+});
+
+export const diskOverageGbSeconds = feature({
+  id: "disk_overage_gb_seconds",
+  name: "disk_overage_gb_seconds",
+  type: "metered",
+  consumable: true,
+});
+
 export const agentRuntime = feature({
   id: "agent_runtime_2gb_1vcpu",
   name: "Agent runtime (2 GB / 1 vCPU)",
@@ -9,36 +74,35 @@ export const agentRuntime = feature({
   consumable: true,
 });
 
-export const modelSpend = feature({
-  id: "model_spend",
-  name: "Managed model spend",
-  type: "metered",
-  consumable: true,
-});
-
 export const credits = feature({
   id: "credits",
-  name: "Credits",
+  name: "credits",
   type: "credit_system",
   creditSchema: [
-    {
-      meteredFeatureId: agentRuntime.id,
-      // $0.00315 per minute, billed in whole seconds.
-      creditCost: 0.0000525,
-    },
+    { meteredFeatureId: compute1gb.id, creditCost: 0.00001666666666 },
+    { meteredFeatureId: compute4gb.id, creditCost: 0.00006666666664 },
+    { meteredFeatureId: compute8gb.id, creditCost: 0.00013333333328 },
+    { meteredFeatureId: compute16gb.id, creditCost: 0.00026666666656 },
+    { meteredFeatureId: compute32gb.id, creditCost: 0.00053333333312 },
+    { meteredFeatureId: compute64gb.id, creditCost: 0.00106666666624 },
     {
       meteredFeatureId: modelSpend.id,
       // The model meter submits provider spend in micro-dollars.
       creditCost: 0.000001,
+    },
+    { meteredFeatureId: browserRuntime.id, creditCost: 0.000133333333 },
+    { meteredFeatureId: diskOverageGbSeconds.id, creditCost: 0.0000001 },
+    {
+      meteredFeatureId: agentRuntime.id,
+      // $0.00315 per minute, billed in whole seconds.
+      creditCost: 0.0000525,
     },
   ],
 });
 
 export const base = plan({
   id: "base",
-  name: "Usage",
-  description: "Default OpenComputer usage balance.",
-  group: "usage_plan",
+  name: "base",
   autoEnable: true,
   items: [
     item({
@@ -47,6 +111,46 @@ export const base = plan({
       reset: { interval: "one_off" },
     }),
   ],
+});
+
+export const topUp = plan({
+  id: "top_up",
+  name: "top_up",
+  items: [
+    item({
+      featureId: credits.id,
+      price: {
+        amount: 1,
+        billingUnits: 1,
+        billingMethod: "prepaid",
+        interval: "one_off",
+      },
+    }),
+  ],
+});
+
+export const concurrencyPro = plan({
+  id: "concurrency_pro",
+  name: "concurrency_pro",
+  addOn: true,
+  price: { amount: 150, interval: "month" },
+  items: [],
+});
+
+export const concurrencyPlus = plan({
+  id: "concurrency_plus",
+  name: "concurrency_plus",
+  addOn: true,
+  price: { amount: 500, interval: "month" },
+  items: [],
+});
+
+export const concurrencyPlusPlus = plan({
+  id: "concurrency_plus_plus",
+  name: "concurrency_plus_plus",
+  addOn: true,
+  price: { amount: 1_000, interval: "month" },
+  items: [],
 });
 
 export const pro = plan({
@@ -75,24 +179,6 @@ export const max = plan({
       featureId: credits.id,
       included: 2_000,
       reset: { interval: "month" },
-    }),
-  ],
-});
-
-export const topUp = plan({
-  id: "top_up",
-  name: "Credit top-up",
-  description: "One-off prepaid OpenComputer credits.",
-  addOn: true,
-  items: [
-    item({
-      featureId: credits.id,
-      price: {
-        amount: 1,
-        billingUnits: 1,
-        billingMethod: "prepaid",
-        interval: "one_off",
-      },
     }),
   ],
 });

--- a/scripts/autumn/autumn.config.ts
+++ b/scripts/autumn/autumn.config.ts
@@ -9,6 +9,13 @@ export const agentRuntime = feature({
   consumable: true,
 });
 
+export const modelSpend = feature({
+  id: "model_spend",
+  name: "Managed model spend",
+  type: "metered",
+  consumable: true,
+});
+
 export const credits = feature({
   id: "credits",
   name: "Credits",
@@ -18,6 +25,11 @@ export const credits = feature({
       meteredFeatureId: agentRuntime.id,
       // $0.00315 per minute, billed in whole seconds.
       creditCost: 0.0000525,
+    },
+    {
+      meteredFeatureId: modelSpend.id,
+      // The model meter submits provider spend in micro-dollars.
+      creditCost: 0.000001,
     },
   ],
 });

--- a/scripts/autumn/package-lock.json
+++ b/scripts/autumn/package-lock.json
@@ -1,0 +1,3273 @@
+{
+  "name": "opencomputer-autumn-catalog",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "opencomputer-autumn-catalog",
+      "devDependencies": {
+        "atmn": "1.1.20"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.2.5.tgz",
+      "integrity": "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mishieck/ink-titled-box": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mishieck/ink-titled-box/-/ink-titled-box-0.3.0.tgz",
+      "integrity": "sha512-ugzVH9hixp3hwKfQ8On/qnsrdAxS3y9rTu/aGOFed4zVUvtZyGZNIR4rxAwXult8HKI4vJEh0OM8wib9NPrwUg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ink": "^6.0.0",
+        "react": "^19.1.0",
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@oslojs/asn1": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/asn1/-/asn1-1.0.0.tgz",
+      "integrity": "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/binary": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/binary/-/binary-1.0.0.tgz",
+      "integrity": "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oslojs/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/asn1": "1.0.0",
+        "@oslojs/binary": "1.0.0"
+      }
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oslojs/jwt": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/jwt/-/jwt-0.2.0.tgz",
+      "integrity": "sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/encoding": "0.4.1"
+      }
+    },
+    "node_modules/@oslojs/jwt/node_modules/@oslojs/encoding": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-0.4.1.tgz",
+      "integrity": "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.102.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.102.0.tgz",
+      "integrity": "sha512-tvBzr11Q7StuMCEsIJdqX8TAWt6WZIzfw/yrSAjObZDerwTTPeCxeLXN2R8ZSn4ZxFpQV819Xn8QmoO+vtnDvw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.102.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.102.0.tgz",
+      "integrity": "sha512-0GyVyEcGt9M7jHPCua16hNVtstUXE2R4HsnNubFYcDs7DJaLzh1dSiXsADDU/cNn/SqrLfa0vRKyjUmbx4rZLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.102.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@types/prettier": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==",
+      "deprecated": "This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/arctic": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/arctic/-/arctic-3.7.0.tgz",
+      "integrity": "sha512-ZMQ+f6VazDgUJOd+qNV+H7GohNSYal1mVjm5kEaZfE2Ifb7Ss70w+Q7xpJC87qZDkMZIXYf0pTIYZA0OPasSbw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oslojs/crypto": "1.0.1",
+        "@oslojs/encoding": "1.1.0",
+        "@oslojs/jwt": "0.2.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/atmn": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/atmn/-/atmn-1.1.20.tgz",
+      "integrity": "sha512-qpFQLISm70J7NLRbJoFv6AjmDlU46MStV0WUcV3fK5soRTF/jUDu76pk5rfiCJuJHB3vclKLHaj8ycJGT2XMJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/prompts": "^7.6.0",
+        "@mishieck/ink-titled-box": "^0.3.0",
+        "@tanstack/react-query": "^5.90.17",
+        "@types/prettier": "^3.0.0",
+        "arctic": "^3.7.0",
+        "axios": "^1.10.0",
+        "cfonts": "^3.3.1",
+        "chalk": "^5.2.0",
+        "clipboardy": "^5.0.2",
+        "commander": "^14.0.0",
+        "conf": "^13.0.1",
+        "dotenv": "^17.2.0",
+        "ervy": "^1.0.7",
+        "ink": "^6.6.0",
+        "ink-big-text": "^2.0.0",
+        "ink-chart": "^0.1.1",
+        "ink-confirm-input": "^2.0.0",
+        "ink-scroll-list": "^0.4.1",
+        "ink-scroll-view": "^0.3.5",
+        "ink-select-input": "^6.2.0",
+        "ink-spinner": "^5.0.0",
+        "ink-table": "^3.1.0",
+        "ink-text-input": "^6.0.0",
+        "inquirer": "^12.7.0",
+        "jiti": "^2.4.2",
+        "open": "^10.1.2",
+        "prettier": "^3.6.2",
+        "react": "^19.2.3",
+        "yocto-spinner": "^1.0.0",
+        "zod": "^4.0.0"
+      },
+      "bin": {
+        "atmn": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/cfonts": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/cfonts/-/cfonts-3.3.1.tgz",
+      "integrity": "sha512-ZGEmN3W9mViWEDjsuPo4nK4h39sfh6YtoneFYp9WLPI/rw8BaSSrfQC6jkrGW3JMvV3ZnExJB/AEqXc/nHYxkw==",
+      "dev": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "supports-color": "^8",
+        "window-size": "^1"
+      },
+      "bin": {
+        "cfonts": "bin/index.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/clipboard-image": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/clipboard-image/-/clipboard-image-0.1.0.tgz",
+      "integrity": "sha512-SWk7FgaXLNFld19peQ/rTe0n97lwR1WbkqxV6JKCAOh7U52AKV/PeMFCyt/8IhBdqyDA8rdyewQMKZqvWT5Akg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-jxa": "^3.0.0"
+      },
+      "bin": {
+        "clipboard-image": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-5.3.2.tgz",
+      "integrity": "sha512-R35PENCHFCw6lsd5SjYPuAVV3Zawr74mKc7ogFNzoDPoQsmWDoJgUNNnWCk/czeqdZGZs8Y0M8zkOlVoySfHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clipboard-image": "^0.1.0",
+        "execa": "^9.6.1",
+        "is-wayland": "^0.1.0",
+        "is-wsl": "^3.1.0",
+        "is64bit": "^2.0.0",
+        "powershell-utils": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/conf": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-13.1.0.tgz",
+      "integrity": "sha512-Bi6v586cy1CoTFViVO4lGTtx780lfF96fUmS1lSX6wpZf6330NvHUu6fReVuDP1de8Mg0nkZb01c8tAQdz1o3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "atomically": "^2.0.3",
+        "debounce-fn": "^6.0.0",
+        "dot-prop": "^9.0.0",
+        "env-paths": "^3.0.0",
+        "json-schema-typed": "^8.0.1",
+        "semver": "^7.6.3",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debounce-fn": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
+      "integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+      "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ervy": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ervy/-/ervy-1.0.7.tgz",
+      "integrity": "sha512-LyHLPwIKxCKKtTO/qBMFzwA1BD5IjpM0AA3k6CeK9hrEn4Kbayi93G9eD/Ko4suEIjerSl7YpMmaOoL0g9OCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.51.0.tgz",
+      "integrity": "sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types",
+        "tests/browser-compat"
+      ]
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-6.8.0.tgz",
+      "integrity": "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.2.4",
+        "ansi-escapes": "^7.3.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.6.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^5.1.1",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.39.10",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^2.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.33.0",
+        "scheduler": "^0.27.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^8.0.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^8.1.1",
+        "terminal-size": "^4.0.1",
+        "type-fest": "^5.4.1",
+        "widest-line": "^6.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@types/react": ">=19.0.0",
+        "react": ">=19.0.0",
+        "react-devtools-core": ">=6.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink-big-text": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ink-big-text/-/ink-big-text-2.0.0.tgz",
+      "integrity": "sha512-Juzqv+rIOLGuhMJiE50VtS6dg6olWfzFdL7wsU/EARSL5Eaa5JNXMogMBm9AkjgzO2Y3UwWCOh87jbhSn8aNdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cfonts": "^3.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      },
+      "peerDependencies": {
+        "ink": ">=4",
+        "react": ">=18"
+      }
+    },
+    "node_modules/ink-chart": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ink-chart/-/ink-chart-0.1.1.tgz",
+      "integrity": "sha512-A3WxEO4t5ueuTves/zhaTJe/XcPXnlmf//gcKni8W1Nme6Dj0KhtWPTrsNpp6cZQR6k6HG/diEvZVcQ8DMmYyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ervy": "^1.0.4",
+        "prop-types": "^15.7.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "ink": ">=2.0.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/ink-confirm-input": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ink-confirm-input/-/ink-confirm-input-2.0.0.tgz",
+      "integrity": "sha512-YCd7a9XW0DIIbOhF3XiLo3WF86mOart9qI1qN56wT5IDJxU+j8BanEZh5/QXoazyIPSv1iXlHPIlRB5cbZIMIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ink-text-input": "^3.2.1",
+        "prop-types": "^15.5.10",
+        "yn": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "ink": ">=2",
+        "react": ">=16"
+      }
+    },
+    "node_modules/ink-confirm-input/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ink-confirm-input/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ink-confirm-input/node_modules/ink-text-input": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-3.3.0.tgz",
+      "integrity": "sha512-gO4wrOf2ie3YuEARTIwGlw37lMjFn3Gk6CKIDrMlHb46WFMagZU7DplohjM24zynlqfnXA5UDEIfC2NBcvD8kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^3.0.0",
+        "prop-types": "^15.5.10"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "ink": "^2.0.0",
+        "react": "^16.5.2"
+      }
+    },
+    "node_modules/ink-confirm-input/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ink-scroll-list": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/ink-scroll-list/-/ink-scroll-list-0.4.1.tgz",
+      "integrity": "sha512-2GcjnBXRe0sTSMC03SCKX6IkNAsYYgcpvAN+ggAiaqeg+s+qA9Ls0iVTOmB+Ize/9AVts8xloG4aRcrOy/7Xxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ink-scroll-view": "^0.3.5"
+      },
+      "peerDependencies": {
+        "ink": ">=6",
+        "react": ">=19"
+      }
+    },
+    "node_modules/ink-scroll-view": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/ink-scroll-view/-/ink-scroll-view-0.3.7.tgz",
+      "integrity": "sha512-lUBLxSbVry/+UtJhuvRu6wumP43+ScVp69J7e+hmYwz1kTkahWfkVwWOu7Mn1DMPb8AU8bnsmEsr6kvSJvnaRw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ink": "^5 || ^6 || ^7",
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/ink-select-input": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ink-select-input/-/ink-select-input-6.2.0.tgz",
+      "integrity": "sha512-304fZXxkpYxJ9si5lxRCaX01GNlmPBgOZumXXRnPYbHW/iI31cgQynqk2tRypGLOF1cMIwPUzL2LSm6q4I5rQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "figures": "^6.1.0",
+        "to-rotated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ink": ">=5.0.0",
+        "react": ">=18.0.0"
+      }
+    },
+    "node_modules/ink-spinner": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
+      "integrity": "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-spinners": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "peerDependencies": {
+        "ink": ">=4.0.0",
+        "react": ">=18.0.0"
+      }
+    },
+    "node_modules/ink-table": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ink-table/-/ink-table-3.1.0.tgz",
+      "integrity": "sha512-qxVb4DIaEaJryvF9uZGydnmP9Hkmas3DCKVpEcBYC0E4eJd3qNgNe+PZKuzgCERFe9LfAS1TNWxCr9+AU4v3YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-hash": "^2.0.3"
+      },
+      "peerDependencies": {
+        "ink": ">=3.0.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/ink-text-input": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
+      "integrity": "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ink": ">=5",
+        "react": ">=18"
+      }
+    },
+    "node_modules/ink/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ink/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ink/node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.11.1.tgz",
+      "integrity": "sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/prompts": "^7.10.1",
+        "@inquirer/type": "^3.0.10",
+        "mute-stream": "^2.0.0",
+        "run-async": "^4.0.6",
+        "rxjs": "^7.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/is-accessor-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.2.tgz",
+      "integrity": "sha512-AIbwAcazqP3R65dGvqk1V+a+vE5Fg1yu/ZKMOiBWSUIXXiwQkYmXQcVa2O0nh0tSDKDFKxG2mY7dB1Sr4hEP1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-data-descriptor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.1.tgz",
+      "integrity": "sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-descriptor": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.4.tgz",
+      "integrity": "sha512-bv5z95W0dDtLfKwDfkTNxaRxmISBD3eQBKJeVxv2AQ7MjuUnDNG7cIQqvFtMOUYhsILWHhMayWdoGqNqYYYjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-accessor-descriptor": "^1.0.2",
+        "is-data-descriptor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz",
+      "integrity": "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wayland": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-wayland/-/is-wayland-0.1.0.tgz",
+      "integrity": "sha512-QkbMsWkIfkrzOPxenwye0h56iAXirZYHG9eHVPb22fO9y+wPbaX/CHacOWBa/I++4ohTcByimhM1/nyCsH8KNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is64bit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is64bit/-/is64bit-2.0.0.tgz",
+      "integrity": "sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "system-architecture": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/macos-version": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/macos-version/-/macos-version-6.0.0.tgz",
+      "integrity": "sha512-O2S8voA+pMfCHhBn/TIYDXzJ1qNHpPDU32oFxglKnVdJABiYYITt45oLkV9yhwA3E2FDwn3tQqUFrTsr1p3sBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
+      "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
+      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/run-jxa": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-jxa/-/run-jxa-3.0.0.tgz",
+      "integrity": "sha512-4f2CrY7H+sXkKXJn/cE6qRA3z+NMVO7zvlZ/nUV0e62yWftpiLAfw5eV9ZdomzWd2TXWwEIiGjAT57+lWIzzvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "macos-version": "^6.0.0",
+        "subsume": "^4.0.0",
+        "type-fest": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-jxa/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/run-jxa/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-jxa/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/run-jxa/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-jxa/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/run-jxa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/run-jxa/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/run-jxa/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/subsume": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/subsume/-/subsume-4.0.0.tgz",
+      "integrity": "sha512-BWnYJElmHbYZ/zKevy+TG+SsyoFCmRPDHJbR1MzLxkPOv1Jp/4hGhVUtP98s+wZBsBsHwCXvPTP0x287/WMjGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/subsume/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/system-architecture": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-0.1.0.tgz",
+      "integrity": "sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-size": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.1.tgz",
+      "integrity": "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/to-rotated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-rotated/-/to-rotated-1.0.0.tgz",
+      "integrity": "sha512-KsEID8AfgUy+pxVRLsWp0VzCa69wxzUDZnzGbyIST/bcgcrMvTYoFBX/QORH4YApoD89EDuUovx4BTdpOn319Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-6.0.0.tgz",
+      "integrity": "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/window-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-1.1.1.tgz",
+      "integrity": "sha512-5D/9vujkmVQ7pSmc0SCBmHXbkv6eaHwXEx65MywhmUMsI8sGqJ972APq1lotfcwMKPFLuCFfL8xGHLIp7jaBmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "is-number": "^3.0.0"
+      },
+      "bin": {
+        "window-size": "cli.js"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yocto-spinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.2.2.tgz",
+      "integrity": "sha512-DODGl1wJjA/s5pnJFKau9lIYHT81lnhob1i3e1TjxZRxEhWRKl74nTbWE6H5KlkViQQTo/Z29YFdxzTZAMY3ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.19"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/scripts/autumn/package.json
+++ b/scripts/autumn/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "opencomputer-autumn-catalog",
+  "private": true,
+  "scripts": {
+    "push:sandbox": "atmn push",
+    "preview": "atmn preview"
+  },
+  "devDependencies": {
+    "atmn": "1.1.20"
+  }
+}

--- a/scripts/autumn/package.json
+++ b/scripts/autumn/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "scripts": {
     "push:sandbox": "atmn push",
-    "preview": "atmn preview"
+    "preview": "atmn preview",
+    "preview:prod": "atmn preview --prod",
+    "push:prod": "atmn push --prod"
   },
   "devDependencies": {
     "atmn": "1.1.20"

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -25,6 +25,8 @@ export type {
   BillingState,
   AutumnAutoTopup,
   AutumnBilling,
+  AgentSessionUsage,
+  AgentSessionUsageRow,
   StripeInvoice,
   SandboxUsageRow,
   SandboxUsage,
@@ -440,6 +442,13 @@ export const redeemPromoCode = (code: string) =>
 // Autumn prepaid billing API
 export const getAutumnBilling = () =>
   apiFetch('/billing/autumn', {}, S.AutumnBillingSchema)
+
+export const getAgentSessionUsage = (limit = 50) =>
+  apiFetch(
+    `/managed-agents/billing/sessions?limit=${limit}`,
+    {},
+    S.AgentSessionUsageSchema,
+  )
 
 // url is non-null → redirect to a hosted Stripe flow (no card yet); null → the
 // existing card was charged server-side, so just refresh the balance.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -465,6 +465,7 @@ export const setAutumnAutoTopup = (cfg: {
   enabled: boolean
   threshold: number
   quantity: number
+  budget: number
 }) =>
   apiFetch<{ ok: boolean; url?: string | null }>('/billing/autumn/auto-topup', {
     method: 'POST',

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -464,6 +464,12 @@ export const autumnSubscribeConcurrency = (plan: string) =>
     body: JSON.stringify({ plan }),
   })
 
+export const autumnSubscribeUsagePlan = (plan: 'pro' | 'max') =>
+  apiFetch<{ url: string | null }>('/billing/autumn/plan', {
+    method: 'POST',
+    body: JSON.stringify({ plan }),
+  })
+
 // Open Autumn's Stripe-hosted billing portal to manage the saved card + invoices.
 export const autumnBillingPortal = () =>
   apiFetch<{ url: string }>('/billing/autumn/portal', { method: 'POST' })

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -330,9 +330,11 @@ const autumn = {
   isHalted: false,
   creditsRemainingCents: 4210,
   concurrencyPlan: 'base',
+  usagePlan: 'base',
   maxConcurrentSandboxes: 5,
   autoTopup: { enabled: false, threshold: 5, quantity: 25, budget: 100 },
   hasToppedUp: true,
+  hasPaidSubscription: false,
   currency: 'usd',
 }
 

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -331,7 +331,7 @@ const autumn = {
   creditsRemainingCents: 4210,
   concurrencyPlan: 'base',
   maxConcurrentSandboxes: 5,
-  autoTopup: { enabled: false, threshold: 5, quantity: 25 },
+  autoTopup: { enabled: false, threshold: 5, quantity: 25, budget: 100 },
   hasToppedUp: true,
   currency: 'usd',
 }

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -208,6 +208,7 @@ export const AutumnAutoTopupSchema = z.object({
   enabled: z.boolean(),
   threshold: z.number(),
   quantity: z.number(),
+  budget: z.number().nullable(),
 })
 
 export const AutumnModelUsageSchema = z.object({

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -225,8 +225,10 @@ export const AutumnBillingSchema = z.object({
   creditsRemainingCents: z.number(),
   maxConcurrentSandboxes: z.number(),
   concurrencyPlan: z.string(),
+  usagePlan: z.enum(['base', 'pro', 'max']),
   isHalted: z.boolean(),
   hasToppedUp: z.boolean(),
+  hasPaidSubscription: z.boolean(),
   autoTopup: AutumnAutoTopupSchema.nullable(),
   modelUsage: AutumnModelUsageSchema.optional(),
 })
@@ -244,9 +246,7 @@ export const AgentSessionUsageRowSchema = z.object({
   updatedAt: z.string(),
   modelCalls: z.number(),
   modelProviderCostUsd: z.number(),
-  modelUsage: z.array(
-    z.object({ timestamp: z.string(), costUsd: z.number() }),
-  ),
+  modelUsage: z.array(z.object({ timestamp: z.string(), costUsd: z.number() })),
   runtimeSecondsByTier: z.record(z.string(), z.number()),
 })
 

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -223,6 +223,13 @@ export const AutumnModelUsageSchema = z.object({
 
 export const AutumnBillingSchema = z.object({
   creditsRemainingCents: z.number(),
+  creditBreakdown: z.object({
+    available: z.boolean(),
+    planRemainingCents: z.number(),
+    topupRemainingCents: z.number(),
+    otherRemainingCents: z.number(),
+    planResetsAt: z.string().nullable(),
+  }),
   maxConcurrentSandboxes: z.number(),
   concurrencyPlan: z.string(),
   usagePlan: z.enum(['base', 'pro', 'max']),

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -218,6 +218,7 @@ export const AutumnModelUsageSchema = z.object({
   providerSpendCents: z.number(),
   billedCreditsCents: z.number(),
   activeKeyCount: z.number(),
+  billingStartedAt: z.string().nullable().optional(),
 })
 
 export const AutumnBillingSchema = z.object({
@@ -228,6 +229,29 @@ export const AutumnBillingSchema = z.object({
   hasToppedUp: z.boolean(),
   autoTopup: AutumnAutoTopupSchema.nullable(),
   modelUsage: AutumnModelUsageSchema.optional(),
+})
+
+export const AgentSessionUsageRowSchema = z.object({
+  id: z.string(),
+  agentId: z.string(),
+  deploymentId: z.string(),
+  projectId: z.string().optional(),
+  projectName: z.string().optional(),
+  source: z.string(),
+  status: z.string(),
+  title: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  modelCalls: z.number(),
+  modelProviderCostUsd: z.number(),
+  modelUsage: z.array(
+    z.object({ timestamp: z.string(), costUsd: z.number() }),
+  ),
+  runtimeSecondsByTier: z.record(z.string(), z.number()),
+})
+
+export const AgentSessionUsageSchema = z.object({
+  sessions: z.array(AgentSessionUsageRowSchema),
 })
 
 export const StripeInvoiceSchema = z.object({
@@ -1215,6 +1239,8 @@ export type Credits = z.infer<typeof CreditsSchema>
 export type BillingState = z.infer<typeof BillingStateSchema>
 export type AutumnAutoTopup = z.infer<typeof AutumnAutoTopupSchema>
 export type AutumnBilling = z.infer<typeof AutumnBillingSchema>
+export type AgentSessionUsageRow = z.infer<typeof AgentSessionUsageRowSchema>
+export type AgentSessionUsage = z.infer<typeof AgentSessionUsageSchema>
 export type StripeInvoice = z.infer<typeof StripeInvoiceSchema>
 export type SandboxUsageRow = z.infer<typeof SandboxUsageRowSchema>
 export type SandboxUsage = z.infer<typeof SandboxUsageSchema>

--- a/web/src/pages/Billing.tsx
+++ b/web/src/pages/Billing.tsx
@@ -275,6 +275,18 @@ const USAGE_PLANS = [
   },
 ] as const
 
+function formatCreditAmount(cents: number) {
+  return `$${(cents / 100).toFixed(2)}`
+}
+
+function formatResetDate(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(value))
+}
+
 function PrepaidPlan() {
   const queryClient = useQueryClient()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -367,6 +379,7 @@ function PrepaidPlan() {
   if (isLoading) return <Skeleton className="h-64 max-w-2xl" />
 
   const credits = (autumn?.creditsRemainingCents ?? 0) / 100
+  const creditBreakdown = autumn?.creditBreakdown
   const halted = autumn?.isHalted ?? false
   const currentPlan = autumn?.concurrencyPlan ?? 'base'
   const tier = CONCURRENCY_TIERS.find((t) => t.id === confirmPlanId)
@@ -415,8 +428,59 @@ function PrepaidPlan() {
             >
               ${credits.toFixed(2)}
             </span>
-            <span className="text-muted-foreground text-xs">remaining</span>
+            <span className="text-muted-foreground text-xs">
+              total available
+            </span>
           </div>
+          {creditBreakdown?.available ? (
+            <div className="mt-5 space-y-3 border-t pt-4 text-sm">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="font-medium">
+                    {autumn?.usagePlan === 'base'
+                      ? 'Signup credits'
+                      : `${autumn?.usagePlan === 'max' ? 'Max' : 'Pro'} plan credits`}
+                  </p>
+                  <p className="text-muted-foreground mt-0.5 text-xs">
+                    {creditBreakdown.planResetsAt
+                      ? `Used first · resets to $${USAGE_PLANS.find((plan) => plan.id === autumn?.usagePlan)?.credits?.toLocaleString() ?? '0'} on ${formatResetDate(creditBreakdown.planResetsAt)}`
+                      : 'One-time included balance'}
+                  </p>
+                </div>
+                <span className="font-mono font-medium">
+                  {formatCreditAmount(creditBreakdown.planRemainingCents)}
+                </span>
+              </div>
+              {creditBreakdown.topupRemainingCents > 0 ? (
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="font-medium">Top-up credits</p>
+                    <p className="text-muted-foreground mt-0.5 text-xs">
+                      Used after plan credits · carries forward
+                    </p>
+                  </div>
+                  <span className="font-mono font-medium">
+                    {formatCreditAmount(creditBreakdown.topupRemainingCents)}
+                  </span>
+                </div>
+              ) : null}
+              {creditBreakdown.otherRemainingCents > 0 ? (
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="font-medium">
+                      Carried or promotional credits
+                    </p>
+                    <p className="text-muted-foreground mt-0.5 text-xs">
+                      Preserved separately from this month&apos;s allowance
+                    </p>
+                  </div>
+                  <span className="font-mono font-medium">
+                    {formatCreditAmount(creditBreakdown.otherRemainingCents)}
+                  </span>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
           {halted ? (
             <p className="text-status-error mt-2 flex items-center gap-1.5 text-sm">
               <CircleAlert className="size-4 shrink-0" />

--- a/web/src/pages/Billing.tsx
+++ b/web/src/pages/Billing.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { CircleAlert, CircleCheck } from 'lucide-react'
@@ -11,12 +12,14 @@ import {
   billingPortal,
   billingSetup,
   getAutumnBilling,
+  getAgentSessionUsage,
   getBilling,
   getBillingInvoices,
   getSandboxUsage,
   redeemPromoCode,
   setAutumnAutoTopup,
   type AutumnBilling,
+  type AgentSessionUsageRow,
   type StripeInvoice,
 } from '@/api/client'
 import { PageHeader } from '@/components/page-header'
@@ -257,6 +260,9 @@ function PrepaidPlan() {
   const [amount, setAmount] = useState(25)
   const [confirmTopup, setConfirmTopup] = useState(false)
   const [confirmPlanId, setConfirmPlanId] = useState<string | null>(null)
+  const [usageProduct, setUsageProduct] = useState<
+    'sandboxes' | 'serverless-agents'
+  >('serverless-agents')
 
   // url present → redirect to hosted checkout (new card); url null → the
   // existing card was charged server-side, so just refresh the balance.
@@ -305,7 +311,8 @@ function PrepaidPlan() {
     (billing?.hasPaymentMethod ?? false) || (autumn?.hasToppedUp ?? false)
 
   return (
-    <div className="grid max-w-5xl grid-cols-1 gap-4 lg:grid-cols-2 lg:items-start">
+    <div className="max-w-5xl space-y-4">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:items-start">
       {/* Credits */}
       <Panel className="p-6">
         <h2 className="mb-4 text-sm font-semibold">Prepaid credits</h2>
@@ -384,67 +391,43 @@ function PrepaidPlan() {
         </Panel>
       ) : null}
 
-      <ModelUsageCard usage={autumn?.modelUsage ?? null} />
+      </div>
 
-      {/* Concurrency */}
-      <Panel className="p-6">
-        <h2 className="mb-2 text-sm font-semibold">Concurrency</h2>
-        <p className="text-muted-foreground mb-4 text-sm">
-          You can run{' '}
-          <strong className="text-foreground">
-            {autumn?.maxConcurrentSandboxes ?? 50}
-          </strong>{' '}
-          sandboxes at once on the{' '}
-          <strong className="text-foreground">
-            {currentPlan === 'base' ? 'Base' : currentPlan}
-          </strong>{' '}
-          tier. Subscribe to a higher tier for more — billed monthly, separate
-          from usage credits.
-        </p>
-        <div className="space-y-2">
-          {CONCURRENCY_TIERS.map((t) => {
-            const active = currentPlan === t.id
-            return (
-              <div
-                key={t.id}
-                className={cn(
-                  'flex items-center justify-between rounded-md border px-4 py-3',
-                  active && 'border-foreground/40 bg-secondary',
-                )}
-              >
-                <div>
-                  <div className="text-foreground text-sm font-medium">
-                    {t.label} — {t.limit} concurrent
-                  </div>
-                  <div className="text-muted-foreground font-mono text-xs">
-                    ${t.price}/mo
-                  </div>
-                </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={active}
-                  onClick={() => setConfirmPlanId(t.id)}
-                >
-                  {active ? 'Current' : 'Subscribe'}
-                </Button>
-              </div>
-            )
-          })}
-          <p className="text-muted-foreground text-xs">
-            Need more than 1000?{' '}
-            <a
-              href="mailto:support@digger.dev"
-              className="text-foreground font-medium underline underline-offset-4"
+      <div>
+        <div className="mb-4 flex gap-1 border-b">
+          {(
+            [
+              ['serverless-agents', 'Serverless agents'],
+              ['sandboxes', 'Sandboxes'],
+            ] as const
+          ).map(([value, label]) => (
+            <button
+              key={value}
+              onClick={() => setUsageProduct(value)}
+              className={cn(
+                '-mb-px border-b-2 px-3 py-2 text-sm transition-colors',
+                usageProduct === value
+                  ? 'border-foreground text-foreground font-medium'
+                  : 'text-muted-foreground hover:text-foreground border-transparent',
+              )}
             >
-              Contact us
-            </a>
-            .
-          </p>
+              {label}
+            </button>
+          ))}
         </div>
-      </Panel>
-
-      <UsageBreakdown />
+        {usageProduct === 'sandboxes' ? (
+          <div className="space-y-4">
+            <ConcurrencyCard
+              currentPlan={currentPlan}
+              maxConcurrent={autumn?.maxConcurrentSandboxes ?? 50}
+              onSelectPlan={setConfirmPlanId}
+            />
+            <UsageBreakdown />
+          </div>
+        ) : (
+          <AgentUsageBreakdown usage={autumn?.modelUsage ?? null} />
+        )}
+      </div>
 
       <ConfirmDialog
         open={confirmTopup}
@@ -472,6 +455,73 @@ function PrepaidPlan() {
   )
 }
 
+function ConcurrencyCard({
+  currentPlan,
+  maxConcurrent,
+  onSelectPlan,
+}: {
+  currentPlan: string
+  maxConcurrent: number
+  onSelectPlan: (plan: string) => void
+}) {
+  return (
+    <Panel className="p-6">
+      <h2 className="mb-2 text-sm font-semibold">Concurrency</h2>
+      <p className="text-muted-foreground mb-4 text-sm">
+        You can run{' '}
+        <strong className="text-foreground">{maxConcurrent}</strong> sandboxes
+        at once on the{' '}
+        <strong className="text-foreground">
+          {currentPlan === 'base' ? 'Base' : currentPlan}
+        </strong>{' '}
+        tier. Subscribe to a higher tier for more — billed monthly, separate
+        from usage credits.
+      </p>
+      <div className="space-y-2">
+        {CONCURRENCY_TIERS.map((tier) => {
+          const active = currentPlan === tier.id
+          return (
+            <div
+              key={tier.id}
+              className={cn(
+                'flex items-center justify-between rounded-md border px-4 py-3',
+                active && 'border-foreground/40 bg-secondary',
+              )}
+            >
+              <div>
+                <div className="text-foreground text-sm font-medium">
+                  {tier.label} — {tier.limit} concurrent
+                </div>
+                <div className="text-muted-foreground font-mono text-xs">
+                  ${tier.price}/mo
+                </div>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={active}
+                onClick={() => onSelectPlan(tier.id)}
+              >
+                {active ? 'Current' : 'Subscribe'}
+              </Button>
+            </div>
+          )
+        })}
+        <p className="text-muted-foreground text-xs">
+          Need more than 1000?{' '}
+          <a
+            href="mailto:support@digger.dev"
+            className="text-foreground font-medium underline underline-offset-4"
+          >
+            Contact us
+          </a>
+          .
+        </p>
+      </div>
+    </Panel>
+  )
+}
+
 function ModelUsageCard({
   usage,
 }: {
@@ -484,7 +534,7 @@ function ModelUsageCard({
   return (
     <Panel className="p-6">
       <div className="mb-3 flex items-center justify-between gap-3">
-        <h2 className="text-sm font-semibold">Managed model usage</h2>
+        <h2 className="text-sm font-semibold">Model usage</h2>
         <StatusBadge
           status={
             enabled ? 'success' : status === 'error' ? 'error' : 'stopped'
@@ -499,8 +549,8 @@ function ModelUsageCard({
         <span className="text-muted-foreground text-xs">credits used</span>
       </div>
       <p className="text-muted-foreground mt-2 text-sm">
-        Managed agent models draw from the same prepaid credits balance as
-        sandbox compute.
+        Serverless-agent models draw from the same prepaid credits balance as
+        agent runtime and sandboxes.
       </p>
       <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
         <div>
@@ -521,6 +571,181 @@ function ModelUsageCard({
         </div>
       </div>
     </Panel>
+  )
+}
+
+const AGENT_RUNTIME_CENTS_PER_SECOND = (0.00315 * 100) / 60
+
+function sessionRuntimeSeconds(session: AgentSessionUsageRow): number {
+  return Object.values(session.runtimeSecondsByTier).reduce(
+    (total, seconds) => total + seconds,
+    0,
+  )
+}
+
+function billableModelUsage(
+  session: AgentSessionUsageRow,
+  billingStartedAt?: string | null,
+): { calls: number; providerCostUsd: number } {
+  const cutoff = billingStartedAt ? Date.parse(billingStartedAt) : NaN
+  const events = Number.isFinite(cutoff)
+    ? session.modelUsage.filter(
+        (event) => Date.parse(event.timestamp) >= cutoff,
+      )
+    : session.modelUsage
+  return {
+    calls: events.length,
+    providerCostUsd: events.reduce(
+      (total, event) => total + event.costUsd,
+      0,
+    ),
+  }
+}
+
+function AgentUsageBreakdown({
+  usage,
+}: {
+  usage: AutumnBilling['modelUsage'] | null
+}) {
+  const { data, isLoading } = useQuery({
+    queryKey: ['agent-session-usage'],
+    queryFn: () => getAgentSessionUsage(100),
+    refetchInterval: 30_000,
+  })
+  const rows = data?.sessions ?? []
+  const markup = 1 + (usage?.markupBps ?? 0) / 10_000
+  const runtimeSeconds = rows.reduce(
+    (total, session) => total + sessionRuntimeSeconds(session),
+    0,
+  )
+  const runtimeCostCents = runtimeSeconds * AGENT_RUNTIME_CENTS_PER_SECOND
+
+  const columns: Column<AgentSessionUsageRow>[] = [
+    {
+      key: 'session',
+      header: 'Session',
+      cell: (session) => {
+        const content = (
+          <>
+            <div className="text-foreground max-w-sm truncate text-sm font-medium">
+              {session.title ?? 'Untitled session'}
+            </div>
+            <div className="text-muted-foreground mt-0.5 flex flex-wrap gap-x-2 font-mono text-xs">
+              <span>{session.projectName ?? 'Unknown project'}</span>
+              <span>{session.id}</span>
+              <span>{session.source}</span>
+              <span>{session.status}</span>
+            </div>
+          </>
+        )
+        return session.projectId ? (
+          <Link
+            to={`/projects/${encodeURIComponent(session.projectId)}/sessions/${encodeURIComponent(session.id)}`}
+            className="block min-w-0 hover:underline hover:underline-offset-4"
+          >
+            {content}
+          </Link>
+        ) : (
+          <div className="min-w-0">{content}</div>
+        )
+      },
+    },
+    {
+      key: 'model',
+      header: 'Model',
+      align: 'right',
+      cell: (session) => {
+        const model = billableModelUsage(session, usage?.billingStartedAt)
+        return (
+          <div className="font-mono text-xs">
+            <div className="text-foreground">
+              {formatCost(model.providerCostUsd * 100 * markup)}
+            </div>
+            <div className="text-muted-foreground">
+              {model.calls} call{model.calls === 1 ? '' : 's'}
+            </div>
+          </div>
+        )
+      },
+    },
+    {
+      key: 'runtime',
+      header: 'Runtime',
+      align: 'right',
+      cell: (session) => {
+        const seconds = sessionRuntimeSeconds(session)
+        return (
+          <div className="font-mono text-xs">
+            <div className="text-foreground">
+              {formatCost(seconds * AGENT_RUNTIME_CENTS_PER_SECOND)}
+            </div>
+            <div className="text-muted-foreground">
+              {formatDuration(seconds)}
+            </div>
+          </div>
+        )
+      },
+    },
+    {
+      key: 'total',
+      header: 'Total',
+      align: 'right',
+      cell: (session) => {
+        const model =
+          billableModelUsage(session, usage?.billingStartedAt)
+            .providerCostUsd *
+          100 *
+          markup
+        const runtime =
+          sessionRuntimeSeconds(session) * AGENT_RUNTIME_CENTS_PER_SECOND
+        return (
+          <span className="text-foreground font-mono text-xs font-medium">
+            {formatCost(model + runtime)}
+          </span>
+        )
+      },
+    },
+  ]
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <ModelUsageCard usage={usage} />
+        <Panel className="p-6">
+          <h2 className="text-sm font-semibold">Agent runtime usage</h2>
+          <div className="mt-3 flex items-baseline gap-2">
+            <span className="text-foreground font-mono text-3xl font-semibold">
+              {formatCost(runtimeCostCents)}
+            </span>
+            <span className="text-muted-foreground text-xs">
+              {formatDuration(runtimeSeconds)} in recent sessions
+            </span>
+          </div>
+          <p className="text-muted-foreground mt-2 text-sm">
+            Runtime is billed per second at the serverless-agent resource rate.
+          </p>
+        </Panel>
+      </div>
+
+      <Panel className="overflow-hidden">
+        <div className="px-6 pt-6">
+          <h2 className="text-sm font-semibold">Usage by agent session</h2>
+          <p className="text-muted-foreground mt-1 text-xs">
+            Recent serverless-agent sessions, split into model and runtime
+            cost. Organization totals remain the billing ledger of record.
+          </p>
+        </div>
+        <div className="mt-3">
+          <ResourceTable
+            columns={columns}
+            rows={rows}
+            rowKey={(session) => session.id}
+            loading={isLoading}
+            empty={<EmptyState title="No serverless-agent usage to show yet." />}
+          />
+        </div>
+      </Panel>
+    </div>
   )
 }
 

--- a/web/src/pages/Billing.tsx
+++ b/web/src/pages/Billing.tsx
@@ -8,6 +8,7 @@ import { useTransientFlag } from '@/lib/use-transient-flag'
 import {
   autumnBillingPortal,
   autumnSubscribeConcurrency,
+  autumnSubscribeUsagePlan,
   autumnTopup,
   billingPortal,
   billingSetup,
@@ -250,6 +251,30 @@ const CONCURRENCY_TIERS = [
   { id: 'concurrency_pro_plus_plus', label: 'Pro++', limit: 1000, price: 1000 },
 ]
 
+const USAGE_PLANS = [
+  {
+    id: 'base',
+    label: 'Usage',
+    price: 0,
+    credits: null,
+    description: 'No subscription. Add prepaid credits whenever you need them.',
+  },
+  {
+    id: 'pro',
+    label: 'Pro',
+    price: 20,
+    credits: 200,
+    description: '$200 in shared credits added every month.',
+  },
+  {
+    id: 'max',
+    label: 'Max',
+    price: 200,
+    credits: 2000,
+    description: '$2,000 in shared credits added every month.',
+  },
+] as const
+
 function PrepaidPlan() {
   const queryClient = useQueryClient()
   const { data: autumn, isLoading } = useQuery({
@@ -260,6 +285,9 @@ function PrepaidPlan() {
   const [amount, setAmount] = useState(25)
   const [confirmTopup, setConfirmTopup] = useState(false)
   const [confirmPlanId, setConfirmPlanId] = useState<string | null>(null)
+  const [confirmUsagePlanId, setConfirmUsagePlanId] = useState<
+    'pro' | 'max' | null
+  >(null)
   const [usageProduct, setUsageProduct] = useState<
     'sandboxes' | 'serverless-agents'
   >('serverless-agents')
@@ -278,13 +306,21 @@ function PrepaidPlan() {
     },
     onError: (e) => notifyError("Couldn't complete the top-up.", e),
   })
-  const planMutation = useMutation({
+  const concurrencyPlanMutation = useMutation({
     mutationFn: (plan: string) => autumnSubscribeConcurrency(plan),
     onSuccess: (d) => {
       setConfirmPlanId(null)
       onPurchase(d)
     },
     onError: (e) => notifyError("Couldn't update your subscription.", e),
+  })
+  const usagePlanMutation = useMutation({
+    mutationFn: (plan: 'pro' | 'max') => autumnSubscribeUsagePlan(plan),
+    onSuccess: (d) => {
+      setConfirmUsagePlanId(null)
+      onPurchase(d)
+    },
+    onError: (e) => notifyError("Couldn't update your plan.", e),
   })
 
   // Whether a card is on file → offer the Stripe portal to manage it. Compliance
@@ -307,90 +343,102 @@ function PrepaidPlan() {
   const halted = autumn?.isHalted ?? false
   const currentPlan = autumn?.concurrencyPlan ?? 'base'
   const tier = CONCURRENCY_TIERS.find((t) => t.id === confirmPlanId)
+  const selectedUsagePlan = USAGE_PLANS.find(
+    (plan) => plan.id === confirmUsagePlanId,
+  )
   const hasCard =
-    (billing?.hasPaymentMethod ?? false) || (autumn?.hasToppedUp ?? false)
+    (billing?.hasPaymentMethod ?? false) ||
+    (autumn?.hasToppedUp ?? false) ||
+    (autumn?.hasPaidSubscription ?? false)
 
   return (
     <div className="max-w-5xl space-y-4">
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:items-start">
-      {/* Credits */}
-      <Panel className="p-6">
-        <h2 className="mb-4 text-sm font-semibold">Prepaid credits</h2>
-        <div className="flex items-baseline gap-3">
-          <span
-            className={cn(
-              'font-mono text-4xl font-semibold',
-              halted ? 'text-status-error' : 'text-status-running',
-            )}
-          >
-            ${credits.toFixed(2)}
-          </span>
-          <span className="text-muted-foreground text-xs">remaining</span>
-        </div>
-        {halted ? (
-          <p className="text-status-error mt-2 flex items-center gap-1.5 text-sm">
-            <CircleAlert className="size-4 shrink-0" />
-            Credits exhausted — top up to resume your agent sessions and
-            sandboxes
-          </p>
-        ) : null}
-
-        <div className="mt-5">
-          <p className="text-muted-foreground mb-2.5 text-sm">
-            Add credits (billed at the same per-second rates)
-          </p>
-          <div className="mb-3 flex flex-wrap items-center gap-2">
-            {TOPUP_AMOUNTS.map((a) => (
-              <Button
-                key={a}
-                variant={amount === a ? 'default' : 'outline'}
-                size="sm"
-                className="font-mono"
-                onClick={() => setAmount(a)}
-              >
-                ${a}
-              </Button>
-            ))}
-            <Input
-              type="number"
-              min={1}
-              value={amount}
-              onChange={(e) =>
-                setAmount(Math.max(1, Math.floor(Number(e.target.value) || 0)))
-              }
-              className="w-24 font-mono"
-            />
-          </div>
-          <Button disabled={amount < 1} onClick={() => setConfirmTopup(true)}>
-            Top up ${amount}
-          </Button>
-        </div>
-      </Panel>
-
-      <AutoTopupCard
-        current={autumn?.autoTopup ?? null}
-        hasToppedUp={autumn?.hasToppedUp ?? false}
+      <UsagePlanCard
+        currentPlan={autumn?.usagePlan ?? 'base'}
+        onSelectPlan={setConfirmUsagePlanId}
+        onManage={() => portalMutation.mutate()}
+        managing={portalMutation.isPending}
       />
-
-      {hasCard ? (
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:items-start">
+        {/* Credits */}
         <Panel className="p-6">
-          <h2 className="mb-2 text-sm font-semibold">Payment method</h2>
-          <p className="text-muted-foreground mb-3 text-sm">
-            Update your card, download invoices, or remove your payment method
-            on Stripe.
-          </p>
-          <Button
-            variant="outline"
-            onClick={() => portalMutation.mutate()}
-            disabled={portalMutation.isPending}
-          >
-            {portalMutation.isPending
-              ? 'Opening Stripe…'
-              : 'Manage payment method ↗'}
-          </Button>
-        </Panel>
-      ) : null}
+          <h2 className="mb-4 text-sm font-semibold">Prepaid credits</h2>
+          <div className="flex items-baseline gap-3">
+            <span
+              className={cn(
+                'font-mono text-4xl font-semibold',
+                halted ? 'text-status-error' : 'text-status-running',
+              )}
+            >
+              ${credits.toFixed(2)}
+            </span>
+            <span className="text-muted-foreground text-xs">remaining</span>
+          </div>
+          {halted ? (
+            <p className="text-status-error mt-2 flex items-center gap-1.5 text-sm">
+              <CircleAlert className="size-4 shrink-0" />
+              Credits exhausted — top up to resume your agent sessions and
+              sandboxes
+            </p>
+          ) : null}
 
+          <div className="mt-5">
+            <p className="text-muted-foreground mb-2.5 text-sm">
+              Add credits (billed at the same per-second rates)
+            </p>
+            <div className="mb-3 flex flex-wrap items-center gap-2">
+              {TOPUP_AMOUNTS.map((a) => (
+                <Button
+                  key={a}
+                  variant={amount === a ? 'default' : 'outline'}
+                  size="sm"
+                  className="font-mono"
+                  onClick={() => setAmount(a)}
+                >
+                  ${a}
+                </Button>
+              ))}
+              <Input
+                type="number"
+                min={1}
+                value={amount}
+                onChange={(e) =>
+                  setAmount(
+                    Math.max(1, Math.floor(Number(e.target.value) || 0)),
+                  )
+                }
+                className="w-24 font-mono"
+              />
+            </div>
+            <Button disabled={amount < 1} onClick={() => setConfirmTopup(true)}>
+              Top up ${amount}
+            </Button>
+          </div>
+        </Panel>
+
+        <AutoTopupCard
+          current={autumn?.autoTopup ?? null}
+          hasToppedUp={autumn?.hasToppedUp ?? false}
+        />
+
+        {hasCard ? (
+          <Panel className="p-6">
+            <h2 className="mb-2 text-sm font-semibold">Payment method</h2>
+            <p className="text-muted-foreground mb-3 text-sm">
+              Update your card, download invoices, or remove your payment method
+              on Stripe.
+            </p>
+            <Button
+              variant="outline"
+              onClick={() => portalMutation.mutate()}
+              disabled={portalMutation.isPending}
+            >
+              {portalMutation.isPending
+                ? 'Opening Stripe…'
+                : 'Manage payment method ↗'}
+            </Button>
+          </Panel>
+        ) : null}
       </div>
 
       <div>
@@ -448,10 +496,112 @@ function PrepaidPlan() {
             : ''
         }
         confirmLabel={tier ? `Subscribe — $${tier.price}/mo` : 'Subscribe'}
-        pending={planMutation.isPending}
-        onConfirm={() => tier && planMutation.mutate(tier.id)}
+        pending={concurrencyPlanMutation.isPending}
+        onConfirm={() => tier && concurrencyPlanMutation.mutate(tier.id)}
+      />
+      <ConfirmDialog
+        open={!!selectedUsagePlan}
+        onOpenChange={(open) => !open && setConfirmUsagePlanId(null)}
+        title={`Switch to ${selectedUsagePlan?.label ?? ''}`}
+        description={
+          selectedUsagePlan
+            ? `${selectedUsagePlan.label} costs $${selectedUsagePlan.price}/month and adds $${selectedUsagePlan.credits?.toLocaleString()} in shared credits each month. Autumn applies the plan change and any required proration through Stripe.`
+            : ''
+        }
+        confirmLabel={
+          selectedUsagePlan
+            ? `${selectedUsagePlan.label} — $${selectedUsagePlan.price}/mo`
+            : 'Continue'
+        }
+        pending={usagePlanMutation.isPending}
+        onConfirm={() =>
+          selectedUsagePlan &&
+          selectedUsagePlan.id !== 'base' &&
+          usagePlanMutation.mutate(selectedUsagePlan.id)
+        }
       />
     </div>
+  )
+}
+
+function UsagePlanCard({
+  currentPlan,
+  onSelectPlan,
+  onManage,
+  managing,
+}: {
+  currentPlan: 'base' | 'pro' | 'max'
+  onSelectPlan: (plan: 'pro' | 'max') => void
+  onManage: () => void
+  managing: boolean
+}) {
+  return (
+    <Panel className="p-6">
+      <div className="mb-4">
+        <h2 className="text-sm font-semibold">Plan</h2>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Monthly credits are shared by serverless-agent sessions and sandboxes.
+          Top-ups stack with every plan.
+        </p>
+      </div>
+      <div className="grid gap-3 md:grid-cols-3">
+        {USAGE_PLANS.map((plan) => {
+          const current = plan.id === currentPlan
+          return (
+            <div key={plan.id} className="rounded-md border p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="font-medium">{plan.label}</div>
+                  <div className="mt-1 font-mono text-xl font-semibold">
+                    ${plan.price}
+                    <span className="text-muted-foreground text-xs font-normal">
+                      /mo
+                    </span>
+                  </div>
+                </div>
+                {current ? <StatusBadge status="active" /> : null}
+              </div>
+              <p className="text-muted-foreground mt-3 min-h-10 text-sm">
+                {plan.description}
+              </p>
+              {current ? (
+                currentPlan === 'base' ? (
+                  <Button className="mt-4 w-full" variant="outline" disabled>
+                    Current plan
+                  </Button>
+                ) : (
+                  <Button
+                    className="mt-4 w-full"
+                    variant="outline"
+                    disabled={managing}
+                    onClick={onManage}
+                  >
+                    Manage subscription
+                  </Button>
+                )
+              ) : plan.id === 'base' ? (
+                <Button
+                  className="mt-4 w-full"
+                  variant="outline"
+                  disabled={currentPlan === 'base' || managing}
+                  onClick={onManage}
+                >
+                  Manage in Stripe
+                </Button>
+              ) : (
+                <Button
+                  className="mt-4 w-full"
+                  variant="outline"
+                  onClick={() => onSelectPlan(plan.id)}
+                >
+                  {currentPlan === 'base' ? 'Upgrade' : 'Switch plan'}
+                </Button>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </Panel>
   )
 }
 
@@ -468,9 +618,8 @@ function ConcurrencyCard({
     <Panel className="p-6">
       <h2 className="mb-2 text-sm font-semibold">Concurrency</h2>
       <p className="text-muted-foreground mb-4 text-sm">
-        You can run{' '}
-        <strong className="text-foreground">{maxConcurrent}</strong> sandboxes
-        at once on the{' '}
+        You can run <strong className="text-foreground">{maxConcurrent}</strong>{' '}
+        sandboxes at once on the{' '}
         <strong className="text-foreground">
           {currentPlan === 'base' ? 'Base' : currentPlan}
         </strong>{' '}
@@ -595,10 +744,7 @@ function billableModelUsage(
     : session.modelUsage
   return {
     calls: events.length,
-    providerCostUsd: events.reduce(
-      (total, event) => total + event.costUsd,
-      0,
-    ),
+    providerCostUsd: events.reduce((total, event) => total + event.costUsd, 0),
   }
 }
 
@@ -692,8 +838,7 @@ function AgentUsageBreakdown({
       align: 'right',
       cell: (session) => {
         const model =
-          billableModelUsage(session, usage?.billingStartedAt)
-            .providerCostUsd *
+          billableModelUsage(session, usage?.billingStartedAt).providerCostUsd *
           100 *
           markup
         const runtime =
@@ -731,8 +876,8 @@ function AgentUsageBreakdown({
         <div className="px-6 pt-6">
           <h2 className="text-sm font-semibold">Usage by agent session</h2>
           <p className="text-muted-foreground mt-1 text-xs">
-            Recent serverless-agent sessions, split into model and runtime
-            cost. Organization totals remain the billing ledger of record.
+            Recent serverless-agent sessions, split into model and runtime cost.
+            Organization totals remain the billing ledger of record.
           </p>
         </div>
         <div className="mt-3">
@@ -741,7 +886,9 @@ function AgentUsageBreakdown({
             rows={rows}
             rowKey={(session) => session.id}
             loading={isLoading}
-            empty={<EmptyState title="No serverless-agent usage to show yet." />}
+            empty={
+              <EmptyState title="No serverless-agent usage to show yet." />
+            }
           />
         </div>
       </Panel>

--- a/web/src/pages/Billing.tsx
+++ b/web/src/pages/Billing.tsx
@@ -283,7 +283,10 @@ function PrepaidPlan() {
 
   // Whether a card is on file → offer the Stripe portal to manage it. Compliance
   // requires that anyone with a saved card can view/update/remove it.
-  const { data: billing } = useQuery({ queryKey: ['billing'], queryFn: getBilling })
+  const { data: billing } = useQuery({
+    queryKey: ['billing'],
+    queryFn: getBilling,
+  })
   const portalMutation = useMutation({
     mutationFn: autumnBillingPortal,
     onSuccess: (data) => {
@@ -366,8 +369,8 @@ function PrepaidPlan() {
         <Panel className="p-6">
           <h2 className="mb-2 text-sm font-semibold">Payment method</h2>
           <p className="text-muted-foreground mb-3 text-sm">
-            Update your card, download invoices, or remove your payment method on
-            Stripe.
+            Update your card, download invoices, or remove your payment method
+            on Stripe.
           </p>
           <Button
             variant="outline"
@@ -483,7 +486,9 @@ function ModelUsageCard({
       <div className="mb-3 flex items-center justify-between gap-3">
         <h2 className="text-sm font-semibold">Managed model usage</h2>
         <StatusBadge
-          status={enabled ? 'success' : status === 'error' ? 'error' : 'stopped'}
+          status={
+            enabled ? 'success' : status === 'error' ? 'error' : 'stopped'
+          }
           label={status}
         />
       </div>
@@ -534,15 +539,18 @@ function AutoTopupCard({
     enabled?: boolean
     threshold?: number
     quantity?: number
+    budget?: number
   }>({})
   const enabled = draft.enabled ?? current?.enabled ?? false
   const threshold = draft.threshold ?? current?.threshold ?? 5
   const quantity = draft.quantity ?? current?.quantity ?? 25
+  const budget = draft.budget ?? current?.budget ?? 100
   const [saved, markSaved] = useTransientFlag(3000)
   const [confirm, setConfirm] = useState(false)
 
   const mutation = useMutation({
-    mutationFn: () => setAutumnAutoTopup({ enabled, threshold, quantity }),
+    mutationFn: () =>
+      setAutumnAutoTopup({ enabled, threshold, quantity, budget }),
     onSuccess: (data) => {
       setConfirm(false)
       if (data?.url) {
@@ -558,7 +566,12 @@ function AutoTopupCard({
 
   // Saving only charges when enabling WITHOUT a card on file. Gate that one path.
   const willCharge = enabled && !hasToppedUp
-  const onSave = () => (willCharge ? setConfirm(true) : mutation.mutate())
+  const validBudget = budget >= quantity && budget % quantity === 0
+  const onSave = () => {
+    if (enabled && !validBudget) return
+    if (willCharge) setConfirm(true)
+    else mutation.mutate()
+  }
 
   return (
     <Panel className="p-6">
@@ -625,13 +638,42 @@ function AutoTopupCard({
               />
             </div>
           </Field>
+          <Field label="Monthly budget" htmlFor="budget">
+            <div className="flex items-center gap-1.5">
+              <span className="text-muted-foreground text-sm">$</span>
+              <Input
+                id="budget"
+                type="number"
+                min={quantity}
+                step={quantity}
+                value={budget}
+                onChange={(e) =>
+                  setDraft((d) => ({
+                    ...d,
+                    budget: Math.max(
+                      0,
+                      Math.floor(Number(e.target.value) || 0),
+                    ),
+                  }))
+                }
+                className="w-24 font-mono"
+              />
+            </div>
+          </Field>
         </div>
+      ) : null}
+
+      {enabled && !validBudget ? (
+        <p className="text-status-error mt-3 text-xs">
+          Monthly budget must be at least ${quantity} and a whole multiple of
+          the ${quantity} top-up amount.
+        </p>
       ) : null}
 
       <div className="mt-4">
         <Button
           variant="outline"
-          disabled={mutation.isPending}
+          disabled={mutation.isPending || (enabled && !validBudget)}
           onClick={onSave}
         >
           {mutation.isPending ? 'Saving…' : saved ? 'Saved' : 'Save'}
@@ -649,7 +691,7 @@ function AutoTopupCard({
         open={confirm}
         onOpenChange={(o) => !o && setConfirm(false)}
         title="Enable automatic top-up"
-        description={`You don't have a saved card yet, so enabling runs your first $${quantity} recharge now to set it up — you'll be charged $${quantity}. After that we top up automatically whenever your balance drops below $${threshold}.`}
+        description={`You don't have a saved card yet, so enabling runs your first $${quantity} recharge now to set it up — you'll be charged $${quantity}. After that we top up automatically whenever your balance drops below $${threshold}, up to $${budget} per month.`}
         confirmLabel={`Charge $${quantity} & enable`}
         pending={mutation.isPending}
         onConfirm={() => mutation.mutate()}

--- a/web/src/pages/Billing.tsx
+++ b/web/src/pages/Billing.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { Link } from 'react-router-dom'
+import { useEffect, useRef, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { CircleAlert, CircleCheck } from 'lucide-react'
@@ -277,10 +277,15 @@ const USAGE_PLANS = [
 
 function PrepaidPlan() {
   const queryClient = useQueryClient()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const redirectedPlan = searchParams.get('usage-plan')
+  const pendingUsagePlan =
+    redirectedPlan === 'pro' || redirectedPlan === 'max' ? redirectedPlan : null
+  const activationToastShown = useRef(false)
   const { data: autumn, isLoading } = useQuery({
     queryKey: ['autumn-billing'],
     queryFn: getAutumnBilling,
-    refetchInterval: 30_000,
+    refetchInterval: pendingUsagePlan != null ? 1_500 : 30_000,
   })
   const [amount, setAmount] = useState(25)
   const [confirmTopup, setConfirmTopup] = useState(false)
@@ -291,6 +296,22 @@ function PrepaidPlan() {
   const [usageProduct, setUsageProduct] = useState<
     'sandboxes' | 'serverless-agents'
   >('serverless-agents')
+
+  useEffect(() => {
+    if (pendingUsagePlan == null || autumn?.usagePlan !== pendingUsagePlan)
+      return
+
+    if (!activationToastShown.current) {
+      const label = pendingUsagePlan === 'pro' ? 'Pro' : 'Max'
+      toast.success(`${label} plan activated`, {
+        description: 'Your monthly credits are ready to use.',
+      })
+      activationToastShown.current = true
+    }
+    const next = new URLSearchParams(searchParams)
+    next.delete('usage-plan')
+    setSearchParams(next, { replace: true })
+  }, [autumn?.usagePlan, pendingUsagePlan, searchParams, setSearchParams])
 
   // url present → redirect to hosted checkout (new card); url null → the
   // existing card was charged server-side, so just refresh the balance.
@@ -316,8 +337,14 @@ function PrepaidPlan() {
   })
   const usagePlanMutation = useMutation({
     mutationFn: (plan: 'pro' | 'max') => autumnSubscribeUsagePlan(plan),
-    onSuccess: (d) => {
+    onSuccess: (d, plan) => {
       setConfirmUsagePlanId(null)
+      if (!d.url) {
+        const label = plan === 'pro' ? 'Pro' : 'Max'
+        toast.success(`${label} plan updated`, {
+          description: 'Your billing status and credits are refreshing.',
+        })
+      }
       onPurchase(d)
     },
     onError: (e) => notifyError("Couldn't update your plan.", e),
@@ -353,6 +380,22 @@ function PrepaidPlan() {
 
   return (
     <div className="max-w-5xl space-y-4">
+      {pendingUsagePlan != null ? (
+        <Panel className="p-4">
+          <div className="flex items-start gap-3">
+            <CircleCheck className="text-status-running mt-0.5 size-5 shrink-0" />
+            <div>
+              <h2 className="text-sm font-semibold">
+                Activating {pendingUsagePlan === 'pro' ? 'Pro' : 'Max'}…
+              </h2>
+              <p className="text-muted-foreground mt-1 text-sm">
+                Payment completed. We are waiting for the plan and monthly
+                credits to synchronize.
+              </p>
+            </div>
+          </div>
+        </Panel>
+      ) : null}
       <UsagePlanCard
         currentPlan={autumn?.usagePlan ?? 'base'}
         onSelectPlan={setConfirmUsagePlanId}


### PR DESCRIPTION
## Decisions and risks

- Uses one organization-wide prepaid credit balance for Serverless Agent sessions.
- Adds Usage, Pro ($20/month for $200 credits), and Max ($200/month for $2,000 credits), with non-expiring one-off top-ups.
- Provisions organization-scoped OpenRouter keys and meters cumulative managed-model provider spend into Autumn; BYOK model spend remains zero.
- Bills active agent runtime at the fixed 2 GB / 1 vCPU baseline rate. Automatic MicroVM bursts are included rather than measured through cgroups.
- Makes Serverless agents the default billing view and keeps raw-sandbox pricing and concurrency in the separate Sandboxes surface and rollout.
- Session rows are attribution views; OpenRouter cumulative spend, bounded runtime leases, and the Autumn ledger remain authoritative.

## Review map

- Model provisioning and metering: `cloudflare-workers/api-edge/src/model_billing.ts` and `model_meter.ts`
- Runtime ingestion and plan projection: API edge billing handlers
- Versioned Usage/Pro/Max catalog: `scripts/autumn`
- Billing UI, upgrade flow, and session links: `web/src/pages/Billing.tsx`

## Verification

- API edge TypeScript check
- Autumn webhook purchase-flow tests
- Web TypeScript check and production Vite build
- Autumn catalog preview and sandbox push to `mo-test`
- API edge/dashboard development deployment to `mo-oc-dev`

## Remaining gates

- Merge with the managed-backend usage-attribution PR.
- Complete payment, lease-failure, halt/resume, and aggregate AWS reconciliation checks before any separately approved production promotion.
