### PR TITLE
feat: BYO Claude/Codex subscription — public API contracts, Autumn entitlement, dashboard, CLI

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -21,6 +21,8 @@ describe that call; they do not perform I/O or run the durable agent loop.
   human-in-the-loop prompt; interactive clarification remains a tool action.
 - `useModel()` chooses a model. A string uses OpenRouter and retains its normal
   `provider/model` spelling.
+- To select an OpenAI-native model that can use a project Codex subscription,
+  use an explicit provider: `useModel({ provider: "openai", model: "gpt-5" })`.
 - `useTool()` and `useSubagent()` select declared capabilities.
 - `useSessionData()` reads the current durable session-data snapshot.
 - `useMcpServer()` conditionally selects a declared MCP server.

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -335,6 +335,28 @@ export class OpenComputerClient {
     });
   }
 
+  // Relays a credential the local CLI obtained through the authorized Codex
+  // OAuth flow into a connected subscription (encrypted custody server-side).
+  relayModelAccess(id: string, credential: {
+    access_token: string;
+    refresh_token?: string;
+    token_type: string;
+    expires_at: number;
+  }) {
+    return this.request<ModelAccessConnection>(
+      `/api/managed-agents/model-access/connections/${encodeURIComponent(id)}/complete`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          access_token: credential.access_token,
+          refresh_token: credential.refresh_token,
+          token_type: credential.token_type,
+          expires_at: credential.expires_at,
+        }),
+      },
+    );
+  }
+
   disconnectModelAccess(id: string) {
     return this.request<ModelAccessConnection>(
       `/api/managed-agents/model-access/connections/${encodeURIComponent(id)}`,

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -63,8 +63,8 @@ export interface ModelAccessConnection {
   id: string;
   organizationId: string;
   connectedByUserId: string;
-  provider: "openai";
-  kind: "codex_subscription";
+  provider: "anthropic" | "openai";
+  kind: "claude_subscription" | "codex_subscription";
   label: string;
   externalAccountHint?: string;
   status: string;
@@ -77,7 +77,7 @@ export interface ModelAccessBinding {
   organizationId: string;
   projectId: string;
   environment: "development" | "production";
-  provider: "openai";
+  provider: "anthropic" | "openai";
   connectionId: string;
   enabled: boolean;
   enabledByUserId?: string;
@@ -337,12 +337,15 @@ export class OpenComputerClient {
 
   // Relays a credential the local CLI obtained through the authorized Codex
   // OAuth flow into a connected subscription (encrypted custody server-side).
-  relayModelAccess(id: string, credential: {
-    access_token: string;
-    refresh_token?: string;
-    token_type: string;
-    expires_at: number;
-  }) {
+  relayModelAccess(
+    id: string,
+    credential: {
+      access_token: string;
+      refresh_token?: string;
+      token_type: string;
+      expires_at: number;
+    },
+  ) {
     return this.request<ModelAccessConnection>(
       `/api/managed-agents/model-access/connections/${encodeURIComponent(id)}/complete`,
       {
@@ -373,7 +376,7 @@ export class OpenComputerClient {
 
   putModelAccessBinding(input: {
     projectId: string;
-    provider: "openai";
+    provider: "anthropic" | "openai";
     environment: "development" | "production";
     enabled: boolean;
   }) {

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -63,8 +63,8 @@ export interface ModelAccessConnection {
   id: string;
   organizationId: string;
   connectedByUserId: string;
-  provider: "anthropic" | "openai";
-  kind: "claude_subscription" | "codex_subscription";
+  provider: "openai";
+  kind: "codex_subscription";
   label: string;
   externalAccountHint?: string;
   status: string;
@@ -77,7 +77,7 @@ export interface ModelAccessBinding {
   organizationId: string;
   projectId: string;
   environment: "development" | "production";
-  provider: "anthropic" | "openai";
+  provider: "openai";
   connectionId: string;
   enabled: boolean;
   enabledByUserId?: string;
@@ -321,15 +321,18 @@ export class OpenComputerClient {
     return result.data;
   }
 
-  connectModelAccess(input: {
-    provider: "anthropic" | "openai";
-    token: string;
-    label?: string;
-  }) {
-    return this.request<ModelAccessConnection>(
-      "/api/managed-agents/model-access/connections",
-      { method: "POST", body: JSON.stringify(input) },
-    );
+  // Starts the personal Codex subscription OAuth flow. No token is given or
+  // accepted; returns a pending intent with an authorize_url.
+  connectModelAccess(input: { provider: "openai"; label?: string }) {
+    return this.request<{
+      connection: ModelAccessConnection;
+      status: "pending";
+      authorize_url: string;
+      expires_at: string;
+    }>("/api/managed-agents/model-access/connections", {
+      method: "POST",
+      body: JSON.stringify(input),
+    });
   }
 
   disconnectModelAccess(id: string) {
@@ -348,7 +351,7 @@ export class OpenComputerClient {
 
   putModelAccessBinding(input: {
     projectId: string;
-    provider: "anthropic" | "openai";
+    provider: "openai";
     environment: "development" | "production";
     enabled: boolean;
   }) {

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -57,6 +57,34 @@ export interface ManagedSecretMetadata {
   updatedAt: string;
 }
 
+// Model access (work 011). The provider token is write-only; these shapes
+// carry only normalized metadata.
+export interface ModelAccessConnection {
+  id: string;
+  organizationId: string;
+  connectedByUserId: string;
+  provider: "anthropic" | "openai";
+  kind: "claude_subscription" | "codex_subscription";
+  label: string;
+  externalAccountHint?: string;
+  status: string;
+  checkedAt?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface ModelAccessBinding {
+  organizationId: string;
+  projectId: string;
+  environment: "development" | "production";
+  provider: "anthropic" | "openai";
+  connectionId: string;
+  enabled: boolean;
+  enabledByUserId?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
 export interface AgentRuntimeVariableMetadata {
   name: string;
   projectId: string;
@@ -282,6 +310,51 @@ export class OpenComputerClient {
     return this.request<void>(
       `/api/managed-agents/projects/${encodeURIComponent(input.projectId)}/secrets/${encodeURIComponent(input.name)}?${query.toString()}`,
       { method: "DELETE" },
+    );
+  }
+
+  // ── Model access (work 011) ──────────────────────────────────────────────
+  async modelAccessConnections(): Promise<ModelAccessConnection[]> {
+    const result = await this.request<{ data: ModelAccessConnection[] }>(
+      "/api/managed-agents/model-access/connections",
+    );
+    return result.data;
+  }
+
+  connectModelAccess(input: {
+    provider: "anthropic" | "openai";
+    token: string;
+    label?: string;
+  }) {
+    return this.request<ModelAccessConnection>(
+      "/api/managed-agents/model-access/connections",
+      { method: "POST", body: JSON.stringify(input) },
+    );
+  }
+
+  disconnectModelAccess(id: string) {
+    return this.request<ModelAccessConnection>(
+      `/api/managed-agents/model-access/connections/${encodeURIComponent(id)}`,
+      { method: "DELETE" },
+    );
+  }
+
+  async modelAccessBindings(projectId: string): Promise<ModelAccessBinding[]> {
+    const result = await this.request<{ data: ModelAccessBinding[] }>(
+      `/api/managed-agents/projects/${encodeURIComponent(projectId)}/model-access/bindings`,
+    );
+    return result.data;
+  }
+
+  putModelAccessBinding(input: {
+    projectId: string;
+    provider: "anthropic" | "openai";
+    environment: "development" | "production";
+    enabled: boolean;
+  }) {
+    return this.request<ModelAccessBinding>(
+      `/api/managed-agents/projects/${encodeURIComponent(input.projectId)}/model-access/bindings/${input.provider}/${input.environment}`,
+      { method: "PUT", body: JSON.stringify({ enabled: input.enabled }) },
     );
   }
 

--- a/cli/src/codex-oauth.test.ts
+++ b/cli/src/codex-oauth.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import test from "node:test";
+
+import { exchangeCodeOnCallback } from "./codex-oauth.js";
+
+async function availablePort(): Promise<number> {
+  const server = http.createServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return port;
+}
+
+test("Codex OAuth callback closes its listener before resolving", async () => {
+  const port = await availablePort();
+  const code = await exchangeCodeOnCallback(
+    "https://auth.openai.com/oauth/authorize",
+    "expected-state",
+    port,
+    () => {
+      void fetch(
+        `http://127.0.0.1:${port}/auth/callback?code=test-code&state=expected-state`,
+      );
+    },
+  );
+  assert.equal(code, "test-code");
+
+  const rebound = http.createServer();
+  await new Promise<void>((resolve) =>
+    rebound.listen(port, "127.0.0.1", resolve),
+  );
+  await new Promise<void>((resolve, reject) =>
+    rebound.close((error) => (error ? reject(error) : resolve())),
+  );
+});

--- a/cli/src/codex-oauth.ts
+++ b/cli/src/codex-oauth.ts
@@ -1,0 +1,191 @@
+import http from "node:http";
+import { randomBytes } from "node:crypto";
+import { spawn } from "node:child_process";
+import { platform } from "node:os";
+
+// Local personal-Codex-subscription OAuth (work 011). The CLI performs the
+// OAuth exchange on the user's machine against the authorized Codex endpoints,
+// then relays the resulting credential to OpenComputer as a connected
+// subscription. Nothing sensitive is ever shown or written to the repo.
+
+// Observed Codex/OpenAI endpoints (see work 011 "Provider authorization").
+const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
+const TOKEN_URL = "https://auth.openai.com/oauth/token";
+const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const SCOPE = "openid profile email offline_access";
+const CALLBACK_PORT = 1455;
+const CALLBACK_PATH = "/auth/callback";
+
+export interface RelayedCodexCredential {
+  access_token: string;
+  refresh_token?: string;
+  token_type: string;
+  expires_at: number;
+}
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  token_type?: string;
+  expires_in: number;
+}
+
+function base64url(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+export async function codexLogin(): Promise<{
+  credential: RelayedCodexCredential;
+  accountHint: string;
+}> {
+  const codeVerifier = base64url(randomBytes(32));
+  const challengeBytes = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(codeVerifier),
+  );
+  const codeChallenge = base64url(new Uint8Array(challengeBytes));
+  const state = base64url(randomBytes(24));
+  const redirectUri = `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`;
+
+  const authorizeUrl = new URL(AUTHORIZE_URL);
+  authorizeUrl.searchParams.set("client_id", CLIENT_ID);
+  authorizeUrl.searchParams.set("redirect_uri", redirectUri);
+  authorizeUrl.searchParams.set("response_type", "code");
+  authorizeUrl.searchParams.set("prompt", "consent");
+  authorizeUrl.searchParams.set("scope", SCOPE);
+  authorizeUrl.searchParams.set("state", state);
+  authorizeUrl.searchParams.set("code_challenge", codeChallenge);
+  authorizeUrl.searchParams.set("code_challenge_method", "S256");
+  authorizeUrl.searchParams.set("id_token_add_organizations", "true");
+  authorizeUrl.searchParams.set("codex_cli_simplified_flow", "true");
+  authorizeUrl.searchParams.set("originator", "opencode");
+
+  const authCode = await exchangeCodeOnCallback(
+    authorizeUrl.toString(),
+    state,
+    CALLBACK_PORT,
+  );
+
+  const token = await exchangeToken({
+    tokenUrl: TOKEN_URL,
+    clientId: CLIENT_ID,
+    code: authCode,
+    codeVerifier,
+    redirectUri,
+  });
+
+  return {
+    credential: {
+      access_token: token.access_token,
+      refresh_token: token.refresh_token,
+      token_type: token.token_type ?? "Bearer",
+      expires_at: Date.now() + token.expires_in * 1_000,
+    },
+    accountHint: token.access_token.slice(0, 8),
+  };
+}
+
+// Starts a temporary localhost callback server, opens the browser to the
+// authorize URL, and resolves the one-time authorization code.
+function exchangeCodeOnCallback(
+  authorizeUrl: string,
+  expectedState: string,
+  port: number,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url ?? "/", `http://localhost:${port}`);
+      if (url.pathname !== CALLBACK_PATH) {
+        res.writeHead(404).end();
+        return;
+      }
+      const code = url.searchParams.get("code");
+      const state = url.searchParams.get("state");
+      if (!state || !secureEqual(state, expectedState)) {
+        res.writeHead(401, { "content-type": "text/plain" });
+        res.end("OAuth state mismatch. Please close this window and retry.");
+        reject(new Error("OAuth state mismatch"));
+        server.close();
+        return;
+      }
+      if (!code) {
+        const error = url.searchParams.get("error") ?? "missing code";
+        res.writeHead(400, { "content-type": "text/plain" });
+        res.end(`Authorization failed: ${error}`);
+        reject(new Error(`Authorization failed: ${error}`));
+        server.close();
+        return;
+      }
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("Authorized. You can close this window.");
+      server.close();
+      resolve(code);
+    });
+
+    server.on("error", (error) => {
+      reject(error);
+    });
+
+    server.listen(port, "127.0.0.1", () => {
+      openBrowser(authorizeUrl);
+    });
+  });
+}
+
+async function exchangeToken(input: {
+  tokenUrl: string;
+  clientId: string;
+  code: string;
+  codeVerifier: string;
+  redirectUri: string;
+}): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    client_id: input.clientId,
+    code: input.code,
+    code_verifier: input.codeVerifier,
+    grant_type: "authorization_code",
+    redirect_uri: input.redirectUri,
+  });
+  const response = await fetch(input.tokenUrl, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  const value: unknown = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new Error(`Codex token exchange failed (${String(response.status)})`);
+  }
+  const token = value as TokenResponse;
+  if (typeof token?.access_token !== "string" || typeof token.expires_in !== "number") {
+    throw new Error("Codex returned an invalid token response");
+  }
+  return token;
+}
+
+export function openBrowser(url: string): void {
+  const command =
+    platform() === "darwin"
+      ? ["open", url]
+      : platform() === "win32"
+        ? ["rundll32", "url.dll,FileProtocolHandler", url]
+        : ["xdg-open", url];
+  const child = spawn(command[0]!, command.slice(1), {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.once("error", () => undefined);
+  child.unref();
+}
+
+function secureEqual(left: string, right: string): boolean {
+  const a = Buffer.from(left);
+  const b = Buffer.from(right);
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i]! ^ b[i]!;
+  return diff === 0;
+}

--- a/cli/src/codex-oauth.ts
+++ b/cli/src/codex-oauth.ts
@@ -91,39 +91,61 @@ export async function codexLogin(): Promise<{
 
 // Starts a temporary localhost callback server, opens the browser to the
 // authorize URL, and resolves the one-time authorization code.
-function exchangeCodeOnCallback(
+export function exchangeCodeOnCallback(
   authorizeUrl: string,
   expectedState: string,
   port: number,
+  launchBrowser: (url: string) => void = openBrowser,
 ): Promise<string> {
   return new Promise((resolve, reject) => {
+    let settled = false;
     const server = http.createServer((req, res) => {
       const url = new URL(req.url ?? "/", `http://localhost:${port}`);
       if (url.pathname !== CALLBACK_PATH) {
         res.writeHead(404).end();
         return;
       }
+      if (settled) {
+        res.writeHead(409, { connection: "close" }).end();
+        return;
+      }
+      settled = true;
+      const finish = (
+        status: number,
+        message: string,
+        result: { code: string } | { error: Error },
+      ): void => {
+        res.writeHead(status, {
+          "content-type": "text/plain",
+          connection: "close",
+        });
+        res.end(message, () => {
+          server.close((closeError) => {
+            if (closeError) reject(closeError);
+            else if ("code" in result) resolve(result.code);
+            else reject(result.error);
+          });
+          server.closeAllConnections();
+        });
+      };
       const code = url.searchParams.get("code");
       const state = url.searchParams.get("state");
       if (!state || !secureEqual(state, expectedState)) {
-        res.writeHead(401, { "content-type": "text/plain" });
-        res.end("OAuth state mismatch. Please close this window and retry.");
-        reject(new Error("OAuth state mismatch"));
-        server.close();
+        finish(
+          401,
+          "OAuth state mismatch. Please close this window and retry.",
+          { error: new Error("OAuth state mismatch") },
+        );
         return;
       }
       if (!code) {
         const error = url.searchParams.get("error") ?? "missing code";
-        res.writeHead(400, { "content-type": "text/plain" });
-        res.end(`Authorization failed: ${error}`);
-        reject(new Error(`Authorization failed: ${error}`));
-        server.close();
+        finish(400, `Authorization failed: ${error}`, {
+          error: new Error(`Authorization failed: ${error}`),
+        });
         return;
       }
-      res.writeHead(200, { "content-type": "text/plain" });
-      res.end("Authorized. You can close this window.");
-      server.close();
-      resolve(code);
+      finish(200, "Authorized. You can close this window.", { code });
     });
 
     server.on("error", (error) => {
@@ -131,7 +153,7 @@ function exchangeCodeOnCallback(
     });
 
     server.listen(port, "127.0.0.1", () => {
-      openBrowser(authorizeUrl);
+      launchBrowser(authorizeUrl);
     });
   });
 }

--- a/cli/src/commands.test.ts
+++ b/cli/src/commands.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { deploymentAlias } from "./commands.js";
+
+test("one-shot deploy defaults to development and production stays explicit", () => {
+  assert.equal(deploymentAlias(), "development");
+  assert.equal(deploymentAlias("development"), "development");
+  assert.equal(deploymentAlias("production"), "production");
+});

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -79,17 +79,11 @@ function environmentOption(
   throw new Error("--environment must be development or production");
 }
 
-function modelAccessEnvironments(
-  value: string | undefined,
-): Array<"development" | "production"> | undefined {
-  if (value === undefined) return undefined;
-  if (value === "development" || value === "production") return [value];
-  if (value === "both") return ["development", "production"];
-  throw new Error("--environment must be development, production, or both");
-}
-
-function consumeCodexProvider(args: string[]): void {
-  if (args[0] === "codex") args.shift();
+function consumeModelAccessProvider(args: string[]): "claude" | "codex" {
+  if (args[0] === "claude" || args[0] === "codex") {
+    return args.shift() as "claude" | "codex";
+  }
+  return "codex";
 }
 
 async function readSecretValue(): Promise<string> {
@@ -777,30 +771,35 @@ export async function runCommand(
   if (command === "model-access") {
     const action = args.shift();
     if (action === "connect") {
-      // Local personal-Codex-subscription OAuth: open a localhost callback
+      // Local Codex-account OAuth: open a localhost callback
       // server, complete the flow in the user's browser, then relay the
-      // credential to OpenComputer as a connected subscription. Nothing secret
+      // credential to OpenComputer as a connected account. Nothing secret
       // is echoed or persisted locally.
-      consumeCodexProvider(args);
-      const projectReference = option(args, "--project");
-      const environments = modelAccessEnvironments(
-        option(args, "--environment"),
-      );
-      if (projectReference && !environments) {
+      const provider = consumeModelAccessProvider(args);
+      if (provider !== "codex") {
         throw new Error(
-          "--project requires --environment development, production, or both",
+          "Claude account BYOK is not supported. Connect a Codex account instead.",
         );
       }
-      if (!projectReference && environments) {
+      const projectReference = option(args, "--project");
+      const legacyEnvironment = option(args, "--environment");
+      if (legacyEnvironment && !projectReference)
         throw new Error("--environment requires --project <id|slug>");
-      }
+      if (
+        legacyEnvironment &&
+        !["development", "production", "both"].includes(legacyEnvironment)
+      )
+        throw new Error("--environment must be development, production, or both");
+      const environments = projectReference
+        ? (["development", "production"] as const)
+        : [];
       if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
       const project = projectReference
         ? await selectedProject(client, config, projectReference, false)
         : undefined;
       const receipt = await client.connectModelAccess({ provider: "openai" });
       process.stdout.write(
-        "Opening a local callback and your browser to authorize your Codex subscription…\n",
+        "Opening a local callback and your browser to authorize your Codex account…\n",
       );
       const { credential, accountHint } = await codexLogin();
       const connection = await client.relayModelAccess(receipt.connection.id, {
@@ -811,7 +810,7 @@ export async function runCommand(
       });
       const bindings = project
         ? await Promise.all(
-            (environments ?? []).map((environment) =>
+            environments.map((environment) =>
               client.putModelAccessBinding({
                 projectId: project.projectId,
                 provider: "openai",
@@ -829,11 +828,11 @@ export async function runCommand(
         });
       else {
         process.stdout.write(
-          `Connected Codex subscription as ${connection.label}; status ${connection.status}.\n`,
+          `Connected Codex account as ${connection.label}; status ${connection.status}.\n`,
         );
-        if (project && environments?.length) {
+        if (project) {
           process.stdout.write(
-            `Enabled Codex for ${project.projectId} (${environments.join(" and ")}).\n`,
+            `Enabled Codex for ${project.projectId} (development and production).\n`,
           );
         }
       }
@@ -855,43 +854,19 @@ export async function runCommand(
       return;
     }
     if (action === "disconnect") {
-      consumeCodexProvider(args);
+      const provider = consumeModelAccessProvider(args);
       if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
       const connections = await client.modelAccessConnections();
-      const connection = connections.find((c) => c.provider === "openai");
-      if (!connection) throw new Error("No Codex connection found.");
+      const apiProvider = provider === "claude" ? "anthropic" : "openai";
+      const connection = connections.find((c) => c.provider === apiProvider);
+      if (!connection) throw new Error(`No ${provider} connection found.`);
       const updated = await client.disconnectModelAccess(connection.id);
       if (globals.json) printJSON(updated);
       else process.stdout.write(`Disconnected ${connection.label}.\n`);
       return;
     }
-    if (action === "enable" || action === "disable") {
-      consumeCodexProvider(args);
-      const projectReference = option(args, "--project");
-      const environment = environmentOption(option(args, "--environment"));
-      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
-      const project = await selectedProject(
-        client,
-        config,
-        projectReference,
-        !globals.json,
-      );
-      const binding = await client.putModelAccessBinding({
-        projectId: project.projectId,
-        provider: "openai",
-        environment,
-        enabled: action === "enable",
-      });
-      if (globals.json) printJSON(binding);
-      else {
-        process.stdout.write(
-          `${action === "enable" ? "Enabled" : "Disabled"} codex for ${project.projectId} (${environment}).\n`,
-        );
-      }
-      return;
-    }
     throw new Error(
-      "Use `opencomputer model-access connect|list|disconnect|enable|disable`.",
+      "Use `opencomputer model-access connect|list|disconnect`.",
     );
   }
 

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -4,7 +4,7 @@ import {
   type ManagedAgentLog,
   type ManagedSessionSnapshot,
 } from "./api.js";
-import { login, logout } from "./auth.js";
+import { login, logout, openBrowser } from "./auth.js";
 import { resolveConfig } from "./config.js";
 import {
   publishProjectDeployment,
@@ -754,32 +754,21 @@ export async function runCommand(
 
   if (command === "model-access") {
     const action = args.shift();
-    // connect <provider> — write-only token via hidden prompt or stdin, never
-    // a command argument, and never echoed or persisted locally.
     if (action === "connect") {
-      const provider = args.shift();
-      if (provider !== "claude" && provider !== "codex") {
-        throw new Error("Use `opencomputer model-access connect claude|codex`.");
-      }
-      if (provider === "claude") {
-        throw new Error(
-          "Claude subscription access is not yet enabled. Only Codex is available in this rollout.",
-        );
-      }
-      const label = option(args, "--label");
+      // Starts the personal Codex subscription OAuth flow and opens the browser.
+      // No credential is accepted or stored locally.
       if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
-      const token = await readSecretValue();
-      const connection = await client.connectModelAccess({
-        provider: "openai",
-        token,
-        ...(label ? { label } : {}),
-      });
-      if (globals.json) printJSON(connection);
-      else {
+      const receipt = await client.connectModelAccess({ provider: "openai" });
+      if (!openBrowser(receipt.authorize_url)) {
         process.stdout.write(
-          `Connected ${connection.label} (${connection.provider}); status ${connection.status}.\n`,
+          `Open this URL to authorize your Codex subscription:\n${receipt.authorize_url}\n`,
+        );
+      } else {
+        process.stdout.write(
+          "Opening OpenAI to authorize your Codex subscription…\n",
         );
       }
+      if (globals.json) printJSON(receipt);
       return;
     }
     if (action === "list" || action === "ls" || action === undefined) {
@@ -798,28 +787,15 @@ export async function runCommand(
       return;
     }
     if (action === "disconnect") {
-      const provider = args.shift();
-      if (provider !== "claude" && provider !== "codex") {
-        throw new Error(
-          "Use `opencomputer model-access disconnect claude|codex`.",
-        );
-      }
-      const apiProvider = provider === "claude" ? "anthropic" : "openai";
       const connections = await client.modelAccessConnections();
-      const connection = connections.find((c) => c.provider === apiProvider);
-      if (!connection) throw new Error(`No ${provider} connection found.`);
+      const connection = connections.find((c) => c.provider === "openai");
+      if (!connection) throw new Error("No Codex connection found.");
       const updated = await client.disconnectModelAccess(connection.id);
       if (globals.json) printJSON(updated);
       else process.stdout.write(`Disconnected ${connection.label}.\n`);
       return;
     }
     if (action === "enable" || action === "disable") {
-      const provider = args.shift();
-      if (provider !== "claude" && provider !== "codex") {
-        throw new Error(
-          `Use \`opencomputer model-access ${action} claude|codex --project <project> --environment development|production\`.`,
-        );
-      }
       const projectReference = option(args, "--project");
       const environment = environmentOption(option(args, "--environment"));
       if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
@@ -829,17 +805,16 @@ export async function runCommand(
         projectReference,
         !globals.json,
       );
-      const apiProvider = provider === "claude" ? "anthropic" : "openai";
       const binding = await client.putModelAccessBinding({
         projectId: project.projectId,
-        provider: apiProvider,
+        provider: "openai",
         environment,
         enabled: action === "enable",
       });
       if (globals.json) printJSON(binding);
       else {
         process.stdout.write(
-          `${action === "enable" ? "Enabled" : "Disabled"} ${provider} for ${project.projectId} (${environment}).\n`,
+          `${action === "enable" ? "Enabled" : "Disabled"} codex for ${project.projectId} (${environment}).\n`,
         );
       }
       return;

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -752,6 +752,103 @@ export async function runCommand(
     throw new Error("Use `opencomputer secrets set`, `list`, or `remove`.");
   }
 
+  if (command === "model-access") {
+    const action = args.shift();
+    // connect <provider> — write-only token via hidden prompt or stdin, never
+    // a command argument, and never echoed or persisted locally.
+    if (action === "connect") {
+      const provider = args.shift();
+      if (provider !== "claude" && provider !== "codex") {
+        throw new Error("Use `opencomputer model-access connect claude|codex`.");
+      }
+      if (provider === "claude") {
+        throw new Error(
+          "Claude subscription access is not yet enabled. Only Codex is available in this rollout.",
+        );
+      }
+      const label = option(args, "--label");
+      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+      const token = await readSecretValue();
+      const connection = await client.connectModelAccess({
+        provider: "openai",
+        token,
+        ...(label ? { label } : {}),
+      });
+      if (globals.json) printJSON(connection);
+      else {
+        process.stdout.write(
+          `Connected ${connection.label} (${connection.provider}); status ${connection.status}.\n`,
+        );
+      }
+      return;
+    }
+    if (action === "list" || action === "ls" || action === undefined) {
+      const connections = await client.modelAccessConnections();
+      if (globals.json) printJSON(connections);
+      else if (!connections.length)
+        process.stdout.write("No model access connections.\n");
+      else {
+        for (const connection of connections) {
+          process.stdout.write(
+            `${connection.provider.padEnd(10)} ${connection.status.padEnd(18)} ` +
+              `${connection.label}${connection.externalAccountHint ? ` (${connection.externalAccountHint})` : ""}\n`,
+          );
+        }
+      }
+      return;
+    }
+    if (action === "disconnect") {
+      const provider = args.shift();
+      if (provider !== "claude" && provider !== "codex") {
+        throw new Error(
+          "Use `opencomputer model-access disconnect claude|codex`.",
+        );
+      }
+      const apiProvider = provider === "claude" ? "anthropic" : "openai";
+      const connections = await client.modelAccessConnections();
+      const connection = connections.find((c) => c.provider === apiProvider);
+      if (!connection) throw new Error(`No ${provider} connection found.`);
+      const updated = await client.disconnectModelAccess(connection.id);
+      if (globals.json) printJSON(updated);
+      else process.stdout.write(`Disconnected ${connection.label}.\n`);
+      return;
+    }
+    if (action === "enable" || action === "disable") {
+      const provider = args.shift();
+      if (provider !== "claude" && provider !== "codex") {
+        throw new Error(
+          `Use \`opencomputer model-access ${action} claude|codex --project <project> --environment development|production\`.`,
+        );
+      }
+      const projectReference = option(args, "--project");
+      const environment = environmentOption(option(args, "--environment"));
+      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+      const project = await selectedProject(
+        client,
+        config,
+        projectReference,
+        !globals.json,
+      );
+      const apiProvider = provider === "claude" ? "anthropic" : "openai";
+      const binding = await client.putModelAccessBinding({
+        projectId: project.projectId,
+        provider: apiProvider,
+        environment,
+        enabled: action === "enable",
+      });
+      if (globals.json) printJSON(binding);
+      else {
+        process.stdout.write(
+          `${action === "enable" ? "Enabled" : "Disabled"} ${provider} for ${project.projectId} (${environment}).\n`,
+        );
+      }
+      return;
+    }
+    throw new Error(
+      "Use `opencomputer model-access connect|list|disconnect|enable|disable`.",
+    );
+  }
+
   if (command === "env") {
     const action = args.shift();
     const projectReference = option(args, "--project");

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -36,6 +36,10 @@ export interface GlobalOptions {
   verbose?: boolean;
 }
 
+export function deploymentAlias(requestedAlias?: string): string {
+  return requestedAlias ?? "development";
+}
+
 function printJSON(value: unknown): void {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
 }
@@ -73,6 +77,19 @@ function environmentOption(
   if (!value || value === "development") return "development";
   if (value === "production") return "production";
   throw new Error("--environment must be development or production");
+}
+
+function modelAccessEnvironments(
+  value: string | undefined,
+): Array<"development" | "production"> | undefined {
+  if (value === undefined) return undefined;
+  if (value === "development" || value === "production") return [value];
+  if (value === "both") return ["development", "production"];
+  throw new Error("--environment must be development, production, or both");
+}
+
+function consumeCodexProvider(args: string[]): void {
+  if (args[0] === "codex") args.shift();
 }
 
 async function readSecretValue(): Promise<string> {
@@ -512,12 +529,16 @@ export async function runCommand(
           `Directory: ${initialized.root}\n` +
           `Project:   choose or create one on the first watched deployment\n` +
           `Agents:    opencomputer/\n` +
-          (spa ? `Web app:   src/ (separate lifecycle)\n\n` : `App:       agent only\n\n`) +
+          (spa
+            ? `Web app:   src/ (separate lifecycle)\n\n`
+            : `App:       agent only\n\n`) +
           `Next:\n` +
           enterDirectory +
           `  npm install\n` +
           `  npm run deploy -- --watch  # deploy changes to Development\n` +
-          (spa ? `  npm run dev:web             # optional local web app\n` : ""),
+          (spa
+            ? `  npm run dev:web             # optional local web app\n`
+            : ""),
       );
     }
     return;
@@ -588,7 +609,7 @@ export async function runCommand(
     if (project || createProjectName) {
       throw new Error("--project and --create-project require --watch");
     }
-    const alias = requestedAlias ?? "production";
+    const alias = deploymentAlias(requestedAlias);
     const binding = await ensureProjectBinding(client, config, root, {
       interactive: !globals.json,
       select: true,
@@ -760,7 +781,23 @@ export async function runCommand(
       // server, complete the flow in the user's browser, then relay the
       // credential to OpenComputer as a connected subscription. Nothing secret
       // is echoed or persisted locally.
+      consumeCodexProvider(args);
+      const projectReference = option(args, "--project");
+      const environments = modelAccessEnvironments(
+        option(args, "--environment"),
+      );
+      if (projectReference && !environments) {
+        throw new Error(
+          "--project requires --environment development, production, or both",
+        );
+      }
+      if (!projectReference && environments) {
+        throw new Error("--environment requires --project <id|slug>");
+      }
       if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+      const project = projectReference
+        ? await selectedProject(client, config, projectReference, false)
+        : undefined;
       const receipt = await client.connectModelAccess({ provider: "openai" });
       process.stdout.write(
         "Opening a local callback and your browser to authorize your Codex subscription…\n",
@@ -772,12 +809,33 @@ export async function runCommand(
         token_type: credential.token_type,
         expires_at: credential.expires_at,
       });
+      const bindings = project
+        ? await Promise.all(
+            (environments ?? []).map((environment) =>
+              client.putModelAccessBinding({
+                projectId: project.projectId,
+                provider: "openai",
+                environment,
+                enabled: true,
+              }),
+            ),
+          )
+        : [];
       if (globals.json)
-        printJSON({ ...connection, external_account_hint: accountHint });
+        printJSON({
+          ...connection,
+          external_account_hint: accountHint,
+          bindings,
+        });
       else {
         process.stdout.write(
           `Connected Codex subscription as ${connection.label}; status ${connection.status}.\n`,
         );
+        if (project && environments?.length) {
+          process.stdout.write(
+            `Enabled Codex for ${project.projectId} (${environments.join(" and ")}).\n`,
+          );
+        }
       }
       return;
     }
@@ -797,6 +855,8 @@ export async function runCommand(
       return;
     }
     if (action === "disconnect") {
+      consumeCodexProvider(args);
+      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
       const connections = await client.modelAccessConnections();
       const connection = connections.find((c) => c.provider === "openai");
       if (!connection) throw new Error("No Codex connection found.");
@@ -806,6 +866,7 @@ export async function runCommand(
       return;
     }
     if (action === "enable" || action === "disable") {
+      consumeCodexProvider(args);
       const projectReference = option(args, "--project");
       const environment = environmentOption(option(args, "--environment"));
       if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -4,7 +4,8 @@ import {
   type ManagedAgentLog,
   type ManagedSessionSnapshot,
 } from "./api.js";
-import { login, logout, openBrowser } from "./auth.js";
+import { login, logout } from "./auth.js";
+import { codexLogin } from "./codex-oauth.js";
 import { resolveConfig } from "./config.js";
 import {
   publishProjectDeployment,
@@ -755,20 +756,29 @@ export async function runCommand(
   if (command === "model-access") {
     const action = args.shift();
     if (action === "connect") {
-      // Starts the personal Codex subscription OAuth flow and opens the browser.
-      // No credential is accepted or stored locally.
+      // Local personal-Codex-subscription OAuth: open a localhost callback
+      // server, complete the flow in the user's browser, then relay the
+      // credential to OpenComputer as a connected subscription. Nothing secret
+      // is echoed or persisted locally.
       if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
       const receipt = await client.connectModelAccess({ provider: "openai" });
-      if (!openBrowser(receipt.authorize_url)) {
+      process.stdout.write(
+        "Opening a local callback and your browser to authorize your Codex subscription…\n",
+      );
+      const { credential, accountHint } = await codexLogin();
+      const connection = await client.relayModelAccess(receipt.connection.id, {
+        access_token: credential.access_token,
+        refresh_token: credential.refresh_token,
+        token_type: credential.token_type,
+        expires_at: credential.expires_at,
+      });
+      if (globals.json)
+        printJSON({ ...connection, external_account_hint: accountHint });
+      else {
         process.stdout.write(
-          `Open this URL to authorize your Codex subscription:\n${receipt.authorize_url}\n`,
-        );
-      } else {
-        process.stdout.write(
-          "Opening OpenAI to authorize your Codex subscription…\n",
+          `Connected Codex subscription as ${connection.label}; status ${connection.status}.\n`,
         );
       }
-      if (globals.json) printJSON(receipt);
       return;
     }
     if (action === "list" || action === "ls" || action === undefined) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -64,7 +64,7 @@ Usage:
   opencomputer env set <name> [--environment development|production] [--agent <agent>|current]
   opencomputer env list [--environment development|production] [--agent <agent>|current]
   opencomputer env remove <name> [--environment development|production] [--agent <agent>|current]
-  opencomputer model-access connect codex [--label <label>]
+  opencomputer model-access connect codex
   opencomputer model-access list
   opencomputer model-access disconnect codex
   opencomputer model-access enable codex --project <id|slug> --environment development|production

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -64,11 +64,9 @@ Usage:
   opencomputer env set <name> [--environment development|production] [--agent <agent>|current]
   opencomputer env list [--environment development|production] [--agent <agent>|current]
   opencomputer env remove <name> [--environment development|production] [--agent <agent>|current]
-  opencomputer model-access connect codex [--project <id|slug> --environment development|production|both]
+  opencomputer model-access connect codex [--project <id|slug>]
   opencomputer model-access list
   opencomputer model-access disconnect codex
-  opencomputer model-access enable codex --project <id|slug> --environment development|production
-  opencomputer model-access disable codex --project <id|slug> --environment development|production
   opencomputer webhooks list [--environment development|production] [--agent <agent>|current]
   opencomputer webhooks create <name> [--environment development|production] [--agent <agent>|current]
   opencomputer webhooks enable <webhook-id> [--project <id|slug>]

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -64,7 +64,7 @@ Usage:
   opencomputer env set <name> [--environment development|production] [--agent <agent>|current]
   opencomputer env list [--environment development|production] [--agent <agent>|current]
   opencomputer env remove <name> [--environment development|production] [--agent <agent>|current]
-  opencomputer model-access connect codex
+  opencomputer model-access connect codex [--project <id|slug> --environment development|production|both]
   opencomputer model-access list
   opencomputer model-access disconnect codex
   opencomputer model-access enable codex --project <id|slug> --environment development|production
@@ -76,7 +76,7 @@ Usage:
   opencomputer webhooks rotate-token <webhook-id> [--project <id|slug>]
   opencomputer webhooks remove <webhook-id> [--project <id|slug>]
   opencomputer logs [--agent <agent>] [--session <session-id>] [--environment development|production] [--follow]
-  opencomputer deploy [--alias <alias>] [--watch]
+  opencomputer deploy [--alias development|production] [--watch]
   opencomputer run <agent> <prompt> [--keep]
 
 Global options:

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -64,6 +64,11 @@ Usage:
   opencomputer env set <name> [--environment development|production] [--agent <agent>|current]
   opencomputer env list [--environment development|production] [--agent <agent>|current]
   opencomputer env remove <name> [--environment development|production] [--agent <agent>|current]
+  opencomputer model-access connect codex [--label <label>]
+  opencomputer model-access list
+  opencomputer model-access disconnect codex
+  opencomputer model-access enable codex --project <id|slug> --environment development|production
+  opencomputer model-access disable codex --project <id|slug> --environment development|production
   opencomputer webhooks list [--environment development|production] [--agent <agent>|current]
   opencomputer webhooks create <name> [--environment development|production] [--agent <agent>|current]
   opencomputer webhooks enable <webhook-id> [--project <id|slug>]

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -347,6 +347,7 @@ export default function Agent() {
         url: string;
         connection?: string;
       }>;
+      models: Array<{ provider: string; model: string }>;
     };
     assert.deepEqual(manifest, {
       version: 2,
@@ -360,9 +361,60 @@ export default function Agent() {
       mcpServerDefinitions: [
         { id: "docs", url: "https://mcp.example.com/" },
       ],
+      models: [
+        {
+          provider: "openrouter",
+          model: "anthropic/claude-sonnet-4.6",
+        },
+      ],
     });
+    assert.equal(
+      (
+        JSON.parse(
+          await readFile(resolve(runtime, "opencode.json"), "utf8"),
+        ) as { model: string }
+      ).model,
+      "openrouter/anthropic/claude-sonnet-4.6",
+    );
     await assert.rejects(
       stat(resolve(initialized.agentRoot, "opencomputer.toml")),
+    );
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+test("the compiler preserves an explicit OpenAI model selection for Codex routing", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-openai-model-"));
+  const root = resolve(parent, "app");
+  try {
+    const initialized = await initializeAgentProject(root);
+    await writeFile(
+      resolve(initialized.agentRoot, "agent.ts"),
+      `import { useModel } from "@opencomputer/agent";
+
+export default function Agent() {
+  useModel({ provider: "openai", model: "gpt-5" });
+  return "Help with the request.";
+}
+`,
+    );
+
+    const runtime = await prepareAgent(initialized.agentRoot);
+    const manifest = JSON.parse(
+      await readFile(
+        resolve(runtime, ".opencomputer", "reactive.json"),
+        "utf8",
+      ),
+    ) as { models: Array<{ provider: string; model: string }> };
+    assert.deepEqual(manifest.models, [{ provider: "openai", model: "gpt-5" }]);
+    assert.equal(
+      (
+        JSON.parse(
+          await readFile(resolve(runtime, "opencode.json"), "utf8"),
+        ) as { model: string }
+      ).model,
+      "openai/gpt-5",
     );
   } finally {
     await rm(parent, { recursive: true, force: true });

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -1582,6 +1582,56 @@ function definedToolIds(source: string): string[] {
     .sort();
 }
 
+function staticModelSelections(
+  source: string,
+): Array<{ provider: string; model: string }> {
+  const file = ts.createSourceFile(
+    "agent.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const selections: Array<{ provider: string; model: string }> = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "useModel"
+    ) {
+      const value = node.arguments[0];
+      if (value && ts.isStringLiteralLike(value)) {
+        selections.push({ provider: "openrouter", model: value.text });
+      } else if (value && ts.isObjectLiteralExpression(value)) {
+        let provider: string | undefined;
+        let model: string | undefined;
+        for (const property of value.properties) {
+          if (!ts.isPropertyAssignment(property)) continue;
+          const name = ts.isIdentifier(property.name)
+            ? property.name.text
+            : ts.isStringLiteralLike(property.name)
+              ? property.name.text
+              : undefined;
+          if (!name || !ts.isStringLiteralLike(property.initializer)) continue;
+          if (name === "provider") provider = property.initializer.text;
+          if (name === "model") model = property.initializer.text;
+        }
+        if (provider && model) selections.push({ provider, model });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(file);
+  return selections.filter(
+    (selection, index) =>
+      selections.findIndex(
+        (candidate) =>
+          candidate.provider === selection.provider &&
+          candidate.model === selection.model,
+      ) === index,
+  );
+}
+
 function agentApiRuntimeSource(): string {
   return `function hooks() {
   const value = globalThis[Symbol.for("opencomputer.agent-hooks")];
@@ -1708,13 +1758,21 @@ the product or support surface presented to users.
 
 `,
   );
+  const declaredModels = staticModelSelections(agentSource);
   const openCodeConfig = resolve(root, "opencode.json");
-  if (await exists(openCodeConfig)) {
-    const parsed: unknown = JSON.parse(await readFile(openCodeConfig, "utf8"));
+  const hasOpenCodeConfig = await exists(openCodeConfig);
+  if (hasOpenCodeConfig || declaredModels.length === 1) {
+    const parsed: unknown = hasOpenCodeConfig
+      ? JSON.parse(await readFile(openCodeConfig, "utf8"))
+      : {};
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       throw new Error("opencode.json must contain a JSON object");
     }
     const config = parsed as Record<string, unknown>;
+    const inferredModel =
+      declaredModels.length === 1
+        ? `${declaredModels[0]!.provider}/${declaredModels[0]!.model}`
+        : undefined;
     const configuredTools =
       config.tools &&
       typeof config.tools === "object" &&
@@ -1735,6 +1793,9 @@ the product or support surface presented to users.
       `${JSON.stringify(
         {
           ...config,
+          ...(config.model === undefined && inferredModel
+            ? { model: inferredModel }
+            : {}),
           tools: { ...configuredTools, question: !questionDenied },
           permission: {
             ...configuredPermission,
@@ -1937,6 +1998,7 @@ the product or support surface presented to users.
           ]),
         ].sort(),
         mcpServerDefinitions,
+        models: declaredModels,
       },
       null,
       2,

--- a/cloudflare-workers/api-edge/src/cli_auth.test.ts
+++ b/cloudflare-workers/api-edge/src/cli_auth.test.ts
@@ -37,8 +37,16 @@ class FakeStatement {
       if (!this.db.user) return null;
       return this.db.user as T;
     }
-    if (this.sql.includes("FROM api_keys WHERE key_hash")) {
-      return { org_id: orgID, created_by: userID, expires_at: null } as T;
+    if (
+      this.sql.includes("FROM api_keys WHERE key_hash") ||
+      this.sql.includes("FROM api_keys k")
+    ) {
+      return {
+        org_id: orgID,
+        created_by: userID,
+        expires_at: null,
+        role: "admin",
+      } as T;
     }
     if (this.sql.includes("SELECT o.name AS org_name")) {
       return { org_name: "Igor's workspace", email: "igor@example.com" } as T;

--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -976,10 +976,20 @@ export async function handleDashboard(
         return json({ error: "managed model billing is unavailable" }, 503);
       }
     }
+    const membership = await env.OPENCOMPUTER_DB.prepare(
+      `SELECT role FROM org_memberships WHERE org_id = ?1 AND user_id = ?2`,
+    ).bind(caller.orgID, caller.userID).first<{ role: string }>();
     return proxyManagedAgents(
       req,
       env,
-      caller,
+      {
+        orgID: caller.orgID,
+        userID: caller.userID,
+        role:
+          membership?.role === "owner" || membership?.role === "admin"
+            ? "admin"
+            : membership?.role,
+      },
       "/api/dashboard/managed-agents",
     );
   }

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -307,6 +307,7 @@ async function mintSandboxToken(
 interface Caller {
   orgID: string;
   userID: string | null;
+  role?: string;
   // Set only for act-as-org provisioning tokens (sessions-api). Least-privilege:
   // the dispatch gates these to sandbox + secret-store routes (provisionScopeGate).
   scope?: "sandbox-provision";
@@ -508,14 +509,28 @@ async function authenticate(req: Request, env: Env): Promise<Caller | null> {
   }
 
   const row = await env.OPENCOMPUTER_DB.prepare(
-    "SELECT org_id, created_by, expires_at FROM api_keys WHERE key_hash = ?1",
+    `SELECT k.org_id, k.created_by, k.expires_at,
+            CASE WHEN m.role IN ('owner', 'admin') THEN 'admin' ELSE m.role END AS role
+       FROM api_keys k
+       LEFT JOIN org_memberships m
+         ON m.org_id = k.org_id AND m.user_id = k.created_by
+      WHERE k.key_hash = ?1`,
   )
     .bind(hash)
-    .first<{ org_id: string; created_by: string | null; expires_at: number | null }>();
+    .first<{
+      org_id: string;
+      created_by: string | null;
+      expires_at: number | null;
+      role: string | null;
+    }>();
   if (!row) return null; // never cache negatives — a freshly-created key must work at once
   if (row.expires_at && row.expires_at < nowSec) return null;
 
-  const caller: Caller = { orgID: row.org_id, userID: row.created_by };
+  const caller: Caller = {
+    orgID: row.org_id,
+    userID: row.created_by,
+    ...(row.role ? { role: row.role } : {}),
+  };
   if (authCache.size >= CACHE_MAX) authCache.clear();
   const entry: AuthEntry = { caller, expiresAt: row.expires_at, cachedAtMs: nowMs, lastBumpMs: 0 };
   authCache.set(hash, entry);

--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -23,6 +23,7 @@ describe("managed agents proxy", () => {
     const token = await mintManagedAgentsAssertion("test-secret", {
       orgID: "org_test",
       userID: "user_test",
+      role: "admin",
     });
     const payload = decodePayload(token);
 
@@ -32,8 +33,67 @@ describe("managed agents proxy", () => {
       sub: "org_test",
       org_id: "org_test",
       user_id: "user_test",
+      role: "admin",
     });
     expect(Number(payload.exp) - Number(payload.iat)).toBe(120);
+  });
+
+  it("returns the public model-access OAuth receipt without custody fields", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          connection: {
+            id: "mac_test",
+            organizationId: "org_test",
+            connectedByUserId: "user_test",
+            provider: "openai",
+            kind: "codex_subscription",
+            label: "Codex subscription",
+            status: "connecting",
+            credentialCiphertext: "must-not-leak",
+            oauthCodeVerifier: "must-not-leak",
+          },
+          status: "pending",
+          authorize_url: "https://auth.openai.com/oauth/authorize?state=test",
+          expires_at: "2026-08-24T00:15:00.000Z",
+        }),
+      ),
+    );
+
+    const response = await proxyManagedAgents(
+      new Request(
+        "https://mo-oc-dev.com/api/managed-agents/model-access/connections",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ provider: "openai" }),
+        },
+      ),
+      {
+        OC_MANAGED_AGENTS_SECRET: "test-secret",
+        MANAGED_AGENTS_API_URL: "https://managedagents.test",
+      },
+      { orgID: "org_test", userID: "user_test", role: "admin" },
+      "/api/managed-agents",
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json<Record<string, unknown>>();
+    expect(body).toMatchObject({
+      status: "pending",
+      authorize_url: "https://auth.openai.com/oauth/authorize?state=test",
+      connection: {
+        id: "mac_test",
+        organizationId: "org_test",
+        connectedByUserId: "user_test",
+        provider: "openai",
+        status: "connecting",
+      },
+    });
+    expect(JSON.stringify(body)).not.toMatch(
+      /credentialCiphertext|oauthCodeVerifier|must-not-leak/,
+    );
   });
 
   it("forwards webhook text and payload without requiring a user API key", async () => {

--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -96,6 +96,41 @@ describe("managed agents proxy", () => {
     );
   });
 
+  it("rejects unsupported Claude account connection", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const response = await proxyManagedAgents(
+      new Request(
+        "https://mo-oc-dev.com/api/managed-agents/model-access/connections",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            provider: "anthropic",
+            token: "must-not-be-returned",
+          }),
+        },
+      ),
+      {
+        OC_MANAGED_AGENTS_SECRET: "test-secret",
+        MANAGED_AGENTS_API_URL: "https://managedagents.test",
+      },
+      { orgID: "org_test", userID: "user_test", role: "admin" },
+      "/api/managed-agents",
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json<Record<string, unknown>>();
+    expect(body).toMatchObject({
+      error: {
+        code: "unsupported_provider",
+        message: "Codex is the only supported BYOK account provider.",
+      },
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("forwards webhook text and payload without requiring a user API key", async () => {
     const fetchSpy = vi.fn(
       async (_target: URL | RequestInfo, init?: RequestInit) => {

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -565,13 +565,18 @@ function publicSuccessBody(
   if (method === "GET" && suffix === "/model-access/connections") {
     return {
       data: Array.isArray(body.data)
-        ? body.data.map((value) =>
-            publicModelAccessConnection(value, includeAdminMetadata),
-          )
+        ? body.data
+            .filter((value) => record(value)?.provider === "openai")
+            .map((value) =>
+              publicModelAccessConnection(value, includeAdminMetadata),
+            )
         : [],
     };
   }
   if (method === "POST" && suffix === "/model-access/connections") {
+    if (!body.connection) {
+      return publicModelAccessConnection(body, includeAdminMetadata);
+    }
     return {
       connection: publicModelAccessConnection(
         body.connection,
@@ -971,7 +976,9 @@ function isAllowedManagedAgentsRoute(method: string, suffix: string): boolean {
   }
   if (
     (method === "GET" || method === "PUT" || method === "DELETE") &&
-    /^\/projects\/[^/]+\/model-access\/bindings(?:\/[^/]+\/[^/]+)?$/.test(suffix)
+    /^\/projects\/[^/]+\/model-access\/bindings(?:\/[^/]+\/[^/]+)?$/.test(
+      suffix,
+    )
   ) {
     return true;
   }
@@ -1245,6 +1252,41 @@ export async function proxyManagedAgents(
     return Response.json(
       { error: "managed agents are not configured" },
       { status: 503 },
+    );
+  }
+  if (
+    request.method.toUpperCase() === "POST" &&
+    suffix === "/model-access/connections"
+  ) {
+    const payload = record(await request.clone().json().catch(() => null));
+    if (payload?.provider !== "openai") {
+      return Response.json(
+        {
+          error: {
+            code: "unsupported_provider",
+            message: "Codex is the only supported BYOK account provider.",
+          },
+        },
+        { status: 400 },
+      );
+    }
+  }
+  const bindingProvider = suffix.match(
+    /^\/projects\/[^/]+\/model-access\/bindings\/([^/]+)\/[^/]+$/,
+  )?.[1];
+  if (
+    request.method.toUpperCase() === "PUT" &&
+    bindingProvider &&
+    bindingProvider !== "openai"
+  ) {
+    return Response.json(
+      {
+        error: {
+          code: "unsupported_provider",
+          message: "Codex is the only supported BYOK account provider.",
+        },
+      },
+      { status: 400 },
     );
   }
   const base = (

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -6,6 +6,7 @@ export interface ManagedAgentsEnv {
 export interface ManagedAgentsCaller {
   orgID: string;
   userID: string | null;
+  role?: string;
 }
 
 const DEFAULT_MANAGED_AGENTS_API_URL = "https://managedagents.opencomputer.dev";
@@ -36,6 +37,7 @@ export async function mintManagedAgentsAssertion(
     exp: now + 120,
   };
   if (caller.userID) payload.user_id = caller.userID;
+  if (caller.role) payload.role = caller.role;
   const encoder = new TextEncoder();
   const signingInput =
     `${b64url(encoder.encode(JSON.stringify(header)))}.` +
@@ -218,6 +220,43 @@ function publicConnection(value: unknown): Record<string, unknown> {
     status: connection.status,
     createdAt: connection.createdAt,
     updatedAt: connection.updatedAt,
+  };
+}
+
+function publicModelAccessConnection(
+  value: unknown,
+  includeAdminMetadata: boolean,
+): Record<string, unknown> {
+  const connection = record(value) ?? {};
+  return {
+    id: connection.id,
+    provider: connection.provider,
+    kind: connection.kind,
+    label: connection.label,
+    status: connection.status,
+    checkedAt: connection.checkedAt,
+    createdAt: connection.createdAt,
+    updatedAt: connection.updatedAt,
+    ...(includeAdminMetadata
+      ? {
+          organizationId: connection.organizationId,
+          connectedByUserId: connection.connectedByUserId,
+          externalAccountHint: connection.externalAccountHint,
+        }
+      : {}),
+  };
+}
+
+function publicModelAccessBinding(value: unknown): Record<string, unknown> {
+  const binding = record(value) ?? {};
+  return {
+    projectId: binding.projectId,
+    environment: binding.environment,
+    provider: binding.provider,
+    connectionId: binding.connectionId,
+    enabled: binding.enabled,
+    createdAt: binding.createdAt,
+    updatedAt: binding.updatedAt,
   };
 }
 
@@ -427,6 +466,7 @@ function publicSuccessBody(
   suffix: string,
   value: unknown,
   publicOrigin?: string,
+  includeAdminMetadata = false,
 ): unknown {
   const body = record(value) ?? {};
   if (method === "GET" && suffix === "/agents") {
@@ -521,6 +561,48 @@ function publicSuccessBody(
   }
   if (method === "GET" && suffix === "/me") {
     return stripPrivateValues(body);
+  }
+  if (method === "GET" && suffix === "/model-access/connections") {
+    return {
+      data: Array.isArray(body.data)
+        ? body.data.map((value) =>
+            publicModelAccessConnection(value, includeAdminMetadata),
+          )
+        : [],
+    };
+  }
+  if (method === "POST" && suffix === "/model-access/connections") {
+    return {
+      connection: publicModelAccessConnection(
+        body.connection,
+        includeAdminMetadata,
+      ),
+      status: body.status,
+      authorize_url: body.authorize_url,
+      expires_at: body.expires_at,
+    };
+  }
+  if (
+    (method === "POST" || method === "DELETE") &&
+    /^\/model-access\/connections\/[^/]+(\/validate|\/complete)?$/.test(suffix)
+  ) {
+    return publicModelAccessConnection(body, includeAdminMetadata);
+  }
+  if (
+    method === "GET" &&
+    /^\/projects\/[^/]+\/model-access\/bindings$/.test(suffix)
+  ) {
+    return {
+      data: Array.isArray(body.data)
+        ? body.data.map(publicModelAccessBinding)
+        : [],
+    };
+  }
+  if (
+    method === "PUT" &&
+    /^\/projects\/[^/]+\/model-access\/bindings\/[^/]+\/[^/]+$/.test(suffix)
+  ) {
+    return publicModelAccessBinding(body);
   }
   if (method === "POST" && suffix === "/deployments") {
     return publicDeployment(body);
@@ -674,6 +756,7 @@ async function publicSuccessResponse(
   method: string,
   suffix: string,
   publicOrigin?: string,
+  includeAdminMetadata = false,
 ): Promise<Response> {
   const value: unknown = await upstream.json();
   const headers = new Headers({ "content-type": "application/json" });
@@ -681,7 +764,15 @@ async function publicSuccessResponse(
   if (cacheControl) headers.set("cache-control", cacheControl);
   if (suffix.includes("/webhooks")) headers.set("cache-control", "no-store");
   return new Response(
-    JSON.stringify(publicSuccessBody(method, suffix, value, publicOrigin)),
+    JSON.stringify(
+      publicSuccessBody(
+        method,
+        suffix,
+        value,
+        publicOrigin,
+        includeAdminMetadata,
+      ),
+    ),
     {
       status: upstream.status,
       headers,
@@ -1208,6 +1299,7 @@ export async function proxyManagedAgents(
       request.method.toUpperCase(),
       suffix,
       requestURL.origin,
+      caller.role === "admin",
     );
   } catch (error) {
     console.error(

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -864,8 +864,8 @@ function isAllowedManagedAgentsRoute(method: string, suffix: string): boolean {
         /^\/channels(?:\/.*)?$/.test(suffix)))
   )
     return true;
-  // Model access (work 011): org-owned Claude/Codex subscription connections
-  // and their project-environment bindings.
+  // Model access (work 011): org-owned Codex subscription connections and their
+  // project-environment bindings.
   if (
     (method === "GET" || method === "POST") &&
     suffix === "/model-access/connections"
@@ -874,7 +874,7 @@ function isAllowedManagedAgentsRoute(method: string, suffix: string): boolean {
   }
   if (
     (method === "POST" || method === "DELETE") &&
-    /^\/model-access\/connections\/[^/]+(\/validate)?$/.test(suffix)
+    /^\/model-access\/connections\/[^/]+(\/validate|\/complete)?$/.test(suffix)
   ) {
     return true;
   }

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -864,6 +864,26 @@ function isAllowedManagedAgentsRoute(method: string, suffix: string): boolean {
         /^\/channels(?:\/.*)?$/.test(suffix)))
   )
     return true;
+  // Model access (work 011): org-owned Claude/Codex subscription connections
+  // and their project-environment bindings.
+  if (
+    (method === "GET" || method === "POST") &&
+    suffix === "/model-access/connections"
+  ) {
+    return true;
+  }
+  if (
+    (method === "POST" || method === "DELETE") &&
+    /^\/model-access\/connections\/[^/]+(\/validate)?$/.test(suffix)
+  ) {
+    return true;
+  }
+  if (
+    (method === "GET" || method === "PUT" || method === "DELETE") &&
+    /^\/projects\/[^/]+\/model-access\/bindings(?:\/[^/]+\/[^/]+)?$/.test(suffix)
+  ) {
+    return true;
+  }
   if (suffix.startsWith("/openrouter/")) return true;
   if (method === "POST" && suffix === "/sessions") return true;
   if (method === "GET" && suffix === "/sessions") return true;

--- a/scripts/autumn/autumn.config.ts
+++ b/scripts/autumn/autumn.config.ts
@@ -74,6 +74,16 @@ export const agentRuntime = feature({
   consumable: true,
 });
 
+// Entitlement gate for connecting an external Claude/Codex subscription
+// (work 011). Boolean feature: present on a plan = allowed, absent = denied.
+// Not metered and not part of the credit system; subscription-routed model
+// inference carries no OpenComputer model charge by design.
+export const byoModelSubscriptions = feature({
+  id: "byo_model_subscriptions",
+  name: "byo_model_subscriptions",
+  type: "boolean",
+});
+
 export const credits = feature({
   id: "credits",
   name: "credits",
@@ -165,6 +175,9 @@ export const pro = plan({
       included: 200,
       reset: { interval: "month" },
     }),
+    item({
+      featureId: byoModelSubscriptions.id,
+    }),
   ],
 });
 
@@ -179,6 +192,9 @@ export const max = plan({
       featureId: credits.id,
       included: 2_000,
       reset: { interval: "month" },
+    }),
+    item({
+      featureId: byoModelSubscriptions.id,
     }),
   ],
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,6 +31,9 @@ const ManagedAgentDetail = lazy(() => import('./managed-agents/Detail'))
 const ManagedProjectDetail = lazy(() => import('./managed-agents/Project'))
 const ManagedSessionDetail = lazy(() => import('./managed-agents/Session'))
 const ManagedAgentChannels = lazy(() => import('./managed-agents/Channels'))
+const ModelAccessCallback = lazy(
+  () => import('./managed-agents/ModelAccessCallback'),
+)
 
 export default function App() {
   return (
@@ -64,6 +67,10 @@ export default function App() {
             <Route
               path="managed-agents/channels"
               element={<ManagedAgentChannels />}
+            />
+            <Route
+              path="model-access/callback"
+              element={<ModelAccessCallback />}
             />
             <Route
               path="managed-agents/connections"

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1003,15 +1003,18 @@ export const rotateCredential = (id: string, key: string) =>
 // The provider token is write-only; every response is normalized metadata only.
 // Secret-bearing provider callbacks terminate at the private credential boundary.
 export const getModelAccessConnections = () =>
-  apiFetch('/v3/model-access/connections', {}, S.ModelAccessConnectionListSchema).then(
-    (r) => r.data,
-  )
+  apiFetch(
+    '/v3/model-access/connections',
+    {},
+    S.ModelAccessConnectionListSchema,
+  ).then((r) => r.data)
 
 // Starts the personal Codex subscription OAuth flow. Returns a pending intent
 // with an authorize_url the dashboard redirects to. No token is accepted here;
 // the provider credential never crosses the browser.
 export const connectModelAccess = (body: {
-  provider: 'openai'
+  provider: 'openai' | 'anthropic'
+  token?: string
   label?: string
 }) =>
   apiFetch(
@@ -1056,7 +1059,7 @@ export const getModelAccessBindings = (projectId: string) =>
 
 export const putModelAccessBinding = (
   projectId: string,
-  provider: 'openai',
+  provider: 'anthropic' | 'openai',
   environment: 'development' | 'production',
   enabled: boolean,
 ) =>
@@ -1068,7 +1071,7 @@ export const putModelAccessBinding = (
 
 export const deleteModelAccessBinding = (
   projectId: string,
-  provider: 'openai',
+  provider: 'anthropic' | 'openai',
   environment: 'development' | 'production',
 ) =>
   apiFetch<void>(

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -59,6 +59,10 @@ export type {
   SandboxWebhook,
   SandboxWebhookDelivery,
   Credential,
+  ModelAccessConnection,
+  ModelAccessBinding,
+  ModelAccessConnectResponse,
+  EffectiveModelRoute,
   AgentSecurityNotification,
   AgentHook,
   AgentHookCreate,
@@ -993,6 +997,71 @@ export const rotateCredential = (id: string, key: string) =>
     `/v3/credentials/${id}`,
     { method: 'PATCH', body: JSON.stringify({ key }) },
     S.CredentialSchema,
+  )
+
+// ── Model access (work 011) — org-owned Claude/Codex subscription connections ──
+// The provider token is write-only; every response is normalized metadata only.
+// Secret-bearing provider callbacks terminate at the private credential boundary.
+export const getModelAccessConnections = () =>
+  apiFetch('/v3/model-access/connections', {}, S.ModelAccessConnectionListSchema).then(
+    (r) => r.data,
+  )
+
+export const connectModelAccess = (body: {
+  provider: 'anthropic' | 'openai'
+  token: string
+  label?: string
+}) =>
+  apiFetch(
+    '/v3/model-access/connections',
+    { method: 'POST', body: JSON.stringify(body) },
+    S.ModelAccessConnectResponseSchema,
+  )
+
+// Re-validate the held credential against the provider (refresh entitlement /
+// account hint / status). Never returns the token.
+export const validateModelAccessConnection = (id: string) =>
+  apiFetch(
+    `/v3/model-access/connections/${encodeURIComponent(id)}/validate`,
+    { method: 'POST' },
+    S.ModelAccessConnectionSchema,
+  )
+
+// Disconnect revokes at the provider when supported, then deletes local secret
+// material even if remote revocation fails.
+export const disconnectModelAccess = (id: string) =>
+  apiFetch<void>(`/v3/model-access/connections/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  })
+
+// Project-environment enablement of the single org connection for a provider.
+export const getModelAccessBindings = (projectId: string) =>
+  apiFetch(
+    `/v3/projects/${encodeURIComponent(projectId)}/model-access/bindings`,
+    {},
+    S.ModelAccessBindingListSchema,
+  ).then((r) => r.data)
+
+export const putModelAccessBinding = (
+  projectId: string,
+  provider: 'anthropic' | 'openai',
+  environment: 'development' | 'production',
+  enabled: boolean,
+) =>
+  apiFetch(
+    `/v3/projects/${encodeURIComponent(projectId)}/model-access/bindings/${provider}/${environment}`,
+    { method: 'PUT', body: JSON.stringify({ enabled }) },
+    S.ModelAccessBindingSchema,
+  )
+
+export const deleteModelAccessBinding = (
+  projectId: string,
+  provider: 'anthropic' | 'openai',
+  environment: 'development' | 'production',
+) =>
+  apiFetch<void>(
+    `/v3/projects/${encodeURIComponent(projectId)}/model-access/bindings/${provider}/${environment}`,
+    { method: 'DELETE' },
   )
 
 // Sessions — the durable runs.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1007,15 +1007,27 @@ export const getModelAccessConnections = () =>
     (r) => r.data,
   )
 
+// Starts the personal Codex subscription OAuth flow. Returns a pending intent
+// with an authorize_url the dashboard redirects to. No token is accepted here;
+// the provider credential never crosses the browser.
 export const connectModelAccess = (body: {
-  provider: 'anthropic' | 'openai'
-  token: string
+  provider: 'openai'
   label?: string
 }) =>
   apiFetch(
     '/v3/model-access/connections',
     { method: 'POST', body: JSON.stringify(body) },
     S.ModelAccessConnectResponseSchema,
+  )
+
+// Completes the OAuth callback (exchanged server-side at the private credential
+// boundary), returning the connected connection. The authorization code is a
+// one-time exchange value, not a stored credential.
+export const completeModelAccess = (id: string, code: string, state: string) =>
+  apiFetch(
+    `/v3/model-access/connections/${encodeURIComponent(id)}/complete`,
+    { method: 'POST', body: JSON.stringify({ code, state }) },
+    S.ModelAccessConnectionSchema,
   )
 
 // Re-validate the held credential against the provider (refresh entitlement /
@@ -1044,7 +1056,7 @@ export const getModelAccessBindings = (projectId: string) =>
 
 export const putModelAccessBinding = (
   projectId: string,
-  provider: 'anthropic' | 'openai',
+  provider: 'openai',
   environment: 'development' | 'production',
   enabled: boolean,
 ) =>
@@ -1056,7 +1068,7 @@ export const putModelAccessBinding = (
 
 export const deleteModelAccessBinding = (
   projectId: string,
-  provider: 'anthropic' | 'openai',
+  provider: 'openai',
   environment: 'development' | 'production',
 ) =>
   apiFetch<void>(

--- a/web/src/api/mock.ts
+++ b/web/src/api/mock.ts
@@ -1245,6 +1245,14 @@ const ROUTES: Array<[RegExp, Handler]> = [
   [/^\/managed-agents\/agents$/, () => ({ agents: managedAgentItems })],
   [/^\/managed-agents\/projects$/, () => ({ projects: managedProjects })],
   [
+    /^\/managed-agents\/model-access\/connections$/,
+    () => ({ data: [] }),
+  ],
+  [
+    /^\/managed-agents\/projects\/[^/]+\/model-access\/bindings$/,
+    () => ({ data: [] }),
+  ],
+  [
     /^\/managed-agents\/projects\/[^/]+$/,
     () => ({
       project: managedProjects[0],

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -904,17 +904,17 @@ export const CredentialListSchema = z.object({
   next_cursor: z.string().nullish(),
 })
 
-// ── Model access (work 011: bring-your-own Claude/Codex subscription) ────────
-// An organization-owned connection to an external provider subscription. The
-// raw provider token is write-only and never appears on this object; the API
-// returns only normalized metadata. At most one connection per provider per
-// organization is enforced server-side (unique (organizationId, provider)).
+// ── Model access (work 011: bring-your-own Codex subscription) ──────────────
+// An organization-owned connection to a Codex subscription. The provider token
+// is write-only and never appears on this object; the API returns only
+// normalized metadata. At most one Codex connection per organization is
+// enforced server-side (unique (organization_id, provider)).
 export const ModelAccessConnectionSchema = z.object({
   id: z.string(),
   organization_id: z.string(),
   connected_by_user_id: z.string(),
-  provider: z.enum(['anthropic', 'openai']),
-  kind: z.enum(['claude_subscription', 'codex_subscription']),
+  provider: z.literal('openai'),
+  kind: z.literal('codex_subscription'),
   label: z.string(),
   external_account_hint: z.string().nullish(),
   status: z.enum([
@@ -937,23 +937,19 @@ export const ModelAccessConnectionListSchema = z.object({
   data: z.array(ModelAccessConnectionSchema),
 })
 
-// Connect/create: the provider token is write-only. `label` defaults server-side
-// when omitted. Returns the normalized connection (never the token).
+// Connect: starts the personal Codex subscription OAuth flow. Returns a pending
+// intent the dashboard redirects to, with the authorize_url. `label` is a
+// display override and defaults server-side.
 export const ModelAccessConnectRequestSchema = z.object({
-  provider: z.enum(['anthropic', 'openai']),
-  token: z.string(),
+  provider: z.literal('openai'),
   label: z.string().optional(),
 })
-export const ModelAccessConnectResponseSchema = z.union([
-  // Token flow: validated synchronously, connection is immediately connected.
-  ModelAccessConnectionSchema,
-  // OAuth/device flow (future): dashboard redirects to authorize_url.
-  z.object({
-    status: z.literal('pending'),
-    authorize_url: z.string(),
-    expires_at: z.string(),
-  }),
-])
+export const ModelAccessConnectResponseSchema = z.object({
+  connection: ModelAccessConnectionSchema,
+  status: z.literal('pending'),
+  authorize_url: z.string(),
+  expires_at: z.string(),
+})
 
 // A project-environment enablement of the single org connection for a provider.
 // One binding per (project, environment, provider). Created disabled by default.
@@ -961,7 +957,7 @@ export const ModelAccessBindingSchema = z.object({
   organization_id: z.string(),
   project_id: z.string(),
   environment: z.enum(['development', 'production']),
-  provider: z.enum(['anthropic', 'openai']),
+  provider: z.literal('openai'),
   connection_id: z.string(),
   enabled: z.boolean(),
   enabled_by_user_id: z.string().nullish(),
@@ -998,13 +994,11 @@ export const ModelAccessErrorSchema = z.object({
 export const EffectiveModelRouteSchema = z.object({
   requested: z.object({ provider: z.string(), model: z.string() }),
   effective: z.object({ provider: z.string(), model: z.string() }),
-  runtime: z.enum(['claude', 'codex']),
+  runtime: z.literal('codex'),
   access: z.object({
     type: z.enum(['managed', 'external_subscription']),
     connection_id: z.string().nullish(),
-    connection_kind: z
-      .enum(['claude_subscription', 'codex_subscription'])
-      .nullish(),
+    connection_kind: z.literal('codex_subscription').nullish(),
   }),
   fallback: z
     .object({

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -913,8 +913,8 @@ export const ModelAccessConnectionSchema = z.object({
   id: z.string(),
   organization_id: z.string(),
   connected_by_user_id: z.string(),
-  provider: z.literal('openai'),
-  kind: z.literal('codex_subscription'),
+  provider: z.enum(['anthropic', 'openai']),
+  kind: z.enum(['claude_subscription', 'codex_subscription']),
   label: z.string(),
   external_account_hint: z.string().nullish(),
   status: z.enum([
@@ -940,16 +940,26 @@ export const ModelAccessConnectionListSchema = z.object({
 // Connect: starts the personal Codex subscription OAuth flow. Returns a pending
 // intent the dashboard redirects to, with the authorize_url. `label` is a
 // display override and defaults server-side.
-export const ModelAccessConnectRequestSchema = z.object({
-  provider: z.literal('openai'),
-  label: z.string().optional(),
-})
-export const ModelAccessConnectResponseSchema = z.object({
-  connection: ModelAccessConnectionSchema,
-  status: z.literal('pending'),
-  authorize_url: z.string(),
-  expires_at: z.string(),
-})
+export const ModelAccessConnectRequestSchema = z.discriminatedUnion(
+  'provider',
+  [
+    z.object({ provider: z.literal('openai'), label: z.string().optional() }),
+    z.object({
+      provider: z.literal('anthropic'),
+      token: z.string(),
+      label: z.string().optional(),
+    }),
+  ],
+)
+export const ModelAccessConnectResponseSchema = z.union([
+  ModelAccessConnectionSchema,
+  z.object({
+    connection: ModelAccessConnectionSchema,
+    status: z.literal('pending'),
+    authorize_url: z.string(),
+    expires_at: z.string(),
+  }),
+])
 
 // A project-environment enablement of the single org connection for a provider.
 // One binding per (project, environment, provider). Created disabled by default.
@@ -957,7 +967,7 @@ export const ModelAccessBindingSchema = z.object({
   organization_id: z.string(),
   project_id: z.string(),
   environment: z.enum(['development', 'production']),
-  provider: z.literal('openai'),
+  provider: z.enum(['anthropic', 'openai']),
   connection_id: z.string(),
   enabled: z.boolean(),
   enabled_by_user_id: z.string().nullish(),
@@ -994,11 +1004,13 @@ export const ModelAccessErrorSchema = z.object({
 export const EffectiveModelRouteSchema = z.object({
   requested: z.object({ provider: z.string(), model: z.string() }),
   effective: z.object({ provider: z.string(), model: z.string() }),
-  runtime: z.literal('codex'),
+  runtime: z.enum(['claude', 'codex']),
   access: z.object({
     type: z.enum(['managed', 'external_subscription']),
     connection_id: z.string().nullish(),
-    connection_kind: z.literal('codex_subscription').nullish(),
+    connection_kind: z
+      .enum(['claude_subscription', 'codex_subscription'])
+      .nullish(),
   }),
   fallback: z
     .object({

--- a/web/src/api/schemas.ts
+++ b/web/src/api/schemas.ts
@@ -904,6 +904,123 @@ export const CredentialListSchema = z.object({
   next_cursor: z.string().nullish(),
 })
 
+// ── Model access (work 011: bring-your-own Claude/Codex subscription) ────────
+// An organization-owned connection to an external provider subscription. The
+// raw provider token is write-only and never appears on this object; the API
+// returns only normalized metadata. At most one connection per provider per
+// organization is enforced server-side (unique (organizationId, provider)).
+export const ModelAccessConnectionSchema = z.object({
+  id: z.string(),
+  organization_id: z.string(),
+  connected_by_user_id: z.string(),
+  provider: z.enum(['anthropic', 'openai']),
+  kind: z.enum(['claude_subscription', 'codex_subscription']),
+  label: z.string(),
+  external_account_hint: z.string().nullish(),
+  status: z.enum([
+    'connecting',
+    'connected',
+    'reauth_required',
+    'provider_limited',
+    'plan_ineligible',
+    'revoked',
+    'unavailable',
+  ]),
+  // Provider-reported entitlement/model snapshot, when a sanctioned capability
+  // surface exists. Opaque to the dashboard; display hints only, never authz.
+  entitlement_snapshot: z.unknown().nullish(),
+  checked_at: z.string().nullish(),
+  created_at: z.string().nullish(),
+  updated_at: z.string().nullish(),
+})
+export const ModelAccessConnectionListSchema = z.object({
+  data: z.array(ModelAccessConnectionSchema),
+})
+
+// Connect/create: the provider token is write-only. `label` defaults server-side
+// when omitted. Returns the normalized connection (never the token).
+export const ModelAccessConnectRequestSchema = z.object({
+  provider: z.enum(['anthropic', 'openai']),
+  token: z.string(),
+  label: z.string().optional(),
+})
+export const ModelAccessConnectResponseSchema = z.union([
+  // Token flow: validated synchronously, connection is immediately connected.
+  ModelAccessConnectionSchema,
+  // OAuth/device flow (future): dashboard redirects to authorize_url.
+  z.object({
+    status: z.literal('pending'),
+    authorize_url: z.string(),
+    expires_at: z.string(),
+  }),
+])
+
+// A project-environment enablement of the single org connection for a provider.
+// One binding per (project, environment, provider). Created disabled by default.
+export const ModelAccessBindingSchema = z.object({
+  organization_id: z.string(),
+  project_id: z.string(),
+  environment: z.enum(['development', 'production']),
+  provider: z.enum(['anthropic', 'openai']),
+  connection_id: z.string(),
+  enabled: z.boolean(),
+  enabled_by_user_id: z.string().nullish(),
+  created_at: z.string().nullish(),
+  updated_at: z.string().nullish(),
+})
+export const ModelAccessBindingListSchema = z.object({
+  data: z.array(ModelAccessBindingSchema),
+})
+export const ModelAccessBindingPutRequestSchema = z.object({
+  enabled: z.boolean(),
+})
+
+// Typed error for model-access failures (resolution + dispatch).
+export const ModelAccessErrorSchema = z.object({
+  error: z.object({
+    code: z.enum([
+      'model_access_unavailable',
+      'plan_ineligible',
+      'provider_not_connected',
+      'model_not_in_subscription',
+      'reauth_required',
+      'provider_allowance_exhausted',
+      'subscription_unavailable',
+    ]),
+    message: z.string(),
+    // Present when both the subscription and Managed reasons must be shown.
+    subscription_reason: z.string().nullish(),
+    managed_reason: z.string().nullish(),
+  }),
+})
+
+// The immutable record of how one provider call was routed and billed.
+export const EffectiveModelRouteSchema = z.object({
+  requested: z.object({ provider: z.string(), model: z.string() }),
+  effective: z.object({ provider: z.string(), model: z.string() }),
+  runtime: z.enum(['claude', 'codex']),
+  access: z.object({
+    type: z.enum(['managed', 'external_subscription']),
+    connection_id: z.string().nullish(),
+    connection_kind: z
+      .enum(['claude_subscription', 'codex_subscription'])
+      .nullish(),
+  }),
+  fallback: z
+    .object({
+      from: z.literal('external_subscription'),
+      reason: z.enum([
+        'provider_not_connected',
+        'model_not_in_subscription',
+        'reauth_required',
+        'provider_allowance_exhausted',
+        'subscription_unavailable',
+      ]),
+    })
+    .nullish(),
+  open_computer_model_charge_usd: z.number(),
+})
+
 // Slack connection (sessions-api `serializeSlackApp`) — an agent's BYO Slack app.
 // Never carries secrets (bot token / signing secret stay in the secret backend).
 // `handle` is the agent's name; slack_app_id/team_id/account_login fill in once
@@ -1199,6 +1316,12 @@ export type RepositorySourceInspection = z.infer<
   typeof RepositorySourceInspectionSchema
 >
 export type Credential = z.infer<typeof CredentialSchema>
+export type ModelAccessConnection = z.infer<typeof ModelAccessConnectionSchema>
+export type ModelAccessBinding = z.infer<typeof ModelAccessBindingSchema>
+export type ModelAccessConnectResponse = z.infer<
+  typeof ModelAccessConnectResponseSchema
+>
+export type EffectiveModelRoute = z.infer<typeof EffectiveModelRouteSchema>
 export type SlackConnection = z.infer<typeof SlackConnectionSchema>
 export type SlackManifestResponse = z.infer<typeof SlackManifestResponseSchema>
 export type ManagedSlackAuthorizeResponse = z.infer<

--- a/web/src/components/app-shell-nav.ts
+++ b/web/src/components/app-shell-nav.ts
@@ -2,9 +2,9 @@ import {
   ArrowLeft,
   Bot,
   Boxes,
+  BrainCircuit,
   CalendarClock,
   KeySquare,
-  KeyRound,
   Layers,
   MessagesSquare,
   Monitor,
@@ -90,7 +90,7 @@ export function managedAgentsNav(options: {
           {
             to: `${projectPath}/byok`,
             label: 'BYOK',
-            icon: KeyRound,
+            icon: BrainCircuit,
           },
           {
             to: projectPath,

--- a/web/src/components/app-shell-nav.ts
+++ b/web/src/components/app-shell-nav.ts
@@ -4,6 +4,7 @@ import {
   Boxes,
   CalendarClock,
   KeySquare,
+  KeyRound,
   Layers,
   MessagesSquare,
   Monitor,
@@ -85,6 +86,11 @@ export function managedAgentsNav(options: {
             to: `${projectPath}/secrets`,
             label: 'Secrets',
             icon: KeySquare,
+          },
+          {
+            to: `${projectPath}/byok`,
+            label: 'BYOK',
+            icon: KeyRound,
           },
           {
             to: projectPath,

--- a/web/src/components/app-shell.test.ts
+++ b/web/src/components/app-shell.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { BrainCircuit, KeySquare } from 'lucide-react'
 import { managedAgentsNav } from './app-shell-nav'
 
 describe('managed agents navigation', () => {
@@ -30,6 +31,12 @@ describe('managed agents navigation', () => {
     ])
     expect(nav[1]?.items[nav[1].items.length - 1]?.to).toBe(
       '/projects/project%20one',
+    )
+    expect(nav[1]?.items.find((item) => item.label === 'Secrets')?.icon).toBe(
+      KeySquare,
+    )
+    expect(nav[1]?.items.find((item) => item.label === 'BYOK')?.icon).toBe(
+      BrainCircuit,
     )
   })
 

--- a/web/src/components/app-shell.test.ts
+++ b/web/src/components/app-shell.test.ts
@@ -25,6 +25,7 @@ describe('managed agents navigation', () => {
       'Schedules',
       'Webhooks',
       'Secrets',
+      'BYOK',
       'Debug playground',
     ])
     expect(nav[1]?.items[nav[1].items.length - 1]?.to).toBe(

--- a/web/src/managed-agents/BYOK.tsx
+++ b/web/src/managed-agents/BYOK.tsx
@@ -1,0 +1,403 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { KeyRound, Loader2, RefreshCw, Unplug } from 'lucide-react'
+import { useLocation } from 'react-router-dom'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+import { CopyRow } from '@/components/copy-row'
+import { EmptyState } from '@/components/empty-state'
+import {
+  Panel,
+  PanelContent,
+  PanelDescription,
+  PanelHeader,
+  PanelTitle,
+} from '@/components/panel'
+import { StatusBadge } from '@/components/status-badge'
+import { Button } from '@/components/ui/button'
+import { useAuth } from '@/hooks/useAuth'
+import { notifyError, notifySuccess } from '@/lib/errors'
+import {
+  connectManagedModelAccess,
+  disconnectManagedModelAccessConnection,
+  getManagedModelAccessBindings,
+  getManagedModelAccessConnections,
+  putManagedModelAccessBinding,
+  validateManagedModelAccessConnection,
+} from './api'
+
+export const MODEL_ACCESS_RETURN_TO_KEY = 'opencomputer:model-access:return-to'
+
+type Environment = 'development' | 'production'
+
+const environments: Environment[] = ['development', 'production']
+
+function connectionTone(status: string) {
+  if (status === 'connected') return 'running'
+  if (status === 'revoked' || status === 'unavailable') return 'stopped'
+  return 'pending'
+}
+
+export function ManagedProjectBYOK({
+  projectId,
+  projectSlug,
+}: {
+  projectId: string
+  projectSlug: string
+}) {
+  const { user } = useAuth()
+  const location = useLocation()
+  const queryClient = useQueryClient()
+  const [confirmReplace, setConfirmReplace] = useState(false)
+  const [confirmDisconnect, setConfirmDisconnect] = useState(false)
+  const [confirmProduction, setConfirmProduction] =
+    useState<Environment | null>(null)
+  const canManageConnection = user?.capabilities?.manageMembers !== false
+  const cliExecutable =
+    window.location.hostname === 'mo-oc-dev.com' ? 'ocdev' : 'opencomputer'
+  const connectionQueryKey = ['managed-model-access-connections']
+  const bindingQueryKey = ['managed-model-access-bindings', projectId]
+  const connections = useQuery({
+    queryKey: connectionQueryKey,
+    queryFn: getManagedModelAccessConnections,
+  })
+  const bindings = useQuery({
+    queryKey: bindingQueryKey,
+    queryFn: () => getManagedModelAccessBindings(projectId),
+  })
+  const codex = connections.data?.find(
+    (connection) => connection.provider === 'openai',
+  )
+
+  const isEnabled = (environment: Environment) => {
+    const binding = bindings.data?.find(
+      (candidate) =>
+        candidate.provider === 'openai' &&
+        candidate.environment === environment,
+    )
+    return Boolean(
+      codex?.status === 'connected' &&
+      binding?.enabled &&
+      binding.connectionId === codex.id,
+    )
+  }
+
+  const connect = useMutation({
+    mutationFn: connectManagedModelAccess,
+    onSuccess: (receipt) => {
+      sessionStorage.setItem(
+        MODEL_ACCESS_RETURN_TO_KEY,
+        `${location.pathname}${location.search}`,
+      )
+      window.location.assign(receipt.authorize_url)
+    },
+    onError: (error) =>
+      notifyError("Couldn't start Codex authorization.", error),
+  })
+  const updateBinding = useMutation({
+    mutationFn: ({
+      environment,
+      enabled,
+    }: {
+      environment: Environment
+      enabled: boolean
+    }) => putManagedModelAccessBinding({ projectId, environment, enabled }),
+    onSuccess: async (updated) => {
+      await queryClient.invalidateQueries({ queryKey: bindingQueryKey })
+      notifySuccess(
+        updated.enabled
+          ? `Codex subscription enabled for ${updated.environment}.`
+          : `Managed inference restored for ${updated.environment}.`,
+      )
+    },
+    onError: (error) =>
+      notifyError("Couldn't update model access for this project.", error),
+  })
+  const validateConnection = useMutation({
+    mutationFn: () => validateManagedModelAccessConnection(codex!.id),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: connectionQueryKey })
+      notifySuccess('Codex subscription revalidated.')
+    },
+    onError: (error) =>
+      notifyError("Couldn't revalidate the Codex subscription.", error),
+  })
+  const disconnectConnection = useMutation({
+    mutationFn: () => disconnectManagedModelAccessConnection(codex!.id),
+    onSuccess: async () => {
+      setConfirmDisconnect(false)
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: connectionQueryKey }),
+        queryClient.invalidateQueries({ queryKey: bindingQueryKey }),
+      ])
+      notifySuccess('Codex subscription disconnected.')
+    },
+    onError: (error) =>
+      notifyError("Couldn't disconnect the Codex subscription.", error),
+  })
+
+  const startConnect = () => {
+    setConfirmReplace(false)
+    connect.mutate()
+  }
+  const setEnvironmentEnabled = (
+    environment: Environment,
+    enabled: boolean,
+  ) => {
+    setConfirmProduction(null)
+    updateBinding.mutate({ environment, enabled })
+  }
+
+  if (connections.isLoading || bindings.isLoading) {
+    return (
+      <Panel>
+        <PanelContent className="text-muted-foreground flex items-center gap-2 text-sm">
+          <Loader2 className="size-4 animate-spin" /> Loading BYOK status…
+        </PanelContent>
+      </Panel>
+    )
+  }
+
+  if (connections.isError || bindings.isError) {
+    return (
+      <Panel>
+        <EmptyState
+          icon={KeyRound}
+          title="BYOK status is temporarily unavailable"
+          description="Try loading the project again."
+          action={
+            <Button
+              variant="outline"
+              onClick={() => {
+                void connections.refetch()
+                void bindings.refetch()
+              }}
+            >
+              Try again
+            </Button>
+          }
+        />
+      </Panel>
+    )
+  }
+
+  return (
+    <div className="space-y-5">
+      <Panel>
+        <PanelHeader>
+          <div>
+            <PanelTitle>BYOK</PanelTitle>
+            <PanelDescription className="mt-1 max-w-2xl">
+              Link your organization&apos;s Codex subscription, then configure
+              this project&apos;s development and production routing. Managed
+              usage-based inference remains the fallback. Runtime compute is
+              still charged.
+            </PanelDescription>
+          </div>
+        </PanelHeader>
+        <PanelContent className="space-y-6">
+          <div>
+            <p className="text-muted-foreground text-xs font-medium uppercase">
+              Organization subscription
+            </p>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <span className="text-sm font-medium">Codex subscription</span>
+              {codex ? (
+                <StatusBadge
+                  status={connectionTone(codex.status)}
+                  label={codex.status.replace(/_/g, ' ')}
+                />
+              ) : (
+                <StatusBadge status="stopped" label="Not connected" />
+              )}
+            </div>
+            <p className="text-muted-foreground mt-2 text-sm">
+              {codex
+                ? `${codex.label}${codex.checkedAt ? ` · checked ${new Date(codex.checkedAt).toLocaleString()}` : ''}`
+                : 'No Codex subscription is linked to this organization.'}
+            </p>
+          </div>
+
+          <div className="grid gap-4 border-t pt-5 md:grid-cols-2">
+            {environments.map((environment) => {
+              const enabled = isEnabled(environment)
+              return (
+                <div
+                  key={environment}
+                  className="bg-panel-2 rounded-lg border p-4"
+                >
+                  <p className="text-xs font-medium capitalize">
+                    {environment}
+                  </p>
+                  <div className="mt-2">
+                    <StatusBadge
+                      status={enabled ? 'running' : 'stopped'}
+                      label={
+                        enabled
+                          ? 'Subscription preferred · Managed fallback'
+                          : 'Managed'
+                      }
+                    />
+                  </div>
+                  <p className="text-muted-foreground mt-2 text-sm">
+                    {enabled
+                      ? 'Model calls prefer the linked subscription.'
+                      : 'Model calls use OpenComputer managed inference.'}
+                  </p>
+                  {codex?.status === 'connected' ? (
+                    <Button
+                      className="mt-4"
+                      size="sm"
+                      variant={enabled ? 'outline' : 'default'}
+                      disabled={updateBinding.isPending}
+                      onClick={() => {
+                        if (enabled) setEnvironmentEnabled(environment, false)
+                        else if (environment === 'production')
+                          setConfirmProduction(environment)
+                        else setEnvironmentEnabled(environment, true)
+                      }}
+                    >
+                      {updateBinding.isPending ? (
+                        <Loader2 className="animate-spin" />
+                      ) : null}
+                      {enabled ? 'Use Managed' : 'Use subscription'}
+                    </Button>
+                  ) : null}
+                </div>
+              )
+            })}
+          </div>
+
+          <div className="flex flex-wrap gap-2 border-t pt-5">
+            {canManageConnection ? (
+              <Button
+                variant={codex ? 'outline' : 'default'}
+                disabled={connect.isPending}
+                onClick={() =>
+                  codex ? setConfirmReplace(true) : startConnect()
+                }
+              >
+                {connect.isPending ? (
+                  <Loader2 className="animate-spin" />
+                ) : (
+                  <KeyRound />
+                )}
+                {codex ? 'Replace subscription' : 'Connect subscription'}
+              </Button>
+            ) : null}
+            {canManageConnection && codex ? (
+              <>
+                <Button
+                  variant="outline"
+                  disabled={validateConnection.isPending}
+                  onClick={() => validateConnection.mutate()}
+                >
+                  {validateConnection.isPending ? (
+                    <Loader2 className="animate-spin" />
+                  ) : (
+                    <RefreshCw />
+                  )}
+                  Revalidate
+                </Button>
+                <Button
+                  variant="outline"
+                  disabled={disconnectConnection.isPending}
+                  onClick={() => setConfirmDisconnect(true)}
+                >
+                  <Unplug /> Disconnect
+                </Button>
+              </>
+            ) : null}
+          </div>
+
+          {!canManageConnection && !codex ? (
+            <p className="text-muted-foreground text-sm">
+              Ask an organization admin to connect a Codex subscription.
+            </p>
+          ) : null}
+        </PanelContent>
+      </Panel>
+
+      <Panel>
+        <PanelHeader>
+          <div>
+            <PanelTitle>Use the subscription in agent code</PanelTitle>
+            <PanelDescription className="mt-1 max-w-2xl">
+              Select the OpenAI provider explicitly. The shorter string form is
+              an OpenRouter catalog model and continues to use Managed access.
+            </PanelDescription>
+          </div>
+        </PanelHeader>
+        <PanelContent className="space-y-4">
+          <div>
+            <p className="mb-2 text-sm font-medium">
+              Codex subscription eligible
+            </p>
+            <CopyRow
+              value={'useModel({ provider: "openai", model: "gpt-5" })'}
+            />
+          </div>
+          <div>
+            <p className="mb-2 text-sm font-medium">Managed OpenRouter</p>
+            <CopyRow value={'useModel("openai/gpt-5")'} />
+          </div>
+        </PanelContent>
+      </Panel>
+
+      <Panel>
+        <PanelHeader>
+          <div>
+            <PanelTitle>Connect with the CLI</PanelTitle>
+            <PanelDescription className="mt-1 max-w-2xl">
+              Each command opens the Codex OAuth flow, links or replaces the
+              organization subscription, and enables it for this project in one
+              run.
+            </PanelDescription>
+          </div>
+        </PanelHeader>
+        <PanelContent className="space-y-4">
+          {(
+            [
+              ['Development', 'development'],
+              ['Production', 'production'],
+              ['Development and production', 'both'],
+            ] as const
+          ).map(([label, environment]) => (
+            <div key={environment}>
+              <p className="mb-2 text-sm font-medium">{label}</p>
+              <CopyRow
+                value={`${cliExecutable} model-access connect codex --project ${projectSlug} --environment ${environment}`}
+              />
+            </div>
+          ))}
+        </PanelContent>
+      </Panel>
+
+      <ConfirmDialog
+        open={confirmReplace}
+        onOpenChange={setConfirmReplace}
+        title="Replace the organization subscription?"
+        description="This reconnects the organization-owned Codex subscription and affects every project environment currently using it."
+        confirmLabel="Continue to OpenAI"
+        onConfirm={startConnect}
+      />
+      <ConfirmDialog
+        open={confirmDisconnect}
+        onOpenChange={setConfirmDisconnect}
+        title="Disconnect the organization subscription?"
+        description="Every project environment using this subscription will return to Managed inference."
+        confirmLabel="Disconnect subscription"
+        onConfirm={() => disconnectConnection.mutate()}
+      />
+      <ConfirmDialog
+        open={confirmProduction !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmProduction(null)
+        }}
+        title="Enable the subscription in production?"
+        description="Production model calls will prefer the Codex subscription and fall back to Managed inference when necessary."
+        confirmLabel="Enable in production"
+        onConfirm={() => setEnvironmentEnabled('production', true)}
+      />
+    </div>
+  )
+}

--- a/web/src/managed-agents/BYOK.tsx
+++ b/web/src/managed-agents/BYOK.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { KeyRound, Loader2, RefreshCw, Unplug } from 'lucide-react'
+import { BrainCircuit, Loader2, RefreshCw, Unplug } from 'lucide-react'
 import { useLocation } from 'react-router-dom'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 import { CopyRow } from '@/components/copy-row'
@@ -19,17 +19,12 @@ import { notifyError, notifySuccess } from '@/lib/errors'
 import {
   connectManagedModelAccess,
   disconnectManagedModelAccessConnection,
-  getManagedModelAccessBindings,
   getManagedModelAccessConnections,
-  putManagedModelAccessBinding,
   validateManagedModelAccessConnection,
 } from './api'
 
 export const MODEL_ACCESS_RETURN_TO_KEY = 'opencomputer:model-access:return-to'
-
-type Environment = 'development' | 'production'
-
-const environments: Environment[] = ['development', 'production']
+export const MODEL_ACCESS_PROJECT_KEY = 'opencomputer:model-access:project'
 
 function connectionTone(status: string) {
   if (status === 'connected') return 'running'
@@ -49,37 +44,17 @@ export function ManagedProjectBYOK({
   const queryClient = useQueryClient()
   const [confirmReplace, setConfirmReplace] = useState(false)
   const [confirmDisconnect, setConfirmDisconnect] = useState(false)
-  const [confirmProduction, setConfirmProduction] =
-    useState<Environment | null>(null)
   const canManageConnection = user?.capabilities?.manageMembers !== false
   const cliExecutable =
     window.location.hostname === 'mo-oc-dev.com' ? 'ocdev' : 'opencomputer'
   const connectionQueryKey = ['managed-model-access-connections']
-  const bindingQueryKey = ['managed-model-access-bindings', projectId]
   const connections = useQuery({
     queryKey: connectionQueryKey,
     queryFn: getManagedModelAccessConnections,
   })
-  const bindings = useQuery({
-    queryKey: bindingQueryKey,
-    queryFn: () => getManagedModelAccessBindings(projectId),
-  })
   const codex = connections.data?.find(
     (connection) => connection.provider === 'openai',
   )
-
-  const isEnabled = (environment: Environment) => {
-    const binding = bindings.data?.find(
-      (candidate) =>
-        candidate.provider === 'openai' &&
-        candidate.environment === environment,
-    )
-    return Boolean(
-      codex?.status === 'connected' &&
-      binding?.enabled &&
-      binding.connectionId === codex.id,
-    )
-  }
 
   const connect = useMutation({
     mutationFn: connectManagedModelAccess,
@@ -88,66 +63,36 @@ export function ManagedProjectBYOK({
         MODEL_ACCESS_RETURN_TO_KEY,
         `${location.pathname}${location.search}`,
       )
+      sessionStorage.setItem(MODEL_ACCESS_PROJECT_KEY, projectId)
       window.location.assign(receipt.authorize_url)
     },
     onError: (error) =>
       notifyError("Couldn't start Codex authorization.", error),
   })
-  const updateBinding = useMutation({
-    mutationFn: ({
-      environment,
-      enabled,
-    }: {
-      environment: Environment
-      enabled: boolean
-    }) => putManagedModelAccessBinding({ projectId, environment, enabled }),
-    onSuccess: async (updated) => {
-      await queryClient.invalidateQueries({ queryKey: bindingQueryKey })
-      notifySuccess(
-        updated.enabled
-          ? `Codex subscription enabled for ${updated.environment}.`
-          : `Managed inference restored for ${updated.environment}.`,
-      )
-    },
-    onError: (error) =>
-      notifyError("Couldn't update model access for this project.", error),
-  })
   const validateConnection = useMutation({
     mutationFn: () => validateManagedModelAccessConnection(codex!.id),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: connectionQueryKey })
-      notifySuccess('Codex subscription revalidated.')
+      notifySuccess('Codex account revalidated.')
     },
     onError: (error) =>
-      notifyError("Couldn't revalidate the Codex subscription.", error),
+      notifyError("Couldn't revalidate the Codex account.", error),
   })
   const disconnectConnection = useMutation({
     mutationFn: () => disconnectManagedModelAccessConnection(codex!.id),
     onSuccess: async () => {
       setConfirmDisconnect(false)
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: connectionQueryKey }),
-        queryClient.invalidateQueries({ queryKey: bindingQueryKey }),
-      ])
-      notifySuccess('Codex subscription disconnected.')
+      await queryClient.invalidateQueries({ queryKey: connectionQueryKey })
+      notifySuccess('Codex account disconnected.')
     },
     onError: (error) =>
-      notifyError("Couldn't disconnect the Codex subscription.", error),
+      notifyError("Couldn't disconnect the Codex account.", error),
   })
-
   const startConnect = () => {
     setConfirmReplace(false)
     connect.mutate()
   }
-  const setEnvironmentEnabled = (
-    environment: Environment,
-    enabled: boolean,
-  ) => {
-    setConfirmProduction(null)
-    updateBinding.mutate({ environment, enabled })
-  }
-
-  if (connections.isLoading || bindings.isLoading) {
+  if (connections.isLoading) {
     return (
       <Panel>
         <PanelContent className="text-muted-foreground flex items-center gap-2 text-sm">
@@ -157,11 +102,11 @@ export function ManagedProjectBYOK({
     )
   }
 
-  if (connections.isError || bindings.isError) {
+  if (connections.isError) {
     return (
       <Panel>
         <EmptyState
-          icon={KeyRound}
+          icon={BrainCircuit}
           title="BYOK status is temporarily unavailable"
           description="Try loading the project again."
           action={
@@ -169,7 +114,6 @@ export function ManagedProjectBYOK({
               variant="outline"
               onClick={() => {
                 void connections.refetch()
-                void bindings.refetch()
               }}
             >
               Try again
@@ -187,20 +131,19 @@ export function ManagedProjectBYOK({
           <div>
             <PanelTitle>BYOK</PanelTitle>
             <PanelDescription className="mt-1 max-w-2xl">
-              Link your organization&apos;s Codex subscription, then configure
-              this project&apos;s development and production routing. Managed
-              usage-based inference remains the fallback. Runtime compute is
-              still charged.
+              Link a Codex account to this project. Connecting it enables the
+              account for both development and production. Managed usage-based
+              inference remains the fallback. Runtime compute is still charged.
             </PanelDescription>
           </div>
         </PanelHeader>
         <PanelContent className="space-y-6">
           <div>
             <p className="text-muted-foreground text-xs font-medium uppercase">
-              Organization subscription
+              Connected accounts
             </p>
             <div className="mt-2 flex flex-wrap items-center gap-2">
-              <span className="text-sm font-medium">Codex subscription</span>
+              <span className="text-sm font-medium">Codex account</span>
               {codex ? (
                 <StatusBadge
                   status={connectionTone(codex.status)}
@@ -212,59 +155,9 @@ export function ManagedProjectBYOK({
             </div>
             <p className="text-muted-foreground mt-2 text-sm">
               {codex
-                ? `${codex.label}${codex.checkedAt ? ` · checked ${new Date(codex.checkedAt).toLocaleString()}` : ''}`
-                : 'No Codex subscription is linked to this organization.'}
+                ? `Connected account${codex.checkedAt ? ` · checked ${new Date(codex.checkedAt).toLocaleString()}` : ''}`
+                : 'No Codex account is linked.'}
             </p>
-          </div>
-
-          <div className="grid gap-4 border-t pt-5 md:grid-cols-2">
-            {environments.map((environment) => {
-              const enabled = isEnabled(environment)
-              return (
-                <div
-                  key={environment}
-                  className="bg-panel-2 rounded-lg border p-4"
-                >
-                  <p className="text-xs font-medium capitalize">
-                    {environment}
-                  </p>
-                  <div className="mt-2">
-                    <StatusBadge
-                      status={enabled ? 'running' : 'stopped'}
-                      label={
-                        enabled
-                          ? 'Subscription preferred · Managed fallback'
-                          : 'Managed'
-                      }
-                    />
-                  </div>
-                  <p className="text-muted-foreground mt-2 text-sm">
-                    {enabled
-                      ? 'Model calls prefer the linked subscription.'
-                      : 'Model calls use OpenComputer managed inference.'}
-                  </p>
-                  {codex?.status === 'connected' ? (
-                    <Button
-                      className="mt-4"
-                      size="sm"
-                      variant={enabled ? 'outline' : 'default'}
-                      disabled={updateBinding.isPending}
-                      onClick={() => {
-                        if (enabled) setEnvironmentEnabled(environment, false)
-                        else if (environment === 'production')
-                          setConfirmProduction(environment)
-                        else setEnvironmentEnabled(environment, true)
-                      }}
-                    >
-                      {updateBinding.isPending ? (
-                        <Loader2 className="animate-spin" />
-                      ) : null}
-                      {enabled ? 'Use Managed' : 'Use subscription'}
-                    </Button>
-                  ) : null}
-                </div>
-              )
-            })}
           </div>
 
           <div className="flex flex-wrap gap-2 border-t pt-5">
@@ -279,9 +172,9 @@ export function ManagedProjectBYOK({
                 {connect.isPending ? (
                   <Loader2 className="animate-spin" />
                 ) : (
-                  <KeyRound />
+                  <BrainCircuit />
                 )}
-                {codex ? 'Replace subscription' : 'Connect subscription'}
+                {codex ? 'Replace Codex account' : 'Connect Codex account'}
               </Button>
             ) : null}
             {canManageConnection && codex ? (
@@ -311,7 +204,7 @@ export function ManagedProjectBYOK({
 
           {!canManageConnection && !codex ? (
             <p className="text-muted-foreground text-sm">
-              Ask an organization admin to connect a Codex subscription.
+              Ask an organization admin to connect a model account.
             </p>
           ) : null}
         </PanelContent>
@@ -320,25 +213,39 @@ export function ManagedProjectBYOK({
       <Panel>
         <PanelHeader>
           <div>
-            <PanelTitle>Use the subscription in agent code</PanelTitle>
+            <PanelTitle>Use the account in agent code</PanelTitle>
             <PanelDescription className="mt-1 max-w-2xl">
-              Select the OpenAI provider explicitly. The shorter string form is
-              an OpenRouter catalog model and continues to use Managed access.
+              Select the model-access provider explicitly. Connected accounts
+              use their native provider; Managed models use OpenRouter.
             </PanelDescription>
           </div>
         </PanelHeader>
         <PanelContent className="space-y-4">
           <div>
-            <p className="mb-2 text-sm font-medium">
-              Codex subscription eligible
-            </p>
+            <p className="mb-2 text-sm font-medium">Codex account eligible</p>
             <CopyRow
-              value={'useModel({ provider: "openai", model: "gpt-5" })'}
+              value={'useModel({ provider: "openai", model: "gpt-5.6-sol" })'}
             />
           </div>
           <div>
-            <p className="mb-2 text-sm font-medium">Managed OpenRouter</p>
-            <CopyRow value={'useModel("openai/gpt-5")'} />
+            <p className="mb-2 text-sm font-medium">
+              Managed OpenRouter · OpenAI
+            </p>
+            <CopyRow
+              value={
+                'useModel({ provider: "openrouter", model: "openai/gpt-5" })'
+              }
+            />
+          </div>
+          <div>
+            <p className="mb-2 text-sm font-medium">
+              Managed OpenRouter · Anthropic
+            </p>
+            <CopyRow
+              value={
+                'useModel({ provider: "openrouter", model: "anthropic/claude-sonnet-4.6" })'
+              }
+            />
           </div>
         </PanelContent>
       </Panel>
@@ -348,55 +255,33 @@ export function ManagedProjectBYOK({
           <div>
             <PanelTitle>Connect with the CLI</PanelTitle>
             <PanelDescription className="mt-1 max-w-2xl">
-              Each command opens the Codex OAuth flow, links or replaces the
-              organization subscription, and enables it for this project in one
-              run.
+              The Codex command opens OAuth, links or replaces the account, and
+              enables it for this project in both development and production.
             </PanelDescription>
           </div>
         </PanelHeader>
         <PanelContent className="space-y-4">
-          {(
-            [
-              ['Development', 'development'],
-              ['Production', 'production'],
-              ['Development and production', 'both'],
-            ] as const
-          ).map(([label, environment]) => (
-            <div key={environment}>
-              <p className="mb-2 text-sm font-medium">{label}</p>
-              <CopyRow
-                value={`${cliExecutable} model-access connect codex --project ${projectSlug} --environment ${environment}`}
-              />
-            </div>
-          ))}
+          <CopyRow
+            value={`${cliExecutable} model-access connect codex --project ${projectSlug}`}
+          />
         </PanelContent>
       </Panel>
 
       <ConfirmDialog
         open={confirmReplace}
         onOpenChange={setConfirmReplace}
-        title="Replace the organization subscription?"
-        description="This reconnects the organization-owned Codex subscription and affects every project environment currently using it."
+        title="Replace the Codex account?"
+        description="This reconnects the Codex account and enables it for both environments in this project."
         confirmLabel="Continue to OpenAI"
         onConfirm={startConnect}
       />
       <ConfirmDialog
         open={confirmDisconnect}
         onOpenChange={setConfirmDisconnect}
-        title="Disconnect the organization subscription?"
-        description="Every project environment using this subscription will return to Managed inference."
-        confirmLabel="Disconnect subscription"
+        title="Disconnect the Codex account?"
+        description="Projects using this account will return to Managed inference."
+        confirmLabel="Disconnect account"
         onConfirm={() => disconnectConnection.mutate()}
-      />
-      <ConfirmDialog
-        open={confirmProduction !== null}
-        onOpenChange={(open) => {
-          if (!open) setConfirmProduction(null)
-        }}
-        title="Enable the subscription in production?"
-        description="Production model calls will prefer the Codex subscription and fall back to Managed inference when necessary."
-        confirmLabel="Enable in production"
-        onConfirm={() => setEnvironmentEnabled('production', true)}
       />
     </div>
   )

--- a/web/src/managed-agents/DebugInspector.tsx
+++ b/web/src/managed-agents/DebugInspector.tsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
+  managedAgentModelRoute,
   managedAgentRenderDebug,
   type ManagedAgentEvent,
   type ManagedAgentRenderDebug,
@@ -173,6 +174,32 @@ export function DebugInspector({
     : -1
   const previous =
     actualIndex > 0 ? renders[actualIndex - 1]?.render : undefined
+  const selectedEventIndex = selected ? events.indexOf(selected.event) : -1
+  const nextRenderIndex =
+    selectedEventIndex >= 0
+      ? events.findIndex(
+          (event, index) =>
+            index > selectedEventIndex && event.type === 'agent.rendered',
+        )
+      : -1
+  const route =
+    selectedEventIndex >= 0
+      ? events
+          .slice(
+            selectedEventIndex + 1,
+            nextRenderIndex < 0 ? undefined : nextRenderIndex,
+          )
+          .map(managedAgentModelRoute)
+          .find(Boolean)
+      : undefined
+  const accessLabel =
+    route?.access.type === 'external_subscription'
+      ? route.access.connectionKind === 'codex_subscription'
+        ? 'Codex account · BYOK'
+        : 'Connected account · BYOK'
+      : route?.access.type === 'managed'
+        ? 'Managed · usage-based'
+        : 'Not resolved yet'
   const activity = events
     .filter(
       (event) =>
@@ -239,6 +266,9 @@ export function DebugInspector({
                   {selected.render.model
                     ? `${selected.render.model.provider}/${selected.render.model.model}`
                     : 'Default'}
+                </p>
+                <p className="text-muted-foreground mt-1 text-[10px]">
+                  {accessLabel}
                 </p>
               </div>
               <div>

--- a/web/src/managed-agents/Detail.tsx
+++ b/web/src/managed-agents/Detail.tsx
@@ -67,6 +67,7 @@ import { ManagedSlackWizard } from './SlackWizard'
 import { ManagedAgentOutboxes } from './Outboxes'
 import { ManagedAgentSchedules } from './Schedules'
 import { ManagedAgentWebhooks } from './Webhooks'
+import { ManagedProjectBYOK } from './BYOK'
 import { AgentMarkdown } from './AgentMarkdown'
 
 type DetailTab =
@@ -78,6 +79,7 @@ type DetailTab =
   | 'schedules'
   | 'webhooks'
   | 'secrets'
+  | 'byok'
 
 function formatDate(value: string) {
   return new Date(value).toLocaleString()
@@ -483,6 +485,7 @@ export default function ManagedAgentDetail({
     'schedules',
     'webhooks',
     'secrets',
+    'byok',
   ])
   const activeTab = project
     ? routeTab && projectTabs.has(routeTab)
@@ -652,6 +655,7 @@ export default function ManagedAgentDetail({
     ...(project ? ([{ id: 'schedules', label: 'Schedules' }] as const) : []),
     ...(project ? ([{ id: 'webhooks', label: 'Webhooks' }] as const) : []),
     ...(project ? ([{ id: 'secrets', label: 'Secrets' }] as const) : []),
+    ...(project ? ([{ id: 'byok', label: 'BYOK' }] as const) : []),
   ]
 
   return (
@@ -1043,6 +1047,13 @@ export default function ManagedAgentDetail({
           projectId={project.project.id}
           agents={project.project.agents}
           environment={environment}
+        />
+      ) : null}
+
+      {activeTab === 'byok' && project ? (
+        <ManagedProjectBYOK
+          projectId={project.project.id}
+          projectSlug={project.project.slug}
         />
       ) : null}
     </div>

--- a/web/src/managed-agents/ModelAccessCallback.tsx
+++ b/web/src/managed-agents/ModelAccessCallback.tsx
@@ -3,8 +3,8 @@ import { CheckCircle2, CircleAlert, Loader2 } from 'lucide-react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { Panel, PanelContent } from '@/components/panel'
 import { Button } from '@/components/ui/button'
-import { completeManagedModelAccess } from './api'
-import { MODEL_ACCESS_RETURN_TO_KEY } from './BYOK'
+import { completeManagedModelAccess, putManagedModelAccessBinding } from './api'
+import { MODEL_ACCESS_PROJECT_KEY, MODEL_ACCESS_RETURN_TO_KEY } from './BYOK'
 
 type CallbackState = 'completing' | 'failed'
 
@@ -33,11 +33,25 @@ export default function ModelAccessCallback() {
     }
 
     void completeManagedModelAccess(connectionId, code, state)
-      .then(() => {
+      .then(async () => {
+        const projectId = sessionStorage.getItem(MODEL_ACCESS_PROJECT_KEY)
+        if (projectId) {
+          await Promise.all(
+            (['development', 'production'] as const).map((environment) =>
+              putManagedModelAccessBinding({
+                projectId,
+                provider: 'openai',
+                environment,
+                enabled: true,
+              }),
+            ),
+          )
+        }
         const storedReturnTo = sessionStorage.getItem(
           MODEL_ACCESS_RETURN_TO_KEY,
         )
         sessionStorage.removeItem(MODEL_ACCESS_RETURN_TO_KEY)
+        sessionStorage.removeItem(MODEL_ACCESS_PROJECT_KEY)
         const returnTo = storedReturnTo?.startsWith('/projects/')
           ? storedReturnTo
           : '/'
@@ -48,7 +62,7 @@ export default function ModelAccessCallback() {
         setMessage(
           error instanceof Error
             ? error.message
-            : 'The Codex subscription could not be connected.',
+            : 'The Codex account could not be connected.',
         )
       })
   }, [navigate, searchParams])
@@ -64,7 +78,7 @@ export default function ModelAccessCallback() {
           )}
           <h1 className="text-lg font-semibold">
             {status === 'completing'
-              ? 'Connecting Codex subscription'
+              ? 'Connecting Codex account'
               : 'Codex authorization failed'}
           </h1>
           <p className="text-muted-foreground mt-2 max-w-md text-sm">

--- a/web/src/managed-agents/ModelAccessCallback.tsx
+++ b/web/src/managed-agents/ModelAccessCallback.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef, useState } from 'react'
+import { CheckCircle2, CircleAlert, Loader2 } from 'lucide-react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { Panel, PanelContent } from '@/components/panel'
+import { Button } from '@/components/ui/button'
+import { completeManagedModelAccess } from './api'
+import { MODEL_ACCESS_RETURN_TO_KEY } from './BYOK'
+
+type CallbackState = 'completing' | 'failed'
+
+export default function ModelAccessCallback() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const started = useRef(false)
+  const [status, setStatus] = useState<CallbackState>('completing')
+  const [message, setMessage] = useState('Completing Codex authorization…')
+
+  useEffect(() => {
+    if (started.current) return
+    started.current = true
+    const providerError = searchParams.get('error')
+    const code = searchParams.get('code')
+    const state = searchParams.get('state')
+    const connectionId = state?.split('.', 1)[0]
+    if (providerError || !code || !state || !connectionId) {
+      setStatus('failed')
+      setMessage(
+        providerError
+          ? `OpenAI authorization failed: ${providerError}`
+          : 'The OAuth callback was incomplete. Return to the project and try again.',
+      )
+      return
+    }
+
+    void completeManagedModelAccess(connectionId, code, state)
+      .then(() => {
+        const storedReturnTo = sessionStorage.getItem(
+          MODEL_ACCESS_RETURN_TO_KEY,
+        )
+        sessionStorage.removeItem(MODEL_ACCESS_RETURN_TO_KEY)
+        const returnTo = storedReturnTo?.startsWith('/projects/')
+          ? storedReturnTo
+          : '/'
+        void navigate(returnTo, { replace: true })
+      })
+      .catch((error: unknown) => {
+        setStatus('failed')
+        setMessage(
+          error instanceof Error
+            ? error.message
+            : 'The Codex subscription could not be connected.',
+        )
+      })
+  }, [navigate, searchParams])
+
+  return (
+    <div className="mx-auto max-w-xl py-16">
+      <Panel>
+        <PanelContent className="flex flex-col items-center py-12 text-center">
+          {status === 'completing' ? (
+            <Loader2 className="text-muted-foreground mb-4 size-8 animate-spin" />
+          ) : (
+            <CircleAlert className="text-destructive mb-4 size-8" />
+          )}
+          <h1 className="text-lg font-semibold">
+            {status === 'completing'
+              ? 'Connecting Codex subscription'
+              : 'Codex authorization failed'}
+          </h1>
+          <p className="text-muted-foreground mt-2 max-w-md text-sm">
+            {message}
+          </p>
+          {status === 'failed' ? (
+            <Button asChild className="mt-6" variant="outline">
+              <Link to="/">
+                <CheckCircle2 /> Return to projects
+              </Link>
+            </Button>
+          ) : null}
+        </PanelContent>
+      </Panel>
+    </div>
+  )
+}

--- a/web/src/managed-agents/api.test.ts
+++ b/web/src/managed-agents/api.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   displayManagedAgentName,
+  managedAgentModelRoute,
   managedAgentRenderDebug,
   nextAgentEventDeadline,
 } from './api'
@@ -63,6 +64,41 @@ describe('managedAgentRenderDebug', () => {
     })
     expect(
       managedAgentRenderDebug({ ...event, type: 'runtime.log' }),
+    ).toBeUndefined()
+  })
+})
+
+describe('managedAgentModelRoute', () => {
+  it('parses Codex BYOK route attribution', () => {
+    const event = {
+      id: 'event-2',
+      seq: 2,
+      timestamp: '2026-08-24T00:00:00.000Z',
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      type: 'model.route_resolved',
+      data: {
+        requested: { provider: 'openai', model: 'gpt-5.6-sol' },
+        effective: { provider: 'openai', model: 'gpt-5.6-sol' },
+        runtime: 'codex',
+        access: {
+          type: 'external_subscription',
+          connectionId: 'mac_1',
+          connectionKind: 'codex_subscription',
+        },
+        openComputerModelChargeUsd: 0,
+      },
+    }
+
+    expect(managedAgentModelRoute(event)).toMatchObject({
+      access: {
+        type: 'external_subscription',
+        connectionKind: 'codex_subscription',
+      },
+      openComputerModelChargeUsd: 0,
+    })
+    expect(
+      managedAgentModelRoute({ ...event, type: 'agent.rendered' }),
     ).toBeUndefined()
   })
 })

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -103,8 +103,8 @@ const modelAccessConnectionSchema = z.object({
   id: z.string(),
   organizationId: z.string().optional(),
   connectedByUserId: z.string().optional(),
-  provider: z.literal('openai'),
-  kind: z.literal('codex_subscription'),
+  provider: z.enum(['anthropic', 'openai']),
+  kind: z.enum(['claude_subscription', 'codex_subscription']),
   label: z.string(),
   externalAccountHint: z.string().nullish(),
   status: z.enum([
@@ -135,7 +135,7 @@ const modelAccessConnectResponseSchema = z.object({
 const modelAccessBindingSchema = z.object({
   projectId: z.string(),
   environment: z.enum(['development', 'production']),
-  provider: z.literal('openai'),
+  provider: z.enum(['anthropic', 'openai']),
   connectionId: z.string(),
   enabled: z.boolean(),
   createdAt: z.string().nullish(),
@@ -354,6 +354,24 @@ const renderDebugSchema = z.object({
   renderedAt: z.string(),
 })
 
+const modelRouteSchema = z.object({
+  requested: z
+    .object({ provider: z.string(), model: z.string() })
+    .nullable()
+    .optional(),
+  effective: z
+    .object({ provider: z.string(), model: z.string() })
+    .nullable()
+    .optional(),
+  runtime: z.string(),
+  access: z.object({
+    type: z.enum(['managed', 'external_subscription']),
+    connectionId: z.string().optional(),
+    connectionKind: z.string().optional(),
+  }),
+  openComputerModelChargeUsd: z.number().nullable(),
+})
+
 const eventsResponseSchema = z.object({
   events: z.array(eventSchema),
 })
@@ -414,6 +432,7 @@ export type ManagedProjectOverview = z.infer<typeof projectOverviewSchema>
 export type ManagedAgentDeployment = z.infer<typeof deploymentSchema>
 export type ManagedAgentEvent = z.infer<typeof eventSchema>
 export type ManagedAgentRenderDebug = z.infer<typeof renderDebugSchema>
+export type ManagedAgentModelRoute = z.infer<typeof modelRouteSchema>
 export type ManagedAgentSession = z.infer<typeof sessionSchema>
 export type ManagedAgentConnection = z.infer<typeof connectionSchema>
 export type ManagedAgentChannel = z.infer<typeof channelSchema>
@@ -529,11 +548,12 @@ export async function getManagedModelAccessBindings(projectId: string) {
 
 export async function putManagedModelAccessBinding(input: {
   projectId: string
+  provider: 'anthropic' | 'openai'
   environment: 'development' | 'production'
   enabled: boolean
 }) {
   return apiFetch(
-    `/managed-agents/projects/${encodeURIComponent(input.projectId)}/model-access/bindings/openai/${input.environment}`,
+    `/managed-agents/projects/${encodeURIComponent(input.projectId)}/model-access/bindings/${input.provider}/${input.environment}`,
     { method: 'PUT', body: JSON.stringify({ enabled: input.enabled }) },
     modelAccessBindingSchema,
   )
@@ -939,6 +959,12 @@ async function suspendManagedAgentIfIdle(sessionId: string) {
 export function managedAgentRenderDebug(event: ManagedAgentEvent) {
   if (event.type !== 'agent.rendered') return undefined
   const parsed = renderDebugSchema.safeParse(event.data)
+  return parsed.success ? parsed.data : undefined
+}
+
+export function managedAgentModelRoute(event: ManagedAgentEvent) {
+  if (event.type !== 'model.route_resolved') return undefined
+  const parsed = modelRouteSchema.safeParse(event.data)
   return parsed.success ? parsed.data : undefined
 }
 

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -99,6 +99,53 @@ const secretSchema = z.object({
 
 const secretsResponseSchema = z.object({ secrets: z.array(secretSchema) })
 
+const modelAccessConnectionSchema = z.object({
+  id: z.string(),
+  organizationId: z.string().optional(),
+  connectedByUserId: z.string().optional(),
+  provider: z.literal('openai'),
+  kind: z.literal('codex_subscription'),
+  label: z.string(),
+  externalAccountHint: z.string().nullish(),
+  status: z.enum([
+    'connecting',
+    'connected',
+    'reauth_required',
+    'provider_limited',
+    'plan_ineligible',
+    'revoked',
+    'unavailable',
+  ]),
+  checkedAt: z.string().nullish(),
+  createdAt: z.string().nullish(),
+  updatedAt: z.string().nullish(),
+})
+
+const modelAccessConnectionsResponseSchema = z.object({
+  data: z.array(modelAccessConnectionSchema),
+})
+
+const modelAccessConnectResponseSchema = z.object({
+  connection: modelAccessConnectionSchema,
+  status: z.literal('pending'),
+  authorize_url: z.string().url(),
+  expires_at: z.string(),
+})
+
+const modelAccessBindingSchema = z.object({
+  projectId: z.string(),
+  environment: z.enum(['development', 'production']),
+  provider: z.literal('openai'),
+  connectionId: z.string(),
+  enabled: z.boolean(),
+  createdAt: z.string().nullish(),
+  updatedAt: z.string().nullish(),
+})
+
+const modelAccessBindingsResponseSchema = z.object({
+  data: z.array(modelAccessBindingSchema),
+})
+
 const runtimeVariableSchema = z.object({
   name: z.string(),
   projectId: z.string(),
@@ -377,6 +424,10 @@ export type ManagedAgentScheduleRun = z.infer<typeof scheduleRunSchema>
 export type ManagedAgentWebhook = z.infer<typeof webhookSchema>
 export type ManagedSlackManifest = z.infer<typeof slackManifestResponseSchema>
 export type ManagedProjectSecret = z.infer<typeof secretSchema>
+export type ManagedModelAccessConnection = z.infer<
+  typeof modelAccessConnectionSchema
+>
+export type ManagedModelAccessBinding = z.infer<typeof modelAccessBindingSchema>
 
 const UUID_NAME =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
@@ -417,6 +468,74 @@ export async function getManagedProject(projectId: string) {
     `/managed-agents/projects/${encodeURIComponent(projectId)}`,
     undefined,
     projectOverviewSchema,
+  )
+}
+
+export async function getManagedModelAccessConnections() {
+  return (
+    await apiFetch(
+      '/managed-agents/model-access/connections',
+      undefined,
+      modelAccessConnectionsResponseSchema,
+    )
+  ).data
+}
+
+export async function connectManagedModelAccess() {
+  return apiFetch(
+    '/managed-agents/model-access/connections',
+    { method: 'POST', body: JSON.stringify({ provider: 'openai' }) },
+    modelAccessConnectResponseSchema,
+  )
+}
+
+export async function completeManagedModelAccess(
+  id: string,
+  code: string,
+  state: string,
+) {
+  return apiFetch(
+    `/managed-agents/model-access/connections/${encodeURIComponent(id)}/complete`,
+    { method: 'POST', body: JSON.stringify({ code, state }) },
+    modelAccessConnectionSchema,
+  )
+}
+
+export async function validateManagedModelAccessConnection(id: string) {
+  return apiFetch(
+    `/managed-agents/model-access/connections/${encodeURIComponent(id)}/validate`,
+    { method: 'POST' },
+    modelAccessConnectionSchema,
+  )
+}
+
+export async function disconnectManagedModelAccessConnection(id: string) {
+  return apiFetch(
+    `/managed-agents/model-access/connections/${encodeURIComponent(id)}`,
+    { method: 'DELETE' },
+    modelAccessConnectionSchema,
+  )
+}
+
+export async function getManagedModelAccessBindings(projectId: string) {
+  return (
+    await apiFetch(
+      `/managed-agents/projects/${encodeURIComponent(projectId)}/model-access/bindings`,
+      undefined,
+      modelAccessBindingsResponseSchema,
+    )
+  ).data
+}
+
+export async function putManagedModelAccessBinding(input: {
+  projectId: string
+  environment: 'development' | 'production'
+  enabled: boolean
+}) {
+  return apiFetch(
+    `/managed-agents/projects/${encodeURIComponent(input.projectId)}/model-access/bindings/openai/${input.environment}`,
+    { method: 'PUT', body: JSON.stringify({ enabled: input.enabled }) },
+    modelAccessBindingSchema,
   )
 }
 

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -423,17 +423,14 @@ function NavigationToggle({
   )
 }
 
-// Model access (work 011). One organization connection per provider. The
-// connect form accepts a write-only provider token; Codex is the only enabled
-// provider in this rollout, so the Claude action is shown disabled.
+// Model access (work 011). One Codex subscription per organization, connected
+// through the authorized personal-subscription OAuth flow on the dashboard.
 function ModelAccessPanel({ canManage }: { canManage: boolean }) {
   const queryClient = useQueryClient()
   const { data: connections, isLoading } = useQuery({
     queryKey: ['model-access-connections'],
     queryFn: getModelAccessConnections,
   })
-  const [token, setToken] = useState('')
-  const [label, setLabel] = useState('')
   const [confirmDisconnect, setConfirmDisconnect] = useState<string | null>(null)
 
   const invalidate = () =>
@@ -442,18 +439,11 @@ function ModelAccessPanel({ canManage }: { canManage: boolean }) {
     })
 
   const connectMutation = useMutation({
-    mutationFn: () =>
-      connectModelAccess({
-        provider: 'openai',
-        token,
-        label: label.trim() || undefined,
-      }),
-    onSuccess: () => {
-      setToken('')
-      setLabel('')
-      invalidate()
+    mutationFn: () => connectModelAccess({ provider: 'openai' }),
+    onSuccess: (result) => {
+      window.location.assign(result.authorize_url)
     },
-    onError: (e) => notifyError("Couldn't connect the subscription.", e),
+    onError: (e) => notifyError("Couldn't start the Codex connection.", e),
   })
 
   const disconnectMutation = useMutation({
@@ -469,16 +459,15 @@ function ModelAccessPanel({ canManage }: { canManage: boolean }) {
   })
 
   const codex = connections?.find((c) => c.provider === 'openai')
-  const claude = connections?.find((c) => c.provider === 'anthropic')
 
   return (
     <Panel className="p-6 lg:col-span-2">
       <div className="mb-5">
         <PanelTitle>Model access</PanelTitle>
         <PanelDescription className="mt-1">
-          Connect an external Claude or Codex subscription so eligible model
-          inference is billed by your subscription, not OpenComputer credits.
-          Runtime compute is still charged. Requires OpenComputer Pro or Max.
+          Connect your Codex subscription so eligible model inference is billed
+          by your subscription, not OpenComputer credits. Runtime compute is
+          still charged. Requires OpenComputer Pro or Max.
         </PanelDescription>
       </div>
 
@@ -488,64 +477,29 @@ function ModelAccessPanel({ canManage }: { canManage: boolean }) {
         <div className="space-y-6">
           <ModelAccessConnectionRow
             title="Codex subscription"
-            provider="openai"
             connection={codex}
             canManage={canManage}
             onValidate={(id) => validateMutation.mutate(id)}
             onDisconnect={(id) => setConfirmDisconnect(id)}
             validating={validateMutation.isPending}
           />
-          <ModelAccessConnectionRow
-            title="Claude subscription"
-            provider="anthropic"
-            connection={claude}
-            canManage={false}
-            disabledReason="Claude subscription access is not yet enabled."
-            onValidate={() => {}}
-            onDisconnect={() => {}}
-            validating={false}
-          />
 
           {canManage && !codex ? (
-            <form
-              className="space-y-3 border-t pt-4"
-              onSubmit={(e) => {
-                e.preventDefault()
-                if (token.trim()) connectMutation.mutate()
-              }}
-            >
-              <div className="grid gap-3 sm:grid-cols-2">
-                <Field>
-                  <Label htmlFor="ma-label">Label (optional)</Label>
-                  <Input
-                    id="ma-label"
-                    value={label}
-                    onChange={(e) => setLabel(e.target.value)}
-                    placeholder="Codex workspace"
-                  />
-                </Field>
-                <Field>
-                  <Label htmlFor="ma-token">Codex access token</Label>
-                  <Input
-                    id="ma-token"
-                    type="password"
-                    value={token}
-                    onChange={(e) => setToken(e.target.value)}
-                    placeholder="Paste the workspace access token"
-                    autoComplete="off"
-                  />
-                </Field>
-              </div>
+            <div className="border-t pt-4">
               <Button
-                type="submit"
                 size="sm"
-                disabled={!token.trim() || connectMutation.isPending}
+                disabled={connectMutation.isPending}
+                onClick={() => connectMutation.mutate()}
               >
                 {connectMutation.isPending
-                  ? 'Connecting…'
+                  ? 'Opening OpenAI…'
                   : 'Connect Codex subscription'}
               </Button>
-            </form>
+              <p className="text-muted-foreground mt-2 text-xs">
+                You will be redirected to OpenAI to authorize your personal Codex
+                subscription. Credentials are never stored in your browser.
+              </p>
+            </div>
           ) : null}
         </div>
       )}
@@ -569,16 +523,13 @@ function ModelAccessConnectionRow({
   title,
   connection,
   canManage,
-  disabledReason,
   onValidate,
   onDisconnect,
   validating,
 }: {
   title: string
-  provider: 'anthropic' | 'openai'
   connection: ModelAccessConnection | undefined
   canManage: boolean
-  disabledReason?: string
   onValidate: (id: string) => void
   onDisconnect: (id: string) => void
   validating: boolean
@@ -609,7 +560,7 @@ function ModelAccessConnectionRow({
           </p>
         ) : (
           <p className="text-muted-foreground mt-1 text-sm">
-            {disabledReason ?? 'No connection configured.'}
+            No connection configured.
           </p>
         )}
       </div>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -15,9 +15,14 @@ import {
   setCustomDomain,
   updateOrg,
   updateNavigationPreferences,
+  getModelAccessConnections,
+  connectModelAccess,
+  disconnectModelAccess,
+  validateModelAccessConnection,
   type NavigationPreferenceUpdate,
   type OrgInvitation,
   type OrgMember,
+  type ModelAccessConnection,
 } from '@/api/client'
 import { PageHeader } from '@/components/page-header'
 import {
@@ -171,6 +176,11 @@ export default function Settings() {
             />
           </div>
         </Panel>
+
+        {/* Model access (work 011) — connect an external Claude/Codex
+            subscription. Connection management is org-admin only; the raw
+            provider token is write-only and never shown. */}
+        <ModelAccessPanel canManage={user?.capabilities?.manageMembers !== false} />
 
         {/* Organization */}
         <Panel className="p-6">
@@ -409,6 +419,219 @@ function NavigationToggle({
         disabled={disabled}
         onCheckedChange={onCheckedChange}
       />
+    </div>
+  )
+}
+
+// Model access (work 011). One organization connection per provider. The
+// connect form accepts a write-only provider token; Codex is the only enabled
+// provider in this rollout, so the Claude action is shown disabled.
+function ModelAccessPanel({ canManage }: { canManage: boolean }) {
+  const queryClient = useQueryClient()
+  const { data: connections, isLoading } = useQuery({
+    queryKey: ['model-access-connections'],
+    queryFn: getModelAccessConnections,
+  })
+  const [token, setToken] = useState('')
+  const [label, setLabel] = useState('')
+  const [confirmDisconnect, setConfirmDisconnect] = useState<string | null>(null)
+
+  const invalidate = () =>
+    void queryClient.invalidateQueries({
+      queryKey: ['model-access-connections'],
+    })
+
+  const connectMutation = useMutation({
+    mutationFn: () =>
+      connectModelAccess({
+        provider: 'openai',
+        token,
+        label: label.trim() || undefined,
+      }),
+    onSuccess: () => {
+      setToken('')
+      setLabel('')
+      invalidate()
+    },
+    onError: (e) => notifyError("Couldn't connect the subscription.", e),
+  })
+
+  const disconnectMutation = useMutation({
+    mutationFn: (id: string) => disconnectModelAccess(id),
+    onSuccess: invalidate,
+    onError: (e) => notifyError("Couldn't disconnect the subscription.", e),
+  })
+
+  const validateMutation = useMutation({
+    mutationFn: (id: string) => validateModelAccessConnection(id),
+    onSuccess: invalidate,
+    onError: (e) => notifyError("Couldn't validate the connection.", e),
+  })
+
+  const codex = connections?.find((c) => c.provider === 'openai')
+  const claude = connections?.find((c) => c.provider === 'anthropic')
+
+  return (
+    <Panel className="p-6 lg:col-span-2">
+      <div className="mb-5">
+        <PanelTitle>Model access</PanelTitle>
+        <PanelDescription className="mt-1">
+          Connect an external Claude or Codex subscription so eligible model
+          inference is billed by your subscription, not OpenComputer credits.
+          Runtime compute is still charged. Requires OpenComputer Pro or Max.
+        </PanelDescription>
+      </div>
+
+      {isLoading ? (
+        <Skeleton className="h-24 w-full" />
+      ) : (
+        <div className="space-y-6">
+          <ModelAccessConnectionRow
+            title="Codex subscription"
+            provider="openai"
+            connection={codex}
+            canManage={canManage}
+            onValidate={(id) => validateMutation.mutate(id)}
+            onDisconnect={(id) => setConfirmDisconnect(id)}
+            validating={validateMutation.isPending}
+          />
+          <ModelAccessConnectionRow
+            title="Claude subscription"
+            provider="anthropic"
+            connection={claude}
+            canManage={false}
+            disabledReason="Claude subscription access is not yet enabled."
+            onValidate={() => {}}
+            onDisconnect={() => {}}
+            validating={false}
+          />
+
+          {canManage && !codex ? (
+            <form
+              className="space-y-3 border-t pt-4"
+              onSubmit={(e) => {
+                e.preventDefault()
+                if (token.trim()) connectMutation.mutate()
+              }}
+            >
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Field>
+                  <Label htmlFor="ma-label">Label (optional)</Label>
+                  <Input
+                    id="ma-label"
+                    value={label}
+                    onChange={(e) => setLabel(e.target.value)}
+                    placeholder="Codex workspace"
+                  />
+                </Field>
+                <Field>
+                  <Label htmlFor="ma-token">Codex access token</Label>
+                  <Input
+                    id="ma-token"
+                    type="password"
+                    value={token}
+                    onChange={(e) => setToken(e.target.value)}
+                    placeholder="Paste the workspace access token"
+                    autoComplete="off"
+                  />
+                </Field>
+              </div>
+              <Button
+                type="submit"
+                size="sm"
+                disabled={!token.trim() || connectMutation.isPending}
+              >
+                {connectMutation.isPending
+                  ? 'Connecting…'
+                  : 'Connect Codex subscription'}
+              </Button>
+            </form>
+          ) : null}
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={confirmDisconnect !== null}
+        onOpenChange={(open) => !open && setConfirmDisconnect(null)}
+        title="Disconnect subscription?"
+        description="This revokes the stored credential and returns affected projects to Managed usage-based inference. This cannot be undone."
+        confirmLabel="Disconnect"
+        onConfirm={() => {
+          if (confirmDisconnect) disconnectMutation.mutate(confirmDisconnect)
+          setConfirmDisconnect(null)
+        }}
+      />
+    </Panel>
+  )
+}
+
+function ModelAccessConnectionRow({
+  title,
+  connection,
+  canManage,
+  disabledReason,
+  onValidate,
+  onDisconnect,
+  validating,
+}: {
+  title: string
+  provider: 'anthropic' | 'openai'
+  connection: ModelAccessConnection | undefined
+  canManage: boolean
+  disabledReason?: string
+  onValidate: (id: string) => void
+  onDisconnect: (id: string) => void
+  validating: boolean
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 border-b pb-4 last:border-0 last:pb-0">
+      <div>
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{title}</span>
+          {connection ? (
+            <StatusBadge
+              status={connection.status === 'connected' ? 'running' : 'pending'}
+              label={connection.status.replace(/_/g, ' ')}
+            />
+          ) : (
+            <StatusBadge status="stopped" label="Not connected" />
+          )}
+        </div>
+        {connection ? (
+          <p className="text-muted-foreground mt-1 text-sm">
+            {connection.label}
+            {connection.external_account_hint
+              ? ` · ${connection.external_account_hint}`
+              : ''}
+            {connection.checked_at
+              ? ` · checked ${new Date(connection.checked_at).toLocaleDateString()}`
+              : ''}
+          </p>
+        ) : (
+          <p className="text-muted-foreground mt-1 text-sm">
+            {disabledReason ?? 'No connection configured.'}
+          </p>
+        )}
+      </div>
+      {connection && canManage ? (
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={validating}
+            onClick={() => onValidate(connection.id)}
+          >
+            Revalidate
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => onDisconnect(connection.id)}
+          >
+            Disconnect
+          </Button>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -15,14 +15,9 @@ import {
   setCustomDomain,
   updateOrg,
   updateNavigationPreferences,
-  getModelAccessConnections,
-  connectModelAccess,
-  disconnectModelAccess,
-  validateModelAccessConnection,
   type NavigationPreferenceUpdate,
   type OrgInvitation,
   type OrgMember,
-  type ModelAccessConnection,
 } from '@/api/client'
 import { PageHeader } from '@/components/page-header'
 import {
@@ -176,11 +171,6 @@ export default function Settings() {
             />
           </div>
         </Panel>
-
-        {/* Model access (work 011) — connect an external Claude/Codex
-            subscription. Connection management is org-admin only; the raw
-            provider token is write-only and never shown. */}
-        <ModelAccessPanel canManage={user?.capabilities?.manageMembers !== false} />
 
         {/* Organization */}
         <Panel className="p-6">
@@ -419,170 +409,6 @@ function NavigationToggle({
         disabled={disabled}
         onCheckedChange={onCheckedChange}
       />
-    </div>
-  )
-}
-
-// Model access (work 011). One Codex subscription per organization, connected
-// through the authorized personal-subscription OAuth flow on the dashboard.
-function ModelAccessPanel({ canManage }: { canManage: boolean }) {
-  const queryClient = useQueryClient()
-  const { data: connections, isLoading } = useQuery({
-    queryKey: ['model-access-connections'],
-    queryFn: getModelAccessConnections,
-  })
-  const [confirmDisconnect, setConfirmDisconnect] = useState<string | null>(null)
-
-  const invalidate = () =>
-    void queryClient.invalidateQueries({
-      queryKey: ['model-access-connections'],
-    })
-
-  const connectMutation = useMutation({
-    mutationFn: () => connectModelAccess({ provider: 'openai' }),
-    onSuccess: (result) => {
-      window.location.assign(result.authorize_url)
-    },
-    onError: (e) => notifyError("Couldn't start the Codex connection.", e),
-  })
-
-  const disconnectMutation = useMutation({
-    mutationFn: (id: string) => disconnectModelAccess(id),
-    onSuccess: invalidate,
-    onError: (e) => notifyError("Couldn't disconnect the subscription.", e),
-  })
-
-  const validateMutation = useMutation({
-    mutationFn: (id: string) => validateModelAccessConnection(id),
-    onSuccess: invalidate,
-    onError: (e) => notifyError("Couldn't validate the connection.", e),
-  })
-
-  const codex = connections?.find((c) => c.provider === 'openai')
-
-  return (
-    <Panel className="p-6 lg:col-span-2">
-      <div className="mb-5">
-        <PanelTitle>Model access</PanelTitle>
-        <PanelDescription className="mt-1">
-          Connect your Codex subscription so eligible model inference is billed
-          by your subscription, not OpenComputer credits. Runtime compute is
-          still charged. Requires OpenComputer Pro or Max.
-        </PanelDescription>
-      </div>
-
-      {isLoading ? (
-        <Skeleton className="h-24 w-full" />
-      ) : (
-        <div className="space-y-6">
-          <ModelAccessConnectionRow
-            title="Codex subscription"
-            connection={codex}
-            canManage={canManage}
-            onValidate={(id) => validateMutation.mutate(id)}
-            onDisconnect={(id) => setConfirmDisconnect(id)}
-            validating={validateMutation.isPending}
-          />
-
-          {canManage && !codex ? (
-            <div className="border-t pt-4">
-              <Button
-                size="sm"
-                disabled={connectMutation.isPending}
-                onClick={() => connectMutation.mutate()}
-              >
-                {connectMutation.isPending
-                  ? 'Opening OpenAI…'
-                  : 'Connect Codex subscription'}
-              </Button>
-              <p className="text-muted-foreground mt-2 text-xs">
-                You will be redirected to OpenAI to authorize your personal Codex
-                subscription. Credentials are never stored in your browser.
-              </p>
-            </div>
-          ) : null}
-        </div>
-      )}
-
-      <ConfirmDialog
-        open={confirmDisconnect !== null}
-        onOpenChange={(open) => !open && setConfirmDisconnect(null)}
-        title="Disconnect subscription?"
-        description="This revokes the stored credential and returns affected projects to Managed usage-based inference. This cannot be undone."
-        confirmLabel="Disconnect"
-        onConfirm={() => {
-          if (confirmDisconnect) disconnectMutation.mutate(confirmDisconnect)
-          setConfirmDisconnect(null)
-        }}
-      />
-    </Panel>
-  )
-}
-
-function ModelAccessConnectionRow({
-  title,
-  connection,
-  canManage,
-  onValidate,
-  onDisconnect,
-  validating,
-}: {
-  title: string
-  connection: ModelAccessConnection | undefined
-  canManage: boolean
-  onValidate: (id: string) => void
-  onDisconnect: (id: string) => void
-  validating: boolean
-}) {
-  return (
-    <div className="flex items-center justify-between gap-4 border-b pb-4 last:border-0 last:pb-0">
-      <div>
-        <div className="flex items-center gap-2">
-          <span className="font-medium">{title}</span>
-          {connection ? (
-            <StatusBadge
-              status={connection.status === 'connected' ? 'running' : 'pending'}
-              label={connection.status.replace(/_/g, ' ')}
-            />
-          ) : (
-            <StatusBadge status="stopped" label="Not connected" />
-          )}
-        </div>
-        {connection ? (
-          <p className="text-muted-foreground mt-1 text-sm">
-            {connection.label}
-            {connection.external_account_hint
-              ? ` · ${connection.external_account_hint}`
-              : ''}
-            {connection.checked_at
-              ? ` · checked ${new Date(connection.checked_at).toLocaleDateString()}`
-              : ''}
-          </p>
-        ) : (
-          <p className="text-muted-foreground mt-1 text-sm">
-            No connection configured.
-          </p>
-        )}
-      </div>
-      {connection && canManage ? (
-        <div className="flex gap-2">
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={validating}
-            onClick={() => onValidate(connection.id)}
-          >
-            Revalidate
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => onDisconnect(connection.id)}
-          >
-            Disconnect
-          </Button>
-        </div>
-      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
Public surface for work 011 (bring-your-own model subscription).

- Autumn catalog: byo_model_subscriptions boolean feature on Pro and Max.
- API client + zod schemas: ModelAccessConnection, ModelAccessBinding, EffectiveModelRoute, typed model-access errors. Provider token is write-only.
- Dashboard: Settings → Model access panel to connect/validate/disconnect a Codex subscription (Claude shown disabled pending its own slice).
- CLI: opencomputer model-access connect|list|disconnect|enable|disable. Token via hidden prompt/stdin, never a command argument.

Codex-first rollout: only the OpenAI/Codex adapter is enabled; Claude is gated behind the same contract until its slice is verified.

Pairs with bluecode feat/byo-model-subscriptions (connection custody, dispatch resolution, events).

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/bd78aed8-e05f-4db3-92ff-b20418933a36)
