### PR TITLE
release: publish OpenComputer CLI 0.6.2

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/cli",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@opencode-ai/sdk": "1.18.4",
         "ai": "^7.0.45",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Build, test, deploy, and share OpenComputer agents as code.",
   "type": "module",
   "bin": {

--- a/create-start/package.json
+++ b/create-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/create-start",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Create a hello-world OpenComputer agent application.",
   "type": "module",
   "bin": {
@@ -18,7 +18,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@opencomputer/cli": "0.6.1"
+    "@opencomputer/cli": "0.6.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
The Codex BYOK implementation merged with CLI version 0.6.1, which was already present on npm, so the successful package workflow skipped publication. This version-only follow-up bumps the coupled CLI and create-start packages to 0.6.2.

Verification:
- package contract passes
- CLI: 41 tests pass
- create-start: 2 tests pass
- CLI build passes
- git diff --check