### PR TITLE
fix: make Codex BYOK project-aware and CLI-only

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/cli",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@opencode-ai/sdk": "1.18.4",
         "ai": "^7.0.45",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Build, test, deploy, and share OpenComputer agents as code.",
   "type": "module",
   "bin": {

--- a/cli/src/commands.test.ts
+++ b/cli/src/commands.test.ts
@@ -1,10 +1,22 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { deploymentAlias } from "./commands.js";
+import {
+  deploymentAlias,
+  shouldBindModelAccessProject,
+} from "./commands.js";
 
 test("one-shot deploy defaults to development and production stays explicit", () => {
   assert.equal(deploymentAlias(), "development");
   assert.equal(deploymentAlias("development"), "development");
   assert.equal(deploymentAlias("production"), "production");
+});
+
+test("model access binds the explicit or current linked project", () => {
+  assert.equal(shouldBindModelAccessProject("test", null), true);
+  assert.equal(
+    shouldBindModelAccessProject(undefined, "/tmp/opencomputer-app"),
+    true,
+  );
+  assert.equal(shouldBindModelAccessProject(undefined, null), false);
 });

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -40,6 +40,13 @@ export function deploymentAlias(requestedAlias?: string): string {
   return requestedAlias ?? "development";
 }
 
+export function shouldBindModelAccessProject(
+  projectReference: string | undefined,
+  currentAgentRoot: string | null | undefined,
+): boolean {
+  return Boolean(projectReference || currentAgentRoot);
+}
+
 function printJSON(value: unknown): void {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
 }
@@ -790,13 +797,15 @@ export async function runCommand(
         !["development", "production", "both"].includes(legacyEnvironment)
       )
         throw new Error("--environment must be development, production, or both");
-      const environments = projectReference
+      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
+      const currentAgentRoot = projectReference ? null : await findAgentRoot();
+      const project =
+        shouldBindModelAccessProject(projectReference, currentAgentRoot)
+          ? await selectedProject(client, config, projectReference, false)
+          : undefined;
+      const environments = project
         ? (["development", "production"] as const)
         : [];
-      if (args.length) throw new Error(`Unexpected argument: ${args[0]}`);
-      const project = projectReference
-        ? await selectedProject(client, config, projectReference, false)
-        : undefined;
       const receipt = await client.connectModelAccess({ provider: "openai" });
       process.stdout.write(
         "Opening a local callback and your browser to authorize your Codex account…\n",

--- a/create-start/package.json
+++ b/create-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/create-start",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Create a hello-world OpenComputer agent application.",
   "type": "module",
   "bin": {
@@ -18,7 +18,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@opencomputer/cli": "0.6.2"
+    "@opencomputer/cli": "0.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/web/src/managed-agents/BYOK.test.ts
+++ b/web/src/managed-agents/BYOK.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { hasProjectCodexAccess, modelAccessCLICommand } from './BYOK'
+
+describe('project BYOK presentation', () => {
+  it('uses an install-free production CLI command', () => {
+    expect(
+      modelAccessCLICommand('test', {
+        hostname: 'app.opencomputer.dev',
+        origin: 'https://app.opencomputer.dev',
+      }),
+    ).toBe(
+      'npx --yes --package=@opencomputer/cli@latest -- opencomputer model-access connect codex --project test',
+    )
+  })
+
+  it('targets the current API outside production', () => {
+    expect(
+      modelAccessCLICommand('test', {
+        hostname: 'mo-oc-dev.com',
+        origin: 'https://mo-oc-dev.com',
+      }),
+    ).toContain('opencomputer --api-url https://mo-oc-dev.com model-access')
+  })
+
+  it('requires enabled Codex bindings in both project environments', () => {
+    expect(
+      hasProjectCodexAccess([
+        {
+          provider: 'openai',
+          environment: 'development',
+          enabled: true,
+        },
+      ]),
+    ).toBe(false)
+    expect(
+      hasProjectCodexAccess([
+        {
+          provider: 'openai',
+          environment: 'development',
+          enabled: true,
+        },
+        {
+          provider: 'openai',
+          environment: 'production',
+          enabled: true,
+        },
+      ]),
+    ).toBe(true)
+  })
+})

--- a/web/src/managed-agents/BYOK.test.ts
+++ b/web/src/managed-agents/BYOK.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { hasProjectCodexAccess, modelAccessCLICommand } from './BYOK'
+import {
+  hasProjectCodexAccess,
+  modelAccessCLICommand,
+  projectCodexBindingUpdates,
+} from './BYOK'
 
 describe('project BYOK presentation', () => {
   it('uses an install-free production CLI command', () => {
@@ -46,5 +50,39 @@ describe('project BYOK presentation', () => {
         },
       ]),
     ).toBe(true)
+  })
+
+  it('enables development and production together without reconnecting', () => {
+    expect(projectCodexBindingUpdates('prj_test', true)).toEqual([
+      {
+        projectId: 'prj_test',
+        provider: 'openai',
+        environment: 'development',
+        enabled: true,
+      },
+      {
+        projectId: 'prj_test',
+        provider: 'openai',
+        environment: 'production',
+        enabled: true,
+      },
+    ])
+  })
+
+  it('disables both environments without disconnecting the account', () => {
+    expect(projectCodexBindingUpdates('prj_test', false)).toEqual([
+      {
+        projectId: 'prj_test',
+        provider: 'openai',
+        environment: 'development',
+        enabled: false,
+      },
+      {
+        projectId: 'prj_test',
+        provider: 'openai',
+        environment: 'production',
+        enabled: false,
+      },
+    ])
   })
 })

--- a/web/src/managed-agents/BYOK.tsx
+++ b/web/src/managed-agents/BYOK.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { BrainCircuit, Loader2, RefreshCw, Unplug } from 'lucide-react'
-import { useLocation } from 'react-router-dom'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 import { CopyRow } from '@/components/copy-row'
 import { EmptyState } from '@/components/empty-state'
@@ -17,9 +16,9 @@ import { Button } from '@/components/ui/button'
 import { useAuth } from '@/hooks/useAuth'
 import { notifyError, notifySuccess } from '@/lib/errors'
 import {
-  connectManagedModelAccess,
   disconnectManagedModelAccessConnection,
   getManagedModelAccessConnections,
+  getManagedModelAccessBindings,
   validateManagedModelAccessConnection,
 } from './api'
 
@@ -32,6 +31,35 @@ function connectionTone(status: string) {
   return 'pending'
 }
 
+export function modelAccessCLICommand(
+  projectSlug: string,
+  location: Pick<Location, 'hostname' | 'origin'>,
+) {
+  const apiArgument =
+    location.hostname === 'app.opencomputer.dev'
+      ? ''
+      : ` --api-url ${location.origin}`
+  return `npx --yes --package=@opencomputer/cli@latest -- opencomputer${apiArgument} model-access connect codex --project ${projectSlug}`
+}
+
+export function hasProjectCodexAccess(
+  bindings:
+    | Array<{
+        enabled: boolean
+        environment: string
+        provider: string
+      }>
+    | undefined,
+) {
+  const enabled = bindings?.filter(
+    (binding) => binding.provider === 'openai' && binding.enabled,
+  )
+  return (
+    enabled?.some((binding) => binding.environment === 'development') ===
+      true && enabled.some((binding) => binding.environment === 'production')
+  )
+}
+
 export function ManagedProjectBYOK({
   projectId,
   projectSlug,
@@ -40,35 +68,24 @@ export function ManagedProjectBYOK({
   projectSlug: string
 }) {
   const { user } = useAuth()
-  const location = useLocation()
   const queryClient = useQueryClient()
-  const [confirmReplace, setConfirmReplace] = useState(false)
   const [confirmDisconnect, setConfirmDisconnect] = useState(false)
   const canManageConnection = user?.capabilities?.manageMembers !== false
-  const cliExecutable =
-    window.location.hostname === 'mo-oc-dev.com' ? 'ocdev' : 'opencomputer'
+  const cliCommand = modelAccessCLICommand(projectSlug, window.location)
   const connectionQueryKey = ['managed-model-access-connections']
+  const bindingQueryKey = ['managed-model-access-bindings', projectId]
   const connections = useQuery({
     queryKey: connectionQueryKey,
     queryFn: getManagedModelAccessConnections,
   })
+  const bindings = useQuery({
+    queryKey: bindingQueryKey,
+    queryFn: () => getManagedModelAccessBindings(projectId),
+  })
   const codex = connections.data?.find(
     (connection) => connection.provider === 'openai',
   )
-
-  const connect = useMutation({
-    mutationFn: connectManagedModelAccess,
-    onSuccess: (receipt) => {
-      sessionStorage.setItem(
-        MODEL_ACCESS_RETURN_TO_KEY,
-        `${location.pathname}${location.search}`,
-      )
-      sessionStorage.setItem(MODEL_ACCESS_PROJECT_KEY, projectId)
-      window.location.assign(receipt.authorize_url)
-    },
-    onError: (error) =>
-      notifyError("Couldn't start Codex authorization.", error),
-  })
+  const projectEnabled = hasProjectCodexAccess(bindings.data)
   const validateConnection = useMutation({
     mutationFn: () => validateManagedModelAccessConnection(codex!.id),
     onSuccess: async () => {
@@ -82,17 +99,16 @@ export function ManagedProjectBYOK({
     mutationFn: () => disconnectManagedModelAccessConnection(codex!.id),
     onSuccess: async () => {
       setConfirmDisconnect(false)
-      await queryClient.invalidateQueries({ queryKey: connectionQueryKey })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: connectionQueryKey }),
+        queryClient.invalidateQueries({ queryKey: bindingQueryKey }),
+      ])
       notifySuccess('Codex account disconnected.')
     },
     onError: (error) =>
       notifyError("Couldn't disconnect the Codex account.", error),
   })
-  const startConnect = () => {
-    setConfirmReplace(false)
-    connect.mutate()
-  }
-  if (connections.isLoading) {
+  if (connections.isLoading || bindings.isLoading) {
     return (
       <Panel>
         <PanelContent className="text-muted-foreground flex items-center gap-2 text-sm">
@@ -102,7 +118,7 @@ export function ManagedProjectBYOK({
     )
   }
 
-  if (connections.isError) {
+  if (connections.isError || bindings.isError) {
     return (
       <Panel>
         <EmptyState
@@ -132,8 +148,9 @@ export function ManagedProjectBYOK({
             <PanelTitle>BYOK</PanelTitle>
             <PanelDescription className="mt-1 max-w-2xl">
               Link a Codex account to this project. Connecting it enables the
-              account for both development and production. Managed usage-based
-              inference remains the fallback. Runtime compute is still charged.
+              account for both development and production. Account connection
+              happens through the CLI. Managed usage-based inference remains the
+              fallback. Runtime compute is still charged.
             </PanelDescription>
           </div>
         </PanelHeader>
@@ -158,49 +175,52 @@ export function ManagedProjectBYOK({
                 ? `Connected account${codex.checkedAt ? ` · checked ${new Date(codex.checkedAt).toLocaleString()}` : ''}`
                 : 'No Codex account is linked.'}
             </p>
+            <div className="mt-4">
+              <p className="text-muted-foreground text-xs font-medium uppercase">
+                Project access
+              </p>
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                <StatusBadge
+                  status={projectEnabled ? 'running' : 'stopped'}
+                  label={
+                    projectEnabled
+                      ? 'Enabled for development and production'
+                      : 'Not enabled for this project'
+                  }
+                />
+              </div>
+              {codex && !projectEnabled ? (
+                <p className="text-muted-foreground mt-2 text-sm">
+                  The organization account is connected, but this project will
+                  use Managed inference until you run the CLI command below.
+                </p>
+              ) : null}
+            </div>
           </div>
 
-          <div className="flex flex-wrap gap-2 border-t pt-5">
-            {canManageConnection ? (
+          {canManageConnection && codex ? (
+            <div className="flex flex-wrap gap-2 border-t pt-5">
               <Button
-                variant={codex ? 'outline' : 'default'}
-                disabled={connect.isPending}
-                onClick={() =>
-                  codex ? setConfirmReplace(true) : startConnect()
-                }
+                variant="outline"
+                disabled={validateConnection.isPending}
+                onClick={() => validateConnection.mutate()}
               >
-                {connect.isPending ? (
+                {validateConnection.isPending ? (
                   <Loader2 className="animate-spin" />
                 ) : (
-                  <BrainCircuit />
+                  <RefreshCw />
                 )}
-                {codex ? 'Replace Codex account' : 'Connect Codex account'}
+                Revalidate
               </Button>
-            ) : null}
-            {canManageConnection && codex ? (
-              <>
-                <Button
-                  variant="outline"
-                  disabled={validateConnection.isPending}
-                  onClick={() => validateConnection.mutate()}
-                >
-                  {validateConnection.isPending ? (
-                    <Loader2 className="animate-spin" />
-                  ) : (
-                    <RefreshCw />
-                  )}
-                  Revalidate
-                </Button>
-                <Button
-                  variant="outline"
-                  disabled={disconnectConnection.isPending}
-                  onClick={() => setConfirmDisconnect(true)}
-                >
-                  <Unplug /> Disconnect
-                </Button>
-              </>
-            ) : null}
-          </div>
+              <Button
+                variant="outline"
+                disabled={disconnectConnection.isPending}
+                onClick={() => setConfirmDisconnect(true)}
+              >
+                <Unplug /> Disconnect
+              </Button>
+            </div>
+          ) : null}
 
           {!canManageConnection && !codex ? (
             <p className="text-muted-foreground text-sm">
@@ -253,7 +273,7 @@ export function ManagedProjectBYOK({
       <Panel>
         <PanelHeader>
           <div>
-            <PanelTitle>Connect with the CLI</PanelTitle>
+            <PanelTitle>Connect or replace with the CLI</PanelTitle>
             <PanelDescription className="mt-1 max-w-2xl">
               The Codex command opens OAuth, links or replaces the account, and
               enables it for this project in both development and production.
@@ -261,20 +281,9 @@ export function ManagedProjectBYOK({
           </div>
         </PanelHeader>
         <PanelContent className="space-y-4">
-          <CopyRow
-            value={`${cliExecutable} model-access connect codex --project ${projectSlug}`}
-          />
+          <CopyRow value={cliCommand} />
         </PanelContent>
       </Panel>
-
-      <ConfirmDialog
-        open={confirmReplace}
-        onOpenChange={setConfirmReplace}
-        title="Replace the Codex account?"
-        description="This reconnects the Codex account and enables it for both environments in this project."
-        confirmLabel="Continue to OpenAI"
-        onConfirm={startConnect}
-      />
       <ConfirmDialog
         open={confirmDisconnect}
         onOpenChange={setConfirmDisconnect}

--- a/web/src/managed-agents/BYOK.tsx
+++ b/web/src/managed-agents/BYOK.tsx
@@ -1,6 +1,13 @@
 import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { BrainCircuit, Loader2, RefreshCw, Unplug } from 'lucide-react'
+import {
+  BrainCircuit,
+  Link2,
+  Link2Off,
+  Loader2,
+  RefreshCw,
+  Unplug,
+} from 'lucide-react'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 import { CopyRow } from '@/components/copy-row'
 import { EmptyState } from '@/components/empty-state'
@@ -19,6 +26,7 @@ import {
   disconnectManagedModelAccessConnection,
   getManagedModelAccessConnections,
   getManagedModelAccessBindings,
+  putManagedModelAccessBinding,
   validateManagedModelAccessConnection,
 } from './api'
 
@@ -60,6 +68,18 @@ export function hasProjectCodexAccess(
   )
 }
 
+export function projectCodexBindingUpdates(
+  projectId: string,
+  enabled: boolean,
+) {
+  return (['development', 'production'] as const).map((environment) => ({
+    projectId,
+    provider: 'openai' as const,
+    environment,
+    enabled,
+  }))
+}
+
 export function ManagedProjectBYOK({
   projectId,
   projectSlug,
@@ -86,6 +106,29 @@ export function ManagedProjectBYOK({
     (connection) => connection.provider === 'openai',
   )
   const projectEnabled = hasProjectCodexAccess(bindings.data)
+  const updateProjectAccess = useMutation({
+    mutationFn: (enabled: boolean) =>
+      Promise.all(
+        projectCodexBindingUpdates(projectId, enabled).map((binding) =>
+          putManagedModelAccessBinding(binding),
+        ),
+      ),
+    onSuccess: async (_bindings, enabled) => {
+      await queryClient.invalidateQueries({ queryKey: bindingQueryKey })
+      notifySuccess(
+        enabled
+          ? 'Codex enabled for this project.'
+          : 'Codex disabled for this project.',
+      )
+    },
+    onError: (error, enabled) =>
+      notifyError(
+        enabled
+          ? "Couldn't enable Codex for this project."
+          : "Couldn't disable Codex for this project.",
+        error,
+      ),
+  })
   const validateConnection = useMutation({
     mutationFn: () => validateManagedModelAccessConnection(codex!.id),
     onSuccess: async () => {
@@ -147,10 +190,10 @@ export function ManagedProjectBYOK({
           <div>
             <PanelTitle>BYOK</PanelTitle>
             <PanelDescription className="mt-1 max-w-2xl">
-              Link a Codex account to this project. Connecting it enables the
-              account for both development and production. Account connection
-              happens through the CLI. Managed usage-based inference remains the
-              fallback. Runtime compute is still charged.
+              Connect one Codex account to your organization, then enable it for
+              the projects that should use it. Project enablement always covers
+              both development and production. Managed usage-based inference
+              remains the fallback. Runtime compute is still charged.
             </PanelDescription>
           </div>
         </PanelHeader>
@@ -172,7 +215,7 @@ export function ManagedProjectBYOK({
             </div>
             <p className="text-muted-foreground mt-2 text-sm">
               {codex
-                ? `Connected account${codex.checkedAt ? ` · checked ${new Date(codex.checkedAt).toLocaleString()}` : ''}`
+                ? `Connected to your organization${codex.checkedAt ? ` · checked ${new Date(codex.checkedAt).toLocaleString()}` : ''}`
                 : 'No Codex account is linked.'}
             </p>
             <div className="mt-4">
@@ -190,10 +233,46 @@ export function ManagedProjectBYOK({
                 />
               </div>
               {codex && !projectEnabled ? (
-                <p className="text-muted-foreground mt-2 text-sm">
-                  The organization account is connected, but this project will
-                  use Managed inference until you run the CLI command below.
-                </p>
+                <div className="mt-3 space-y-3">
+                  <p className="text-muted-foreground text-sm">
+                    The organization account is connected, but this project will
+                    use Managed inference until it is enabled.
+                  </p>
+                  {canManageConnection && codex.status === 'connected' ? (
+                    <Button
+                      variant="outline"
+                      disabled={updateProjectAccess.isPending}
+                      onClick={() => updateProjectAccess.mutate(true)}
+                    >
+                      {updateProjectAccess.isPending ? (
+                        <Loader2 className="animate-spin" />
+                      ) : (
+                        <Link2 />
+                      )}
+                      Enable for this project
+                    </Button>
+                  ) : null}
+                </div>
+              ) : null}
+              {canManageConnection && projectEnabled ? (
+                <div className="mt-3 space-y-3">
+                  <p className="text-muted-foreground text-sm">
+                    Disable Codex here to return this project to Managed
+                    inference without disconnecting the organization account.
+                  </p>
+                  <Button
+                    variant="outline"
+                    disabled={updateProjectAccess.isPending}
+                    onClick={() => updateProjectAccess.mutate(false)}
+                  >
+                    {updateProjectAccess.isPending ? (
+                      <Loader2 className="animate-spin" />
+                    ) : (
+                      <Link2Off />
+                    )}
+                    Disable for this project
+                  </Button>
+                </div>
               ) : null}
             </div>
           </div>
@@ -273,10 +352,16 @@ export function ManagedProjectBYOK({
       <Panel>
         <PanelHeader>
           <div>
-            <PanelTitle>Connect or replace with the CLI</PanelTitle>
+            <PanelTitle>
+              {codex
+                ? 'Replace the organization account with the CLI'
+                : 'Connect an organization account with the CLI'}
+            </PanelTitle>
             <PanelDescription className="mt-1 max-w-2xl">
-              The Codex command opens OAuth, links or replaces the account, and
-              enables it for this project in both development and production.
+              The Codex command opens OAuth, links or replaces the organization
+              account, and enables it for this project. If the account is
+              already connected, use the button above to enable this project
+              without repeating OAuth.
             </PanelDescription>
           </div>
         </PanelHeader>


### PR DESCRIPTION
## Decisions and risks

- Remove unsupported dashboard-initiated Codex OAuth; connection and replacement use the local CLI.
- Distinguish the organization Codex connection from per-project development/production bindings so Managed fallback charges are visible before a test.
- Let organization admins enable or disable an already-connected Codex account for the current project without repeating OAuth; both environments update together.
- Make CLI connect infer the current linked project when `--project` is omitted; outside a linked repo it remains organization-only.
- Bump the coupled CLI/create packages to 0.6.3 so the fix is publishable.

## Review map

- `web/src/managed-agents/BYOK.tsx`: CLI-only connection, project binding status, and project enable/disable actions.
- `cli/src/commands.ts`: linked-project inference.
- Package manifests: 0.6.3 release.

## Verification

- CLI: 42 tests passed, including linked-project inference.
- Dashboard: 5 focused tests passed, TypeScript passed, production build passed.
- create-start: 2 tests passed.
- Deployed to `mo-oc-dev.com` as Worker version `5ee7efc4-b7de-400f-bfe5-39dbed47eeb0`; deployed assets verified for both project actions.
