### PR TITLE
fix: retire durable session navigation toggle

### DIFF
--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -396,10 +396,7 @@ async function handleMe(req: Request, env: DashboardEnv, caller: Caller): Promis
     name: user.name,
     orgId: caller.orgID,
     orgs,
-    // The legacy durable-session navigation is globally retired. Keep the
-    // response field for client compatibility, but never expose the stored
-    // preference as enabled.
-    durableSessionsEnabled: false,
+    durableSessionsEnabled: !!user.durable_sessions_enabled,
     infrastructureEnabled: !!user.infrastructure_enabled,
   });
 }
@@ -413,8 +410,8 @@ async function handleUpdateMePreferences(req: Request, env: DashboardEnv, caller
   if (body.durableSessionsEnabled !== undefined && typeof body.durableSessionsEnabled !== "boolean") {
     return json({ error: "durableSessionsEnabled must be a boolean" }, 400);
   }
-  if (body.durableSessionsEnabled === true) {
-    return json({ error: "durable session navigation is no longer available" }, 403);
+  if (body.durableSessionsEnabled !== undefined) {
+    return json({ error: "durable session navigation is managed by an administrator" }, 403);
   }
   if (body.infrastructureEnabled !== undefined && typeof body.infrastructureEnabled !== "boolean") {
     return json({ error: "infrastructureEnabled must be a boolean" }, 400);

--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -396,7 +396,10 @@ async function handleMe(req: Request, env: DashboardEnv, caller: Caller): Promis
     name: user.name,
     orgId: caller.orgID,
     orgs,
-    durableSessionsEnabled: !!user.durable_sessions_enabled,
+    // The legacy durable-session navigation is globally retired. Keep the
+    // response field for client compatibility, but never expose the stored
+    // preference as enabled.
+    durableSessionsEnabled: false,
     infrastructureEnabled: !!user.infrastructure_enabled,
   });
 }
@@ -410,6 +413,9 @@ async function handleUpdateMePreferences(req: Request, env: DashboardEnv, caller
   if (body.durableSessionsEnabled !== undefined && typeof body.durableSessionsEnabled !== "boolean") {
     return json({ error: "durableSessionsEnabled must be a boolean" }, 400);
   }
+  if (body.durableSessionsEnabled === true) {
+    return json({ error: "durable session navigation is no longer available" }, 403);
+  }
   if (body.infrastructureEnabled !== undefined && typeof body.infrastructureEnabled !== "boolean") {
     return json({ error: "infrastructureEnabled must be a boolean" }, 400);
   }
@@ -418,12 +424,10 @@ async function handleUpdateMePreferences(req: Request, env: DashboardEnv, caller
   }
   await env.OPENCOMPUTER_DB.prepare(
     `UPDATE users
-        SET durable_sessions_enabled = COALESCE(?1, durable_sessions_enabled),
-            infrastructure_enabled = COALESCE(?2, infrastructure_enabled)
-      WHERE id = ?3`,
+        SET infrastructure_enabled = COALESCE(?1, infrastructure_enabled)
+      WHERE id = ?2`,
   )
     .bind(
-      typeof body.durableSessionsEnabled === "boolean" ? Number(body.durableSessionsEnabled) : null,
       typeof body.infrastructureEnabled === "boolean" ? Number(body.infrastructureEnabled) : null,
       caller.userID,
     )

--- a/cloudflare-workers/api-edge/src/dashboard_preferences.test.ts
+++ b/cloudflare-workers/api-edge/src/dashboard_preferences.test.ts
@@ -46,9 +46,9 @@ async function sessionToken(): Promise<string> {
   return `${header}.${payload}.${b64url(signature)}`;
 }
 
-function testEnv() {
+function testEnv(durableSessionsEnabled = false) {
   const preferences = {
-    durableSessionsEnabled: false,
+    durableSessionsEnabled,
     infrastructureEnabled: true,
   };
 
@@ -88,10 +88,7 @@ function testEnv() {
     async run() {
       if (this.sql.includes("UPDATE users")) {
         if (this.args[0] !== null) {
-          preferences.durableSessionsEnabled = this.args[0] === 1;
-        }
-        if (this.args[1] !== null) {
-          preferences.infrastructureEnabled = this.args[1] === 1;
+          preferences.infrastructureEnabled = this.args[0] === 1;
         }
       }
       return {};
@@ -119,8 +116,50 @@ async function request(body: unknown): Promise<Request> {
   });
 }
 
+async function meRequest(): Promise<Request> {
+  return new Request("https://app.test/api/dashboard/me", {
+    headers: { cookie: `oc_session=${await sessionToken()}` },
+  });
+}
+
 describe("dashboard navigation preferences", () => {
+  it("reports durable session navigation as disabled regardless of stored state", async () => {
+    const { env } = testEnv(true);
+    const response = await handleDashboard(
+      await meRequest(),
+      env,
+      {} as ExecutionContext,
+      "/api/dashboard/me",
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      durableSessionsEnabled: false,
+      infrastructureEnabled: true,
+    });
+  });
+
   it("updates one preference without changing the other", async () => {
+    const { env, preferences } = testEnv();
+    const response = await handleDashboard(
+      await request({ infrastructureEnabled: false }),
+      env,
+      {} as ExecutionContext,
+      "/api/dashboard/me/preferences",
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      durableSessionsEnabled: false,
+      infrastructureEnabled: false,
+    });
+    expect(preferences).toEqual({
+      durableSessionsEnabled: false,
+      infrastructureEnabled: false,
+    });
+  });
+
+  it("rejects attempts to re-enable durable session navigation", async () => {
     const { env, preferences } = testEnv();
     const response = await handleDashboard(
       await request({ durableSessionsEnabled: true }),
@@ -129,15 +168,8 @@ describe("dashboard navigation preferences", () => {
       "/api/dashboard/me/preferences",
     );
 
-    expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({
-      durableSessionsEnabled: true,
-      infrastructureEnabled: true,
-    });
-    expect(preferences).toEqual({
-      durableSessionsEnabled: true,
-      infrastructureEnabled: true,
-    });
+    expect(response.status).toBe(403);
+    expect(preferences.durableSessionsEnabled).toBe(false);
   });
 
   it("rejects non-boolean preferences", async () => {

--- a/cloudflare-workers/api-edge/src/dashboard_preferences.test.ts
+++ b/cloudflare-workers/api-edge/src/dashboard_preferences.test.ts
@@ -123,7 +123,7 @@ async function meRequest(): Promise<Request> {
 }
 
 describe("dashboard navigation preferences", () => {
-  it("reports durable session navigation as disabled regardless of stored state", async () => {
+  it("reports the administrator-managed durable session navigation state", async () => {
     const { env } = testEnv(true);
     const response = await handleDashboard(
       await meRequest(),
@@ -134,7 +134,7 @@ describe("dashboard navigation preferences", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({
-      durableSessionsEnabled: false,
+      durableSessionsEnabled: true,
       infrastructureEnabled: true,
     });
   });
@@ -159,18 +159,21 @@ describe("dashboard navigation preferences", () => {
     });
   });
 
-  it("rejects attempts to re-enable durable session navigation", async () => {
-    const { env, preferences } = testEnv();
-    const response = await handleDashboard(
-      await request({ durableSessionsEnabled: true }),
-      env,
-      {} as ExecutionContext,
-      "/api/dashboard/me/preferences",
-    );
+  it.each([true, false])(
+    "rejects attempts to set administrator-managed durable session navigation to %s",
+    async (durableSessionsEnabled) => {
+      const { env, preferences } = testEnv();
+      const response = await handleDashboard(
+        await request({ durableSessionsEnabled }),
+        env,
+        {} as ExecutionContext,
+        "/api/dashboard/me/preferences",
+      );
 
-    expect(response.status).toBe(403);
-    expect(preferences.durableSessionsEnabled).toBe(false);
-  });
+      expect(response.status).toBe(403);
+      expect(preferences.durableSessionsEnabled).toBe(false);
+    },
+  );
 
   it("rejects non-boolean preferences", async () => {
     const { env, preferences } = testEnv();

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -352,7 +352,6 @@ export const updateOrg = (updates: OrgUpdate) =>
   )
 
 export type NavigationPreferenceUpdate = {
-  durableSessionsEnabled?: boolean
   infrastructureEnabled?: boolean
 }
 

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -148,18 +148,6 @@ export default function Settings() {
           </div>
           <div className="divide-y">
             <NavigationToggle
-              id="durable-sessions-enabled"
-              label="Enable durable sessions"
-              description="Show durable agents, sessions, and credentials."
-              checked={user?.durableSessionsEnabled ?? false}
-              disabled={navigationMutation.isPending}
-              onCheckedChange={(checked) =>
-                navigationMutation.mutate({
-                  durableSessionsEnabled: checked,
-                })
-              }
-            />
-            <NavigationToggle
               id="infrastructure-enabled"
               label="Enable infrastructure"
               description="Show sandboxes, checkpoints, templates, webhooks, and browsers."


### PR DESCRIPTION
## Summary
- remove the legacy durable sessions checkbox from Settings
- keep the D1 value authoritative so administrators can control visibility centrally
- reject user/API attempts to modify the administrator-managed value
- leave project sessions and the infrastructure preference unchanged

## Verification
- edge: 142 tests passed
- web: 191 tests passed
- edge TypeScript check passed
- web production build passed