### PR TITLE
fix: keep active CLI agent turns attached

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/cli",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "dependencies": {
         "@opencode-ai/sdk": "1.18.4",
         "ai": "^7.0.45",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Build, test, deploy, and share OpenComputer agents as code.",
   "type": "module",
   "bin": {

--- a/cli/src/commands.test.ts
+++ b/cli/src/commands.test.ts
@@ -3,8 +3,14 @@ import test from "node:test";
 
 import {
   deploymentAlias,
+  nextAgentEventDeadline,
   shouldBindModelAccessProject,
 } from "./commands.js";
+
+test("agent event progress refreshes the inactivity deadline", () => {
+  assert.equal(nextAgentEventDeadline(10_000, 3_000, 0, 9_000), 10_000);
+  assert.equal(nextAgentEventDeadline(10_000, 3_000, 1, 9_000), 12_000);
+});
 
 test("one-shot deploy defaults to development and production stays explicit", () => {
   assert.equal(deploymentAlias(), "development");

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -362,6 +362,15 @@ async function attachSession(
   }
 }
 
+export function nextAgentEventDeadline(
+  deadline: number,
+  timeoutMs: number,
+  receivedEvents: number,
+  now = Date.now(),
+): number {
+  return receivedEvents > 0 ? now + timeoutMs : deadline;
+}
+
 async function waitForEvent(
   client: OpenComputerClient,
   sessionId: string,
@@ -370,10 +379,11 @@ async function waitForEvent(
   onEvent: (event: ManagedAgentEvent) => void,
   timeoutMs: number,
 ): Promise<{ event: ManagedAgentEvent; cursor: number }> {
-  const deadline = Date.now() + timeoutMs;
+  let deadline = Date.now() + timeoutMs;
   let cursor = after;
   while (Date.now() < deadline) {
-    for (const event of await client.events(sessionId, cursor)) {
+    const events = await client.events(sessionId, cursor);
+    for (const event of events) {
       cursor = Math.max(cursor, event.seq);
       onEvent(event);
       if (event.type === "runtime.disconnected") {
@@ -385,6 +395,10 @@ async function waitForEvent(
       }
       if (terminal(event)) return { event, cursor };
     }
+    // Long-running agent turns may exceed one fixed timeout window while
+    // continuing to emit useful progress. Timeout only after a full quiet
+    // window with no new durable session events.
+    deadline = nextAgentEventDeadline(deadline, timeoutMs, events.length);
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
   throw new Error("Timed out waiting for the agent.");

--- a/create-start/package.json
+++ b/create-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/create-start",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Create a hello-world OpenComputer agent application.",
   "type": "module",
   "bin": {
@@ -18,7 +18,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@opencomputer/cli": "0.6.3"
+    "@opencomputer/cli": "0.6.4"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Why
The CLI treated its 180-second agent wait as a fixed wall-clock deadline. A multi-step turn that continued emitting durable progress was detached with `Timed out waiting for the agent` even though the server remained healthy and completed shortly afterward.
## Change
- Refresh the CLI deadline whenever new session events arrive, matching the dashboard's inactivity-timeout behavior.
- Preserve the existing timeout for genuinely quiet or stuck sessions.
- Add a regression test for deadline refresh semantics.
- Bump `@opencomputer/cli` and the contract-coupled `@opencomputer/create-start` package to `0.6.4` so the version-gated publish workflow ships the fix.
## Verification
- `cd cli && npm test` — 43 tests passed; server/UI builds completed.
- `cd create-start && npm test` — 2 tests passed.
- `node scripts/check-opencomputer-package-contract.mjs` — passed for `0.6.4`.
- `git diff --check` — passed.
## Risk
A session that emits endless events will remain attached until it completes or the user interrupts it. That is intentional; Ctrl-C still detaches locally and the remote session remains durable.