### PR TITLE
feat: stream active session responses in dashboard

### DIFF
--- a/web/src/managed-agents/Session.tsx
+++ b/web/src/managed-agents/Session.tsx
@@ -19,6 +19,7 @@ import {
   getManagedProject,
 } from './api'
 import { AgentMarkdown } from './AgentMarkdown'
+import { turnAssistantText } from './session-history'
 
 function formatDate(value: string) {
   return new Date(value).toLocaleString()
@@ -45,7 +46,7 @@ export default function ManagedSessionDetail() {
     queryKey: ['managed-agent-session-events', sessionId],
     queryFn: () => getManagedAgentSessionEvents(sessionId),
     enabled: Boolean(sessionId),
-    refetchInterval: 2_000,
+    refetchInterval: 1_000,
   })
 
   if (project.isLoading || session.isLoading) {
@@ -78,9 +79,6 @@ export default function ManagedSessionDetail() {
     )
   }
 
-  const replies = (events.data ?? []).filter(
-    (event) => event.type === 'message.completed',
-  )
   const sessionPath = `/projects/${encodeURIComponent(projectId)}/sessions`
 
   return (
@@ -167,9 +165,11 @@ export default function ManagedSessionDetail() {
               <p className="text-muted-foreground text-sm">No turns yet.</p>
             ) : (
               session.data.turns.map((turn) => {
-                const response = replies.find(
-                  (event) => event.turnId === turn.id,
+                const responseText = turnAssistantText(
+                  events.data ?? [],
+                  turn.id,
                 )
+                const running = !['completed', 'failed'].includes(turn.status)
                 return (
                   <div key={turn.id} className="space-y-6">
                     <div>
@@ -184,8 +184,19 @@ export default function ManagedSessionDetail() {
                       <p className="text-muted-foreground mb-1.5 flex items-center gap-1.5 text-[10px] font-semibold tracking-wider uppercase">
                         <Bot className="size-3" /> Agent
                       </p>
-                      {response && typeof response.data.text === 'string' ? (
-                        <AgentMarkdown>{response.data.text}</AgentMarkdown>
+                      {responseText ? (
+                        <div aria-live={running ? 'polite' : undefined}>
+                          <AgentMarkdown>{responseText}</AgentMarkdown>
+                          {running ? (
+                            <p className="text-muted-foreground mt-3 flex items-center gap-1.5 text-xs">
+                              <Loader2
+                                className="size-3 animate-spin"
+                                aria-hidden
+                              />
+                              Streaming response…
+                            </p>
+                          ) : null}
+                        </div>
                       ) : (
                         <p className="text-muted-foreground text-sm">
                           {turn.status === 'completed'

--- a/web/src/managed-agents/session-history.test.ts
+++ b/web/src/managed-agents/session-history.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest'
-import type { ManagedAgentDeployment, ManagedAgentSession } from './api'
+import type {
+  ManagedAgentDeployment,
+  ManagedAgentEvent,
+  ManagedAgentSession,
+} from './api'
 import {
   playgroundSessionIdFromSearch,
   playgroundSessionSearch,
   sessionsForEnvironment,
+  turnAssistantText,
 } from './session-history'
 
 function deployment(
@@ -85,5 +90,41 @@ describe('playground session URL state', () => {
     expect(playgroundSessionSearch('?agent=reviewer&session=session-1')).toBe(
       '?agent=reviewer',
     )
+  })
+})
+
+describe('turnAssistantText', () => {
+  const event = (
+    seq: number,
+    turnId: string,
+    type: string,
+    text: string,
+  ): ManagedAgentEvent => ({
+    seq,
+    turnId,
+    type,
+    data: { text },
+  })
+
+  it('joins streamed deltas for only the requested turn', () => {
+    expect(
+      turnAssistantText(
+        [
+          event(1, 'turn-1', 'message.delta', 'Reviewing '),
+          event(2, 'turn-2', 'message.delta', 'Ignore me'),
+          event(3, 'turn-1', 'message.delta', 'the repository.'),
+        ],
+        'turn-1',
+      ),
+    ).toBe('Reviewing the repository.')
+  })
+
+  it('uses the completed response when no deltas were recorded', () => {
+    expect(
+      turnAssistantText(
+        [event(1, 'turn-1', 'message.completed', 'Finished response')],
+        'turn-1',
+      ),
+    ).toBe('Finished response')
   })
 })

--- a/web/src/managed-agents/session-history.ts
+++ b/web/src/managed-agents/session-history.ts
@@ -1,4 +1,8 @@
-import type { ManagedAgentDeployment, ManagedAgentSession } from './api'
+import type {
+  ManagedAgentDeployment,
+  ManagedAgentEvent,
+  ManagedAgentSession,
+} from './api'
 import type { ProjectEnvironment } from './project-context'
 
 export function sessionsForEnvironment(
@@ -27,4 +31,15 @@ export function playgroundSessionSearch(search: string, sessionId?: string) {
   if (sessionId) next.set('session', sessionId)
   else next.delete('session')
   return next.size ? `?${next.toString()}` : ''
+}
+
+export function turnAssistantText(events: ManagedAgentEvent[], turnId: string) {
+  let streamedText = ''
+  let completedText = ''
+  for (const event of events) {
+    if (event.turnId !== turnId || typeof event.data.text !== 'string') continue
+    if (event.type === 'message.delta') streamedText += event.data.text
+    if (event.type === 'message.completed') completedText = event.data.text
+  }
+  return streamedText || completedText
 }


### PR DESCRIPTION
## Why
The managed-session detail page polled durable events but ignored `message.delta` entries. While a turn was active, the Conversation tab therefore showed only `Turn running.` even though the CLI and Events tab already had substantial streamed output.
## Change
- Reconstruct each turn's partial assistant response from durable `message.delta` events.
- Fall back to `message.completed` for histories without deltas.
- Keep events isolated by turn and refresh the page's event query once per second.
- Show an explicit streaming indicator while the turn remains active.
## Verification
- `cd web && npm test` — 47 files, 193 tests passed.
- `npm run typecheck` — passed.
- ESLint and Prettier checks for changed files — passed.
- `npm run build` — production build passed.
## Risk
The page requests the complete durable event list every second instead of every two seconds while mounted. This matches its existing polling model but modestly increases read traffic for open session-detail pages. A future cursor-based live query can remove that overhead.
## Visual verification
Automated local browser verification was unavailable because the connected browser blocked loopback access. No visual pass is claimed; behavior is covered by the event-aggregation tests and production build.