### PR TITLE
fix: paginate managed session event history

### DIFF
--- a/web/src/managed-agents/Session.tsx
+++ b/web/src/managed-agents/Session.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, Bot, Clock3, Loader2, TerminalSquare } from 'lucide-react'
 import { Link, useParams, useSearchParams } from 'react-router-dom'
 import { EmptyState } from '@/components/empty-state'
@@ -27,6 +27,7 @@ function formatDate(value: string) {
 
 export default function ManagedSessionDetail() {
   const { projectId = '', sessionId = '' } = useParams()
+  const queryClient = useQueryClient()
   const [searchParams] = useSearchParams()
   const [activeTab, setActiveTab] = useState<'conversation' | 'events'>(
     'conversation',
@@ -44,7 +45,18 @@ export default function ManagedSessionDetail() {
   })
   const events = useQuery({
     queryKey: ['managed-agent-session-events', sessionId],
-    queryFn: () => getManagedAgentSessionEvents(sessionId),
+    queryFn: async () => {
+      const queryKey = ['managed-agent-session-events', sessionId]
+      const existing =
+        queryClient.getQueryData<
+          Awaited<ReturnType<typeof getManagedAgentSessionEvents>>
+        >(queryKey) ?? []
+      const next = await getManagedAgentSessionEvents(
+        sessionId,
+        existing[existing.length - 1]?.seq ?? 0,
+      )
+      return [...existing, ...next]
+    },
     enabled: Boolean(sessionId),
     refetchInterval: 1_000,
   })

--- a/web/src/managed-agents/api.test.ts
+++ b/web/src/managed-agents/api.test.ts
@@ -1,10 +1,36 @@
 import { describe, expect, it } from 'vitest'
 import {
+  collectManagedAgentEventPages,
   displayManagedAgentName,
   managedAgentModelRoute,
   managedAgentRenderDebug,
   nextAgentEventDeadline,
 } from './api'
+
+describe('collectManagedAgentEventPages', () => {
+  it('follows event cursors until the API returns an empty page', async () => {
+    const cursors: number[] = []
+    const pages = new Map([
+      [0, [{ seq: 1 }, { seq: 500 }]],
+      [500, [{ seq: 501 }]],
+      [501, []],
+    ])
+
+    const events = await collectManagedAgentEventPages((after) => {
+      cursors.push(after)
+      return Promise.resolve(
+        (pages.get(after) ?? []).map(({ seq }) => ({
+          seq,
+          type: 'message.delta',
+          data: { text: String(seq) },
+        })),
+      )
+    })
+
+    expect(cursors).toEqual([0, 500, 501])
+    expect(events.map(({ seq }) => seq)).toEqual([1, 500, 501])
+  })
+})
 
 describe('nextAgentEventDeadline', () => {
   it('refreshes the inactivity deadline only when progress arrives', () => {

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -916,14 +916,35 @@ export async function getManagedAgentSessions(agentId?: string) {
     : sessions
 }
 
-export async function getManagedAgentSessionEvents(sessionId: string) {
-  return (
-    await apiFetch(
-      `/managed-agents/sessions/${encodeURIComponent(sessionId)}/events?after=0`,
-      undefined,
-      eventsResponseSchema,
-    )
-  ).events
+export async function collectManagedAgentEventPages(
+  loadPage: (after: number) => Promise<ManagedAgentEvent[]>,
+  after = 0,
+) {
+  const collected: ManagedAgentEvent[] = []
+  let cursor = after
+  for (;;) {
+    const events = await loadPage(cursor)
+    if (events.length === 0) return collected
+    collected.push(...events)
+    const nextCursor = Math.max(cursor, ...events.map((event) => event.seq))
+    if (nextCursor === cursor) return collected
+    cursor = nextCursor
+  }
+}
+
+export async function getManagedAgentSessionEvents(
+  sessionId: string,
+  after = 0,
+) {
+  return collectManagedAgentEventPages(async (cursor) => {
+    return (
+      await apiFetch(
+        `/managed-agents/sessions/${encodeURIComponent(sessionId)}/events?after=${cursor}`,
+        undefined,
+        eventsResponseSchema,
+      )
+    ).events
+  }, after)
 }
 
 export async function admitManagedAgentInput(


### PR DESCRIPTION
## Why

Managed-session event reads are capped at 500 events. The dashboard requested only `?after=0`, so long sessions displayed exactly 500 events and reconstructed a partial assistant response even though the durable session had completed with more output. The CLI appeared correct because it advances its event cursor continuously.

Observed on session `fe5f2810-a2a9-44e9-8194-c87761799235`: the dashboard stopped at 500 events while CLI attachment replayed the complete final response.

## Change

- Follow the durable event cursor across pages until the API returns no more events.
- On subsequent one-second refreshes, request only events newer than the last cached sequence.
- Guard against a malformed page that does not advance the cursor.
- Add regression coverage for multi-page cursor traversal.

## Verification

- `cd web && npm test` — 47 files, 194 tests passed.
- `npm run typecheck` — passed.
- ESLint and Prettier checks for changed files — passed.
- `npm run build` — production build passed.
- `git diff --check` — passed.

## Risk

Initial history loading now makes additional requests for sessions with more than 500 events. Later refreshes are incremental, so polling does not repeatedly download prior pages.
