### PR TITLE
feat(edge): /internal/warm-org — pre-populate a colo's auth + create-context caches

### DIFF
--- a/cloudflare-workers/api-edge/src/index.test.ts
+++ b/cloudflare-workers/api-edge/src/index.test.ts
@@ -424,3 +424,49 @@ describe("safeReturnTo — deferred-action deep-link validation", () => {
     expect(safeReturnTo(undefined)).toBeNull();
   });
 });
+
+// /internal/warm-org pre-populates this colo's auth + create-context caches so a
+// key used rarely (a weekly benchmark) is not cold when it matters. It is
+// HMAC-auth'd because it reads every API-key hash on an org, so the auth gate is
+// the part worth pinning down — a warm cache is an optimisation, but an open
+// route that enumerates key material is not.
+describe("/internal/warm-org — auth boundary", () => {
+  const ADMIN = "admin-secret";
+  const authEnv = { ...env, CF_ADMIN_SECRET: ADMIN } as unknown as Env;
+  const sign = async (secret: string, ts: string, body: string): Promise<string> => {
+    const key = await crypto.subtle.importKey("raw", new TextEncoder().encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+    const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(`${ts}.${body}`));
+    return [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, "0")).join("");
+  };
+  const post = async (o: { secret?: string; ts?: string; sig?: string; body?: string } = {}) => {
+    const body = o.body ?? JSON.stringify({ org_id: "org-x" });
+    const ts = o.ts ?? Math.floor(Date.now() / 1000).toString();
+    const sig = o.sig ?? (await sign(o.secret ?? ADMIN, ts, body));
+    return worker.fetch(
+      new Request("https://app.opencomputer.dev/internal/warm-org", {
+        method: "POST",
+        headers: { "content-type": "application/json", "X-Timestamp": ts, "X-Signature": sig },
+        body,
+      }),
+      authEnv,
+      ctx,
+    );
+  };
+
+  it("rejects a wrong signature", async () => {
+    expect((await post({ secret: "not-the-admin-secret" })).status).toBe(401);
+  });
+
+  it("rejects a stale timestamp even with a valid signature", async () => {
+    const ts = (Math.floor(Date.now() / 1000) - 3600).toString();
+    expect((await post({ ts })).status).toBe(401);
+  });
+
+  it("requires org_id", async () => {
+    expect((await post({ body: JSON.stringify({}) })).status).toBe(400);
+  });
+
+  it("authorizes with the admin secret", async () => {
+    expect((await post()).status).not.toBe(401);
+  });
+});

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -42,6 +42,7 @@ import {
   ORG_STALE_MAX_MS,
   RUNNING_COUNT_SQL,
   keepCreateContextWarm,
+  warmCreateContextColo,
   type CellRow,
   type OrgPolicy,
 } from "./create_context_cache";
@@ -5010,6 +5011,75 @@ export default {
       const stub = env.CREDIT_ACCOUNT.get(env.CREDIT_ACCOUNT.idFromName(parsed.org_id));
       const r = await stub.fetch(`https://do/mark-free?org_id=${encodeURIComponent(parsed.org_id)}`, { method: "POST" });
       return new Response(await r.text(), { status: r.status, headers: { "content-type": "application/json" } });
+    }
+
+    // /internal/warm-org — pre-populate this colo's caches for one org.
+    //
+    // The auth and create-context tiers live in the colo cache, and every entry
+    // in them expires (auth 10min, org/cells/count 5min). An API key used once
+    // a week is therefore always cold when it matters, and a cold miss costs a
+    // D1 read against a primary in WNAM while the request runs in IAD —
+    // measured at 340ms, paid by EVERY request in a burst because the cold path
+    // is not single-flighted. On a burst-100 that is the difference between a
+    // 339ms TTI and a 1585ms one.
+    //
+    // Warming has to run IN the colo it warms: the cache is per-colo, and a
+    // Worker cron fires wherever Cloudflare puts it. So this is a route, driven
+    // from a host in the target metro, rather than a scheduled handler.
+    //
+    // Keys are warmed by HASH, read from D1 — the plaintext never leaves the
+    // database and the caller never needs it. That also means every key on the
+    // org is warmed, so this keeps working when a key is rotated.
+    //
+    // HMAC-auth'd with CF_ADMIN_SECRET, same scheme as do-mark-free.
+    if (path === "/internal/warm-org" && req.method === "POST") {
+      const ts = req.headers.get("X-Timestamp") ?? "";
+      const sig = req.headers.get("X-Signature") ?? "";
+      const body = await req.text();
+      const expected = await hmacHex(env.CF_ADMIN_SECRET, `${ts}.${body}`);
+      if (!constantTimeEqual(expected, sig)) return json({ error: "signature mismatch" }, 401);
+      if (Math.abs(Math.floor(Date.now() / 1000) - Number(ts)) > 300) return json({ error: "timestamp out of window" }, 401);
+      const parsed = JSON.parse(body) as { org_id?: string };
+      if (!parsed.org_id) return json({ error: "org_id required" }, 400);
+
+      // Same projection resolveCaller caches, so a warmed entry is byte-for-byte
+      // what a real miss would have written. Drift here would be invisible: the
+      // cache would hit and serve a subtly different caller.
+      const rows = await env.OPENCOMPUTER_DB.prepare(
+        `SELECT k.key_hash, k.org_id, k.created_by, k.expires_at,
+                CASE WHEN m.role IN ('owner', 'admin') THEN 'admin' ELSE m.role END AS role
+           FROM api_keys k
+           LEFT JOIN org_memberships m
+             ON m.org_id = k.org_id AND m.user_id = k.created_by
+          WHERE k.org_id = ?1`,
+      ).bind(parsed.org_id).all<{
+        key_hash: string;
+        org_id: string;
+        created_by: string | null;
+        expires_at: number | null;
+        role: string | null;
+      }>();
+
+      const at = Date.now();
+      let warmed = 0;
+      for (const row of rows.results ?? []) {
+        const caller: Caller = {
+          orgID: row.org_id,
+          userID: row.created_by,
+          ...(row.role ? { role: row.role } : {}),
+        };
+        await coloPut("auth", row.key_hash, { caller, expiresAt: row.expires_at, cachedAtMs: at }, AUTH_STALE_MAX_MS / 1000);
+        warmed++;
+      }
+      // org policy + concurrency count + the active-cell list, the other three
+      // reads a cold create pays.
+      await warmCreateContextColo(env.OPENCOMPUTER_DB, [parsed.org_id]);
+
+      return json({
+        warmed,
+        org_id: parsed.org_id,
+        colo: (req as { cf?: { colo?: string } }).cf?.colo ?? "unknown",
+      });
     }
 
     // /internal/model-billing/enable|disable — operator-triggered managed-billing


### PR DESCRIPTION
The auth and create-context tiers live in the per-colo cache and every entry expires — auth at 10 min, org/cells/count at 5 min. A key used once a week is therefore always cold when it matters, and a cold miss is a D1 read against a primary in WNAM while the request runs in IAD.

Measured on prod, burst-100 from an IAD host:

| | cold | warm |
|---|---|---|
| create p50 | 1304ms | 199ms |
| TTI p50 | **1585ms** | **339ms** |

The cold path is not single-flighted, so *every* request in a burst pays it, not just the first.

`POST /internal/warm-org` takes `{org_id}` and populates both tiers for that org. Keys are warmed **by hash, read from D1** — the plaintext never leaves the database and the caller never needs it, so this also survives key rotation and warms every key on the org.

It has to be a route rather than a scheduled handler: the cache is per-colo, and a Worker cron fires wherever Cloudflare places it. Driving it from a host in the target metro is what pins the warm to that colo.

HMAC-auth'd with `CF_ADMIN_SECRET`, same scheme as `do-mark-free` — it enumerates key hashes for an org, so the auth gate is tested (wrong signature, stale timestamp, missing org_id, happy path).