### PR TITLE
Expose internal billing and agent session analytics

### DIFF
--- a/cloudflare-workers/api-edge/src/dashboard.ts
+++ b/cloudflare-workers/api-edge/src/dashboard.ts
@@ -1549,7 +1549,7 @@ const AUTUMN_USAGE_PLANS: Record<string, number> = {
 // GET /api/dashboard/billing/autumn — prepaid credit balance + concurrency plan.
 // Re-syncs Autumn → D1 on the way (this is the checkout-return / page-view resume
 // trigger: a just-topped-up user's is_halted clears here even if the webhook lagged).
-async function handleAutumnBilling(_req: Request, env: DashboardEnv, caller: { orgID: string }): Promise<Response> {
+export async function handleAutumnBilling(_req: Request, env: DashboardEnv, caller: { orgID: string }): Promise<Response> {
   if (!env.AUTUMN_SECRET_KEY) return json({ error: "autumn billing not configured" }, 503);
   let r;
   try {

--- a/cloudflare-workers/api-edge/src/data_analyst.test.ts
+++ b/cloudflare-workers/api-edge/src/data_analyst.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  annotateBillingResponse,
+  dataAnalystTokenMatches,
+  handleDataAnalystAPI,
+  type DataAnalystEnv,
+} from "./data_analyst";
+
+function env(overrides: Partial<DataAnalystEnv> = {}): DataAnalystEnv {
+  return {
+    DATA_ANALYST_API_TOKEN: "analyst-secret",
+    OC_MANAGED_AGENTS_SECRET: "managed-secret",
+    MANAGED_AGENTS_API_URL: "https://managedagents.test",
+    ...overrides,
+  } as DataAnalystEnv;
+}
+
+function request(path: string, token = "analyst-secret", method = "GET") {
+  return new Request(`https://app.test${path}`, {
+    method,
+    headers: { authorization: `Bearer ${token}` },
+  });
+}
+
+describe("internal data analyst API", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("compares credentials without comparing their raw values", async () => {
+    await expect(
+      dataAnalystTokenMatches("analyst-secret", "analyst-secret"),
+    ).resolves.toBe(true);
+    await expect(
+      dataAnalystTokenMatches("wrong-secret", "analyst-secret"),
+    ).resolves.toBe(false);
+  });
+
+  it("is disabled when the dedicated credential is absent", async () => {
+    const response = await handleDataAnalystAPI(
+      request("/api/internal/data-analyst/orgs/org_1/sessions"),
+      env({ DATA_ANALYST_API_TOKEN: undefined }),
+      "/api/internal/data-analyst/orgs/org_1/sessions",
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("authenticates before resolving an organization and remains GET-only", async () => {
+    const path = "/api/internal/data-analyst/orgs/org_1/sessions";
+    const unauthorized = await handleDataAnalystAPI(
+      request(path, "wrong-secret"),
+      env(),
+      path,
+    );
+    expect(unauthorized.status).toBe(401);
+
+    const wrongMethod = await handleDataAnalystAPI(
+      request(path, "analyst-secret", "POST"),
+      env(),
+      path,
+    );
+    expect(wrongMethod.status).toBe(405);
+  });
+
+  it("bounds session fan-out and omits the initial-input preview by default", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        sessions: [
+          {
+            id: "session_1",
+            title: "customer-provided first turn",
+            source: "schedule",
+            runtimeSecondsByTier: { "2gb_1vcpu": 60 },
+          },
+        ],
+      }),
+    );
+    const requestPath =
+      "/api/internal/data-analyst/orgs/org_1/sessions?limit=999";
+    const path = "/api/internal/data-analyst/orgs/org_1/sessions";
+    const response = await handleDataAnalystAPI(
+      request(requestPath),
+      env(),
+      path,
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      "/v1/billing/sessions?limit=100",
+    );
+    const body = await response.json();
+    expect(body).toMatchObject({
+      orgId: "org_1",
+      sessions: [
+        {
+          id: "session_1",
+          source: "schedule",
+          runtimeSecondsByTier: { "2gb_1vcpu": 60 },
+        },
+      ],
+    });
+    expect(JSON.stringify(body)).not.toContain("customer-provided");
+  });
+
+  it("returns the bounded preview only when explicitly requested", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        sessions: [{ id: "session_1", title: "first turn" }],
+      }),
+    );
+    const requestPath =
+      "/api/internal/data-analyst/orgs/org_1/sessions?include_preview=true";
+    const path = "/api/internal/data-analyst/orgs/org_1/sessions";
+    const response = await handleDataAnalystAPI(
+      request(requestPath),
+      env(),
+      path,
+    );
+
+    expect(await response.json()).toMatchObject({
+      sessions: [{ id: "session_1", title: "first turn" }],
+    });
+  });
+
+  it("adds organization scope and freshness to a successful billing response", async () => {
+    const response = await annotateBillingResponse(
+      Response.json({ creditsRemainingCents: 1234 }),
+      "org_1",
+      "2026-09-01T12:00:00.000Z",
+    );
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({
+      orgId: "org_1",
+      observedAt: "2026-09-01T12:00:00.000Z",
+      creditsRemainingCents: 1234,
+    });
+  });
+});

--- a/cloudflare-workers/api-edge/src/data_analyst.ts
+++ b/cloudflare-workers/api-edge/src/data_analyst.ts
@@ -1,0 +1,170 @@
+import {
+  handleAutumnBilling,
+  type DashboardEnv,
+} from "./dashboard";
+import { proxyManagedAgents } from "./managed_agents";
+
+export type DataAnalystEnv = DashboardEnv & {
+  DATA_ANALYST_API_TOKEN?: string;
+};
+
+const DATA_ANALYST_PREFIX = "/api/internal/data-analyst/orgs/";
+const MAX_SESSION_ROWS = 100;
+
+function json(body: unknown, status = 200): Response {
+  return Response.json(body, {
+    status,
+    headers: { "cache-control": "no-store" },
+  });
+}
+
+async function sha256(value: string): Promise<Uint8Array> {
+  return new Uint8Array(
+    await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value)),
+  );
+}
+
+export async function dataAnalystTokenMatches(
+  candidate: string,
+  expected: string,
+): Promise<boolean> {
+  const [candidateDigest, expectedDigest] = await Promise.all([
+    sha256(candidate),
+    sha256(expected),
+  ]);
+  let mismatch = 0;
+  for (let index = 0; index < expectedDigest.length; index += 1) {
+    mismatch |= candidateDigest[index] ^ expectedDigest[index];
+  }
+  return mismatch === 0;
+}
+
+async function authenticateDataAnalyst(
+  request: Request,
+  env: DataAnalystEnv,
+): Promise<boolean> {
+  if (!env.DATA_ANALYST_API_TOKEN) return false;
+  const authorization = request.headers.get("authorization") ?? "";
+  const candidate = authorization.match(/^Bearer ([^\s]+)$/i)?.[1] ?? "";
+  return dataAnalystTokenMatches(candidate, env.DATA_ANALYST_API_TOKEN);
+}
+
+function boundedLimit(url: URL): number {
+  const requested = Number.parseInt(url.searchParams.get("limit") ?? "50", 10);
+  return Number.isFinite(requested)
+    ? Math.max(1, Math.min(requested, MAX_SESSION_ROWS))
+    : 50;
+}
+
+export async function annotateBillingResponse(
+  response: Response,
+  orgId: string,
+  observedAt: string,
+): Promise<Response> {
+  if (!response.ok) return response;
+  const body = await response.json<Record<string, unknown>>();
+  return json({ orgId, observedAt, ...body });
+}
+
+async function sessionsResponse(
+  request: Request,
+  env: DataAnalystEnv,
+  orgId: string,
+  observedAt: string,
+): Promise<Response> {
+  const sourceURL = new URL(request.url);
+  const limit = boundedLimit(sourceURL);
+  const includePreview = sourceURL.searchParams.get("include_preview") === "true";
+  const upstreamURL = new URL(
+    "/api/managed-agents/billing/sessions",
+    sourceURL.origin,
+  );
+  upstreamURL.searchParams.set("limit", String(limit));
+  const upstream = await proxyManagedAgents(
+    new Request(upstreamURL, {
+      method: "GET",
+      headers: { accept: "application/json" },
+    }),
+    env,
+    { orgID: orgId, userID: null },
+    "/api/managed-agents",
+  );
+  if (!upstream.ok) return upstream;
+  const body = await upstream.json<{ sessions?: unknown[] }>();
+  const sessions = Array.isArray(body.sessions)
+    ? body.sessions.map((value) => {
+        if (
+          includePreview ||
+          !value ||
+          typeof value !== "object" ||
+          Array.isArray(value)
+        ) {
+          return value;
+        }
+        const { title: _title, ...withoutPreview } = value as Record<
+          string,
+          unknown
+        >;
+        return withoutPreview;
+      })
+    : [];
+  return json({ orgId, observedAt, sessions });
+}
+
+export async function handleDataAnalystAPI(
+  request: Request,
+  env: DataAnalystEnv,
+  path: string,
+): Promise<Response> {
+  if (!env.DATA_ANALYST_API_TOKEN) {
+    return json({ error: "not found" }, 404);
+  }
+  if (!(await authenticateDataAnalyst(request, env))) {
+    return json({ error: "unauthorized" }, 401);
+  }
+  if (request.method !== "GET") {
+    return json({ error: "method not allowed" }, 405);
+  }
+  if (!path.startsWith(DATA_ANALYST_PREFIX)) {
+    return json({ error: "not found" }, 404);
+  }
+  const suffix = path.slice(DATA_ANALYST_PREFIX.length);
+  const separator = suffix.lastIndexOf("/");
+  if (separator <= 0) return json({ error: "not found" }, 404);
+  let orgId: string;
+  try {
+    orgId = decodeURIComponent(suffix.slice(0, separator));
+  } catch {
+    return json({ error: "not found" }, 404);
+  }
+  if (!orgId || orgId.length > 256 || orgId.includes("/")) {
+    return json({ error: "not found" }, 404);
+  }
+  const resource = suffix.slice(separator + 1);
+  const observedAt = new Date().toISOString();
+  console.log(
+    JSON.stringify({
+      event: "data_analyst.read",
+      orgId,
+      resource,
+      ...(resource === "sessions"
+        ? {
+            includePreview:
+              new URL(request.url).searchParams.get("include_preview") ===
+              "true",
+          }
+        : {}),
+    }),
+  );
+  if (resource === "billing") {
+    return annotateBillingResponse(
+      await handleAutumnBilling(request, env, { orgID: orgId }),
+      orgId,
+      observedAt,
+    );
+  }
+  if (resource === "sessions") {
+    return sessionsResponse(request, env, orgId, observedAt);
+  }
+  return json({ error: "not found" }, 404);
+}

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -78,8 +78,12 @@ import {
   handleManagedAgentChannelConnection,
   proxyManagedAgents,
 } from "./managed_agents";
+import { handleDataAnalystAPI } from "./data_analyst";
 
 export interface Env extends DashboardEnv {
+  // Dedicated bearer secret for the GET-only internal data-analyst API.
+  // It is not a customer API key and must not be reused for other routes.
+  DATA_ANALYST_API_TOKEN?: string;
   CF_ADMIN_SECRET: string;
   STRIPE_WEBHOOK_SECRET: string;
   EVENT_SECRET: string;
@@ -5281,6 +5285,10 @@ export default {
     // Auth via the oc_session cookie minted at /auth/callback.
     if (path.startsWith("/api/dashboard")) {
       return handleDashboard(req, env, ctx, path);
+    }
+
+    if (path.startsWith("/api/internal/data-analyst/")) {
+      return handleDataAnalystAPI(req, env, path);
     }
 
     // Managed Agents public API. Customers authenticate with their ordinary

--- a/cloudflare-workers/api-edge/wrangler.prod.toml
+++ b/cloudflare-workers/api-edge/wrangler.prod.toml
@@ -134,6 +134,8 @@ deleted_classes = ["VmSession"]
 #                            browser-session proxy requests
 #   OC_MANAGED_AGENTS_SECRET — dedicated HS256 secret shared only with the
 #                            managed-agents backend
+#   DATA_ANALYST_API_TOKEN — dedicated bearer secret for the GET-only internal
+#                            data-analyst billing and session routes
 # Optional vars: OPENROUTER_BASE_URL (default https://openrouter.ai/api/v1),
 #   OPENROUTER_MARKUP_BPS (env-default markup; per-org orgs.model_markup_bps wins).
 

--- a/cloudflare-workers/api-edge/wrangler.toml
+++ b/cloudflare-workers/api-edge/wrangler.toml
@@ -150,6 +150,8 @@ deleted_classes = ["VmSession"]
 #                            exposure alerts from sessions-api.
 #   OC_MANAGED_AGENTS_SECRET — dedicated HS256 secret shared only with the
 #                            managed-agents backend.
+#   DATA_ANALYST_API_TOKEN — dedicated bearer secret for the GET-only internal
+#                            data-analyst billing and session routes.
 # The VM-DO exec data plane (VM_SESSIONS DO) needs NO dedicated secret: the worker
 # host authenticates its /internal/vms/:id/connect dial with a per-sandbox HMAC
 # over the already-shared SESSION_JWT_SECRET (minted by the CP, re-derived here).


### PR DESCRIPTION
## Decisions

- Implements the contract in https://github.com/diggerhq/serverless-agents-ws/pull/16.
- Add dedicated GET-only internal routes protected by `DATA_ANALYST_API_TOKEN`.
- Reuse the dashboard's live Autumn summary for billing instead of copying billing state.
- Reuse the organization-scoped managed-agent session assertion backed by Account and Session Durable Objects.
- Bound session fan-out to 100 records and omit prompt previews unless explicitly requested.
- Emit structured read audit events without logging credentials or full session events.

## Review map

- `cloudflare-workers/api-edge/src/data_analyst.ts`: authorization, validation, billing, and session projections.
- `cloudflare-workers/api-edge/src/data_analyst.test.ts`: route and security coverage.
- `cloudflare-workers/api-edge/src/index.ts`: internal route wiring.
- `cloudflare-workers/api-edge/src/dashboard.ts`: shared Autumn billing summary.
- Wrangler configs: required secret documentation.

## Verification

- API-edge tests: 152 passed.
- `npx tsc --noEmit` passed.
- Diff check passed.

## Rollout

- Deploy the API edge and install `DATA_ANALYST_API_TOKEN`.
- Deploy https://github.com/diggerhq/internaldataagent/pull/1 afterward with the matching token.

No production resources or secrets were changed by this PR.
