### PR TITLE
Publish OpenComputer CLI 0.6.6

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/cli",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "dependencies": {
         "@opencode-ai/sdk": "1.18.4",
         "ai": "^7.0.45",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Build, test, deploy, and share OpenComputer agents as code.",
   "type": "module",
   "bin": {

--- a/create-start/package.json
+++ b/create-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/create-start",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Create a hello-world OpenComputer agent application.",
   "type": "module",
   "bin": {
@@ -18,7 +18,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@opencomputer/cli": "0.6.5"
+    "@opencomputer/cli": "0.6.6"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Why

PR #705 merged the agent-first CLI without changing the package version, so the npm publisher correctly skipped the already-published 0.6.5 artifacts.

## Change

- bump `@opencomputer/cli` from 0.6.5 to 0.6.6
- keep `cli/package-lock.json` synchronized
- bump the contract-coupled `@opencomputer/create-start` package and its exact CLI dependency to 0.6.6

Merging to `main` triggers `publish-opencomputer-packages.yml`, which publishes both packages if 0.6.6 is not already present.

## Verification

- `node scripts/check-opencomputer-package-contract.mjs`
- `cd cli && npm test` (50 passing)
- `cd create-start && npm test` (2 passing)
