### PR TITLE
docs: custom templates on v2

### DIFF
--- a/docs/migrating-from-v1.mdx
+++ b/docs/migrating-from-v1.mdx
@@ -88,7 +88,8 @@ A v1 template captures the whole disk. v2 can only replay the workspace half, an
 silently would hand you your files while dropping every system change the template existed for.
 So it refuses, loudly, at create.
 
-Rebuild affected templates as workspace templates or checkpoints on v2.
+Rebuild them on v2 — usually by re-running the same `Image` definition under the same name.
+See [Templates](/sandboxes/templates).
 
 ### Sizes are fixed steps, and 16 GB is gone
 

--- a/docs/migrating-from-v1.mdx
+++ b/docs/migrating-from-v1.mdx
@@ -36,7 +36,9 @@ Seven questions. If every answer is "no", your migration is a configuration chan
     None of these exist in v2.
   </Step>
   <Step title="Do you build images or fork from checkpoints?">
-    Image builds are unavailable. Fork is unavailable today and being worked on.
+    Image builds work, but only ahead of time — see [Templates](/sandboxes/templates).
+    Passing `image:` directly to a create is refused. Fork is unavailable today and being
+    worked on.
   </Step>
 </Steps>
 
@@ -134,7 +136,7 @@ that sandbox. See [Secrets](/sandboxes/secrets).
 |---|---|
 | `scale()`, `setAutoscale()` | memory is fixed at launch |
 | Mounts (FUSE, NFS, overlay) | the guest cannot perform `mount` |
-| Image builds (`image:`) | no build pipeline in v2 |
+| Inline `image:` on create | build ahead of time instead — see [Templates](/sandboxes/templates) |
 | Fork from a checkpoint | in progress |
 | Checkpoint patches | not wired up |
 | Live migration | not applicable |

--- a/docs/reference/typescript-sdk/image.mdx
+++ b/docs/reference/typescript-sdk/image.mdx
@@ -7,7 +7,14 @@ Fluent, immutable builder for declarative sandbox images. Each method returns a 
 
 ## `Image.base()`
 
-Start from the default OpenSandbox environment (Ubuntu 22.04, Python, Node.js, build tools).
+Start from the default OpenSandbox environment (Amazon Linux 2023, Python, Node.js, build
+tools) on ARM64.
+
+<Note>
+Images are built ahead of time and started by name — see
+[Templates](/sandboxes/templates). Passing an `Image` directly to `Sandbox.create()` is
+refused, because a build takes minutes.
+</Note>
 
 ```typescript
 import { Image } from "@opencomputer/sdk";
@@ -28,8 +35,14 @@ const image = Image.base()
 ### `image.aptInstall(packages)`
 
 <ParamField body="packages" type="string[]" required>
-  System packages to install via apt-get
+  System packages to install
 </ParamField>
+
+<Note>
+The base is Amazon Linux 2023, so these are installed with `dnf`. Common Debian names are
+translated (`build-essential` becomes `gcc gcc-c++ make`); a package that exists only on
+Debian fails the build and the error names it.
+</Note>
 
 **Returns:** `Image`
 

--- a/docs/sandboxes/templates.mdx
+++ b/docs/sandboxes/templates.mdx
@@ -1,72 +1,137 @@
 ---
 title: "Templates"
-description: "Which templates carry over, and which do not"
+description: "Two ways to prepare an environment, and which one you need"
 ---
 
-Templates work on v2, but **the templates you have today probably do not.** This is
-the migration issue most likely to affect you, and it is worth checking before anything moves.
+A template is an environment prepared once and reused by many sandboxes. v2 has **two
+mechanisms**, and which one you need depends on a single question: does your setup write
+outside the home directory?
 
-## How a template is applied here
+| Your setup | Mechanism | Create speed |
+| --- | --- | --- |
+| Python/Node packages, files, env vars | **Workspace template** | Full pooled speed |
+| System packages (`apt`/`dnf`), anything in `/usr` | **Custom image** | Cold start, a few seconds |
 
-A template create claims a standard pooled sandbox and unpacks the template's **workspace
-archive** on top of it. That keeps the fast pooled create and makes a template cost a tarball
-rather than a separately published machine image.
+If a workspace template covers you, use it — it is faster at create time and has no limits
+worth worrying about.
+
+## Workspace templates
+
+A workspace template claims a standard pooled sandbox and unpacks your saved workspace on top
+of it. You keep the fast pooled create, and the template costs nothing but a tarball.
 
 ```typescript
 const sandbox = await Sandbox.create({ templateID: "my-template" });
 ```
 
-## The catch: rootfs templates are refused
+This captures **everything under your home directory**. That is more than it sounds: `pip` and
+`npm` are configured to install there, so a Python or Node toolchain is captured for free.
+
+```typescript
+// Both of these are captured by a workspace template.
+await sandbox.exec.run("pip install pandas");
+await sandbox.exec.run("npm install -g typescript");
+```
+
+What it does **not** capture is anything outside your home directory — `dnf install` writing to
+`/usr`, system services, files in `/etc`. For those you need a custom image.
+
+## Custom images
+
+A custom image bakes your setup into the machine image the sandbox boots from, so system-level
+changes persist. You define it with the same `Image` builder v1 uses:
+
+```typescript
+import { Image, Snapshots, Sandbox } from "@opencomputer/sdk";
+
+const snapshots = new Snapshots();
+
+await snapshots.create({
+  name: "video-tools",
+  image: Image.base()
+    .aptInstall(["ffmpeg"])
+    .pipInstall(["numpy"]),
+});
+
+// Building takes minutes — wait for it before using it.
+await snapshots.waitUntilReady("video-tools");
+
+const sandbox = await Sandbox.create({ template: "video-tools" });
+```
+
+### Four things to know
+
+<Warning>
+**Builds take minutes, not seconds.** The image is built by the platform, not in your sandbox.
+Build once, then start as many sandboxes from it as you like.
+</Warning>
+
+**Sandboxes from a custom image cold-start.** The warm pool holds standard sandboxes, so a
+custom-image create takes a few seconds instead of milliseconds. If create latency matters more
+than system packages, prefer a workspace template.
+
+**The base is Amazon Linux 2023, not Ubuntu.** `aptInstall` still works — package names are
+translated where they differ (`build-essential` becomes `gcc gcc-c++ make`) — but a package that
+exists only on Debian will fail the build, and the error names the package.
+
+**Everything runs on ARM64.** A build step that downloads an x86-64 binary will fail. Use your
+package manager, or fetch the `aarch64`/`arm64` build.
+
+### Limits
+
+Custom images are a limited resource, so each org can hold **10** at a time. Delete one you are
+no longer using to make room.
+
+Two identical definitions share a single image, so rebuilding an unchanged template costs
+nothing and returns immediately.
+
+## Building inline is not supported
+
+<Warning>
+Passing `image:` directly to `Sandbox.create()` is refused on v2. Create the image first, then
+create sandboxes from it by name.
+</Warning>
+
+A build takes minutes; a create that waited for one would time out. The refusal names the
+supported path rather than quietly handing you a sandbox without your packages.
+
+```typescript
+// Refused on v2
+await Sandbox.create({ image: Image.base().aptInstall(["ffmpeg"]) });
+
+// Do this instead
+await snapshots.create({ name: "tools", image: Image.base().aptInstall(["ffmpeg"]) });
+await snapshots.waitUntilReady("tools");
+await Sandbox.create({ template: "tools" });
+```
+
+## Migrating a v1 template
 
 <Warning>
 A template that carries a **rootfs image** cannot be used on v2. The create fails with
 *"template … carries a rootfs image, which v2 cannot restore."*
 </Warning>
 
-Templates built on v1 capture the **whole disk** — every system-level change,
-not just your workspace. This runtime can only replay the workspace half, and doing that
-silently would hand you your files while dropping every system change the template existed for:
-a template that looks like it worked and hasn't.
-
-So it refuses instead. That is the right failure, but it means:
-
-**Any template that installed system packages, changed system configuration, or was built
-before your org moved will need rebuilding on the new runtime.**
-
-## What to do
+v1 templates capture the whole disk. v2 cannot replay that, and replaying only the workspace half
+would hand you your files while dropping every system change the template existed for — a
+template that looks like it worked and hasn't. So it refuses instead.
 
 <Steps>
-  <Step title="List your templates and try each one">
-    A refused template fails loudly at create with the message above. That is the fastest audit
-    — you do not need to inspect anything.
+  <Step title="Try each template">
+    A template that cannot be used fails loudly at create with the message above. That is the
+    fastest audit — nothing to inspect.
   </Step>
-  <Step title="Rebuild the ones that fail">
-    Start a sandbox on the new runtime, install what the template provided, and capture it as a
-    [checkpoint](/sandboxes/checkpoints) or a new template. What can be captured is the
-    filesystem, so anything you can install with files and packages carries over.
-  </Step>
-  <Step title="Move system-level setup into the image, or into your startup">
-    If the template depended on changes outside the workspace, they need to live somewhere else
-    — either in a published image (talk to us) or as a step your sandbox runs on boot.
+  <Step title="Rebuild it in the right place">
+    Packages installed into your home directory become a workspace template. System packages
+    become a custom image, using the same `Image` definition you already have.
   </Step>
 </Steps>
 
-## Image builds are not available
-
-<Warning>
-Declarative image manifests (`image:` on create) and the image build pipeline are **not
-supported** on v2. They depend on a build fleet it does not have.
-</Warning>
-
-If you build images today, that workflow needs an alternative before you migrate:
-
 <CardGroup cols={2}>
-  <Card title="Workspace templates" icon="layer-group">
-    Prepare a workspace once and start sandboxes from it — as long as it does not need a
-    rootfs.
+  <Card title="Checkpoints" icon="camera" href="/sandboxes/checkpoints">
+    Save a running sandbox's workspace and restore it later.
   </Card>
-  <Card title="Checkpoints" icon="camera">
-    Install into a sandbox, checkpoint it, and restore that checkpoint when you need the
-    environment again.
+  <Card title="Migrating from v1" icon="arrow-right" href="/migrating-from-v1">
+    Every behaviour that differs between v1 and v2.
   </Card>
 </CardGroup>

--- a/docs/sandboxes/templates.mdx
+++ b/docs/sandboxes/templates.mdx
@@ -1,45 +1,10 @@
 ---
 title: "Templates"
-description: "Two ways to prepare an environment, and which one you need"
+description: "Same API as v1, with two differences worth knowing"
 ---
 
-A template is an environment prepared once and reused by many sandboxes. v2 has **two
-mechanisms**, and which one you need depends on a single question: does your setup write
-outside the home directory?
-
-| Your setup | Mechanism | Create speed |
-| --- | --- | --- |
-| Python/Node packages, files, env vars | **Workspace template** | Full pooled speed |
-| System packages (`apt`/`dnf`), anything in `/usr` | **Custom image** | Cold start, a few seconds |
-
-If a workspace template covers you, use it — it is faster at create time and has no limits
-worth worrying about.
-
-## Workspace templates
-
-A workspace template claims a standard pooled sandbox and unpacks your saved workspace on top
-of it. You keep the fast pooled create, and the template costs nothing but a tarball.
-
-```typescript
-const sandbox = await Sandbox.create({ templateID: "my-template" });
-```
-
-This captures **everything under your home directory**. That is more than it sounds: `pip` and
-`npm` are configured to install there, so a Python or Node toolchain is captured for free.
-
-```typescript
-// Both of these are captured by a workspace template.
-await sandbox.exec.run("pip install pandas");
-await sandbox.exec.run("npm install -g typescript");
-```
-
-What it does **not** capture is anything outside your home directory — `dnf install` writing to
-`/usr`, system services, files in `/etc`. For those you need a custom image.
-
-## Custom images
-
-A custom image bakes your setup into the machine image the sandbox boots from, so system-level
-changes persist. You define it with the same `Image` builder v1 uses:
+Templates work on v2, and **the contract is unchanged**. You define an environment once,
+give it a name, and start sandboxes from that name:
 
 ```typescript
 import { Image, Snapshots, Sandbox } from "@opencomputer/sdk";
@@ -53,83 +18,87 @@ await snapshots.create({
     .pipInstall(["numpy"]),
 });
 
-// Building takes minutes — wait for it before using it.
 await snapshots.waitUntilReady("video-tools");
 
 const sandbox = await Sandbox.create({ template: "video-tools" });
 ```
 
-### Four things to know
+Same `Image` builder, same names, same `list` / `get` / `delete`. Your existing definitions
+carry over as written — what changes is how they are built underneath, and two consequences of
+that are visible to you.
 
-<Warning>
-**Builds take minutes, not seconds.** The image is built by the platform, not in your sandbox.
-Build once, then start as many sandboxes from it as you like.
-</Warning>
+## 1. Build ahead of time
 
-**Sandboxes from a custom image cold-start.** The warm pool holds standard sandboxes, so a
-custom-image create takes a few seconds instead of milliseconds. If create latency matters more
-than system packages, prefer a workspace template.
-
-**The base is Amazon Linux 2023, not Ubuntu.** `aptInstall` still works — package names are
-translated where they differ (`build-essential` becomes `gcc gcc-c++ make`) — but a package that
-exists only on Debian will fail the build, and the error names the package.
-
-**Everything runs on ARM64.** A build step that downloads an x86-64 binary will fail. Use your
-package manager, or fetch the `aarch64`/`arm64` build.
-
-### Limits
-
-Custom images are a limited resource, so each org can hold **10** at a time. Delete one you are
-no longer using to make room.
-
-Two identical definitions share a single image, so rebuilding an unchanged template costs
-nothing and returns immediately.
-
-## Building inline is not supported
-
-<Warning>
-Passing `image:` directly to `Sandbox.create()` is refused on v2. Create the image first, then
-create sandboxes from it by name.
-</Warning>
-
-A build takes minutes; a create that waited for one would time out. The refusal names the
-supported path rather than quietly handing you a sandbox without your packages.
+A template is built into a machine image before any sandbox uses it, which takes minutes rather
+than seconds. So the build is a separate step from the create, and you wait for it once:
 
 ```typescript
-// Refused on v2
-await Sandbox.create({ image: Image.base().aptInstall(["ffmpeg"]) });
-
-// Do this instead
-await snapshots.create({ name: "tools", image: Image.base().aptInstall(["ffmpeg"]) });
-await snapshots.waitUntilReady("tools");
-await Sandbox.create({ template: "tools" });
+await snapshots.create({ name: "tools", image });
+await snapshots.waitUntilReady("tools");   // minutes, once
+await Sandbox.create({ template: "tools" }); // fast, every time after
 ```
 
-## Migrating a v1 template
+<Warning>
+Passing `image:` directly to `Sandbox.create()` is refused on v2. A create that waited for a
+build would time out, so the error names the two-step path instead of returning a sandbox
+without your packages.
+</Warning>
+
+## 2. Sandboxes from a template cold-start
+
+Standard sandboxes come from a warm pool. A sandbox built on your template does not, because the
+pool holds standard sandboxes — so expect a few seconds rather than milliseconds on create.
+
+Everything the template installed is already baked in, so this is paid at create, not on your
+first command.
+
+## What your definitions run on
+
+The environment underneath is Amazon Linux 2023 on ARM64, so two things in an existing
+definition can need attention:
+
+<CardGroup cols={2}>
+  <Card title="Package names" icon="box">
+    `aptInstall` works and common Debian names are translated — `build-essential` becomes
+    `gcc gcc-c++ make`. A package that exists only on Debian fails the build, and the error
+    names it.
+  </Card>
+  <Card title="Architecture" icon="microchip">
+    A step that downloads an x86-64 binary fails. Use your package manager, or fetch the
+    `aarch64` build.
+  </Card>
+</CardGroup>
+
+Each org holds up to **10** templates at a time; delete one to make room. Two identical
+definitions share one build, so rebuilding an unchanged template returns immediately.
+
+## Templates built on v1
 
 <Warning>
 A template that carries a **rootfs image** cannot be used on v2. The create fails with
 *"template … carries a rootfs image, which v2 cannot restore."*
 </Warning>
 
-v1 templates capture the whole disk. v2 cannot replay that, and replaying only the workspace half
-would hand you your files while dropping every system change the template existed for — a
-template that looks like it worked and hasn't. So it refuses instead.
+v1 templates capture the whole disk. Replaying only part of that would hand you your files while
+dropping every system change the template existed for — a template that looks like it worked and
+hasn't — so it refuses instead.
+
+Rebuilding is the fix, and usually means re-running the `Image` definition you already have.
 
 <Steps>
   <Step title="Try each template">
-    A template that cannot be used fails loudly at create with the message above. That is the
-    fastest audit — nothing to inspect.
+    One that cannot be used fails loudly at create with the message above. That is the fastest
+    audit — nothing to inspect.
   </Step>
-  <Step title="Rebuild it in the right place">
-    Packages installed into your home directory become a workspace template. System packages
-    become a custom image, using the same `Image` definition you already have.
+  <Step title="Rebuild it">
+    Create it again by name with the same definition, wait for the build, and point your creates
+    at it.
   </Step>
 </Steps>
 
 <CardGroup cols={2}>
   <Card title="Checkpoints" icon="camera" href="/sandboxes/checkpoints">
-    Save a running sandbox's workspace and restore it later.
+    Save a running sandbox and restore it later.
   </Card>
   <Card title="Migrating from v1" icon="arrow-right" href="/migrating-from-v1">
     Every behaviour that differs between v1 and v2.

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -100,5 +100,12 @@ export {
   type TagKeyInfo,
 } from "./usage.js";
 // Node.js-only modules (use crypto, fs, path) — import via "@opencomputer/sdk/node".
+// The Image builder and the Snapshots client are exported as VALUES, not only
+// as types. Both were type-only, so `import { Image } from "@opencomputer/sdk"`
+// — which the Image reference documents — failed at runtime with "does not
+// provide an export named 'Image'", and there was no supported way to define a
+// template through the SDK at all.
+export { Image } from "./image.js";
 export type { ImageManifest, ImageStep } from "./image.js";
+export { Snapshots } from "./snapshot.js";
 export type { SnapshotInfo, CreateSnapshotOpts, WaitForReadyOpts } from "./snapshot.js";


### PR DESCRIPTION
Updates the templates docs for v2, and fixes the SDK export the docs depend on.

## Why

The templates page said image builds were **not supported on v2**. They now are — `parity-microvm` (#703) implements them — so the page described a gap that no longer exists.

## Docs

**`sandboxes/templates.mdx`** — leads with the contract being *unchanged*: same `Image` builder, same names, same `Sandbox.create({ template })`. Existing definitions carry over as written.

It then covers only what a customer can actually observe:

- **Build ahead of time.** A build takes minutes, so it is a separate step; passing `image:` inline to a create is refused rather than timing out or silently returning a sandbox without the packages.
- **Template creates cold-start.** The warm pool holds standard sandboxes.
- **AL2023 on ARM64.** `aptInstall` works and common Debian names are translated (`build-essential` → `gcc gcc-c++ make`); a Debian-only package fails the build and the error names it. A step that downloads an x86-64 binary fails.
- **10 templates per org**, identical definitions deduped.

An earlier draft offered a choice between "workspace templates" and "custom images". That was wrong — there is one templates path in the API, and "workspace template" named an internal mechanism customers never see. Removed, including a pre-existing use of the term in the migration guide.

**Consistency fixes** — pages that would otherwise contradict the above: `migrating-from-v1.mdx` ("Image builds are unavailable" / "no build pipeline in v2") and `reference/typescript-sdk/image.mdx`, which described the base as Ubuntu 22.04 with `apt-get`.

## SDK fix (why it is in this PR)

`Image` and `Snapshots` were exported **as types only**, so `import { Image } from "@opencomputer/sdk"` — exactly what the Image reference documents — failed at runtime with *"does not provide an export named 'Image'"*. There was no supported way to define a template through the SDK at all.

Found by the first end-to-end template run, which could not import them. The docs here show that import, so the fix ships alongside. Also on #703; harmless if that merges first.

## Validation

The flow these docs describe was run end to end against the dev cell:

```
snapshots.create({name, image: Image.base().aptInstall(["tree"])})
waitUntilReady(name)                → ready
Sandbox.create({template: name})    → 8.6s cold launch
exec "command -v tree"              → /usr/bin/tree
```

`tree` is absent from the base image, so its presence confirms the customer's package came from their template.