### PR TITLE
Add project deletion and secret editing to dashboard

### DIFF
--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -588,6 +588,59 @@ describe("managed agents proxy", () => {
     expect(JSON.stringify(body)).not.toContain("private-account");
   });
 
+  it("allows organization admins to delete projects", async () => {
+    const fetchSpy = vi.fn(
+      async (_request: URL | RequestInfo, init?: RequestInit) => {
+        expect(init?.method).toBe("DELETE");
+        return new Response(null, { status: 204 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const response = await proxyManagedAgents(
+      new Request(
+        "https://app.opencomputer.dev/api/managed-agents/projects/prj_test",
+        { method: "DELETE" },
+      ),
+      {
+        OC_MANAGED_AGENTS_SECRET: "test-secret",
+        MANAGED_AGENTS_API_URL: "https://managedagents.test",
+      },
+      { orgID: "org_test", userID: "user_test", role: "admin" },
+      "/api/managed-agents",
+    );
+
+    expect(response.status).toBe(204);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("does not allow organization members to delete projects", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const response = await proxyManagedAgents(
+      new Request(
+        "https://app.opencomputer.dev/api/managed-agents/projects/prj_test",
+        { method: "DELETE" },
+      ),
+      {
+        OC_MANAGED_AGENTS_SECRET: "test-secret",
+        MANAGED_AGENTS_API_URL: "https://managedagents.test",
+      },
+      { orgID: "org_test", userID: "user_test", role: "member" },
+      "/api/managed-agents",
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "forbidden",
+        message: "Organization admin role is required to delete a project.",
+      },
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("exposes public template provenance on a project overview", async () => {
     vi.stubGlobal(
       "fetch",

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -1123,6 +1123,7 @@ function isAllowedManagedAgentsRoute(method: string, suffix: string): boolean {
     return true;
   }
   if (method === "GET" && /^\/projects\/[^/]+$/.test(suffix)) return true;
+  if (method === "DELETE" && /^\/projects\/[^/]+$/.test(suffix)) return true;
   if (method === "GET" && /^\/projects\/[^/]+\/source-archive$/.test(suffix)) {
     return true;
   }
@@ -1472,6 +1473,21 @@ export async function proxyManagedAgents(
     return Response.json(
       { error: "managed agents are not configured" },
       { status: 503 },
+    );
+  }
+  if (
+    request.method.toUpperCase() === "DELETE" &&
+    /^\/projects\/[^/]+$/.test(suffix) &&
+    caller.role !== "admin"
+  ) {
+    return Response.json(
+      {
+        error: {
+          code: "forbidden",
+          message: "Organization admin role is required to delete a project.",
+        },
+      },
+      { status: 403 },
     );
   }
   if (

--- a/web/src/components/app-shell-nav.ts
+++ b/web/src/components/app-shell-nav.ts
@@ -12,6 +12,7 @@ import {
   Radio,
   Rocket,
   Send,
+  Settings2,
   Webhook,
   type LucideIcon,
 } from 'lucide-react'
@@ -91,6 +92,11 @@ export function managedAgentsNav(options: {
             to: `${projectPath}/byok`,
             label: 'BYOK',
             icon: BrainCircuit,
+          },
+          {
+            to: `${projectPath}/settings`,
+            label: 'Settings',
+            icon: Settings2,
           },
           {
             to: projectPath,

--- a/web/src/components/app-shell.test.ts
+++ b/web/src/components/app-shell.test.ts
@@ -27,6 +27,7 @@ describe('managed agents navigation', () => {
       'Webhooks',
       'Secrets',
       'BYOK',
+      'Settings',
       'Debug playground',
     ])
     expect(nav[1]?.items[nav[1].items.length - 1]?.to).toBe(

--- a/web/src/managed-agents/Detail.tsx
+++ b/web/src/managed-agents/Detail.tsx
@@ -1126,6 +1126,7 @@ export default function ManagedAgentDetail({
 
       {activeTab === 'secrets' && project ? (
         <ManagedProjectSecrets
+          key={`${project.project.id}:${environment}`}
           projectId={project.project.id}
           agents={project.project.agents}
           environment={environment}

--- a/web/src/managed-agents/Project.tsx
+++ b/web/src/managed-agents/Project.tsx
@@ -2,14 +2,16 @@ import { useQuery } from '@tanstack/react-query'
 import { Link, useLocation, useParams } from 'react-router-dom'
 import { FolderKanban, Loader2 } from 'lucide-react'
 import { EmptyState } from '@/components/empty-state'
+import { PageHeader } from '@/components/page-header'
 import { Panel } from '@/components/panel'
 import { Button } from '@/components/ui/button'
 import ManagedAgentDetail from './Detail'
 import { getManagedProject } from './api'
 import { selectedProjectAgentId } from './project-context'
+import { ManagedProjectSettings } from './ProjectSettings'
 
 export default function ProjectDetail() {
-  const { projectId = '', projectAgentId } = useParams()
+  const { projectId = '', projectAgentId, tab } = useParams()
   const location = useLocation()
   const project = useQuery({
     queryKey: ['managed-project', projectId],
@@ -39,6 +41,21 @@ export default function ProjectDetail() {
           }
         />
       </Panel>
+    )
+  }
+
+  if (tab === 'settings') {
+    return (
+      <div className="space-y-5">
+        <PageHeader
+          title={project.data.project.name}
+          description={`${project.data.project.agents.length} ${project.data.project.agents.length === 1 ? 'agent' : 'agents'} · project settings`}
+        />
+        <ManagedProjectSettings
+          projectId={project.data.project.id}
+          projectName={project.data.project.name}
+        />
+      </div>
     )
   }
 

--- a/web/src/managed-agents/ProjectSettings.test.ts
+++ b/web/src/managed-agents/ProjectSettings.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { canConfirmProjectDeletion } from './project-settings'
+
+describe('canConfirmProjectDeletion', () => {
+  it('requires the exact project name', () => {
+    expect(canConfirmProjectDeletion('Incident Agent', 'Incident Agent')).toBe(
+      true,
+    )
+    expect(canConfirmProjectDeletion('incident agent', 'Incident Agent')).toBe(
+      false,
+    )
+    expect(canConfirmProjectDeletion('Incident Agent ', 'Incident Agent')).toBe(
+      false,
+    )
+  })
+})

--- a/web/src/managed-agents/ProjectSettings.tsx
+++ b/web/src/managed-agents/ProjectSettings.tsx
@@ -1,0 +1,128 @@
+import { useRef, useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { Loader2, Trash2 } from 'lucide-react'
+import { notifyError, notifySuccess } from '@/lib/errors'
+import {
+  Panel,
+  PanelContent,
+  PanelDescription,
+  PanelHeader,
+  PanelTitle,
+} from '@/components/panel'
+import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { deleteManagedProject } from './api'
+import { canConfirmProjectDeletion } from './project-settings'
+
+export function ManagedProjectSettings({
+  projectId,
+  projectName,
+}: {
+  projectId: string
+  projectName: string
+}) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [confirmation, setConfirmation] = useState('')
+  const confirmationInput = useRef<HTMLInputElement>(null)
+  const remove = useMutation({
+    mutationFn: () => deleteManagedProject(projectId),
+    onSuccess: () => {
+      queryClient.removeQueries({ queryKey: ['managed-project', projectId] })
+      void queryClient.invalidateQueries({ queryKey: ['managed-projects'] })
+      notifySuccess('Project deleted.')
+      void navigate('/', { replace: true })
+    },
+    onError: (error) => notifyError("Couldn't delete the project.", error),
+  })
+  const confirmed = canConfirmProjectDeletion(confirmation, projectName)
+
+  return (
+    <>
+      <Panel className="border-destructive/40">
+        <PanelHeader>
+          <div>
+            <PanelTitle>Delete project</PanelTitle>
+            <PanelDescription className="mt-1">
+              Permanently remove this project and its agents, deployments,
+              sessions, credentials, triggers, and environment configuration.
+            </PanelDescription>
+          </div>
+        </PanelHeader>
+        <PanelContent>
+          <Button
+            variant="destructive"
+            onClick={() => {
+              setConfirmation('')
+              setDialogOpen(true)
+              requestAnimationFrame(() => confirmationInput.current?.focus())
+            }}
+          >
+            <Trash2 /> Delete project
+          </Button>
+        </PanelContent>
+      </Panel>
+
+      <AlertDialog
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          if (remove.isPending) return
+          setDialogOpen(open)
+          if (!open) setConfirmation('')
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {projectName}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This cannot be undone. Active sessions will end, project access
+              tokens will stop working, and linked local checkouts will need to
+              link or create a project before deploying again.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="project-delete-confirmation">
+              Type <span className="font-mono">{projectName}</span> to confirm
+            </Label>
+            <Input
+              id="project-delete-confirmation"
+              ref={confirmationInput}
+              value={confirmation}
+              onChange={(event) => setConfirmation(event.target.value)}
+              autoComplete="off"
+            />
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={remove.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <Button
+              variant="destructive"
+              disabled={!confirmed || remove.isPending}
+              onClick={() => remove.mutate()}
+            >
+              {remove.isPending ? (
+                <Loader2 className="animate-spin" aria-hidden />
+              ) : (
+                <Trash2 aria-hidden />
+              )}
+              Delete project
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/web/src/managed-agents/Secrets.tsx
+++ b/web/src/managed-agents/Secrets.tsx
@@ -1,6 +1,6 @@
-import { type FormEvent, useState } from 'react'
+import { type FormEvent, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { KeyRound, Loader2, Trash2 } from 'lucide-react'
+import { KeyRound, Loader2, Pencil, Trash2 } from 'lucide-react'
 import {
   Panel,
   PanelContent,
@@ -19,6 +19,7 @@ import {
   getManagedProjectSecrets,
   putAgentRuntimeVariable,
   putManagedProjectSecret,
+  type ManagedProjectSecret,
 } from './api'
 
 type Environment = 'development' | 'production'
@@ -43,6 +44,8 @@ export function ManagedProjectSecrets({
   const [value, setValue] = useState('')
   const [origins, setOrigins] = useState('')
   const [agentId, setAgentId] = useState('')
+  const [editing, setEditing] = useState<ManagedProjectSecret | null>(null)
+  const valueInput = useRef<HTMLInputElement>(null)
   const queryKey = ['managed-project-secrets', projectId, environment]
   const secrets = useQuery({
     queryKey,
@@ -54,6 +57,8 @@ export function ManagedProjectSecrets({
       setName('')
       setValue('')
       setOrigins('')
+      setAgentId('')
+      setEditing(null)
       await queryClient.invalidateQueries({ queryKey })
       notifySuccess('Secret saved.', 'Its value remains write-only.')
     },
@@ -68,6 +73,27 @@ export function ManagedProjectSecrets({
     onError: (error) => notifyError("Couldn't remove the secret.", error),
   })
   const agentNames = new Map(agents.map((agent) => [agent.id, agent.name]))
+
+  function edit(secret: ManagedProjectSecret) {
+    setEditing(secret)
+    setName(secret.name)
+    setValue('')
+    setOrigins(
+      secret.allowedOrigins.includes('*')
+        ? ''
+        : secret.allowedOrigins.join(', '),
+    )
+    setAgentId(secret.agentId ?? '')
+    requestAnimationFrame(() => valueInput.current?.focus())
+  }
+
+  function cancelEdit() {
+    setEditing(null)
+    setName('')
+    setValue('')
+    setOrigins('')
+    setAgentId('')
+  }
 
   function submit(event: FormEvent) {
     event.preventDefault()
@@ -98,7 +124,9 @@ export function ManagedProjectSecrets({
       <Panel>
         <PanelHeader>
           <div>
-            <PanelTitle>Secrets</PanelTitle>
+            <PanelTitle>
+              {editing ? `Edit ${editing.name}` : 'Secrets'}
+            </PanelTitle>
             <PanelDescription className="mt-1">
               Write-only values injected by the managed egress gateway for the
               selected environment. Values never enter agent runtimes or logs.
@@ -118,6 +146,7 @@ export function ManagedProjectSecrets({
                 onChange={(event) => setName(event.target.value.toUpperCase())}
                 placeholder="GITHUB_TOKEN"
                 autoComplete="off"
+                disabled={Boolean(editing)}
               />
             </div>
             <div className="space-y-2">
@@ -126,6 +155,7 @@ export function ManagedProjectSecrets({
                 id="secret-scope"
                 value={agentId}
                 onChange={(event) => setAgentId(event.target.value)}
+                disabled={Boolean(editing)}
                 className="border-input bg-background h-8 w-full rounded-md border px-2.5 text-sm outline-none"
               >
                 <option value="">Entire project</option>
@@ -140,6 +170,7 @@ export function ManagedProjectSecrets({
               <Label htmlFor="secret-value">Value</Label>
               <Input
                 id="secret-value"
+                ref={valueInput}
                 type="password"
                 value={value}
                 onChange={(event) => setValue(event.target.value)}
@@ -181,8 +212,19 @@ export function ManagedProjectSecrets({
                 ) : (
                   <KeyRound />
                 )}
-                Save secret
+                {editing ? 'Replace secret' : 'Save secret'}
               </Button>
+              {editing ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="ml-2"
+                  disabled={save.isPending}
+                  onClick={cancelEdit}
+                >
+                  Cancel
+                </Button>
+              ) : null}
             </div>
           </form>
         </PanelContent>
@@ -245,22 +287,33 @@ export function ManagedProjectSecrets({
                     </p>
                   )}
                 </div>
-                <Button
-                  type="button"
-                  variant="destructive"
-                  size="sm"
-                  disabled={remove.isPending}
-                  onClick={() =>
-                    remove.mutate({
-                      projectId,
-                      environment: secret.environment,
-                      ...(secret.agentId ? { agentId: secret.agentId } : {}),
-                      name: secret.name,
-                    })
-                  }
-                >
-                  <Trash2 /> Remove
-                </Button>
+                <div className="flex justify-end gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={save.isPending || remove.isPending}
+                    onClick={() => edit(secret)}
+                  >
+                    <Pencil /> Edit
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="sm"
+                    disabled={save.isPending || remove.isPending}
+                    onClick={() =>
+                      remove.mutate({
+                        projectId,
+                        environment: secret.environment,
+                        ...(secret.agentId ? { agentId: secret.agentId } : {}),
+                        name: secret.name,
+                      })
+                    }
+                  >
+                    <Trash2 /> Remove
+                  </Button>
+                </div>
               </div>
             ))}
           </div>

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -627,6 +627,12 @@ export async function getManagedProject(projectId: string) {
   )
 }
 
+export async function deleteManagedProject(projectId: string) {
+  await apiFetch(`/managed-agents/projects/${encodeURIComponent(projectId)}`, {
+    method: 'DELETE',
+  })
+}
+
 export async function getManagedModelAccessConnections() {
   return (
     await apiFetch(

--- a/web/src/managed-agents/project-settings.ts
+++ b/web/src/managed-agents/project-settings.ts
@@ -1,0 +1,6 @@
+export function canConfirmProjectDeletion(
+  confirmation: string,
+  projectName: string,
+) {
+  return confirmation === projectName
+}


### PR DESCRIPTION
Adds the public API and dashboard half of project deletion, plus an explicit write-only secret replacement flow.

Key behavior:
- adds Project Settings with typed-name confirmation
- restricts project deletion to organization admins
- proxies `DELETE /projects/:projectId` through the public edge
- removes deleted project queries and returns to the project list
- adds Edit on configured secrets while keeping name and scope fixed

Depends on diggerhq/blue#44.

Verification:
- dashboard build and typecheck
- changed-file ESLint
- focused dashboard tests (10)
- managed-edge tests (37)

The repository-wide dashboard lint still reports unrelated pre-existing findings outside this change.