### PR TITLE
Make project onboarding CLI-first

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,7 +31,9 @@ const ManagedAgentDetail = lazy(() => import('./managed-agents/Detail'))
 const ManagedProjectDetail = lazy(() => import('./managed-agents/Project'))
 const ManagedSessionDetail = lazy(() => import('./managed-agents/Session'))
 const ManagedAgentChannels = lazy(() => import('./managed-agents/Channels'))
-const ManagedTemplateNew = lazy(() => import('./managed-agents/TemplateNew'))
+const ManagedProjectOnboarding = lazy(
+  () => import('./managed-agents/ProjectOnboarding'),
+)
 const ModelAccessCallback = lazy(
   () => import('./managed-agents/ModelAccessCallback'),
 )
@@ -79,9 +81,9 @@ export default function App() {
             />
             <Route
               path="managed-agents/new"
-              element={<Navigate to="/" replace />}
+              element={<Navigate to="/new" replace />}
             />
-            <Route path="new" element={<ManagedTemplateNew />} />
+            <Route path="new" element={<ManagedProjectOnboarding />} />
             <Route
               path="projects/:projectId"
               element={<ManagedProjectDetail />}

--- a/web/src/managed-agents/Home.test.tsx
+++ b/web/src/managed-agents/Home.test.tsx
@@ -1,0 +1,48 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import ProjectsHome from './Home'
+import { INSTALL_CLI_COMMAND } from './ProjectOnboarding'
+
+function renderProjects(projects: unknown[]) {
+  const queryClient = new QueryClient()
+  queryClient.setQueryData(['managed-projects'], projects)
+
+  return renderToStaticMarkup(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ProjectsHome />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('projects home onboarding', () => {
+  it('shows CLI onboarding when the account has no projects', () => {
+    const markup = renderProjects([])
+
+    expect(markup).toContain(INSTALL_CLI_COMMAND)
+    expect(markup).not.toContain('Create project')
+    expect(markup).not.toContain('Start from a template')
+  })
+
+  it('sends New project to the same CLI onboarding route', () => {
+    const now = new Date().toISOString()
+    const markup = renderProjects([
+      {
+        id: 'project_1',
+        slug: 'support',
+        name: 'Support',
+        environments: [{ name: 'development', updatedAt: now }],
+        agents: [{ id: 'agent_1', name: 'Support agent' }],
+        createdAt: now,
+        updatedAt: now,
+      },
+    ])
+
+    expect(markup).toContain('New project')
+    expect(markup).toContain('href="/new"')
+    expect(markup).not.toContain('Start from a template')
+  })
+})

--- a/web/src/managed-agents/Home.tsx
+++ b/web/src/managed-agents/Home.tsx
@@ -1,64 +1,46 @@
-import { FormEvent, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Link, useNavigate } from 'react-router-dom'
-import {
-  ChevronLeft,
-  ChevronRight,
-  FolderGit2,
-  FolderKanban,
-  Loader2,
-  Plus,
-  Rocket,
-  Sparkles,
-} from 'lucide-react'
+import { Link } from 'react-router-dom'
+import { ChevronRight, FolderKanban, Loader2, Plus } from 'lucide-react'
 import { EmptyState } from '@/components/empty-state'
 import { PageHeader } from '@/components/page-header'
 import { Panel, PanelContent } from '@/components/panel'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
 import { getManagedProjects } from './api'
-import {
-  CURATED_TEMPLATES,
-  HELLO_WORLD_TEMPLATE_REPOSITORY,
-  templateDeployPath,
-} from './templates'
-
-type CreateStep = 'choose' | 'templates'
+import ProjectOnboarding from './ProjectOnboarding'
 
 export default function ProjectsHome() {
-  const navigate = useNavigate()
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const [createStep, setCreateStep] = useState<CreateStep>('choose')
-  const [repositoryUrl, setRepositoryUrl] = useState('')
   const projects = useQuery({
     queryKey: ['managed-projects'],
     queryFn: getManagedProjects,
   })
   const items = projects.data ?? []
 
-  function openCreate() {
-    setCreateStep('choose')
-    setRepositoryUrl('')
-    setDialogOpen(true)
+  if (projects.isLoading) {
+    return (
+      <div className="flex min-h-64 items-center justify-center">
+        <Loader2 className="text-muted-foreground size-5 animate-spin" />
+      </div>
+    )
   }
 
-  function openTemplate(url: string) {
-    setDialogOpen(false)
-    void navigate(templateDeployPath(url))
+  if (projects.isError) {
+    return (
+      <Panel>
+        <EmptyState
+          icon={FolderKanban}
+          title="Your projects are temporarily unavailable"
+          description="Try loading the projects page again."
+          action={
+            <Button variant="outline" onClick={() => void projects.refetch()}>
+              Try again
+            </Button>
+          }
+        />
+      </Panel>
+    )
   }
 
-  function submitRepository(event: FormEvent) {
-    event.preventDefault()
-    const url = repositoryUrl.trim()
-    if (url) openTemplate(url)
-  }
+  if (items.length === 0) return <ProjectOnboarding />
 
   return (
     <div className="space-y-8">
@@ -66,180 +48,44 @@ export default function ProjectsHome() {
         title="Projects"
         description="Choose a project to open its agent playground, deployments, sessions, and resources."
         actions={
-          items.length > 0 ? (
-            <Button onClick={openCreate}>
+          <Button asChild>
+            <Link to="/new">
               <Plus /> New project
-            </Button>
-          ) : undefined
+            </Link>
+          </Button>
         }
       />
 
-      {projects.isLoading ? (
-        <div className="flex min-h-64 items-center justify-center">
-          <Loader2 className="text-muted-foreground size-5 animate-spin" />
-        </div>
-      ) : projects.isError ? (
-        <Panel>
-          <EmptyState
-            icon={FolderKanban}
-            title="Your projects are temporarily unavailable"
-            description="Try loading the projects page again."
-            action={
-              <Button variant="outline" onClick={() => void projects.refetch()}>
-                Try again
-              </Button>
-            }
-          />
-        </Panel>
-      ) : items.length === 0 ? (
-        <div className="overflow-hidden rounded-xl border bg-[radial-gradient(circle_at_top_right,color-mix(in_oklch,var(--primary)_14%,transparent),transparent_45%)] px-6 py-10 sm:px-10">
-          <div className="max-w-2xl">
-            <div className="bg-primary/10 text-primary mb-4 inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium">
-              <Sparkles className="size-3.5" /> Your first project
-            </div>
-            <h2 className="text-3xl font-semibold tracking-tight">
-              Create your first agent
-            </h2>
-            <p className="text-muted-foreground mt-3 max-w-xl text-sm leading-6">
-              Start from a ready-to-run Hello World or choose an example. We’ll
-              deploy it and open its first Debug session.
-            </p>
-            <div className="mt-6">
-              <Button onClick={openCreate}>
-                <Plus /> Create project
-              </Button>
-            </div>
-          </div>
-        </div>
-      ) : (
-        <section className="space-y-3">
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {items.map((project) => (
-              <Link
-                key={project.id}
-                to={`/projects/${encodeURIComponent(project.id)}`}
-                className="group focus-visible:ring-ring/50 rounded-lg outline-none focus-visible:ring-3"
-              >
-                <Panel className="group-hover:border-foreground/20 group-hover:bg-muted/25 h-full transition-colors">
-                  <PanelContent className="flex items-center gap-3">
-                    <div className="bg-primary/10 text-primary flex size-10 shrink-0 items-center justify-center rounded-lg">
-                      <FolderKanban className="size-4" aria-hidden />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm font-medium">
-                        {project.name}
-                      </p>
-                      <p className="text-muted-foreground mt-0.5 text-xs">
-                        {project.agents.length}{' '}
-                        {project.agents.length === 1 ? 'agent' : 'agents'} ·{' '}
-                        {project.environments.length} environments
-                      </p>
-                    </div>
-                    <ChevronRight className="text-muted-foreground size-4 transition-transform group-hover:translate-x-0.5" />
-                  </PanelContent>
-                </Panel>
-              </Link>
-            ))}
-          </div>
-        </section>
-      )}
-
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <DialogContent className="sm:max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>
-              {createStep === 'choose'
-                ? 'Create project'
-                : 'Start from a template'}
-            </DialogTitle>
-            <DialogDescription>
-              {createStep === 'choose'
-                ? 'Deploy a working first agent now. You can add more agents later.'
-                : 'Choose an example or deploy another public GitHub repository.'}
-            </DialogDescription>
-          </DialogHeader>
-
-          {createStep === 'choose' ? (
-            <div className="grid gap-3 sm:grid-cols-2">
-              <button
-                type="button"
-                autoFocus
-                className="hover:bg-muted/40 focus-visible:ring-ring/50 rounded-lg border p-5 text-left outline-none focus-visible:ring-3"
-                onClick={() => {
-                  setDialogOpen(false)
-                  void navigate(
-                    templateDeployPath(HELLO_WORLD_TEMPLATE_REPOSITORY, true),
-                  )
-                }}
-              >
-                <Rocket className="text-primary mb-4 size-5" />
-                <p className="font-medium">From scratch</p>
-                <p className="text-muted-foreground mt-1 text-sm leading-5">
-                  Deploy a minimal Hello World and start its first Debug
-                  session.
-                </p>
-                <span className="text-primary mt-4 inline-flex items-center gap-1 text-sm font-medium">
-                  Quick start <ChevronRight className="size-4" />
-                </span>
-              </button>
-              <button
-                type="button"
-                className="hover:bg-muted/40 focus-visible:ring-ring/50 rounded-lg border p-5 text-left outline-none focus-visible:ring-3"
-                onClick={() => setCreateStep('templates')}
-              >
-                <FolderGit2 className="text-primary mb-4 size-5" />
-                <p className="font-medium">Start from a template</p>
-                <p className="text-muted-foreground mt-1 text-sm leading-5">
-                  Begin with a complete example and configure its integrations.
-                </p>
-                <span className="text-primary mt-4 inline-flex items-center gap-1 text-sm font-medium">
-                  Browse templates <ChevronRight className="size-4" />
-                </span>
-              </button>
-            </div>
-          ) : (
-            <div className="space-y-4">
-              <div className="grid max-h-[45vh] gap-2 overflow-y-auto pr-1 sm:grid-cols-2">
-                {CURATED_TEMPLATES.map((template) => (
-                  <button
-                    key={template.repositoryUrl}
-                    type="button"
-                    className="hover:bg-muted/40 focus-visible:ring-ring/50 rounded-lg border p-4 text-left outline-none focus-visible:ring-3"
-                    onClick={() => openTemplate(template.repositoryUrl)}
-                  >
-                    <p className="text-sm font-medium">{template.name}</p>
-                    <p className="text-muted-foreground mt-1 text-xs leading-5">
-                      {template.description}
+      <section className="space-y-3">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {items.map((project) => (
+            <Link
+              key={project.id}
+              to={`/projects/${encodeURIComponent(project.id)}`}
+              className="group focus-visible:ring-ring/50 rounded-lg outline-none focus-visible:ring-3"
+            >
+              <Panel className="group-hover:border-foreground/20 group-hover:bg-muted/25 h-full transition-colors">
+                <PanelContent className="flex items-center gap-3">
+                  <div className="bg-primary/10 text-primary flex size-10 shrink-0 items-center justify-center rounded-lg">
+                    <FolderKanban className="size-4" aria-hidden />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">
+                      {project.name}
                     </p>
-                  </button>
-                ))}
-              </div>
-              <form
-                className="flex gap-2 border-t pt-4"
-                onSubmit={submitRepository}
-              >
-                <Input
-                  value={repositoryUrl}
-                  onChange={(event) => setRepositoryUrl(event.target.value)}
-                  placeholder="https://github.com/owner/repository"
-                  aria-label="Template repository URL"
-                />
-                <Button type="submit" disabled={!repositoryUrl.trim()}>
-                  Continue
-                </Button>
-              </form>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => setCreateStep('choose')}
-              >
-                <ChevronLeft /> Back
-              </Button>
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
+                    <p className="text-muted-foreground mt-0.5 text-xs">
+                      {project.agents.length}{' '}
+                      {project.agents.length === 1 ? 'agent' : 'agents'} ·{' '}
+                      {project.environments.length} environments
+                    </p>
+                  </div>
+                  <ChevronRight className="text-muted-foreground size-4 transition-transform group-hover:translate-x-0.5" />
+                </PanelContent>
+              </Panel>
+            </Link>
+          ))}
+        </div>
+      </section>
     </div>
   )
 }

--- a/web/src/managed-agents/ProjectOnboarding.test.tsx
+++ b/web/src/managed-agents/ProjectOnboarding.test.tsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import ProjectOnboarding, {
+  CREATE_AGENT_PROMPT,
+  INSTALL_CLI_COMMAND,
+  LOGIN_COMMAND,
+} from './ProjectOnboarding'
+
+describe('project onboarding', () => {
+  it('presents the CLI-only three-step flow', () => {
+    const markup = renderToStaticMarkup(<ProjectOnboarding />)
+
+    expect(markup).toContain('Create your first agent')
+    expect(markup).toContain('Install the OpenComputer CLI')
+    expect(markup).toContain(INSTALL_CLI_COMMAND)
+    expect(markup).toContain('Sign in to OpenComputer')
+    expect(markup).toContain(LOGIN_COMMAND)
+    expect(markup).toContain('Codex, Claude Code, or OpenCode')
+    expect(markup).toContain(CREATE_AGENT_PROMPT)
+    expect(markup).not.toContain('template')
+    expect(markup).not.toContain('repository URL')
+  })
+})

--- a/web/src/managed-agents/ProjectOnboarding.tsx
+++ b/web/src/managed-agents/ProjectOnboarding.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from 'react'
+import { CopyRow } from '@/components/copy-row'
+import { PageHeader } from '@/components/page-header'
+
+export const INSTALL_CLI_COMMAND = 'npm i -g @opencomputer/cli'
+export const LOGIN_COMMAND = 'opencomputer login'
+export const CREATE_AGENT_PROMPT =
+  'Using the OpenComputer CLI, create my first agent which would [describe what you want it to do].'
+
+function OnboardingStep({
+  number,
+  title,
+  children,
+}: {
+  number: number
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <li className="relative grid grid-cols-[2.5rem_minmax(0,1fr)] gap-5 pb-12 last:pb-0">
+      <div className="bg-background z-10 flex size-10 items-center justify-center rounded-full border text-sm font-semibold shadow-sm">
+        {number}
+      </div>
+      <section className="max-w-3xl pt-1" aria-labelledby={`step-${number}`}>
+        <h2
+          id={`step-${number}`}
+          className="text-lg font-semibold tracking-tight"
+        >
+          {title}
+        </h2>
+        <div className="text-muted-foreground mt-3 space-y-4 text-sm leading-6">
+          {children}
+        </div>
+      </section>
+    </li>
+  )
+}
+
+export default function ProjectOnboarding() {
+  return (
+    <div className="mx-auto max-w-5xl">
+      <PageHeader
+        title="Create your first agent"
+        description="Start in your local workspace. Your project will appear here after its first deployment."
+        className="mb-10"
+      />
+
+      <ol className="before:bg-border relative before:absolute before:top-5 before:bottom-5 before:left-5 before:w-px">
+        <OnboardingStep number={1} title="Install the OpenComputer CLI">
+          <p>Install the CLI globally with npm.</p>
+          <CopyRow value={INSTALL_CLI_COMMAND} className="bg-background py-3" />
+        </OnboardingStep>
+
+        <OnboardingStep number={2} title="Sign in to OpenComputer">
+          <p>
+            Open a terminal in the directory where you want your agent to live,
+            then authenticate the CLI.
+          </p>
+          <CopyRow value={LOGIN_COMMAND} className="bg-background py-3" />
+        </OnboardingStep>
+
+        <OnboardingStep number={3} title="Create your first agent">
+          <p>
+            Open Codex, Claude Code, or OpenCode in that directory and paste
+            this prompt. Replace the bracketed text with what you want your
+            agent to do.
+          </p>
+          <CopyRow value={CREATE_AGENT_PROMPT} className="bg-background py-3" />
+          <p>
+            Your coding agent will guide you through creating and deploying the
+            project with the OpenComputer CLI. Return here when it finishes to
+            open the project.
+          </p>
+        </OnboardingStep>
+      </ol>
+    </div>
+  )
+}


### PR DESCRIPTION
## Outcome

Fresh users now get a focused three-step onboarding flow: install the CLI, run `opencomputer login`, then paste a copyable creation prompt into Codex, Claude Code, or OpenCode. Existing users see the same flow from **New project**.

Dashboard template and repository project creation are no longer reachable; project creation starts locally through the CLI.

## Review map

- `web/src/managed-agents/ProjectOnboarding.tsx`: shared three-step screen
- `web/src/managed-agents/Home.tsx`: zero-project and **New project** behavior
- `web/src/App.tsx`: onboarding route
- Product contract: https://github.com/diggerhq/serverless-agents-ws/pull/21

## Verification

- Focused tests: 10 passed
- Changed-file ESLint
- TypeScript typecheck
- Production dashboard build
- Deployed and smoke-tested at https://mo-oc-dev.com/new

## Rollout note

This branch was deployed only to the explicitly named `mo-oc-dev.com` development Worker.
