### PR TITLE
Restore template installation at /template

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,6 +34,7 @@ const ManagedAgentChannels = lazy(() => import('./managed-agents/Channels'))
 const ManagedProjectOnboarding = lazy(
   () => import('./managed-agents/ProjectOnboarding'),
 )
+const ManagedTemplateNew = lazy(() => import('./managed-agents/TemplateNew'))
 const ModelAccessCallback = lazy(
   () => import('./managed-agents/ModelAccessCallback'),
 )
@@ -84,6 +85,7 @@ export default function App() {
               element={<Navigate to="/new" replace />}
             />
             <Route path="new" element={<ManagedProjectOnboarding />} />
+            <Route path="template" element={<ManagedTemplateNew />} />
             <Route
               path="projects/:projectId"
               element={<ManagedProjectDetail />}

--- a/web/src/managed-agents/templates.test.ts
+++ b/web/src/managed-agents/templates.test.ts
@@ -8,7 +8,7 @@ import {
 describe('project creation templates', () => {
   it('keeps Hello World on the ordinary main-branch template path', () => {
     expect(templateDeployPath(HELLO_WORLD_TEMPLATE_REPOSITORY, true)).toBe(
-      '/new?repository-url=https%3A%2F%2Fgithub.com%2Fdiggerhq%2Fopencomputer-example-hello-world&quick-start=1',
+      '/template?repository-url=https%3A%2F%2Fgithub.com%2Fdiggerhq%2Fopencomputer-example-hello-world&quick-start=1',
     )
   })
 

--- a/web/src/managed-agents/templates.ts
+++ b/web/src/managed-agents/templates.ts
@@ -35,5 +35,5 @@ export const CURATED_TEMPLATES = [
 export function templateDeployPath(repositoryUrl: string, quickStart = false) {
   const query = new URLSearchParams({ 'repository-url': repositoryUrl })
   if (quickStart) query.set('quick-start', '1')
-  return `/new?${query.toString()}`
+  return `/template?${query.toString()}`
 }


### PR DESCRIPTION
## Outcome

Restores template deep links without reopening project creation from the dashboard:

- `/new` remains the CLI-first onboarding screen.
- `/template?repository-url=...` loads the existing reviewed template installation flow.
- Generated template links now target `/template`.

## Review map

- `web/src/App.tsx`: dedicated template route
- `web/src/managed-agents/templates.ts`: canonical template URL generation
- `web/src/managed-agents/templates.test.ts`: route regression coverage
- Product contract: https://github.com/diggerhq/serverless-agents-ws/pull/22

## Verification

- Focused onboarding and template tests: 5 passed
- Changed-file ESLint
- TypeScript typecheck
- Production dashboard build
- `git diff --check`
