### PR TITLE
Allow providers to invoke agent webhooks through credential URLs

### DIFF
--- a/.github/workflows/deploy-log-tail.yml
+++ b/.github/workflows/deploy-log-tail.yml
@@ -1,0 +1,55 @@
+name: Deploy log tail
+
+# The collector receives every console line and exception from the API edge
+# and events-ingest Workers and forwards them to Axiom. It redacts webhook
+# credentials on the way, so it must be live before the edge starts issuing
+# credential-bearing webhook URLs: to release in that order, run this
+# workflow by hand from the branch first, then merge.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cloudflare-workers/log-tail/**'
+      - '.github/workflows/deploy-log-tail.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-log-tail
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy log tail
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: cloudflare-workers/log-tail
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: cloudflare-workers/log-tail/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Deploy opencomputer-log-tail-prod
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "CLOUDFLARE_API_TOKEN GitHub secret is required for Wrangler deploys" >&2
+            exit 1
+          fi
+          # AXIOM_TOKEN is a Worker secret set once with `wrangler secret put`;
+          # --keep-vars leaves it and any dashboard-set vars in place.
+          npm run deploy:prod

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/cli",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "dependencies": {
         "@opencode-ai/sdk": "1.18.4",
         "ai": "^7.0.45",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Build, test, deploy, and share OpenComputer agents as code.",
   "type": "module",
   "bin": {

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -169,6 +169,8 @@ export interface ManagedAgentWebhook {
   agentId: string;
   name: string;
   enabled: boolean;
+  /** Delivery identity source, `header:<name>` or `body:<json-pointer>`. */
+  identity?: string;
   invocationUrl: string;
   token?: string;
   createdAt: string;
@@ -630,6 +632,7 @@ export class OpenComputerClient {
     name: string;
     environment: "development" | "production";
     agentId: string;
+    identity?: string;
   }) {
     return this.request<{ webhook: ManagedAgentWebhook }>(
       `/api/managed-agents/projects/${encodeURIComponent(input.projectId)}/webhooks`,
@@ -639,6 +642,7 @@ export class OpenComputerClient {
           name: input.name,
           environment: input.environment,
           agentId: input.agentId,
+          ...(input.identity !== undefined ? { identity: input.identity } : {}),
         }),
       },
     ).then((result) => result.webhook);
@@ -649,6 +653,8 @@ export class OpenComputerClient {
     webhookId: string;
     name?: string;
     enabled?: boolean;
+    /** A source sets it; null clears it. */
+    identity?: string | null;
   }) {
     return this.request<{ webhook: ManagedAgentWebhook }>(
       `/api/managed-agents/projects/${encodeURIComponent(input.projectId)}/webhooks/${encodeURIComponent(input.webhookId)}`,
@@ -657,6 +663,7 @@ export class OpenComputerClient {
         body: JSON.stringify({
           ...(input.name !== undefined ? { name: input.name } : {}),
           ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
+          ...(input.identity !== undefined ? { identity: input.identity } : {}),
         }),
       },
     ).then((result) => result.webhook);

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1408,8 +1408,9 @@ export async function runCommand(
           `${existing ? "Reused" : "Created"} ${webhook.name} (${webhook.id}) for ${agentId}@${environment}.\n` +
             `URL: ${webhook.invocationUrl}\n` +
             (existing
-              ? "The existing token remains unchanged.\n"
-              : `Token: ${webhook.token ?? "unavailable"}\nSave this token now. It will not be shown again.\n`),
+              ? "The existing token remains unchanged; this URL omits it.\n"
+              : `Token: ${webhook.token ?? "unavailable"}\n` +
+                "Save this URL now. It carries the token and will not be shown again.\n"),
         );
       }
       return;
@@ -1442,8 +1443,9 @@ export async function runCommand(
       else {
         process.stdout.write(
           `Rotated the token for ${webhook.name}.\n` +
+            `URL: ${webhook.invocationUrl}\n` +
             `Token: ${webhook.token ?? "unavailable"}\n` +
-            "Save this token now. The previous token no longer works.\n",
+            "Save this URL now. The previous token and URL no longer work.\n",
         );
       }
       return;

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -1378,7 +1378,9 @@ export async function runCommand(
         for (const webhook of webhooks) {
           process.stdout.write(
             `${webhook.id}  ${webhook.enabled ? "enabled " : "disabled"}  ` +
-              `${webhook.name}  ${webhook.invocationUrl}\n`,
+              `${webhook.name}  ${webhook.invocationUrl}` +
+              (webhook.identity ? `  identity=${webhook.identity}` : "") +
+              "\n",
           );
         }
       }
@@ -1386,8 +1388,9 @@ export async function runCommand(
     }
     if (action === "create") {
       const name = args.shift()?.trim();
+      const identity = option(args, "--identity");
       if (!name || args.length) {
-        throw new Error("Use `opencomputer webhooks create <name>`.");
+        throw new Error("Use `opencomputer webhooks create <name> [--identity header:<name>|body:<json-pointer>]`.");
       }
       const existing = (await client.webhooks({
         projectId: project.projectId,
@@ -1401,12 +1404,14 @@ export async function runCommand(
           name,
           environment,
           agentId,
+          ...(identity ? { identity } : {}),
         }));
       if (globals.json) printJSON({ ...webhook, reused: Boolean(existing) });
       else {
         process.stdout.write(
           `${existing ? "Reused" : "Created"} ${webhook.name} (${webhook.id}) for ${agentId}@${environment}.\n` +
             `URL: ${webhook.invocationUrl}\n` +
+            (webhook.identity ? `Identity: ${webhook.identity}\n` : "") +
             (existing
               ? "The existing token remains unchanged; this URL omits it.\n"
               : `Token: ${webhook.token ?? "unavailable"}\n` +
@@ -1416,10 +1421,29 @@ export async function runCommand(
       return;
     }
     const webhookId = args.shift();
+    const identityOption = action === "update" ? option(args, "--identity") : undefined;
     if (!webhookId || args.length) {
       throw new Error(
-        "Use `opencomputer webhooks list|create|enable|disable|rotate-token|remove`.",
+        "Use `opencomputer webhooks list|create|update|enable|disable|rotate-token|remove`.",
       );
+    }
+    if (action === "update") {
+      if (identityOption === undefined) {
+        throw new Error("Use `opencomputer webhooks update <id> --identity header:<name>|body:<json-pointer>|none`.");
+      }
+      const webhook = await client.updateWebhook({
+        projectId: project.projectId,
+        webhookId,
+        identity: identityOption === "none" ? null : identityOption,
+      });
+      if (globals.json) printJSON(webhook);
+      else
+        process.stdout.write(
+          webhook.identity
+            ? `${webhook.name} now takes its delivery identity from ${webhook.identity}.\n`
+            : `${webhook.name} now treats every delivery without an Idempotency-Key as new.\n`,
+        );
+      return;
     }
     if (action === "enable" || action === "disable") {
       const webhook = await client.updateWebhook({
@@ -1457,7 +1481,7 @@ export async function runCommand(
       return;
     }
     throw new Error(
-      "Use `opencomputer webhooks list|create|enable|disable|rotate-token|remove`.",
+      "Use `opencomputer webhooks list|create|update|enable|disable|rotate-token|remove`.",
     );
   }
 

--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -379,7 +379,8 @@ describe("managed agents proxy", () => {
         const headers = new Headers(init?.headers);
         expect(headers.get("authorization")).toBeNull();
         expect(headers.get("request-id")).toBe("sentry-delivery-1");
-        expect(headers.get("sentry-hook-resource")).toBeNull();
+        expect(headers.get("sentry-hook-resource")).toBe("event_alert");
+        expect(headers.get("sentry-hook-signature")).toBeNull();
         expect(await new Response(init?.body).json()).toEqual(sentryBody);
         return Response.json({
           request: {
@@ -408,6 +409,7 @@ describe("managed agents proxy", () => {
             "content-type": "application/json",
             "request-id": "sentry-delivery-1",
             "sentry-hook-resource": "event_alert",
+            "sentry-hook-signature": "abc",
           },
           body: JSON.stringify(sentryBody),
         },

--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -378,9 +378,17 @@ describe("managed agents proxy", () => {
         );
         const headers = new Headers(init?.headers);
         expect(headers.get("authorization")).toBeNull();
+        // The sender's own headers reach the backend, which reads whichever
+        // one the webhook is configured to use as its identity.
         expect(headers.get("request-id")).toBe("sentry-delivery-1");
         expect(headers.get("sentry-hook-resource")).toBe("event_alert");
-        expect(headers.get("sentry-hook-signature")).toBeNull();
+        expect(headers.get("sentry-hook-signature")).toBe("abc");
+        // Credentials, transport, and edge-trusted headers do not.
+        expect(headers.get("cookie")).toBeNull();
+        expect(headers.get("x-oc-managed-sig")).toBeNull();
+        expect(headers.get("x-api-key")).toBeNull();
+        expect(headers.get("x-forwarded-for")).toBeNull();
+        expect(headers.get("x-request-id")).not.toBe("spoofed");
         expect(await new Response(init?.body).json()).toEqual(sentryBody);
         return Response.json({
           request: {
@@ -410,6 +418,11 @@ describe("managed agents proxy", () => {
             "request-id": "sentry-delivery-1",
             "sentry-hook-resource": "event_alert",
             "sentry-hook-signature": "abc",
+            cookie: "session=1",
+            "x-oc-managed-sig": "forged",
+            "x-api-key": "forged",
+            "x-forwarded-for": "1.2.3.4",
+            "x-request-id": "spoofed",
           },
           body: JSON.stringify(sentryBody),
         },

--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -365,6 +365,78 @@ describe("managed agents proxy", () => {
     expect(JSON.stringify(body)).not.toContain("internal");
   });
 
+  it("forwards a URL-credential delivery with the provider's delivery id and no bearer header", async () => {
+    const sentryBody = {
+      action: "triggered",
+      data: { event: { event_id: "a".repeat(32) } },
+      installation: { uuid: "inst" },
+    };
+    const fetchSpy = vi.fn(
+      async (target: URL | RequestInfo, init?: RequestInit) => {
+        expect(String(target)).toBe(
+          "https://managedagents.test/v1/agent-webhooks/wh_0123456789abcdef0123456789abcdef/ocwh_token-segment_0123456789",
+        );
+        const headers = new Headers(init?.headers);
+        expect(headers.get("authorization")).toBeNull();
+        expect(headers.get("request-id")).toBe("sentry-delivery-1");
+        expect(headers.get("sentry-hook-resource")).toBeNull();
+        expect(await new Response(init?.body).json()).toEqual(sentryBody);
+        return Response.json({
+          request: {
+            id: "whr_request",
+            webhookId: "wh_0123456789abcdef0123456789abcdef",
+            projectId: "prj_test",
+            environment: "development",
+            agentId: "oncall",
+            sessionId: "session_pending",
+            outcome: "pending",
+            attempt: 0,
+            createdAt: "2026-09-08T00:00:00.000Z",
+            updatedAt: "2026-09-08T00:00:00.000Z",
+          },
+        }, { status: 202 });
+      },
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const response = await handleAgentWebhookInvocation(
+      new Request(
+        "https://app.opencomputer.dev/api/agent-webhooks/wh_0123456789abcdef0123456789abcdef/ocwh_token-segment_0123456789",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "request-id": "sentry-delivery-1",
+            "sentry-hook-resource": "event_alert",
+          },
+          body: JSON.stringify(sentryBody),
+        },
+      ),
+      { MANAGED_AGENTS_API_URL: "https://managedagents.test" },
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      request: { sessionId: "session_pending", outcome: "pending" },
+      sessionUrl:
+        "https://app.opencomputer.dev/projects/prj_test/sessions/session_pending?agent=oncall&environment=development",
+    });
+  });
+
+  it("rejects a malformed path token before reaching the backend", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    const response = await handleAgentWebhookInvocation(
+      new Request(
+        "https://app.opencomputer.dev/api/agent-webhooks/wh_0123456789abcdef0123456789abcdef/bad%20token",
+        { method: "POST", headers: { "content-type": "application/json" }, body: "{}" },
+      ),
+      {},
+    );
+    expect(response.status).toBe(404);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("rejects webhook calls without bearer credentials", async () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal("fetch", fetchSpy);

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -476,6 +476,7 @@ function publicWebhook(
     agentId: webhook.agentId,
     name: webhook.name,
     enabled: webhook.enabled,
+    ...(typeof webhook.identity === "string" ? { identity: webhook.identity } : {}),
     // The token is the credential; when this response carries it (create,
     // rotate), the URL carries it too and is shown once. Listings never do.
     ...(publicOrigin && id
@@ -1346,17 +1347,29 @@ export async function handleManagedAgentChannelConnection(
   });
 }
 
-// Headers that carry or select a delivery identity; the backend decides
-// precedence (Sentry deliveries are identified by the alerted object named
-// by `sentry-hook-resource`, not by the per-attempt `request-id`).
-const WEBHOOK_DELIVERY_ID_HEADERS = [
-  "idempotency-key",
-  "sentry-hook-resource",
-  "x-github-delivery",
-  "stripe-signature",
-  "svix-id",
-  "request-id",
-] as const;
+// A webhook may read its delivery identity from any request header the
+// sender chose at configuration time, so the sender's headers pass through
+// except credentials, transport headers, and anything the backend trusts
+// from this edge.
+const WEBHOOK_HEADERS_NOT_FORWARDED = new Set([
+  "authorization",
+  "cookie",
+  "host",
+  "content-length",
+  "connection",
+  "transfer-encoding",
+  "x-request-id",
+  "x-api-key",
+]);
+const WEBHOOK_HEADER_PREFIXES_NOT_FORWARDED = ["x-oc-", "cf-", "x-forwarded-", "x-real-"];
+
+function forwardableWebhookHeader(name: string): boolean {
+  const lower = name.toLowerCase();
+  return (
+    !WEBHOOK_HEADERS_NOT_FORWARDED.has(lower) &&
+    !WEBHOOK_HEADER_PREFIXES_NOT_FORWARDED.some((prefix) => lower.startsWith(prefix))
+  );
+}
 
 export async function handleAgentWebhookInvocation(
   request: Request,
@@ -1420,9 +1433,8 @@ export async function handleAgentWebhookInvocation(
     "x-request-id": crypto.randomUUID(),
   });
   if (authorization) headers.set("authorization", authorization);
-  for (const header of WEBHOOK_DELIVERY_ID_HEADERS) {
-    const value = request.headers.get(header);
-    if (value) headers.set(header, value);
+  for (const [name, value] of request.headers) {
+    if (forwardableWebhookHeader(name) && !headers.has(name)) headers.set(name, value);
   }
   try {
     const upstream = await fetch(target, {

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -476,9 +476,15 @@ function publicWebhook(
     agentId: webhook.agentId,
     name: webhook.name,
     enabled: webhook.enabled,
+    // The token is the credential; when this response carries it (create,
+    // rotate), the URL carries it too and is shown once. Listings never do.
     ...(publicOrigin && id
       ? {
-          invocationUrl: `${publicOrigin}/api/agent-webhooks/${encodeURIComponent(id)}`,
+          invocationUrl:
+            `${publicOrigin}/api/agent-webhooks/${encodeURIComponent(id)}` +
+            (typeof webhook.token === "string"
+              ? `/${encodeURIComponent(webhook.token)}`
+              : ""),
         }
       : {}),
     ...(typeof webhook.token === "string" ? { token: webhook.token } : {}),
@@ -1340,12 +1346,21 @@ export async function handleManagedAgentChannelConnection(
   });
 }
 
+const WEBHOOK_DELIVERY_ID_HEADERS = [
+  "idempotency-key",
+  "request-id",
+  "x-github-delivery",
+  "svix-id",
+] as const;
+
 export async function handleAgentWebhookInvocation(
   request: Request,
   env: ManagedAgentsEnv,
 ): Promise<Response> {
   const url = new URL(request.url);
-  const match = url.pathname.match(/^\/api\/agent-webhooks\/([^/]+)$/);
+  const match = url.pathname.match(
+    /^\/api\/agent-webhooks\/([^/]+)(?:\/([^/]+))?$/,
+  );
   if (!match?.[1] || request.method !== "POST") {
     return Response.json(
       { error: { code: "not_found", message: "Webhook not found." } },
@@ -1353,14 +1368,20 @@ export async function handleAgentWebhookInvocation(
     );
   }
   const webhookId = match[1];
-  if (!/^wh_[a-f0-9]{32}$/.test(webhookId)) {
+  const pathToken = match[2];
+  if (
+    !/^wh_[a-f0-9]{32}$/.test(webhookId) ||
+    (pathToken !== undefined && !/^[A-Za-z0-9_-]{16,128}$/.test(pathToken))
+  ) {
     return Response.json(
       { error: { code: "not_found", message: "Webhook not found." } },
       { status: 404 },
     );
   }
+  // The credential is the token: in the path, or as a bearer header for
+  // senders that can set one. Providers that can do neither use the URL.
   const authorization = request.headers.get("authorization");
-  if (!authorization?.startsWith("Bearer ")) {
+  if (!pathToken && !authorization?.startsWith("Bearer ")) {
     return Response.json(
       {
         error: {
@@ -1375,7 +1396,8 @@ export async function handleAgentWebhookInvocation(
     env.MANAGED_AGENTS_API_URL ?? DEFAULT_MANAGED_AGENTS_API_URL
   ).replace(/\/+$/, "");
   const target = new URL(
-    `${base}/v1/agent-webhooks/${encodeURIComponent(webhookId)}`,
+    `${base}/v1/agent-webhooks/${encodeURIComponent(webhookId)}` +
+      (pathToken ? `/${encodeURIComponent(pathToken)}` : ""),
   );
   if (target.protocol !== "https:" && target.hostname !== "localhost") {
     return Response.json(
@@ -1389,12 +1411,16 @@ export async function handleAgentWebhookInvocation(
     );
   }
   const headers = new Headers({
-    authorization,
     "content-type": request.headers.get("content-type") ?? "application/json",
     "x-request-id": crypto.randomUUID(),
   });
-  const idempotencyKey = request.headers.get("idempotency-key");
-  if (idempotencyKey) headers.set("idempotency-key", idempotencyKey);
+  if (authorization) headers.set("authorization", authorization);
+  // Delivery identity, in the backend's order of precedence: the caller's
+  // key, else the delivery id a provider sends.
+  for (const header of WEBHOOK_DELIVERY_ID_HEADERS) {
+    const value = request.headers.get(header);
+    if (value) headers.set(header, value);
+  }
   try {
     const upstream = await fetch(target, {
       method: "POST",

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -506,6 +506,8 @@ function publicWebhookRequest(value: unknown): Record<string, unknown> {
     deploymentId: request.deploymentId,
     sessionId: request.sessionId,
     outcome: request.outcome,
+    ...(typeof request.attempt === "number" ? { attempt: request.attempt } : {}),
+    ...(request.terminal === true ? { terminal: true } : {}),
     ...(request.error
       ? { error: "The webhook request could not start a session." }
       : {}),
@@ -1350,7 +1352,8 @@ export async function handleManagedAgentChannelConnection(
 // A webhook may read its delivery identity from any request header the
 // sender chose at configuration time, so the sender's headers pass through
 // except credentials, transport headers, and anything the backend trusts
-// from this edge.
+// from this edge. The backend rejects identity sources naming these headers
+// (`bluecode/src/edge/webhook-input.ts`); change both together.
 const WEBHOOK_HEADERS_NOT_FORWARDED = new Set([
   "authorization",
   "cookie",

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -1346,11 +1346,16 @@ export async function handleManagedAgentChannelConnection(
   });
 }
 
+// Headers that carry or select a delivery identity; the backend decides
+// precedence (Sentry deliveries are identified by the alerted object named
+// by `sentry-hook-resource`, not by the per-attempt `request-id`).
 const WEBHOOK_DELIVERY_ID_HEADERS = [
   "idempotency-key",
-  "request-id",
+  "sentry-hook-resource",
   "x-github-delivery",
+  "stripe-signature",
   "svix-id",
+  "request-id",
 ] as const;
 
 export async function handleAgentWebhookInvocation(
@@ -1415,8 +1420,6 @@ export async function handleAgentWebhookInvocation(
     "x-request-id": crypto.randomUUID(),
   });
   if (authorization) headers.set("authorization", authorization);
-  // Delivery identity, in the backend's order of precedence: the caller's
-  // key, else the delivery id a provider sends.
   for (const header of WEBHOOK_DELIVERY_ID_HEADERS) {
     const value = request.headers.get(header);
     if (value) headers.set(header, value);

--- a/cloudflare-workers/log-tail/package-lock.json
+++ b/cloudflare-workers/log-tail/package-lock.json
@@ -1,0 +1,1542 @@
+{
+  "name": "opencomputer-log-tail",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "opencomputer-log-tail",
+      "version": "0.0.0",
+      "devDependencies": {
+        "wrangler": "^4.92.0"
+      },
+      "engines": {
+        "node": ">=22.6"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260908.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260908.1.tgz",
+      "integrity": "sha512-t3juyCXFn12OklBL0S7UC98py3nLEmuioBOUOazeyeVsLUu8fv+pfJrR+XzwSH2Uh6rCXZNogRh+LtV0YpzMcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260908.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260908.1.tgz",
+      "integrity": "sha512-I1nwA4qm/fUNSKhPSO76YA6JAhcA0KU63yFcYHN6AiDowGbDyfjDPH9KCVopT5rI1LY4GfbdAi5b9gODqZsAkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260908.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260908.1.tgz",
+      "integrity": "sha512-s/h5uSW1UC6dGeVKSqrPLpTu+vo0fKJZCNEokW1Ol1qcCB2oN6WCRHhoyzo4Y69oONAXRgLfLBYaHWe7z51Vnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260908.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260908.1.tgz",
+      "integrity": "sha512-PP/nUKl0R6colwfocggL8dctO/dFMqMft12unzFUkoAJr0aXQeT+ia0JuNmOUWXe6EfvyCSmAbijEsTKQ5t/ew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260908.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260908.1.tgz",
+      "integrity": "sha512-jkaS5EKKTvzAdIlbMfOYrHoTucWVRwYBwIig+xRsjXQv5BXTLA2Llg+iM8djlKtk0CjkztZhXmuxuqoqWKZmFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260908.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260908.0-alpha.tgz",
+      "integrity": "sha512-BHIknb0u6vLIvb+R8PsUAzgoWWk3OlW85DrV2SG0EydfSpIba28YT0rH6xZThjnSwDxzNuW3FDRNSWvbiI/DVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260908.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260908.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260908.1.tgz",
+      "integrity": "sha512-rYhpW6NWHD++p34ej+VXWzi5Pdnmd7ncdbB/ux4s+i3mf7IeOpW3O4roqClQ+Z8ernvyMCknBLCb76z1rA+a7Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260908.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260908.1",
+        "@cloudflare/workerd-linux-64": "1.20260908.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260908.1",
+        "@cloudflare/workerd-windows-64": "1.20260908.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.130.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.130.0.tgz",
+      "integrity": "sha512-fzNjnTzyZl31PGJOFXbiLeZqEIToQ9KOzkkvGdQz4wlB+BoHnl3BRwCR5xg8AqYyzVunvvMHlMzvlbThQ7rrAA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260908.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260908.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260908.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/cloudflare-workers/log-tail/package.json
+++ b/cloudflare-workers/log-tail/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "opencomputer-log-tail",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Tail consumer that forwards Worker console output and exceptions to Axiom with credentials redacted.",
+  "type": "module",
+  "engines": { "node": ">=22.6" },
+  "scripts": {
+    "test": "node --test --experimental-strip-types src/index.test.ts",
+    "deploy:prod": "wrangler deploy -c wrangler.prod.toml --keep-vars",
+    "deploy:dev": "wrangler deploy -c wrangler.toml --keep-vars"
+  },
+  "devDependencies": {
+    "wrangler": "^4.92.0"
+  }
+}

--- a/cloudflare-workers/log-tail/src/index.test.ts
+++ b/cloudflare-workers/log-tail/src/index.test.ts
@@ -45,6 +45,59 @@ test("records a silent HTTP 5xx even when the invocation outcome is ok", async (
   assert.equal(JSON.stringify(records[0]).includes("password"), false);
 });
 
+test("redacts the webhook credential segment from request URLs", async () => {
+  const originalFetch = globalThis.fetch;
+  let records: Array<Record<string, unknown>> = [];
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    records = JSON.parse(String(init?.body));
+    return new Response(null, { status: 200 });
+  }) as typeof fetch;
+  const token = "ocwh_dummy-credential-segment_0123456789";
+
+  try {
+    await worker.tail([{
+      scriptName: "api-edge",
+      outcome: "ok",
+      eventTimestamp: Date.parse("2026-09-08T20:00:00Z"),
+      event: {
+        request: {
+          method: "POST",
+          url: `https://app.opencomputer.dev/api/agent-webhooks/wh_0123456789abcdef0123456789abcdef/${token}`,
+        },
+        response: { status: 502 },
+      },
+      logs: [],
+      exceptions: [],
+    }, {
+      scriptName: "managed-agents",
+      outcome: "ok",
+      eventTimestamp: Date.parse("2026-09-08T20:00:01Z"),
+      event: {
+        request: {
+          method: "POST",
+          url: `https://managedagents.example/v1/agent-webhooks/wh_0123456789abcdef0123456789abcdef/${token}`,
+        },
+        response: { status: 502 },
+      },
+      logs: [],
+      exceptions: [],
+    }], env, {} as ExecutionContext);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(records.length, 2);
+  assert.equal(
+    records[0]?.request_url,
+    "https://app.opencomputer.dev/api/agent-webhooks/wh_0123456789abcdef0123456789abcdef/redacted",
+  );
+  assert.equal(
+    records[1]?.request_url,
+    "https://managedagents.example/v1/agent-webhooks/wh_0123456789abcdef0123456789abcdef/redacted",
+  );
+  assert.equal(JSON.stringify(records).includes(token), false);
+});
+
 test("fails the collector invocation when the durable sink rejects a batch", async () => {
   const originalFetch = globalThis.fetch;
   const originalConsoleError = console.error;

--- a/cloudflare-workers/log-tail/src/index.test.ts
+++ b/cloudflare-workers/log-tail/src/index.test.ts
@@ -94,12 +94,31 @@ test("redacts the webhook credential segment from request URLs", async () => {
       },
       logs: [],
       exceptions: [],
+    }, {
+      scriptName: "managed-agents",
+      outcome: "ok",
+      eventTimestamp: Date.parse("2026-09-08T20:00:03Z"),
+      event: {
+        request: { method: "POST", url: "https://managedagents.example/v1/other" },
+        response: { status: 500 },
+      },
+      // A console message that quoted the path, as an unredacted emitter would.
+      logs: [{
+        level: "error",
+        timestamp: Date.parse("2026-09-08T20:00:03Z"),
+        message: [`{"event":"edge.request_failed","path":"/v1/agent-webhooks/wh_0123456789abcdef0123456789abcdef/${token}"}`],
+      }],
+      exceptions: [],
     }], env, {} as ExecutionContext);
   } finally {
     globalThis.fetch = originalFetch;
   }
 
-  assert.equal(records.length, 3);
+  assert.equal(records.length, 4);
+  assert.equal(
+    records[3]?.msg,
+    `{"event":"edge.request_failed","path":"/v1/agent-webhooks/wh_0123456789abcdef0123456789abcdef/redacted"}`,
+  );
   assert.equal(
     records[2]?.request_url,
     "https://app.opencomputer.dev/api/agent-webhooks/wh_0123456789abcdef0123456789abcdef/redacted",

--- a/cloudflare-workers/log-tail/src/index.test.ts
+++ b/cloudflare-workers/log-tail/src/index.test.ts
@@ -81,12 +81,29 @@ test("redacts the webhook credential segment from request URLs", async () => {
       },
       logs: [],
       exceptions: [],
+    }, {
+      scriptName: "api-edge",
+      outcome: "ok",
+      eventTimestamp: Date.parse("2026-09-08T20:00:02Z"),
+      event: {
+        request: {
+          method: "POST",
+          url: `https://app.opencomputer.dev/api/agent-webhooks/wh_0123456789abcdef0123456789abcdef/${token}/extra/`,
+        },
+        response: { status: 502 },
+      },
+      logs: [],
+      exceptions: [],
     }], env, {} as ExecutionContext);
   } finally {
     globalThis.fetch = originalFetch;
   }
 
-  assert.equal(records.length, 2);
+  assert.equal(records.length, 3);
+  assert.equal(
+    records[2]?.request_url,
+    "https://app.opencomputer.dev/api/agent-webhooks/wh_0123456789abcdef0123456789abcdef/redacted",
+  );
   assert.equal(
     records[0]?.request_url,
     "https://app.opencomputer.dev/api/agent-webhooks/wh_0123456789abcdef0123456789abcdef/redacted",

--- a/cloudflare-workers/log-tail/src/index.ts
+++ b/cloudflare-workers/log-tail/src/index.ts
@@ -54,8 +54,13 @@ function safeStringify(v: unknown): string {
   catch { return String(v); }
 }
 
-// Request query strings can carry browser client tokens (`?token=...`). Keep
-// the route useful for diagnostics without copying credentials into Axiom.
+// Agent webhook URLs carry their credential as the last path segment
+// (public `/api/agent-webhooks/<id>/<token>`, backend `/v1/agent-webhooks/<id>/<token>`).
+const WEBHOOK_TOKEN_PATH = /^(\/(?:api|v1)\/agent-webhooks\/[^/]+)\/[^/]+$/;
+
+// Request query strings can carry browser client tokens (`?token=...`), and
+// webhook paths carry the webhook credential. Keep the route useful for
+// diagnostics without copying credentials into Axiom.
 function requestUrlForLogs(value?: string): string | undefined {
   if (!value) return undefined;
   try {
@@ -64,6 +69,7 @@ function requestUrlForLogs(value?: string): string | undefined {
     url.password = "";
     url.search = "";
     url.hash = "";
+    url.pathname = url.pathname.replace(WEBHOOK_TOKEN_PATH, "$1/redacted");
     return url.toString();
   } catch {
     return undefined;

--- a/cloudflare-workers/log-tail/src/index.ts
+++ b/cloudflare-workers/log-tail/src/index.ts
@@ -44,9 +44,11 @@ interface TraceItem {
 }
 
 function fmtMessage(parts: unknown[]): string {
-  return parts
-    .map((p) => (typeof p === "string" ? p : safeStringify(p)))
-    .join(" ");
+  return redactWebhookTokens(
+    parts
+      .map((p) => (typeof p === "string" ? p : safeStringify(p)))
+      .join(" "),
+  );
 }
 
 function safeStringify(v: unknown): string {
@@ -58,6 +60,13 @@ function safeStringify(v: unknown): string {
 // `/api/agent-webhooks/<id>/<token>`, backend `/v1/agent-webhooks/<id>/<token>`).
 // Everything after the id is redacted, whatever suffix a malformed request adds.
 const WEBHOOK_TOKEN_PATH = /^(\/(?:api|v1)\/agent-webhooks\/[^/]+)\/.*$/;
+// The same credential position anywhere in free text (a console message or
+// an exception that quoted the path). Defense in depth: emitters redact too.
+const WEBHOOK_TOKEN_IN_TEXT = /(\/(?:api|v1)\/agent-webhooks\/wh_[a-f0-9]{32})\/[^\s"'\\]+/g;
+
+function redactWebhookTokens(text: string): string {
+  return text.replace(WEBHOOK_TOKEN_IN_TEXT, "$1/redacted");
+}
 
 // Request query strings can carry browser client tokens (`?token=...`), and
 // webhook paths carry the webhook credential. Keep the route useful for
@@ -121,7 +130,7 @@ export default {
           _time: new Date(ex.timestamp).toISOString(),
           time: new Date(ex.timestamp).toISOString(),
           level: "ERROR",
-          msg: `${ex.name}: ${ex.message}`,
+          msg: redactWebhookTokens(`${ex.name}: ${ex.message}`),
           stack: ex.stack,
           ...baseEnvelope,
         });

--- a/cloudflare-workers/log-tail/src/index.ts
+++ b/cloudflare-workers/log-tail/src/index.ts
@@ -54,9 +54,10 @@ function safeStringify(v: unknown): string {
   catch { return String(v); }
 }
 
-// Agent webhook URLs carry their credential as the last path segment
-// (public `/api/agent-webhooks/<id>/<token>`, backend `/v1/agent-webhooks/<id>/<token>`).
-const WEBHOOK_TOKEN_PATH = /^(\/(?:api|v1)\/agent-webhooks\/[^/]+)\/[^/]+$/;
+// Agent webhook URLs carry their credential after the webhook id (public
+// `/api/agent-webhooks/<id>/<token>`, backend `/v1/agent-webhooks/<id>/<token>`).
+// Everything after the id is redacted, whatever suffix a malformed request adds.
+const WEBHOOK_TOKEN_PATH = /^(\/(?:api|v1)\/agent-webhooks\/[^/]+)\/.*$/;
 
 // Request query strings can carry browser client tokens (`?token=...`), and
 // webhook paths carry the webhook credential. Keep the route useful for

--- a/cloudflare-workers/log-tail/wrangler.prod.toml
+++ b/cloudflare-workers/log-tail/wrangler.prod.toml
@@ -1,7 +1,8 @@
 # log-tail Worker — PROD on Mo's CF account.
 # Tail consumer for opencomputer-edge-prod + opencomputer-events-ingest-prod.
 # Forwards console output + exceptions to Axiom dataset oc-platform-edge.
-# Deploy: `wrangler deploy -c wrangler.prod.toml`
+# Deployed by .github/workflows/deploy-log-tail.yml on push to main; manually:
+# `npm run deploy:prod` (needs CLOUDFLARE_API_TOKEN for this account).
 
 name = "opencomputer-log-tail-prod"
 main = "src/index.ts"

--- a/create-start/package.json
+++ b/create-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/create-start",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Create a hello-world OpenComputer agent application.",
   "type": "module",
   "bin": {
@@ -18,7 +18,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@opencomputer/cli": "0.6.7"
+    "@opencomputer/cli": "0.6.8"
   },
   "publishConfig": {
     "access": "public"

--- a/docs/agents/webhooks.mdx
+++ b/docs/agents/webhooks.mdx
@@ -66,15 +66,25 @@ The response is HTTP 202 with the request, session ID, and dashboard session
 URL. It is sent as soon as the delivery is stored; the session starts
 afterwards, so the response arrives within Sentry's and GitHub's timeouts.
 The request's `outcome` is `pending` in the response and becomes `accepted`
-once the session is running, or `failed` after the platform has retried the
-start for about forty minutes. The dashboard's Webhooks tab lists requests
-with their outcomes.
+once the session is running, or `failed` after five start attempts over
+about thirteen minutes. Read outcomes from the request ledger with your API
+key; the session id there is authoritative, since a retried start can use a
+different session than the one first announced:
+
+```bash
+curl 'https://app.opencomputer.dev/api/managed-agents/projects/<project-id>/webhooks/<webhook-id>/requests?environment=production' \
+  -H 'Authorization: Bearer <api-key>'
+```
 
 Each delivery needs an identity so that a retry does not start a second
-session. OpenComputer uses the first present of `Idempotency-Key`,
-`Request-ID` (Sentry), `X-GitHub-Delivery`, and `Svix-Id`. Retrying the same
-body with the same identity returns the original request and session; if
-that request had failed to start, the retry starts it again.
+session. OpenComputer uses the first available of: your `Idempotency-Key`;
+for Sentry, the alerted event or issue named in the body together with the
+`Sentry-Hook-Resource` header, which stays the same across Sentry's retries
+while its `Request-ID` does not; `X-GitHub-Delivery`; for Stripe, the event
+id in the body; `Svix-Id`; and finally `Request-ID`. Retrying with the same
+identity and body returns the original request and session; if that request
+had failed to start, the retry starts it again. A body larger than 256 KiB
+once wrapped as agent input is rejected with 400 before acknowledgement.
 
 ## Read webhook input
 

--- a/docs/agents/webhooks.mdx
+++ b/docs/agents/webhooks.mdx
@@ -64,7 +64,7 @@ credential.
 
 The response is HTTP 202 with the request, session ID, and dashboard session
 URL. It is sent as soon as the delivery is stored; the session starts
-afterwards, so the response arrives within Sentry's and GitHub's timeouts.
+afterwards, so acknowledgement does not wait for a runtime.
 The request's `outcome` is `pending` in the response and becomes `accepted`
 once the session is running, or `failed` after five start attempts over
 about thirteen minutes. Read outcomes from the request ledger with your API
@@ -78,13 +78,16 @@ curl 'https://app.opencomputer.dev/api/managed-agents/projects/<project-id>/webh
 
 Each delivery needs an identity so that a retry does not start a second
 session. OpenComputer uses the first available of: your `Idempotency-Key`;
-for Sentry, the alerted event or issue named in the body together with the
+for Sentry event alerts and errors, the event id in the body under the
 `Sentry-Hook-Resource` header, which stays the same across Sentry's retries
 while its `Request-ID` does not; `X-GitHub-Delivery`; for Stripe, the event
-id in the body; `Svix-Id`; and finally `Request-ID`. Retrying with the same
-identity and body returns the original request and session; if that request
-had failed to start, the retry starts it again. A body larger than 256 KiB
-once wrapped as agent input is rejected with 400 before acknowledgement.
+id in the body; `Svix-Id`; and finally `Request-ID`. Other Sentry
+notifications, such as issue and comment changes, use `Request-ID`.
+Retrying with the same `Idempotency-Key` and a different body is a 409; a
+provider retry under a derived identity returns the original request even
+if the provider reserialized the body. If the original request had failed
+to start, the retry starts it again. A body larger than 256 KiB once wrapped
+as agent input is rejected with 400 before acknowledgement.
 
 ## Read webhook input
 

--- a/docs/agents/webhooks.mdx
+++ b/docs/agents/webhooks.mdx
@@ -65,11 +65,14 @@ credential.
 The response is HTTP 202 with the request, session ID, and dashboard session
 URL. It is sent as soon as the delivery is stored; the session starts
 afterwards, so acknowledgement does not wait for a runtime.
-The request's `outcome` is `pending` in the response and becomes `accepted`
-once the session is running, or `failed` after five start attempts over
-about thirteen minutes. Read outcomes from the request ledger with your API
-key; the session id there is authoritative, since a retried start can use a
-different session than the one first announced:
+The request's `outcome` is `pending` in the response. It becomes `accepted`
+once the session holds the turn, which is the point of no return: from
+there the session runs it, even if the runtime has to be started again.
+It becomes `failed` after five start attempts over about thirteen minutes,
+or at once when the platform can tell that no retry would help; such a
+request carries `terminal: true`. Read outcomes from the request ledger
+with your API key; the session id there is authoritative, since a retried
+start can use a different session than the one first announced:
 
 ```bash
 curl 'https://app.opencomputer.dev/api/managed-agents/projects/<project-id>/webhooks/<webhook-id>/requests?environment=production' \
@@ -97,8 +100,18 @@ id in the body. Without a source, every delivery that sets no
 Retrying with the same `Idempotency-Key` and a different body is a 409. A
 retry under a configured source returns the original request even if the
 provider reserialized the body. If the original request had failed to
-start, the retry starts it again. A body larger than 256 KiB once wrapped
-as agent input is rejected with 400 before acknowledgement.
+start after its attempts, the retry starts it again; if it failed with
+`terminal: true`, the retry returns that failure unchanged. To recover a
+terminal failure, resend the saved payload with a fresh `Idempotency-Key`,
+which overrides the configured source and starts a new request. A body
+larger than 256 KiB once wrapped as agent input is rejected with 400
+before acknowledgement.
+
+A header source cannot name a header the platform sets or strips before
+the backend reads it: `Authorization`, `Cookie`, `Idempotency-Key`,
+`X-Request-Id`, `X-Api-Key`, transport headers, and anything starting with
+`x-oc-`, `cf-`, `x-forwarded-`, or `x-real-`. Creating a webhook with one
+of these is rejected.
 
 ## Read webhook input
 

--- a/docs/agents/webhooks.mdx
+++ b/docs/agents/webhooks.mdx
@@ -14,8 +14,9 @@ webhook URL.
 ## Create a webhook
 
 Open an agent's **Webhooks** tab, select Development or Production, and choose
-**Create webhook**. The dashboard shows the bearer token once. Store it in the
-calling service's secret store.
+**Create webhook**. The dashboard shows the webhook URL once. The URL carries
+the credential: store it in the calling service's secret store, and treat it
+as you would a token.
 
 The CLI supports the same lifecycle:
 
@@ -31,16 +32,15 @@ opencomputer webhooks rotate-token <webhook-id>
 opencomputer webhooks remove <webhook-id>
 ```
 
-Rotation invalidates the previous token immediately. List output never
-contains a token.
+`create` and `rotate-token` print the URL with its token once. Rotation
+invalidates the previous URL immediately. `list` prints URLs without tokens.
 
 ## Invoke it
 
-Send `POST` with `application/json` and the token as a bearer credential:
+Send `POST` with `application/json` to the URL:
 
 ```bash
-curl -X POST 'https://app.opencomputer.dev/api/agent-webhooks/wh_...' \
-  -H 'Authorization: Bearer <token>' \
+curl -X POST 'https://app.opencomputer.dev/api/agent-webhooks/wh_.../ocwh_...' \
   -H 'Content-Type: application/json' \
   -H 'Idempotency-Key: delivery-123' \
   -d '{
@@ -52,14 +52,29 @@ curl -X POST 'https://app.opencomputer.dev/api/agent-webhooks/wh_...' \
   }'
 ```
 
-At least one of `text` or `payload` is required. `text` becomes the initial
-turn prompt. `payload` remains structured JSON available to the agent. The
-response is HTTP 202 with the request, session ID, and dashboard session URL;
-the agent continues asynchronously.
+`text` becomes the initial turn prompt. `payload` remains structured JSON
+available to the agent. A body with neither key is delivered whole as
+`payload`, so a provider such as Sentry, GitHub, or Stripe can point its
+webhook at the URL directly; the prompt is then `Webhook <name> invoked`.
+Bodies are limited to 256 KiB.
 
-Use a unique `Idempotency-Key` for each upstream delivery. Retrying the same
-body with the same key returns the original request and session instead of
-starting another one.
+A sender that sets headers may omit the last path segment and send the token
+as `Authorization: Bearer <token>` instead. Both forms verify the same
+credential.
+
+The response is HTTP 202 with the request, session ID, and dashboard session
+URL. It is sent as soon as the delivery is stored; the session starts
+afterwards, so the response arrives within Sentry's and GitHub's timeouts.
+The request's `outcome` is `pending` in the response and becomes `accepted`
+once the session is running, or `failed` after the platform has retried the
+start for about forty minutes. The dashboard's Webhooks tab lists requests
+with their outcomes.
+
+Each delivery needs an identity so that a retry does not start a second
+session. OpenComputer uses the first present of `Idempotency-Key`,
+`Request-ID` (Sentry), `X-GitHub-Delivery`, and `Svix-Id`. Retrying the same
+body with the same identity returns the original request and session; if
+that request had failed to start, the retry starts it again.
 
 ## Read webhook input
 
@@ -88,6 +103,22 @@ export default function Agent() {
 Use payload fields such as `mode` for business behavior. `input.source` is
 `"webhook"` and `input.webhook` contains the webhook ID, request ID, and receive
 time for provenance and correlation.
+
+## Provider deliveries
+
+A provider body arrives unchanged as `input.payload`. Narrow it to what the
+agent needs; for a Sentry issue alert that is the event under `data.event`:
+
+```tsx
+const payload = (input.payload ?? {}) as {
+  data?: { event?: { event_id?: string; release?: string } };
+};
+const event = payload.data?.event;
+```
+
+Configure the provider with the full webhook URL. Sentry's internal
+integrations and GitHub repository webhooks accept it as is; both send a
+delivery id header that OpenComputer uses as the request identity.
 
 Development and Production webhooks have separate URLs, tokens, and sessions.
 Disable or remove a webhook when its caller should no longer start sessions.

--- a/docs/agents/webhooks.mdx
+++ b/docs/agents/webhooks.mdx
@@ -77,16 +77,27 @@ curl 'https://app.opencomputer.dev/api/managed-agents/projects/<project-id>/webh
 ```
 
 Each delivery needs an identity so that a retry does not start a second
-session. OpenComputer uses the first available of: your `Idempotency-Key`;
-for Sentry event alerts and errors, the event id in the body under the
-`Sentry-Hook-Resource` header, which stays the same across Sentry's retries
-while its `Request-ID` does not; `X-GitHub-Delivery`; for Stripe, the event
-id in the body; `Svix-Id`; and finally `Request-ID`. Other Sentry
-notifications, such as issue and comment changes, use `Request-ID`.
-Retrying with the same `Idempotency-Key` and a different body is a 409; a
-provider retry under a derived identity returns the original request even
-if the provider reserialized the body. If the original request had failed
-to start, the retry starts it again. A body larger than 256 KiB once wrapped
+session. A sender that can set headers sends `Idempotency-Key`. For a
+provider that cannot, give the webhook an identity source when you create
+it: a request header, or a JSON Pointer into the body.
+
+```bash
+opencomputer webhooks create sentry-alerts --agent current --environment production \
+  --identity body:/data/event/event_id
+opencomputer webhooks update <webhook-id> --identity header:X-GitHub-Delivery
+opencomputer webhooks update <webhook-id> --identity none
+```
+
+Choose a value that stays the same when the provider retries and differs
+between deliveries you want handled separately. Sentry's per-request
+`Request-ID` changes on every retry, so for its issue alerts use the event
+id in the body. Without a source, every delivery that sets no
+`Idempotency-Key` starts a session.
+
+Retrying with the same `Idempotency-Key` and a different body is a 409. A
+retry under a configured source returns the original request even if the
+provider reserialized the body. If the original request had failed to
+start, the retry starts it again. A body larger than 256 KiB once wrapped
 as agent input is rejected with 400 before acknowledgement.
 
 ## Read webhook input
@@ -129,9 +140,9 @@ const payload = (input.payload ?? {}) as {
 const event = payload.data?.event;
 ```
 
-Configure the provider with the full webhook URL. Sentry's internal
-integrations and GitHub repository webhooks accept it as is; both send a
-delivery id header that OpenComputer uses as the request identity.
+Configure the provider with the full webhook URL and set the webhook's
+identity source to the field that names the delivery, for example
+`body:/data/event/event_id` for a Sentry issue alert.
 
 Development and Production webhooks have separate URLs, tokens, and sessions.
 Disable or remove a webhook when its caller should no longer start sessions.

--- a/web/src/managed-agents/Webhooks.tsx
+++ b/web/src/managed-agents/Webhooks.tsx
@@ -38,10 +38,12 @@ function formatDate(value?: string) {
   return value ? new Date(value).toLocaleString() : 'Never'
 }
 
+// The URL carries the token, so a request needs no credential header. Any
+// JSON object is accepted; one without `text` or `payload` is delivered whole
+// as the agent's payload.
 function curlCommand(webhook: ManagedAgentWebhook) {
   return [
     `curl -X POST '${webhook.invocationUrl}' \\`,
-    `  -H 'Authorization: Bearer ${webhook.token ?? '<token>'}' \\`,
     "  -H 'Content-Type: application/json' \\",
     "  -H 'Idempotency-Key: <unique-request-id>' \\",
     `  -d '{"text":"Run this workflow","payload":{"mode":"default"}}'`,
@@ -249,7 +251,8 @@ export function ManagedAgentWebhooks({
             <DialogTitle>Create webhook</DialogTitle>
             <DialogDescription>
               This webhook will trigger {agentName} in {environment}. Give the
-              ingress point a name; its bearer token is shown once.
+              ingress point a name; its URL, which carries the credential, is
+              shown once.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-2">
@@ -283,14 +286,20 @@ export function ManagedAgentWebhooks({
       >
         <DialogContent className="max-w-2xl">
           <DialogHeader>
-            <DialogTitle>Save this webhook token</DialogTitle>
+            <DialogTitle>Save this webhook URL</DialogTitle>
             <DialogDescription>
-              OpenComputer stores only its hash, so this token cannot be shown
-              again. Rotating it invalidates the previous token.
+              The URL carries the credential and OpenComputer stores only its
+              hash, so it cannot be shown again. Rotating the token invalidates
+              this URL. Senders that set headers may instead call the URL
+              without its last segment with the token as a bearer credential.
             </DialogDescription>
           </DialogHeader>
           {credentials?.token ? (
             <div className="space-y-4">
+              <div className="space-y-2">
+                <Label>Webhook URL</Label>
+                <CopyRow value={credentials.invocationUrl} maskable />
+              </div>
               <div className="space-y-2">
                 <Label>Token</Label>
                 <CopyRow value={credentials.token} maskable />

--- a/web/src/managed-agents/Webhooks.tsx
+++ b/web/src/managed-agents/Webhooks.tsx
@@ -67,6 +67,7 @@ export function ManagedAgentWebhooks({
   const queryKey = ['managed-agent-webhooks', projectId, agentId, environment]
   const [creating, setCreating] = useState(false)
   const [name, setName] = useState('')
+  const [identity, setIdentity] = useState('')
   const [credentials, setCredentials] = useState<ManagedAgentWebhook>()
   const [removing, setRemoving] = useState<ManagedAgentWebhook>()
 
@@ -82,10 +83,12 @@ export function ManagedAgentWebhooks({
         agentId,
         environment,
         name: name.trim(),
+        ...(identity.trim() ? { identity: identity.trim() } : {}),
       }),
     onSuccess: async (webhook) => {
       setCreating(false)
       setName('')
+      setIdentity('')
       setCredentials(webhook)
       await queryClient.invalidateQueries({ queryKey })
     },
@@ -160,6 +163,11 @@ export function ManagedAgentWebhooks({
           <p className="text-muted-foreground mt-1 max-w-xl truncate font-mono text-xs">
             {webhook.invocationUrl}
           </p>
+          {webhook.identity ? (
+            <p className="text-muted-foreground mt-1 font-mono text-xs">
+              identity {webhook.identity}
+            </p>
+          ) : null}
         </div>
       ),
     },
@@ -264,6 +272,21 @@ export function ManagedAgentWebhooks({
               placeholder="Daily hygiene trigger"
               onChange={(event) => setName(event.target.value)}
             />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="webhook-identity">Delivery identity (optional)</Label>
+            <Input
+              id="webhook-identity"
+              value={identity}
+              maxLength={300}
+              placeholder="body:/data/event/event_id or header:X-GitHub-Delivery"
+              onChange={(event) => setIdentity(event.target.value)}
+            />
+            <p className="text-muted-foreground text-xs">
+              Where a delivery&apos;s identity is read when the sender sets no
+              Idempotency-Key, so a provider&apos;s retry does not start a second
+              session. A header name, or a JSON Pointer into the body.
+            </p>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setCreating(false)}>

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -378,6 +378,7 @@ const webhookSchema = z.object({
   agentId: z.string(),
   name: z.string(),
   enabled: z.boolean(),
+  identity: z.string().optional(),
   invocationUrl: z.string().url(),
   token: z.string().optional(),
   createdAt: z.string(),
@@ -917,6 +918,7 @@ export async function createManagedAgentWebhook(input: {
   agentId: string
   environment: 'development' | 'production'
   name: string
+  identity?: string
 }) {
   return (
     await apiFetch(
@@ -927,6 +929,7 @@ export async function createManagedAgentWebhook(input: {
           agentId: input.agentId,
           environment: input.environment,
           name: input.name,
+          ...(input.identity ? { identity: input.identity } : {}),
         }),
       },
       webhookResponseSchema,


### PR DESCRIPTION
Providers can invoke an agent webhook by POSTing JSON to a credential URL. Create/rotate return that URL once; listings omit its token. This PR adds the public route, identity configuration, CLI/dashboard setup, operator docs and collector redaction. The URL form requires https://github.com/diggerhq/blue/pull/45; existing bearer calls remain supported.

## Contract and review scope

- **The URL is a credential.** The collector redacts the complete suffix after the webhook ID, including malformed paths. Cloudflare's own URL logging is outside that redaction.
- **Provider bodies pass through unchanged.** A configured `header:<name>` or `body:<JSON Pointer>` supplies delivery identity; an explicit `Idempotency-Key` takes precedence. The edge forwards headers except credentials, reserved names and transport metadata. This does not verify provider signatures.
- **Admission is asynchronous.** 202 acknowledges stored input; the request ledger exposes the admission outcome and current session ID. CLI and create-start move to 0.6.8 for publication.

## Open review findings

- **P1:** redacting `request_url` is insufficient: a backend admission error emits the token-bearing pathname inside a console message, which this collector copies into `msg`. Reproduced through the real backend and collector with a forced storage failure.
- **P2:** the API accepts identity headers that this edge replaces or strips. `header:x-request-id` derives a new key on every retry; `header:x-oc-delivery-id` derives no key. Reject unsupported configurations or preserve sender identity separately.
- **P2, docs:** `accepted` means a keyed turn was committed, not that a runtime is running. The backend's new terminal case can fail on attempt one and cannot recover under the same identity. Document a fresh explicit `Idempotency-Key` for manual replay. Backend re-arm behavior also needs correction.

[Current review and reproductions](https://github.com/diggerhq/serverless-agents-ws/blob/main/.agents/work/023-direct-provider-webhooks.md#2026-09-08--fresh-review-after-the-terminal-trim). Earlier replacement-recovery, provider-table and malformed-suffix findings are superseded by the current implementation.

## Verification and rollout

At `5e0eed9d`: 37 public-edge tests, 3 collector tests and 4 existing CLI tests pass; web and CLI typechecks pass. Existing CLI tests contain no webhook cases. Additional cross-repository probes reproduce the findings above; live delivery and acknowledgement latency remain unverified.

**Deploy the collector separately first**; the API-edge workflow does not deploy it. Backend precedes the public surface and CLI release. Complete the first end-to-end validation on Development before merge: direct provider delivery, running session, bounded acknowledgement time, and no second session on an identical retry. No merge or deployment occurred during this review.
