### PR TITLE
Channels multi provider

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -88,30 +88,81 @@ export interface McpServerDefinition extends ResourceReference {
   readonly connection?: ConnectionReference;
 }
 
-export type SlackChannelEvent = "app_mention" | "message.im";
-export type ChannelTrigger = "mention" | "direct-message";
+/**
+ * A channel is a conversation the agent takes part in, keyed by an external
+ * participant. What differs between providers is transport, addressing, and
+ * authentication; what does not differ is that an inbound message continues the
+ * conversation it belongs to. Agents see the second part and never the first.
+ */
+export type ChannelProvider = "slack" | "sms" | "email";
 
-export interface ChannelDestinationDefinition {
+export type SlackChannelEvent = "app_mention" | "message.im";
+/** Providers without a mention/DM distinction have exactly one inbound event. */
+export type MessageChannelEvent = "message.inbound";
+export type ChannelEvent = SlackChannelEvent | MessageChannelEvent;
+
+export type ChannelTrigger = "mention" | "direct-message" | "message";
+
+export interface ConversationDestination {
   readonly type: "conversation";
   readonly visibility: "public" | "private";
 }
 
-export interface SlackChannelDefinition extends ResourceReference {
+/** Reply on the conversation the message arrived on. */
+export interface ReplyDestination {
+  readonly type: "reply";
+}
+
+export type ChannelDestinationDefinition =
+  | ConversationDestination
+  | ReplyDestination;
+
+interface ChannelDefinitionBase extends ResourceReference {
   readonly kind: "channel";
   readonly version: 1;
-  readonly type: "slack";
   readonly displayName?: string;
-  readonly scopes: {
-    readonly bot: readonly string[];
-  };
-  readonly events: readonly SlackChannelEvent[];
   readonly destinations: Readonly<
     Record<string, Readonly<ChannelDestinationDefinition>>
   >;
   readonly routing: {
     readonly whenAmbiguous: "ask";
   };
+  /**
+   * Agent runtime is billed by wall-clock time, and a conversation spends most
+   * of its life waiting for a human. Suspend the runtime this long after the
+   * last message; an inbound message resumes it. Without this a channel-backed
+   * conversation bills for the hours nobody is typing.
+   */
+  readonly idle: {
+    readonly suspendAfterSeconds: number;
+  };
 }
+
+export interface SlackChannelDefinition extends ChannelDefinitionBase {
+  readonly type: "slack";
+  readonly scopes: {
+    readonly bot: readonly string[];
+  };
+  readonly events: readonly SlackChannelEvent[];
+}
+
+export interface SmsChannelDefinition extends ChannelDefinitionBase {
+  readonly type: "sms";
+  /** The number customers reply to, in E.164. */
+  readonly from: string;
+  readonly events: readonly MessageChannelEvent[];
+}
+
+export interface EmailChannelDefinition extends ChannelDefinitionBase {
+  readonly type: "email";
+  readonly address: string;
+  readonly events: readonly MessageChannelEvent[];
+}
+
+export type ChannelDefinition =
+  | SlackChannelDefinition
+  | SmsChannelDefinition
+  | EmailChannelDefinition;
 
 export interface ChannelRegistrationDefinition extends ResourceReference {
   readonly kind: "channel-registration";
@@ -265,6 +316,9 @@ function identifier(value: string, kind: string): string {
   return id;
 }
 
+const OPENCOMPUTER_USER_AGENT =
+  "OpenComputer-Agent/1 (+https://opencomputer.dev)";
+
 export function useSecret(name: string): SecretReference {
   const id = identifier(name, "useSecret");
   if (!/^[A-Z][A-Z0-9_]{0,127}$/.test(id)) {
@@ -373,6 +427,15 @@ export function defineConnection(input: {
         throw new Error("Connection requests require an absolute path");
       }
       const headers = Object.fromEntries(new Headers(init.headers).entries());
+      // Some APIs reject a request that carries no User-Agent — GitHub answers
+      // 403 with an empty body, which is undiagnosable from the caller's side.
+      // Default one unless the connection or this request already sets it.
+      const declaresUserAgent = Object.keys(input.headers ?? {}).some(
+        (name) => name.toLowerCase() === "user-agent",
+      );
+      if (!declaresUserAgent && !("user-agent" in headers)) {
+        headers["user-agent"] = OPENCOMPUTER_USER_AGENT;
+      }
       const body =
         init.body === undefined || init.body === null
           ? undefined
@@ -433,10 +496,23 @@ const SLACK_EVENT_SCOPE: Readonly<Record<SlackChannelEvent, string>> = {
   app_mention: "app_mentions:read",
   "message.im": "im:history",
 };
-const TRIGGER_EVENT: Readonly<Record<ChannelTrigger, SlackChannelEvent>> = {
+const TRIGGER_EVENT: Readonly<Record<ChannelTrigger, ChannelEvent>> = {
   mention: "app_mention",
   "direct-message": "message.im",
+  message: "message.inbound",
 };
+const PROVIDER_TRIGGERS: Readonly<
+  Record<ChannelProvider, readonly ChannelTrigger[]>
+> = {
+  slack: ["mention", "direct-message"],
+  sms: ["message"],
+  email: ["message"],
+};
+// Suspend quickly by default. A resume costs a moment; an idle runtime costs
+// for every second nobody is typing, and on SMS or email that is most of them.
+const DEFAULT_IDLE_SUSPEND_SECONDS = 300;
+const E164 = /^\+[1-9]\d{7,14}$/;
+const EMAIL_ADDRESS = /^[^@\s]+@[^@\s.]+\.[^@\s]+$/;
 
 function resourceIdentifier(value: string, kind: string): string {
   const id = identifier(value, kind);
@@ -527,16 +603,130 @@ export function defineSchedule(input: {
   });
 }
 
-export function defineChannel(input: {
+interface ChannelInputBase {
   id: string;
-  type: "slack";
   displayName?: string;
-  scopes: { bot: readonly string[] };
-  events?: readonly SlackChannelEvent[];
   destinations?: Readonly<Record<string, ChannelDestinationDefinition>>;
   routing?: { whenAmbiguous?: "ask" };
-}): SlackChannelDefinition {
+  idle?: { suspendAfterSeconds?: number };
+}
+
+export interface SlackChannelInput extends ChannelInputBase {
+  type: "slack";
+  scopes: { bot: readonly string[] };
+  events?: readonly SlackChannelEvent[];
+}
+
+export interface SmsChannelInput extends ChannelInputBase {
+  type: "sms";
+  from: string;
+}
+
+export interface EmailChannelInput extends ChannelInputBase {
+  type: "email";
+  address: string;
+}
+
+export type ChannelInput =
+  | SlackChannelInput
+  | SmsChannelInput
+  | EmailChannelInput;
+
+function channelCommon(input: ChannelInputBase): {
+  id: string;
+  displayName?: string;
+  routing: { whenAmbiguous: "ask" };
+  idle: { suspendAfterSeconds: number };
+} {
   const id = resourceIdentifier(input.id, "defineChannel");
+  const seconds =
+    input.idle?.suspendAfterSeconds ?? DEFAULT_IDLE_SUSPEND_SECONDS;
+  if (!Number.isInteger(seconds) || seconds < 30 || seconds > 86_400) {
+    throw new Error(
+      "Channel idle.suspendAfterSeconds must be a whole number of seconds between 30 and 86400",
+    );
+  }
+  return {
+    id,
+    ...(input.displayName?.trim()
+      ? { displayName: input.displayName.trim() }
+      : {}),
+    routing: { whenAmbiguous: input.routing?.whenAmbiguous ?? "ask" },
+    idle: { suspendAfterSeconds: seconds },
+  };
+}
+
+/**
+ * Providers other than Slack address a single participant, so their only
+ * destination is a reply on the conversation the message arrived on.
+ */
+function replyDestinations(
+  input: ChannelInputBase,
+  provider: ChannelProvider,
+): Record<string, Readonly<ChannelDestinationDefinition>> {
+  const destinations: Record<string, Readonly<ChannelDestinationDefinition>> =
+    {};
+  for (const [name, destination] of Object.entries(input.destinations ?? {})) {
+    const destinationId = resourceIdentifier(name, "Channel destination");
+    if (destination.type !== "reply") {
+      throw new Error(
+        `${provider} destination ${destinationId} must be { type: "reply" }`,
+      );
+    }
+    destinations[destinationId] = Object.freeze({ type: "reply" as const });
+  }
+  if (!Object.keys(destinations).length) {
+    destinations.reply = Object.freeze({ type: "reply" as const });
+  }
+  return destinations;
+}
+
+export function defineChannel(input: SlackChannelInput): SlackChannelDefinition;
+export function defineChannel(input: SmsChannelInput): SmsChannelDefinition;
+export function defineChannel(input: EmailChannelInput): EmailChannelDefinition;
+export function defineChannel(input: ChannelInput): ChannelDefinition {
+  const common = channelCommon(input);
+
+  if (input.type === "sms") {
+    const from = input.from.trim();
+    if (!E164.test(from)) {
+      throw new Error(
+        `SMS channel ${common.id} needs a from number in E.164, such as +15125550100`,
+      );
+    }
+    return Object.freeze({
+      kind: "channel" as const,
+      version: 1 as const,
+      type: "sms" as const,
+      ...common,
+      from,
+      events: Object.freeze(["message.inbound" as const]),
+      destinations: Object.freeze(replyDestinations(input, "sms")),
+      routing: Object.freeze(common.routing),
+      idle: Object.freeze(common.idle),
+    });
+  }
+
+  if (input.type === "email") {
+    const address = input.address.trim().toLowerCase();
+    if (!EMAIL_ADDRESS.test(address)) {
+      throw new Error(
+        `Email channel ${common.id} needs a deliverable address, such as help@example.com`,
+      );
+    }
+    return Object.freeze({
+      kind: "channel" as const,
+      version: 1 as const,
+      type: "email" as const,
+      ...common,
+      address,
+      events: Object.freeze(["message.inbound" as const]),
+      destinations: Object.freeze(replyDestinations(input, "email")),
+      routing: Object.freeze(common.routing),
+      idle: Object.freeze(common.idle),
+    });
+  }
+
   const scopes = [...new Set(input.scopes.bot.map((scope) => scope.trim()))];
   if (
     !scopes.length ||
@@ -557,6 +747,11 @@ export function defineChannel(input: {
   > = {};
   for (const [name, destination] of Object.entries(input.destinations ?? {})) {
     const destinationId = resourceIdentifier(name, "Channel destination");
+    if (destination.type !== "conversation") {
+      throw new Error(
+        `Slack destination ${destinationId} must be { type: "conversation" }`,
+      );
+    }
     const required =
       destination.visibility === "private" ? "groups:read" : "channels:read";
     if (!scopes.includes(required)) {
@@ -574,31 +769,36 @@ export function defineChannel(input: {
   return Object.freeze({
     kind: "channel" as const,
     version: 1 as const,
-    id,
-    type: input.type,
-    ...(input.displayName?.trim()
-      ? { displayName: input.displayName.trim() }
-      : {}),
+    type: "slack" as const,
+    ...common,
     scopes: Object.freeze({ bot: Object.freeze(scopes) }),
     events: Object.freeze(events),
     destinations: Object.freeze(destinations),
-    routing: Object.freeze({
-      whenAmbiguous: input.routing?.whenAmbiguous ?? "ask",
-    }),
+    routing: Object.freeze(common.routing),
+    idle: Object.freeze(common.idle),
   });
 }
 
 export function registerChannel(
-  channel: SlackChannelDefinition,
+  channel: ChannelDefinition,
   input: { on: readonly ChannelTrigger[] },
 ): ChannelRegistrationDefinition {
   const triggers = [...new Set(input.on)];
   if (!triggers.length) {
     throw new Error("registerChannel requires at least one trigger");
   }
+  const supported = PROVIDER_TRIGGERS[channel.type];
+  // Each variant narrows `events` to its own literal union; widen once so the
+  // membership check reads the same for every provider.
+  const declared: readonly ChannelEvent[] = channel.events;
   for (const trigger of triggers) {
+    if (!supported.includes(trigger)) {
+      throw new Error(
+        `Channel ${channel.id} is a ${channel.type} channel, which supports ${supported.join(" and ")}, not ${trigger}`,
+      );
+    }
     const event = TRIGGER_EVENT[trigger];
-    if (!channel.events.includes(event)) {
+    if (!declared.includes(event)) {
       throw new Error(
         `Channel ${channel.id} does not declare the event required by ${trigger}`,
       );

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -94,7 +94,7 @@ export interface McpServerDefinition extends ResourceReference {
  * authentication; what does not differ is that an inbound message continues the
  * conversation it belongs to. Agents see the second part and never the first.
  */
-export type ChannelProvider = "slack" | "sms" | "email";
+export type ChannelProvider = "slack" | "twilio" | "email";
 
 export type SlackChannelEvent = "app_mention" | "message.im";
 /** Providers without a mention/DM distinction have exactly one inbound event. */
@@ -146,22 +146,36 @@ export interface SlackChannelDefinition extends ChannelDefinitionBase {
   readonly events: readonly SlackChannelEvent[];
 }
 
-export interface SmsChannelDefinition extends ChannelDefinitionBase {
-  readonly type: "sms";
-  /** The number customers reply to, in E.164. */
-  readonly from: string;
+/**
+ * Named for the vendor, as `slack` is, because that is what actually differs:
+ * the signature is Twilio's HMAC over the request URL and sorted parameters,
+ * and the payload is Twilio's form encoding. A different SMS vendor is a
+ * different adapter, not a variant of this one.
+ *
+ * Twilio WhatsApp rides the same API, webhook, and signature — addresses just
+ * carry a `whatsapp:` prefix — so it needs no separate provider.
+ *
+ * The number itself is not here. It is per-environment operational
+ * configuration, bound to a connection in the dashboard, exactly as Slack
+ * conversation IDs are.
+ */
+export interface TwilioChannelDefinition extends ChannelDefinitionBase {
+  readonly type: "twilio";
   readonly events: readonly MessageChannelEvent[];
 }
 
+/**
+ * The address is likewise a per-environment binding, not source: development
+ * and production do not share an inbox.
+ */
 export interface EmailChannelDefinition extends ChannelDefinitionBase {
   readonly type: "email";
-  readonly address: string;
   readonly events: readonly MessageChannelEvent[];
 }
 
 export type ChannelDefinition =
   | SlackChannelDefinition
-  | SmsChannelDefinition
+  | TwilioChannelDefinition
   | EmailChannelDefinition;
 
 export interface ChannelRegistrationDefinition extends ResourceReference {
@@ -505,14 +519,12 @@ const PROVIDER_TRIGGERS: Readonly<
   Record<ChannelProvider, readonly ChannelTrigger[]>
 > = {
   slack: ["mention", "direct-message"],
-  sms: ["message"],
+  twilio: ["message"],
   email: ["message"],
 };
 // Suspend quickly by default. A resume costs a moment; an idle runtime costs
 // for every second nobody is typing, and on SMS or email that is most of them.
 const DEFAULT_IDLE_SUSPEND_SECONDS = 300;
-const E164 = /^\+[1-9]\d{7,14}$/;
-const EMAIL_ADDRESS = /^[^@\s]+@[^@\s.]+\.[^@\s]+$/;
 
 function resourceIdentifier(value: string, kind: string): string {
   const id = identifier(value, kind);
@@ -617,19 +629,17 @@ export interface SlackChannelInput extends ChannelInputBase {
   events?: readonly SlackChannelEvent[];
 }
 
-export interface SmsChannelInput extends ChannelInputBase {
-  type: "sms";
-  from: string;
+export interface TwilioChannelInput extends ChannelInputBase {
+  type: "twilio";
 }
 
 export interface EmailChannelInput extends ChannelInputBase {
   type: "email";
-  address: string;
 }
 
 export type ChannelInput =
   | SlackChannelInput
-  | SmsChannelInput
+  | TwilioChannelInput
   | EmailChannelInput;
 
 function channelCommon(input: ChannelInputBase): {
@@ -682,49 +692,22 @@ function replyDestinations(
 }
 
 export function defineChannel(input: SlackChannelInput): SlackChannelDefinition;
-export function defineChannel(input: SmsChannelInput): SmsChannelDefinition;
+export function defineChannel(input: TwilioChannelInput): TwilioChannelDefinition;
 export function defineChannel(input: EmailChannelInput): EmailChannelDefinition;
 export function defineChannel(input: ChannelInput): ChannelDefinition {
   const common = channelCommon(input);
 
-  if (input.type === "sms") {
-    const from = input.from.trim();
-    if (!E164.test(from)) {
-      throw new Error(
-        `SMS channel ${common.id} needs a from number in E.164, such as +15125550100`,
-      );
-    }
+  if (input.type === "twilio" || input.type === "email") {
     return Object.freeze({
       kind: "channel" as const,
       version: 1 as const,
-      type: "sms" as const,
+      type: input.type,
       ...common,
-      from,
       events: Object.freeze(["message.inbound" as const]),
-      destinations: Object.freeze(replyDestinations(input, "sms")),
+      destinations: Object.freeze(replyDestinations(input, input.type)),
       routing: Object.freeze(common.routing),
       idle: Object.freeze(common.idle),
-    });
-  }
-
-  if (input.type === "email") {
-    const address = input.address.trim().toLowerCase();
-    if (!EMAIL_ADDRESS.test(address)) {
-      throw new Error(
-        `Email channel ${common.id} needs a deliverable address, such as help@example.com`,
-      );
-    }
-    return Object.freeze({
-      kind: "channel" as const,
-      version: 1 as const,
-      type: "email" as const,
-      ...common,
-      address,
-      events: Object.freeze(["message.inbound" as const]),
-      destinations: Object.freeze(replyDestinations(input, "email")),
-      routing: Object.freeze(common.routing),
-      idle: Object.freeze(common.idle),
-    });
+    }) as ChannelDefinition;
   }
 
   const scopes = [...new Set(input.scopes.bot.map((scope) => scope.trim()))];

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -174,6 +174,7 @@ export default registerOutbox(reviewRequests);
             },
           },
           routing: { whenAmbiguous: "ask" },
+          idle: { suspendAfterSeconds: 300 },
         },
       ],
       channelRegistrations: [
@@ -771,6 +772,126 @@ export default function Agent() {
       buildAgentArtifact(initialized.agentRoot),
       /must stay inside the agent directory/,
     );
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+test("the compiler accepts SMS and email channels alongside Slack", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-providers-"));
+  const root = resolve(parent, "app");
+  try {
+    const initialized = await initializeAgentProject(root);
+    await mkdir(resolve(root, "opencomputer", "channels"), { recursive: true });
+    await mkdir(resolve(initialized.agentRoot, "channels"), { recursive: true });
+
+    await writeFile(
+      resolve(root, "opencomputer", "channels", "shop-sms.ts"),
+      `import { defineChannel } from "@opencomputer/agent";
+
+export default defineChannel({
+  id: "shop-sms",
+  type: "sms",
+  from: "+15125550100",
+  idle: { suspendAfterSeconds: 60 },
+});
+`,
+    );
+    await writeFile(
+      resolve(root, "opencomputer", "channels", "support-email.ts"),
+      `import { defineChannel } from "@opencomputer/agent";
+
+export default defineChannel({
+  id: "support-email",
+  type: "email",
+  address: "Help@Example.COM",
+});
+`,
+    );
+    await writeFile(
+      resolve(initialized.agentRoot, "channels", "shop-sms.ts"),
+      `import { registerChannel } from "@opencomputer/agent";
+import shopSms from "../../../channels/shop-sms.js";
+export default registerChannel(shopSms, { on: ["message"] });
+`,
+    );
+
+    const built = await readProjectResources(root);
+    const sms = built.manifest.channels.find((c) => c.id === "shop-sms");
+    const email = built.manifest.channels.find((c) => c.id === "support-email");
+
+    assert.deepEqual(sms, {
+      id: "shop-sms",
+      type: "sms",
+      routing: { whenAmbiguous: "ask" },
+      idle: { suspendAfterSeconds: 60 },
+      from: "+15125550100",
+      events: ["message.inbound"],
+      destinations: { reply: { type: "reply" } },
+    });
+    // Addresses normalize to lower case so a conversation key is stable.
+    assert.equal(email?.address, "help@example.com");
+    assert.deepEqual(email?.idle, { suspendAfterSeconds: 300 });
+    assert.deepEqual(built.manifest.channelRegistrations, [
+      { agentId: "hello-world", channelId: "shop-sms", triggers: ["message"] },
+    ]);
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+test("the compiler rejects a trigger the provider cannot deliver", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-trigger-"));
+  const root = resolve(parent, "app");
+  try {
+    const initialized = await initializeAgentProject(root);
+    await mkdir(resolve(root, "opencomputer", "channels"), { recursive: true });
+    await mkdir(resolve(initialized.agentRoot, "channels"), { recursive: true });
+    await writeFile(
+      resolve(root, "opencomputer", "channels", "shop-sms.ts"),
+      `import { defineChannel } from "@opencomputer/agent";
+export default defineChannel({ id: "shop-sms", type: "sms", from: "+15125550100" });
+`,
+    );
+    await writeFile(
+      resolve(initialized.agentRoot, "channels", "shop-sms.ts"),
+      `import { registerChannel } from "@opencomputer/agent";
+import shopSms from "../../../channels/shop-sms.js";
+export default registerChannel(shopSms, { on: ["mention"] });
+`,
+    );
+    await assert.rejects(
+      readProjectResources(root),
+      /trigger mention is not available on a sms channel/,
+    );
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+test("the compiler rejects malformed provider addresses", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-addr-"));
+  const root = resolve(parent, "app");
+  try {
+    await initializeAgentProject(root);
+    await mkdir(resolve(root, "opencomputer", "channels"), { recursive: true });
+    const channel = resolve(root, "opencomputer", "channels", "shop-sms.ts");
+    await writeFile(
+      channel,
+      `import { defineChannel } from "@opencomputer/agent";
+export default defineChannel({ id: "shop-sms", type: "sms", from: "512-555-0100" });
+`,
+    );
+    await assert.rejects(readProjectResources(root), /E\.164/);
+
+    await rm(channel);
+    await writeFile(
+      resolve(root, "opencomputer", "channels", "support-email.ts"),
+      `import { defineChannel } from "@opencomputer/agent";
+export default defineChannel({ id: "support-email", type: "email", address: "not-an-address" });
+`,
+    );
+    await assert.rejects(readProjectResources(root), /deliverable email address/);
   } finally {
     await rm(parent, { recursive: true, force: true });
   }

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -777,7 +777,7 @@ export default function Agent() {
   }
 });
 
-test("the compiler accepts SMS and email channels alongside Slack", async () => {
+test("the compiler accepts Twilio and email channels alongside Slack", async () => {
   const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-providers-"));
   const root = resolve(parent, "app");
   try {
@@ -791,8 +791,7 @@ test("the compiler accepts SMS and email channels alongside Slack", async () => 
 
 export default defineChannel({
   id: "shop-sms",
-  type: "sms",
-  from: "+15125550100",
+  type: "twilio",
   idle: { suspendAfterSeconds: 60 },
 });
 `,
@@ -804,7 +803,6 @@ export default defineChannel({
 export default defineChannel({
   id: "support-email",
   type: "email",
-  address: "Help@Example.COM",
 });
 `,
     );
@@ -820,17 +818,17 @@ export default registerChannel(shopSms, { on: ["message"] });
     const sms = built.manifest.channels.find((c) => c.id === "shop-sms");
     const email = built.manifest.channels.find((c) => c.id === "support-email");
 
+    // No number in the manifest: it is per-environment operational config,
+    // bound to a connection the same way Slack conversation IDs are.
     assert.deepEqual(sms, {
       id: "shop-sms",
-      type: "sms",
+      type: "twilio",
       routing: { whenAmbiguous: "ask" },
       idle: { suspendAfterSeconds: 60 },
-      from: "+15125550100",
       events: ["message.inbound"],
       destinations: { reply: { type: "reply" } },
     });
-    // Addresses normalize to lower case so a conversation key is stable.
-    assert.equal(email?.address, "help@example.com");
+    assert.equal(email?.type, "email");
     assert.deepEqual(email?.idle, { suspendAfterSeconds: 300 });
     assert.deepEqual(built.manifest.channelRegistrations, [
       { agentId: "hello-world", channelId: "shop-sms", triggers: ["message"] },
@@ -850,7 +848,7 @@ test("the compiler rejects a trigger the provider cannot deliver", async () => {
     await writeFile(
       resolve(root, "opencomputer", "channels", "shop-sms.ts"),
       `import { defineChannel } from "@opencomputer/agent";
-export default defineChannel({ id: "shop-sms", type: "sms", from: "+15125550100" });
+export default defineChannel({ id: "shop-sms", type: "twilio" });
 `,
     );
     await writeFile(
@@ -862,36 +860,31 @@ export default registerChannel(shopSms, { on: ["mention"] });
     );
     await assert.rejects(
       readProjectResources(root),
-      /trigger mention is not available on a sms channel/,
+      /trigger mention is not available on a twilio channel/,
     );
   } finally {
     await rm(parent, { recursive: true, force: true });
   }
 });
 
-test("the compiler rejects malformed provider addresses", async () => {
-  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-addr-"));
+test("the compiler names providers by vendor, not by medium", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-vendor-"));
   const root = resolve(parent, "app");
   try {
     await initializeAgentProject(root);
     await mkdir(resolve(root, "opencomputer", "channels"), { recursive: true });
-    const channel = resolve(root, "opencomputer", "channels", "shop-sms.ts");
+    // "sms" is a medium; the signature and payload this has to parse belong to
+    // one vendor. A different SMS vendor is a different adapter.
     await writeFile(
-      channel,
+      resolve(root, "opencomputer", "channels", "shop-sms.ts"),
       `import { defineChannel } from "@opencomputer/agent";
-export default defineChannel({ id: "shop-sms", type: "sms", from: "512-555-0100" });
+export default defineChannel({ id: "shop-sms", type: "sms" });
 `,
     );
-    await assert.rejects(readProjectResources(root), /E\.164/);
-
-    await rm(channel);
-    await writeFile(
-      resolve(root, "opencomputer", "channels", "support-email.ts"),
-      `import { defineChannel } from "@opencomputer/agent";
-export default defineChannel({ id: "support-email", type: "email", address: "not-an-address" });
-`,
+    await assert.rejects(
+      readProjectResources(root),
+      /unsupported channel type "sms". Supported: slack, twilio, email/,
     );
-    await assert.rejects(readProjectResources(root), /deliverable email address/);
   } finally {
     await rm(parent, { recursive: true, force: true });
   }

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -48,25 +48,33 @@ export interface McpServerManifest {
   connection?: string;
 }
 
+export type ChannelProviderManifest = "slack" | "sms" | "email";
+
 export interface ChannelDestinationManifest {
-  type: "conversation";
-  visibility: "public" | "private";
+  type: "conversation" | "reply";
+  visibility?: "public" | "private";
 }
 
 export interface ChannelDefinitionManifest {
   id: string;
-  type: "slack";
+  type: ChannelProviderManifest;
   displayName?: string;
-  scopes: { bot: string[] };
-  events: Array<"app_mention" | "message.im">;
+  /** Slack only. */
+  scopes?: { bot: string[] };
+  /** SMS only, E.164. */
+  from?: string;
+  /** Email only. */
+  address?: string;
+  events: string[];
   destinations: Record<string, ChannelDestinationManifest>;
   routing: { whenAmbiguous: "ask" };
+  idle: { suspendAfterSeconds: number };
 }
 
 export interface ChannelRegistrationManifest {
   agentId: string;
   channelId: string;
-  triggers: Array<"mention" | "direct-message">;
+  triggers: Array<"mention" | "direct-message" | "message">;
 }
 
 export interface OutboxDefinitionManifest {
@@ -928,6 +936,110 @@ function importedResourceId(
   return module;
 }
 
+/** Shared across every provider: routing, display name, idle policy. */
+function channelCommonManifest(
+  input: ts.ObjectLiteralExpression,
+  path: string,
+): {
+  displayName?: string;
+  routing: { whenAmbiguous: "ask" };
+  idle: { suspendAfterSeconds: number };
+} {
+  const routingExpression = objectProperty(input, "routing");
+  if (routingExpression && !ts.isObjectLiteralExpression(routingExpression)) {
+    throw new Error(`${path} routing must be an object literal`);
+  }
+  if (routingExpression) {
+    const ambiguity = objectProperty(routingExpression, "whenAmbiguous");
+    if (
+      ambiguity &&
+      literalStringValue(ambiguity, `${path} ambiguity policy`) !== "ask"
+    ) {
+      throw new Error(`${path} supports only routing.whenAmbiguous = "ask"`);
+    }
+  }
+  let suspendAfterSeconds = 300;
+  const idleExpression = objectProperty(input, "idle");
+  if (idleExpression) {
+    if (!ts.isObjectLiteralExpression(idleExpression)) {
+      throw new Error(`${path} idle must be an object literal`);
+    }
+    const seconds = objectProperty(idleExpression, "suspendAfterSeconds");
+    if (seconds) {
+      if (!ts.isNumericLiteral(seconds)) {
+        throw new Error(
+          `${path} idle.suspendAfterSeconds must be a literal number`,
+        );
+      }
+      suspendAfterSeconds = Number(seconds.text);
+      if (
+        !Number.isInteger(suspendAfterSeconds) ||
+        suspendAfterSeconds < 30 ||
+        suspendAfterSeconds > 86_400
+      ) {
+        throw new Error(
+          `${path} idle.suspendAfterSeconds must be between 30 and 86400`,
+        );
+      }
+    }
+  }
+  const displayNameExpression = objectProperty(input, "displayName");
+  return {
+    ...(displayNameExpression
+      ? {
+          displayName: literalStringValue(
+            displayNameExpression,
+            `${path} displayName`,
+          ),
+        }
+      : {}),
+    routing: { whenAmbiguous: "ask" as const },
+    idle: { suspendAfterSeconds },
+  };
+}
+
+/**
+ * SMS and email address one participant, so their only destination is a reply
+ * on the conversation the message arrived on. Declaring none is the common
+ * case and yields a single `reply` destination.
+ */
+function replyDestinationsManifest(
+  input: ts.ObjectLiteralExpression,
+  path: string,
+): Record<string, ChannelDestinationManifest> {
+  const destinations: Record<string, ChannelDestinationManifest> = {};
+  const expression = objectProperty(input, "destinations");
+  if (expression) {
+    if (!ts.isObjectLiteralExpression(expression)) {
+      throw new Error(`${path} destinations must be an object literal`);
+    }
+    for (const property of expression.properties) {
+      if (!ts.isPropertyAssignment(property)) {
+        throw new Error(`${path} destinations cannot use spreads`);
+      }
+      const name = staticPropertyName(property.name, `${path} destination`);
+      if (!AGENT_ID_PATTERN.test(name)) {
+        throw new Error(`${path} has invalid destination ${name}`);
+      }
+      if (!ts.isObjectLiteralExpression(property.initializer)) {
+        throw new Error(`${path} destination ${name} must be an object literal`);
+      }
+      const type = literalStringValue(
+        objectProperty(property.initializer, "type"),
+        `${path} destination ${name} type`,
+      );
+      if (type !== "reply") {
+        throw new Error(
+          `${path} destination ${name} must be { type: "reply" }`,
+        );
+      }
+      destinations[name] = { type: "reply" };
+    }
+  }
+  if (!Object.keys(destinations).length) destinations.reply = { type: "reply" };
+  return destinations;
+}
+
 function channelDefinition(
   source: string,
   path: string,
@@ -945,7 +1057,52 @@ function channelDefinition(
     objectProperty(input, "type"),
     `${path} channel type`,
   );
-  if (type !== "slack") throw new Error(`${path} supports only type "slack"`);
+  const common = channelCommonManifest(input, path);
+
+  if (type === "sms") {
+    const from = literalStringValue(
+      objectProperty(input, "from"),
+      `${path} SMS from number`,
+    );
+    if (!/^\+[1-9]\d{7,14}$/.test(from)) {
+      throw new Error(
+        `${path} from must be an E.164 number such as +15125550100`,
+      );
+    }
+    return {
+      id,
+      type: "sms",
+      ...common,
+      from,
+      events: ["message.inbound"],
+      destinations: replyDestinationsManifest(input, path),
+    };
+  }
+
+  if (type === "email") {
+    const address = literalStringValue(
+      objectProperty(input, "address"),
+      `${path} email address`,
+    ).toLowerCase();
+    if (!/^[^@\s]+@[^@\s.]+\.[^@\s]+$/.test(address)) {
+      throw new Error(`${path} address must be a deliverable email address`);
+    }
+    return {
+      id,
+      type: "email",
+      ...common,
+      address,
+      events: ["message.inbound"],
+      destinations: replyDestinationsManifest(input, path),
+    };
+  }
+
+  if (type !== "slack") {
+    throw new Error(
+      `${path} has unsupported channel type ${JSON.stringify(type)}. Supported: slack, sms, email`,
+    );
+  }
+
   const scopesExpression = objectProperty(input, "scopes");
   if (!scopesExpression || !ts.isObjectLiteralExpression(scopesExpression)) {
     throw new Error(`${path} scopes must be an object literal`);
@@ -1019,27 +1176,13 @@ function channelDefinition(
       destinations[name] = { type: "conversation", visibility };
     }
   }
-  const routingExpression = objectProperty(input, "routing");
-  if (routingExpression && !ts.isObjectLiteralExpression(routingExpression)) {
-    throw new Error(`${path} routing must be an object literal`);
-  }
-  if (routingExpression) {
-    const ambiguity = objectProperty(routingExpression, "whenAmbiguous");
-    if (ambiguity && literalStringValue(ambiguity, `${path} ambiguity policy`) !== "ask") {
-      throw new Error(`${path} supports only routing.whenAmbiguous = "ask"`);
-    }
-  }
-  const displayNameExpression = objectProperty(input, "displayName");
   return {
     id,
     type: "slack",
-    ...(displayNameExpression
-      ? { displayName: literalStringValue(displayNameExpression, `${path} displayName`) }
-      : {}),
+    ...common,
     scopes: { bot: scopes },
-    events: events as ChannelDefinitionManifest["events"],
+    events,
     destinations,
-    routing: { whenAmbiguous: "ask" },
   };
 }
 
@@ -1074,10 +1217,22 @@ function channelRegistration(
   const triggerEvents: Record<string, string> = {
     mention: "app_mention",
     "direct-message": "message.im",
+    message: "message.inbound",
   };
+  const providerTriggers: Record<string, string[]> = {
+    slack: ["mention", "direct-message"],
+    sms: ["message"],
+    email: ["message"],
+  };
+  const supported = providerTriggers[channel.type] ?? [];
   for (const trigger of triggers) {
+    if (!supported.includes(trigger)) {
+      throw new Error(
+        `${path} trigger ${trigger} is not available on a ${channel.type} channel (supported: ${supported.join(", ")})`,
+      );
+    }
     const event = triggerEvents[trigger];
-    if (!event || !channel.events.includes(event as "app_mention" | "message.im")) {
+    if (!event || !channel.events.includes(event)) {
       throw new Error(`${path} trigger ${trigger} is not declared by ${channelId}`);
     }
   }
@@ -1639,6 +1794,7 @@ function agentApiRuntimeSource(): string {
   if (!value) throw new Error("OpenComputer hooks can only run while rendering an agent");
   return value;
 }
+const OPENCOMPUTER_USER_AGENT = "OpenComputer-Agent/1 (+https://opencomputer.dev)";
 function id(value, kind) {
   const normalized = String(value).trim();
   if (!normalized) throw new Error(kind + " requires a non-empty id");
@@ -1680,6 +1836,11 @@ export const defineConnection = (input) => {
       if (!path.startsWith("/")) throw new Error("Connection requests require an absolute path");
       const headers = {};
       new Headers(init.headers).forEach((value, name) => { headers[name] = value; });
+      // Some APIs reject a request that carries no User-Agent — GitHub answers
+      // 403 with an empty body, which is undiagnosable from the caller's side.
+      // Default one unless the connection or the request already sets it.
+      const declaresUserAgent = Object.keys(input.headers || {}).some((name) => name.toLowerCase() === "user-agent");
+      if (!declaresUserAgent && !("user-agent" in headers)) headers["user-agent"] = OPENCOMPUTER_USER_AGENT;
       if (init.body != null && typeof init.body !== "string") throw new Error("Managed connection request bodies must currently be strings");
       if (typeof init.body === "string" && init.body.length > 5 * 1024 * 1024) throw new Error("Managed connection request bodies cannot exceed 5 MiB");
       return fetch(base.replace(/\\\/$/, "") + "/" + encodeURIComponent(connectionId) + "/fetch", {

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -48,7 +48,7 @@ export interface McpServerManifest {
   connection?: string;
 }
 
-export type ChannelProviderManifest = "slack" | "sms" | "email";
+export type ChannelProviderManifest = "slack" | "twilio" | "email";
 
 export interface ChannelDestinationManifest {
   type: "conversation" | "reply";
@@ -61,10 +61,6 @@ export interface ChannelDefinitionManifest {
   displayName?: string;
   /** Slack only. */
   scopes?: { bot: string[] };
-  /** SMS only, E.164. */
-  from?: string;
-  /** Email only. */
-  address?: string;
   events: string[];
   destinations: Record<string, ChannelDestinationManifest>;
   routing: { whenAmbiguous: "ask" };
@@ -1059,39 +1055,11 @@ function channelDefinition(
   );
   const common = channelCommonManifest(input, path);
 
-  if (type === "sms") {
-    const from = literalStringValue(
-      objectProperty(input, "from"),
-      `${path} SMS from number`,
-    );
-    if (!/^\+[1-9]\d{7,14}$/.test(from)) {
-      throw new Error(
-        `${path} from must be an E.164 number such as +15125550100`,
-      );
-    }
+  if (type === "twilio" || type === "email") {
     return {
       id,
-      type: "sms",
+      type,
       ...common,
-      from,
-      events: ["message.inbound"],
-      destinations: replyDestinationsManifest(input, path),
-    };
-  }
-
-  if (type === "email") {
-    const address = literalStringValue(
-      objectProperty(input, "address"),
-      `${path} email address`,
-    ).toLowerCase();
-    if (!/^[^@\s]+@[^@\s.]+\.[^@\s]+$/.test(address)) {
-      throw new Error(`${path} address must be a deliverable email address`);
-    }
-    return {
-      id,
-      type: "email",
-      ...common,
-      address,
       events: ["message.inbound"],
       destinations: replyDestinationsManifest(input, path),
     };
@@ -1099,7 +1067,7 @@ function channelDefinition(
 
   if (type !== "slack") {
     throw new Error(
-      `${path} has unsupported channel type ${JSON.stringify(type)}. Supported: slack, sms, email`,
+      `${path} has unsupported channel type ${JSON.stringify(type)}. Supported: slack, twilio, email`,
     );
   }
 
@@ -1221,7 +1189,7 @@ function channelRegistration(
   };
   const providerTriggers: Record<string, string[]> = {
     slack: ["mention", "direct-message"],
-    sms: ["message"],
+    twilio: ["message"],
     email: ["message"],
   };
   const supported = providerTriggers[channel.type] ?? [];

--- a/docs/agents/channels.mdx
+++ b/docs/agents/channels.mdx
@@ -1,13 +1,71 @@
 ---
-title: "Slack channels"
-description: "Declare Slack capabilities in code and connect them per environment"
+title: "Channels"
+description: "Declare a conversational surface in code and connect it per environment"
 ---
 
 Channels connect a project to a messaging provider. The channel definition is
-code-owned; provider credentials and Slack conversation IDs are configured in
+code-owned; provider credentials and conversation IDs are configured in
 the dashboard for each environment.
 
-The current channel provider is Slack.
+A channel is a conversation keyed by an external participant. What differs
+between providers is transport, addressing, and authentication; what does not
+differ is that an inbound message continues the conversation it belongs to.
+Agents see the second part and never the first — one `useInput().source ===
+"channel"` branch handles every provider.
+
+| Provider | `type` | Addressed by | Triggers |
+| --- | --- | --- | --- |
+| Slack | `"slack"` | bot scopes and events | `mention`, `direct-message` |
+| SMS | `"sms"` | `from`, an E.164 number | `message` |
+| Email | `"email"` | `address` | `message` |
+
+## Define an SMS or email channel
+
+Providers other than Slack address one participant, so they need no scopes and
+have a single inbound event:
+
+```tsx opencomputer/channels/shop-sms.ts
+import { defineChannel } from "@opencomputer/agent";
+
+export default defineChannel({
+  id: "shop-sms",
+  type: "sms",
+  from: "+15125550100",
+  idle: { suspendAfterSeconds: 120 },
+});
+```
+
+```tsx opencomputer/channels/support-email.ts
+import { defineChannel } from "@opencomputer/agent";
+
+export default defineChannel({
+  id: "support-email",
+  type: "email",
+  address: "help@example.com",
+});
+```
+
+Register them the same way as Slack, with the trigger the provider supports:
+
+```tsx opencomputer/agents/receptionist/channels/shop-sms.ts
+import { registerChannel } from "@opencomputer/agent";
+import shopSms from "../../../channels/shop-sms.js";
+
+export default registerChannel(shopSms, { on: ["message"] });
+```
+
+Registering a Slack trigger on an SMS channel is a build error, and the reverse
+is too.
+
+## Idle and cost
+
+Agent runtime is billed by wall-clock time, and a conversation spends most of
+its life waiting for a person. `idle.suspendAfterSeconds` says how long to hold
+the runtime after the last message; an inbound message resumes it. It defaults
+to 300 seconds, and the default matters most where replies are slowest — an SMS
+conversation that waits hours for an answer should not bill for those hours.
+
+## Slack
 
 ## Define a Slack channel
 

--- a/docs/agents/channels.mdx
+++ b/docs/agents/channels.mdx
@@ -13,13 +13,19 @@ differ is that an inbound message continues the conversation it belongs to.
 Agents see the second part and never the first — one `useInput().source ===
 "channel"` branch handles every provider.
 
-| Provider | `type` | Addressed by | Triggers |
-| --- | --- | --- | --- |
-| Slack | `"slack"` | bot scopes and events | `mention`, `direct-message` |
-| SMS | `"sms"` | `from`, an E.164 number | `message` |
-| Email | `"email"` | `address` | `message` |
+| Provider | `type` | Triggers |
+| --- | --- | --- |
+| Slack | `"slack"` | `mention`, `direct-message` |
+| Twilio (SMS, WhatsApp) | `"twilio"` | `message` |
+| Email | `"email"` | `message` |
 
-## Define an SMS or email channel
+Providers are named for the vendor rather than the medium, because the vendor is
+what actually differs: Twilio signs the request URL and its sorted parameters,
+Slack signs a timestamp and the raw body. A different SMS vendor is a different
+adapter, not a variant of this one. Twilio WhatsApp needs no separate provider —
+same API, same webhook, same signature, with a `whatsapp:` prefix on addresses.
+
+## Define a Twilio or email channel
 
 Providers other than Slack address one participant, so they need no scopes and
 have a single inbound event:
@@ -29,8 +35,7 @@ import { defineChannel } from "@opencomputer/agent";
 
 export default defineChannel({
   id: "shop-sms",
-  type: "sms",
-  from: "+15125550100",
+  type: "twilio",
   idle: { suspendAfterSeconds: 120 },
 });
 ```
@@ -41,9 +46,13 @@ import { defineChannel } from "@opencomputer/agent";
 export default defineChannel({
   id: "support-email",
   type: "email",
-  address: "help@example.com",
 });
 ```
+
+Note what is **not** in the definition: the phone number and the inbox address.
+Those are per-environment operational configuration, bound to a connection in
+the dashboard, exactly as Slack workspace and conversation IDs are. Development
+and production do not share a number.
 
 Register them the same way as Slack, with the trigger the provider supports:
 
@@ -54,7 +63,7 @@ import shopSms from "../../../channels/shop-sms.js";
 export default registerChannel(shopSms, { on: ["message"] });
 ```
 
-Registering a Slack trigger on an SMS channel is a build error, and the reverse
+Registering a Slack trigger on a Twilio channel is a build error, and the reverse
 is too.
 
 ## Idle and cost
@@ -62,7 +71,7 @@ is too.
 Agent runtime is billed by wall-clock time, and a conversation spends most of
 its life waiting for a person. `idle.suspendAfterSeconds` says how long to hold
 the runtime after the last message; an inbound message resumes it. It defaults
-to 300 seconds, and the default matters most where replies are slowest — an SMS
+to 300 seconds, and the default matters most where replies are slowest — a text
 conversation that waits hours for an answer should not bill for those hours.
 
 ## Slack

--- a/web/src/managed-agents/Detail.tsx
+++ b/web/src/managed-agents/Detail.tsx
@@ -72,6 +72,7 @@ import {
 } from './session-history'
 import { ManagedProjectSecrets } from './Secrets'
 import { ManagedSlackWizard } from './SlackWizard'
+import { ManagedTwilioWizard } from './TwilioWizard'
 import { ManagedAgentOutboxes } from './Outboxes'
 import { ManagedAgentSchedules } from './Schedules'
 import { ManagedAgentWebhooks } from './Webhooks'
@@ -1064,22 +1065,38 @@ export default function ManagedAgentDetail({
           </PanelHeader>
           {agent && activeDeployment.data ? (
             declaredChannels.length ? (
-              declaredChannels.map((declaredChannel) => (
-                <ManagedSlackWizard
-                  key={declaredChannel.id}
-                  agentId={agent.id}
-                  alias={activeDeployment.data.alias}
-                  agentName={displayManagedAgentName(agent)}
-                  channelName={
-                    declaredChannel.displayName ?? declaredChannel.id
-                  }
-                  connection={activeAliasChannels.find(
-                    (channel) => channel.channelId === declaredChannel.id,
-                  )}
-                  channelId={declaredChannel.id}
-                  destinations={Object.keys(declaredChannel.destinations)}
-                />
-              ))
+              // The wizard follows the channel's declared provider: Slack has
+              // an app to install, Twilio has credentials to paste and a
+              // number to point here. Nothing about connecting one resembles
+              // connecting the other.
+              declaredChannels.map((declaredChannel) =>
+                declaredChannel.type === 'twilio' ? (
+                  <ManagedTwilioWizard
+                    key={declaredChannel.id}
+                    agentId={agent.id}
+                    alias={activeDeployment.data.alias}
+                    connection={activeAliasChannels.find(
+                      (channel) => channel.channelId === declaredChannel.id,
+                    )}
+                    channelId={declaredChannel.id}
+                  />
+                ) : (
+                  <ManagedSlackWizard
+                    key={declaredChannel.id}
+                    agentId={agent.id}
+                    alias={activeDeployment.data.alias}
+                    agentName={displayManagedAgentName(agent)}
+                    channelName={
+                      declaredChannel.displayName ?? declaredChannel.id
+                    }
+                    connection={activeAliasChannels.find(
+                      (channel) => channel.channelId === declaredChannel.id,
+                    )}
+                    channelId={declaredChannel.id}
+                    destinations={Object.keys(declaredChannel.destinations)}
+                  />
+                ),
+              )
             ) : (
               <ManagedSlackWizard
                 agentId={agent.id}

--- a/web/src/managed-agents/TwilioWizard.test.ts
+++ b/web/src/managed-agents/TwilioWizard.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+/**
+ * The declared-channel schema is what decides which wizard a customer sees.
+ * Slack has an app to install; Twilio has credentials to paste and a number to
+ * point here. Getting the discriminator wrong shows the wrong form entirely.
+ */
+const declaredChannel = z.object({
+  id: z.string(),
+  type: z.enum(['slack', 'twilio', 'email']),
+  displayName: z.string().optional(),
+  destinations: z.record(
+    z.string(),
+    z.object({
+      type: z.enum(['conversation', 'reply']),
+      visibility: z.enum(['public', 'private']).optional(),
+    }),
+  ),
+})
+
+describe('declared channels drive the connect flow', () => {
+  it('accepts a Twilio channel, which has no scopes and no visibility', () => {
+    const parsed = declaredChannel.parse({
+      id: 'shop-sms',
+      type: 'twilio',
+      destinations: { reply: { type: 'reply' } },
+    })
+    expect(parsed.type).toBe('twilio')
+    expect(parsed.destinations.reply?.visibility).toBeUndefined()
+  })
+
+  it('still accepts a Slack channel with a public conversation', () => {
+    const parsed = declaredChannel.parse({
+      id: 'team-slack',
+      type: 'slack',
+      displayName: 'Engineering',
+      destinations: {
+        'pull-request-reviews': { type: 'conversation', visibility: 'public' },
+      },
+    })
+    expect(parsed.destinations['pull-request-reviews']?.visibility).toBe('public')
+  })
+
+  it('refuses a provider the dashboard has no flow for', () => {
+    expect(() =>
+      declaredChannel.parse({ id: 'x', type: 'carrier-pigeon', destinations: {} }),
+    ).toThrow()
+  })
+})

--- a/web/src/managed-agents/TwilioWizard.tsx
+++ b/web/src/managed-agents/TwilioWizard.tsx
@@ -1,0 +1,333 @@
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Check, LoaderCircle, Phone, TriangleAlert } from 'lucide-react'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+import { Field, Input } from '@/components/form'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { StatusBadge } from '@/components/status-badge'
+import { notifyError, notifySuccess } from '@/lib/errors'
+import { cn } from '@/lib/utils'
+import {
+  completeManagedAgentTwilio,
+  disconnectManagedAgentTwilio,
+  startManagedAgentTwilio,
+  type ManagedAgentChannel,
+  type ManagedTwilioSetup,
+} from './api'
+
+type Step = 'credentials' | 'number' | 'forwarding'
+const STEPS = ['Credentials', 'Choose a number', 'Forward your line']
+
+function WizardSteps({ current }: { current: number }) {
+  return (
+    <ol className="flex items-center gap-2 pt-2">
+      {STEPS.map((label, index) => (
+        <li key={label} className="flex min-w-0 items-center gap-2">
+          <span
+            className={cn(
+              'flex size-5 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold',
+              index <= current
+                ? 'bg-foreground text-background'
+                : 'bg-secondary text-muted-foreground',
+            )}
+          >
+            {index < current ? <Check className="size-3" /> : index + 1}
+          </span>
+          <span
+            className={cn(
+              'truncate text-xs',
+              index === current
+                ? 'text-foreground font-medium'
+                : 'text-muted-foreground',
+            )}
+          >
+            {label}
+          </span>
+          {index < STEPS.length - 1 ? (
+            <span className="bg-border h-px w-4 shrink-0" />
+          ) : null}
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+export function ManagedTwilioWizard({
+  agentId,
+  alias,
+  connection,
+  channelId,
+}: {
+  agentId: string
+  alias: string
+  connection?: ManagedAgentChannel
+  channelId?: string
+}) {
+  const queryClient = useQueryClient()
+  const [open, setOpen] = useState(false)
+  const [step, setStep] = useState<Step>('credentials')
+  const [accountSid, setAccountSid] = useState('')
+  const [authToken, setAuthToken] = useState('')
+  const [setup, setSetup] = useState<ManagedTwilioSetup>()
+  const [numberSid, setNumberSid] = useState('')
+  const [connectedNumber, setConnectedNumber] = useState('')
+  const [confirmDisconnect, setConfirmDisconnect] = useState(false)
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ['managed-agent-channels'] })
+
+  const start = useMutation({
+    mutationFn: () =>
+      startManagedAgentTwilio(`${agentId}@${alias}`, {
+        accountSid: accountSid.trim(),
+        authToken: authToken.trim(),
+        ...(channelId ? { channelId } : {}),
+      }),
+    onSuccess: (result) => {
+      setSetup(result)
+      // Clear the token as soon as it has been exchanged; the browser has no
+      // further use for it.
+      setAuthToken('')
+      setNumberSid(result.numbers[0]?.sid ?? '')
+      setStep('number')
+      void invalidate()
+    },
+    onError: (error) =>
+      notifyError('Twilio did not accept those credentials.', error),
+  })
+
+  const complete = useMutation({
+    mutationFn: () => {
+      const chosen = setup?.numbers.find((number) => number.sid === numberSid)
+      if (!setup || !chosen) throw new Error('Choose a number to continue')
+      return completeManagedAgentTwilio(setup.connection.id, {
+        numberSid: chosen.sid,
+        phoneNumber: chosen.phoneNumber,
+        webhookToken: setup.webhookToken,
+      })
+    },
+    onSuccess: (result) => {
+      setConnectedNumber(result.connection.phoneNumber ?? '')
+      setStep('forwarding')
+      notifySuccess('Twilio is connected.')
+      void invalidate()
+    },
+    onError: (error) =>
+      notifyError("Twilio wouldn't accept the webhook setup.", error),
+  })
+
+  const disconnect = useMutation({
+    mutationFn: () => disconnectManagedAgentTwilio(connection!.id),
+    onSuccess: () => {
+      setConfirmDisconnect(false)
+      void invalidate()
+    },
+    onError: (error) => notifyError("Couldn't disconnect Twilio.", error),
+  })
+
+  const begin = () => {
+    setStep('credentials')
+    setAccountSid('')
+    setAuthToken('')
+    setSetup(undefined)
+    setNumberSid('')
+    setConnectedNumber('')
+    setOpen(true)
+  }
+
+  const isConnected = connection?.status === 'connected'
+
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        {isConnected ? (
+          <>
+            <StatusBadge status="active" label="Connected" />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setConfirmDisconnect(true)}
+            >
+              Disconnect
+            </Button>
+          </>
+        ) : (
+          <Button size="sm" onClick={begin}>
+            <Phone className="size-4" />
+            Connect Twilio
+          </Button>
+        )}
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Connect Twilio</DialogTitle>
+            <DialogDescription>
+              Calls and texts to a Twilio number reach this agent.
+            </DialogDescription>
+            <WizardSteps current={STEPS.indexOf(
+              step === 'credentials'
+                ? 'Credentials'
+                : step === 'number'
+                  ? 'Choose a number'
+                  : 'Forward your line',
+            )} />
+          </DialogHeader>
+
+          {step === 'credentials' ? (
+            <div className="space-y-4">
+              <p className="text-muted-foreground text-sm">
+                Both values are on your Twilio console dashboard. We check them
+                with Twilio before storing anything.
+              </p>
+              <Field label="Account SID">
+                <Input
+                  value={accountSid}
+                  onChange={(event) => setAccountSid(event.target.value)}
+                  placeholder="AC…"
+                  autoComplete="off"
+                />
+              </Field>
+              <Field label="Auth token">
+                <Input
+                  type="password"
+                  value={authToken}
+                  onChange={(event) => setAuthToken(event.target.value)}
+                  placeholder="Your Twilio auth token"
+                  autoComplete="off"
+                />
+              </Field>
+              <DialogFooter>
+                <Button
+                  onClick={() => start.mutate()}
+                  disabled={
+                    start.isPending || !accountSid.trim() || !authToken.trim()
+                  }
+                >
+                  {start.isPending ? (
+                    <LoaderCircle className="size-4 animate-spin" />
+                  ) : null}
+                  Continue
+                </Button>
+              </DialogFooter>
+            </div>
+          ) : null}
+
+          {step === 'number' && setup ? (
+            <div className="space-y-4">
+              <p className="text-muted-foreground text-sm">
+                Connected to{' '}
+                <span className="text-foreground font-medium">
+                  {setup.account.friendlyName}
+                </span>
+                . Choose the number this agent should answer. We'll point it at
+                OpenComputer for you.
+              </p>
+              {setup.numbers.length === 0 ? (
+                <div className="flex items-start gap-2 rounded-md border p-3 text-sm">
+                  <TriangleAlert className="text-muted-foreground mt-0.5 size-4 shrink-0" />
+                  <p>
+                    This account has no number that can take both calls and
+                    texts. Buy one in Twilio, then come back — a number without
+                    voice can't catch a missed call.
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {setup.numbers.map((number) => (
+                    <label
+                      key={number.sid}
+                      className={cn(
+                        'flex cursor-pointer items-center gap-3 rounded-md border p-3 text-sm',
+                        numberSid === number.sid
+                          ? 'border-foreground'
+                          : 'border-border',
+                      )}
+                    >
+                      <input
+                        type="radio"
+                        name="twilio-number"
+                        value={number.sid}
+                        checked={numberSid === number.sid}
+                        onChange={() => setNumberSid(number.sid)}
+                      />
+                      <span className="min-w-0">
+                        <span className="block font-medium">
+                          {number.phoneNumber}
+                        </span>
+                        <span className="text-muted-foreground block truncate text-xs">
+                          {number.friendlyName}
+                        </span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              )}
+              <DialogFooter>
+                <Button
+                  onClick={() => complete.mutate()}
+                  disabled={complete.isPending || !numberSid}
+                >
+                  {complete.isPending ? (
+                    <LoaderCircle className="size-4 animate-spin" />
+                  ) : null}
+                  Connect this number
+                </Button>
+              </DialogFooter>
+            </div>
+          ) : null}
+
+          {step === 'forwarding' ? (
+            <div className="space-y-4">
+              <div className="flex items-start gap-2 rounded-md border p-3 text-sm">
+                <Check className="mt-0.5 size-4 shrink-0" />
+                <p>
+                  <span className="font-medium">{connectedNumber}</span> now
+                  reaches this agent. Texts to it start a conversation, and
+                  calls take a voicemail the agent reads.
+                </p>
+              </div>
+              <div className="space-y-2 text-sm">
+                <p className="font-medium">
+                  One last step, on your existing business line
+                </p>
+                <p className="text-muted-foreground">
+                  Set busy and no-answer forwarding to {connectedNumber}. On
+                  most carriers that is a code you dial once from the phone
+                  itself, or a single setting if the line is VoIP. Calls you
+                  answer are unaffected — only the ones you miss come here.
+                </p>
+                <p className="text-muted-foreground">
+                  This replaces your carrier's voicemail with one the agent can
+                  act on, so keep your greeting in mind before you switch it.
+                </p>
+              </div>
+              <DialogFooter>
+                <Button onClick={() => setOpen(false)}>Done</Button>
+              </DialogFooter>
+            </div>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={confirmDisconnect}
+        onOpenChange={setConfirmDisconnect}
+        title="Disconnect Twilio?"
+        description="Calls and texts to this number stop reaching the agent. Your Twilio number and its history are untouched, and the forwarding on your business line stays until you remove it."
+        confirmLabel="Disconnect"
+        onConfirm={() => disconnect.mutate()}
+        pending={disconnect.isPending}
+      />
+    </>
+  )
+}

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -27,13 +27,15 @@ const deploymentSchema = z.object({
         channels: z.array(
           z.object({
             id: z.string(),
-            type: z.literal('slack'),
+            type: z.enum(['slack', 'twilio', 'email']),
             displayName: z.string().optional(),
+            // Slack addresses a named conversation; the others reply on the
+            // one the message arrived on, so visibility does not apply.
             destinations: z.record(
               z.string(),
               z.object({
-                type: z.literal('conversation'),
-                visibility: z.enum(['public', 'private']),
+                type: z.enum(['conversation', 'reply']),
+                visibility: z.enum(['public', 'private']).optional(),
               }),
             ),
           }),
@@ -1013,6 +1015,74 @@ export async function completeManagedAgentSlack(
     `/managed-agents/channels/slack/connections/${encodeURIComponent(connectionId)}`,
     { method: 'PUT', body: JSON.stringify(input) },
     channelSchema,
+  )
+}
+
+const twilioNumberSchema = z.object({
+  sid: z.string(),
+  phoneNumber: z.string(),
+  friendlyName: z.string(),
+  capabilities: z.object({ sms: z.boolean(), voice: z.boolean() }),
+})
+
+const twilioSetupSchema = z.object({
+  connection: z.object({
+    id: z.string(),
+    provider: z.string(),
+    status: z.string(),
+  }),
+  account: z.object({ sid: z.string(), friendlyName: z.string() }),
+  numbers: z.array(twilioNumberSchema),
+  // Shown once, held only in the browser between the two steps, and never
+  // stored: it is half of what authenticates the webhook.
+  webhookToken: z.string(),
+})
+
+const twilioConnectionSchema = z.object({
+  connection: z.object({
+    id: z.string(),
+    provider: z.string().optional(),
+    status: z.string(),
+    phoneNumber: z.string().optional(),
+  }),
+})
+
+export type ManagedTwilioNumber = z.infer<typeof twilioNumberSchema>
+export type ManagedTwilioSetup = z.infer<typeof twilioSetupSchema>
+
+/**
+ * Step one. The credentials are checked against Twilio before anything is
+ * stored, so a mistyped SID comes back as a message rather than a broken
+ * connection nobody can see is broken.
+ */
+export async function startManagedAgentTwilio(
+  agentId: string,
+  input: { accountSid: string; authToken: string; channelId?: string },
+) {
+  return apiFetch(
+    '/managed-agents/channels/twilio/connections',
+    { method: 'POST', body: JSON.stringify({ agentId, ...input }) },
+    twilioSetupSchema,
+  )
+}
+
+/** Step two. Points the chosen number at OpenComputer and opens the line. */
+export async function completeManagedAgentTwilio(
+  connectionId: string,
+  input: { numberSid: string; phoneNumber: string; webhookToken: string },
+) {
+  return apiFetch(
+    `/managed-agents/channels/twilio/connections/${encodeURIComponent(connectionId)}`,
+    { method: 'PUT', body: JSON.stringify(input) },
+    twilioConnectionSchema,
+  )
+}
+
+export async function disconnectManagedAgentTwilio(connectionId: string) {
+  return apiFetch(
+    `/managed-agents/channels/twilio/connections/${encodeURIComponent(connectionId)}`,
+    { method: 'DELETE' },
+    twilioConnectionSchema,
   )
 }
 


### PR DESCRIPTION
The authoring half of diggerhq/blue#52. Merge that first — the dashboard here
calls endpoints that only exist there.

`defineChannel` was typed `type: "slack"` and the compiler refused anything
else outright, so a second provider couldn't be declared. It's now a union over
slack | twilio | email, with triggers validated per provider: `mention` and
`direct-message` are Slack's, `message` belongs to the others, and crossing
them is a build error.

Named for the vendor, as `slack` is, because that's what differs — Twilio signs
the request URL where Slack signs the body. Twilio WhatsApp then needs no
separate provider.

Phone numbers and inbox addresses are not in the definitions. They're
per-environment config bound to a connection, exactly as Slack conversation IDs
already are, and hardcoding one would make dev and prod share a number.

Adds `idle.suspendAfterSeconds`: runtime bills wall-clock, and a conversation
waiting hours for a reply shouldn't.

Plus the Twilio connect flow in the dashboard.