### PR TITLE
Memory authoring: defineMemory, useMemory and manifest registration

### DIFF
--- a/.github/workflows/publish-opencomputer-packages.yml
+++ b/.github/workflows/publish-opencomputer-packages.yml
@@ -47,11 +47,11 @@ jobs:
       - name: Verify package version contract
         run: node scripts/check-opencomputer-package-contract.mjs
 
-      - name: Install and build agent package
+      - name: Install and test agent package
         working-directory: agent
         run: |
           npm ci
-          npm run build
+          npm test
 
       - name: Install and test CLI package
         working-directory: cli

--- a/agent/README.md
+++ b/agent/README.md
@@ -26,6 +26,10 @@ describe that call; they do not perform I/O or run the durable agent loop.
 - `useTool()` and `useSubagent()` select declared capabilities.
 - `useSessionData()` reads the current durable session-data snapshot.
 - `useMcpServer()` conditionally selects a declared MCP server.
+- `useMemory()` reads the projection of a memory resource bound to the
+  session (`text`, `sources`, `writable`) and selects its tools. Declare the
+  resource with `defineMemory()`; `documentMemory()` is the default provider
+  and `httpMemory()` delegates recall and tools to a declared connection.
 
 Use `defineMcpServer()` for stable MCP declarations. Never put credentials
 directly in these declarations: OpenComputer resolves referenced secrets

--- a/agent/package-lock.json
+++ b/agent/package-lock.json
@@ -1,20 +1,31 @@
 {
   "name": "@opencomputer/agent",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/agent",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "dependencies": {
         "croner": "^9.1.0"
       },
       "devDependencies": {
+        "@types/node": "^24.0.0",
         "typescript": "^5.9.0"
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.4.tgz",
+      "integrity": "sha512-YJ7EqCstVTzIr0fMr7qul/977en+pQHrfmuKIo6Zr9i75Be21dr3MovcfvGtyvi2HAUrRerWps5sMO9I7WaxDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/croner": {
@@ -39,6 +50,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/agent",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Reactive agent authoring API for OpenComputer.",
   "type": "module",
   "main": "./dist/index.js",
@@ -17,7 +17,8 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "prepack": "npm run build"
+    "prepack": "npm run build",
+    "test": "npm run build && node --test dist/*.test.js"
   },
   "engines": {
     "node": ">=22.0.0"
@@ -31,7 +32,8 @@
     "directory": "agent"
   },
   "devDependencies": {
-    "typescript": "^5.9.0"
+    "typescript": "^5.9.0",
+    "@types/node": "^24.0.0"
   },
   "dependencies": {
     "croner": "^9.1.0"

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -1,0 +1,320 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  bearer,
+  defineConnection,
+  defineMemory,
+  documentMemory,
+  httpMemory,
+  useMemory,
+  useSecret,
+  type MemoryProjection,
+} from "./index.js";
+
+const HOOKS = Symbol.for("opencomputer.agent-hooks");
+
+/**
+ * Mirrors the host's render worker: a per-render scope with the projections
+ * the host resolved, keyed by resource id, and the ids the render selected.
+ */
+function renderWith<T>(
+  memory: Record<string, MemoryProjection>,
+  render: () => T,
+): { result: T; selectedMemory: string[] } {
+  const scope = { memory, selectedMemory: new Set<string>() };
+  const globals = globalThis as Record<PropertyKey, unknown>;
+  globals[HOOKS] = {
+    useMemory(id: string) {
+      const projection = scope.memory[id];
+      if (projection) scope.selectedMemory.add(id);
+      return projection;
+    },
+  };
+  try {
+    return { result: render(), selectedMemory: [...scope.selectedMemory].sort() };
+  } finally {
+    delete globals[HOOKS];
+  }
+}
+
+test("defineMemory returns a frozen document declaration by default", () => {
+  const memory = defineMemory({
+    id: "requirements",
+    description: "  Verified requirements for a workshop.  ",
+  });
+  assert.deepEqual(memory, {
+    kind: "memory",
+    version: 1,
+    id: "requirements",
+    description: "Verified requirements for a workshop.",
+    provider: { kind: "document", maxBytes: 8192 },
+  });
+  assert.ok(Object.isFrozen(memory));
+  assert.ok(Object.isFrozen(memory.provider));
+  assert.equal(JSON.parse(JSON.stringify(memory)).provider.maxBytes, 8192);
+});
+
+test("documentMemory validates maxBytes at definition time", () => {
+  assert.deepEqual(documentMemory({ maxBytes: 16_384 }), {
+    kind: "document",
+    maxBytes: 16_384,
+  });
+  for (const maxBytes of [0, -1, 1.5, 16_385, Number.NaN]) {
+    assert.throws(
+      () => documentMemory({ maxBytes }),
+      /maxBytes must be a whole number between 1 and 16384/,
+    );
+  }
+});
+
+test("defineMemory applies the framework identifier rules", () => {
+  for (const id of ["", " ", "Requirements", "notes_v2", "-notes", "a--b"]) {
+    assert.throws(() => defineMemory({ id, description: "x" }));
+  }
+  assert.throws(
+    () => defineMemory({ id: "a".repeat(129), description: "x" }),
+    /at most 128 characters/,
+  );
+  assert.throws(
+    () => defineMemory({ id: "notes", description: "   " }),
+    /requires a non-empty description/,
+  );
+});
+
+const connection = defineConnection({
+  id: "memory-service",
+  origin: "https://memory.example.com",
+  methods: ["POST"],
+  pathPrefix: "/oc-memory",
+  headers: { Authorization: bearer(useSecret("MEMORY_TOKEN")) },
+});
+
+test("httpMemory serializes the connection id, path, limit, and tools", () => {
+  const provider = httpMemory({
+    connection,
+    path: "/oc-memory",
+    tools: [
+      {
+        name: "remember",
+        description: "Save a verified fact for future work.",
+        access: "write",
+        input: {
+          type: "object",
+          properties: { fact: { type: "string", maxLength: 2_000 } },
+          required: ["fact"],
+          additionalProperties: false,
+        },
+      },
+    ],
+  });
+  assert.deepEqual(JSON.parse(JSON.stringify(provider)), {
+    kind: "http",
+    connection: "memory-service",
+    path: "/oc-memory",
+    maxBytes: 8192,
+    tools: [
+      {
+        name: "remember",
+        description: "Save a verified fact for future work.",
+        access: "write",
+        idempotent: false,
+        input: {
+          type: "object",
+          properties: { fact: { type: "string", maxLength: 2_000 } },
+          required: ["fact"],
+          additionalProperties: false,
+        },
+      },
+    ],
+  });
+  assert.ok(Object.isFrozen(provider.tools));
+  assert.ok(Object.isFrozen(provider.tools[0]));
+});
+
+test("httpMemory defaults the path and tools and keeps them inside the connection", () => {
+  const open = defineConnection({
+    id: "open-memory",
+    origin: "https://memory.example.com",
+  });
+  assert.deepEqual(httpMemory({ connection: open }), {
+    kind: "http",
+    connection: "open-memory",
+    path: "/memory",
+    maxBytes: 8192,
+    tools: [],
+  });
+  assert.throws(
+    () => httpMemory({ connection }),
+    /outside connection memory-service pathPrefix \/oc-memory/,
+  );
+  const readOnly = defineConnection({
+    id: "read-only",
+    origin: "https://memory.example.com",
+    methods: ["GET"],
+  });
+  assert.throws(
+    () => httpMemory({ connection: readOnly }),
+    /requires connection read-only to allow POST/,
+  );
+  for (const path of ["memory", "//memory", "/memory?x=1", "/memory#top", "/a b"]) {
+    assert.throws(
+      () => httpMemory({ connection: open, path }),
+      /must begin with a single \/ and contain no query or fragment/,
+    );
+  }
+  assert.throws(
+    () => httpMemory({ connection: open, maxBytes: 20_000 }),
+    /maxBytes must be a whole number between 1 and 16384/,
+  );
+  assert.throws(
+    () => httpMemory({ connection: undefined as never }),
+    /requires a defineConnection\(\) connection/,
+  );
+});
+
+test("httpMemory validates tool declarations", () => {
+  const open = defineConnection({
+    id: "open-memory",
+    origin: "https://memory.example.com",
+  });
+  const tool: Record<string, unknown> = {
+    name: "remember",
+    description: "Save a fact.",
+    access: "write",
+    input: { type: "object", properties: {} },
+  };
+  const declare = (tools: Array<Record<string, unknown>>) =>
+    httpMemory({ connection: open, tools: tools as never });
+  for (const name of ["", "Remember", "re-member", "a".repeat(33)]) {
+    assert.throws(
+      () => declare([{ ...tool, name }]),
+      /tool names must use 1 to 32 lowercase letters, numbers, and underscores/,
+    );
+  }
+  assert.throws(() => declare([tool, tool]), /remember is declared more than once/);
+  assert.throws(
+    () => declare(Array.from({ length: 9 }, (_, i) => ({ ...tool, name: `t${i}` }))),
+    /at most 8 tools/,
+  );
+  assert.throws(() => declare([{ ...tool, description: " " }]), /requires a description/);
+  assert.throws(
+    () => declare([{ ...tool, access: "admin" }]),
+    /access must be "read" or "write"/,
+  );
+  assert.throws(
+    () => declare([{ ...tool, idempotent: "yes" }]),
+    /idempotent must be true or false/,
+  );
+  assert.equal(declare([{ ...tool, idempotent: true }]).tools[0]!.idempotent, true);
+  assert.throws(
+    () => declare([{ ...tool, input: { type: "string" } }]),
+    /input must be a JSON Schema with type "object"/,
+  );
+  assert.throws(() => declare([{ ...tool, input: undefined }]), /input must be a JSON Schema object/);
+  assert.throws(
+    () => declare([{ ...tool, input: { type: "object", properties: { a: { $ref: "#/x" } } } }]),
+    /input cannot use \$ref/,
+  );
+});
+
+test("httpMemory rejects the reserved memory argument in tool input", () => {
+  const open = defineConnection({
+    id: "open-memory",
+    origin: "https://memory.example.com",
+  });
+  const reserved = /cannot declare the reserved memory argument/;
+  assert.throws(
+    () =>
+      httpMemory({
+        connection: open,
+        tools: [
+          {
+            name: "search",
+            description: "Search.",
+            access: "read",
+            input: {
+              type: "object",
+              properties: { memory: { type: "string" }, query: { type: "string" } },
+            },
+          },
+        ],
+      }),
+    reserved,
+  );
+  assert.throws(
+    () =>
+      httpMemory({
+        connection: open,
+        tools: [
+          {
+            name: "search",
+            description: "Search.",
+            access: "read",
+            input: { type: "object", required: ["memory"] },
+          },
+        ],
+      }),
+    reserved,
+  );
+});
+
+test("defineMemory rejects providers that are not descriptors", () => {
+  assert.throws(
+    () =>
+      defineMemory({
+        id: "notes",
+        description: "Notes.",
+        provider: { kind: "redis" } as never,
+      }),
+    /provider must be documentMemory\(\) or httpMemory\(\)/,
+  );
+});
+
+test("useMemory reads the host projection and records the selection", () => {
+  const requirements = defineMemory({
+    id: "requirements",
+    description: "Requirements.",
+  });
+  const projection: MemoryProjection = {
+    text: "Node.js 22, no paid services.",
+    sources: [
+      {
+        id: "workshop",
+        title: "Workshop requirements",
+        revision: "r2",
+        updatedAt: "2026-09-10T12:00:00.000Z",
+      },
+    ],
+    writable: true,
+  };
+  const { result, selectedMemory } = renderWith(
+    { requirements: projection, budget: { text: "", sources: [], writable: false } },
+    () => useMemory(requirements),
+  );
+  assert.equal(result, projection);
+  assert.deepEqual(selectedMemory, ["requirements"]);
+  assert.deepEqual(
+    renderWith({ requirements: projection }, () => useMemory("requirements")).result,
+    projection,
+  );
+});
+
+test("useMemory fails a render whose session has no binding for the resource", () => {
+  assert.throws(
+    () => renderWith({}, () => useMemory("requirements")),
+    /Memory "requirements" is not bound to this session/,
+  );
+  assert.throws(
+    () =>
+      renderWith(
+        { requirements: { text: "x" } as never },
+        () => useMemory("requirements"),
+      ),
+    /Memory "requirements" is not bound to this session/,
+  );
+  assert.throws(() => renderWith({}, () => useMemory("Not Valid")));
+  assert.throws(
+    () => useMemory("requirements"),
+    /hooks can only run while rendering an agent/,
+  );
+});

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -270,6 +270,90 @@ test("defineMemory rejects providers that are not descriptors", () => {
   );
 });
 
+test("defineMemory normalizes a hand-written descriptor like the provider functions do", () => {
+  assert.deepEqual(
+    defineMemory({
+      id: "notes",
+      description: "Notes.",
+      provider: { kind: "document", maxBytes: 4_096 },
+    }).provider,
+    documentMemory({ maxBytes: 4_096 }),
+  );
+  assert.throws(
+    () =>
+      defineMemory({
+        id: "notes",
+        description: "Notes.",
+        provider: { kind: "document", maxBytes: 16_385 },
+      }),
+    /Memory notes maxBytes must be a whole number between 1 and 16384/,
+  );
+  assert.throws(
+    () =>
+      defineMemory({
+        id: "notes",
+        description: "Notes.",
+        provider: { kind: "http", connection: "", path: "/memory", maxBytes: 1, tools: [] },
+      }),
+    /Memory notes requires a defineConnection\(\) connection/,
+  );
+  assert.throws(
+    () =>
+      defineMemory({
+        id: "notes",
+        description: "Notes.",
+        provider: {
+          kind: "http",
+          connection: "memory-service",
+          path: "/memory",
+          maxBytes: 1,
+          tools: [{ name: "x", description: "X.", access: "read", idempotent: false, input: { type: "object", required: ["memory"] } }],
+        },
+      }),
+    /Memory notes tool x input cannot declare the reserved memory argument/,
+  );
+});
+
+test("httpMemory freezes tool descriptors deeply and copies the caller's schema", () => {
+  const open = defineConnection({
+    id: "open-memory",
+    origin: "https://memory.example.com",
+  });
+  const input = {
+    type: "object",
+    properties: { fact: { type: "string", maxLength: 2_000 } },
+    required: ["fact"],
+  };
+  const provider = httpMemory({
+    connection: open,
+    tools: [{ name: "remember", description: "Save.", access: "write", input }],
+  });
+  const tool = provider.tools[0]!;
+  assert.ok(Object.isFrozen(provider));
+  assert.ok(Object.isFrozen(provider.tools));
+  assert.ok(Object.isFrozen(tool));
+  assert.ok(Object.isFrozen(tool.input));
+  assert.ok(Object.isFrozen(tool.input.properties));
+  assert.ok(Object.isFrozen(tool.input.required));
+  assert.ok(
+    Object.isFrozen((tool.input.properties as Record<string, unknown>).fact),
+  );
+  assert.notEqual(tool.input, input);
+  input.properties.fact.maxLength = 1;
+  assert.equal(
+    (tool.input.properties as Record<string, { maxLength: number }>).fact!.maxLength,
+    2_000,
+  );
+});
+
+test("a projection carries no provider read state", () => {
+  // Cursors stay with the host: the type is the promise, checked at build.
+  const keys: Array<keyof MemoryProjection> = ["text", "sources", "writable"];
+  // @ts-expect-error a cursor is not a hook value.
+  const cursor: keyof MemoryProjection = "cursor";
+  assert.deepEqual([...keys, cursor].length, 4);
+});
+
 test("useMemory reads the host projection and records the selection", () => {
   const requirements = defineMemory({
     id: "requirements",

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -287,7 +287,10 @@ export type ToolInputSchema = Readonly<Record<string, unknown>>;
 export interface ToolExecutionContext {
   readonly input: Record<string, unknown>;
   readonly sessionId: string;
+  /** The assistant message that emitted this call. */
   readonly messageId: string;
+  /** The host-assigned id of this tool call, unique within the session. */
+  readonly toolCallId: string;
   readonly agentId: string;
   readonly signal?: AbortSignal;
   reportProgress(metadata: Readonly<Record<string, DataValue>>): Promise<void>;
@@ -305,6 +308,95 @@ export interface ToolDefinition<
   run(context: ToolExecutionContext): Output | Promise<Output>;
 }
 
+export interface MemoryReference extends ResourceReference {
+  readonly kind: "memory";
+}
+
+/** Bounded text documents stored by OpenComputer. */
+export interface DocumentMemoryProvider {
+  readonly kind: "document";
+  /** Maximum UTF-8 size of each document's text, for every writer. */
+  readonly maxBytes: number;
+}
+
+export type MemoryToolAccess = "read" | "write";
+
+/**
+ * A tool an HTTP memory endpoint executes. The model sees it as
+ * `memory_<name>` with the reserved `memory` argument naming the resource, so
+ * `input` may not declare a `memory` property of its own.
+ */
+export interface HttpMemoryToolDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly access: MemoryToolAccess;
+  /**
+   * Only an idempotent write is retried after a transport failure or timeout.
+   * Declare it only when the endpoint deduplicates `(partition, operationId)`.
+   */
+  readonly idempotent: boolean;
+  readonly input: ToolInputSchema;
+}
+
+/** Recall and tools served by another service through a declared connection. */
+export interface HttpMemoryProvider {
+  readonly kind: "http";
+  readonly connection: string;
+  readonly path: string;
+  /** Maximum UTF-8 size of recalled text. */
+  readonly maxBytes: number;
+  readonly tools: readonly HttpMemoryToolDefinition[];
+}
+
+export type MemoryProvider = DocumentMemoryProvider | HttpMemoryProvider;
+
+/**
+ * A memory resource, registered by the compiler and admitted per session.
+ * The same id in every agent of a project names the same resource.
+ */
+export interface MemoryDefinition extends MemoryReference {
+  readonly version: 1;
+  /** Model-facing guidance, shown in the resource's tool descriptions. */
+  readonly description: string;
+  readonly provider: MemoryProvider;
+}
+
+export interface MemorySource {
+  readonly id: string;
+  readonly title?: string;
+  readonly revision?: string;
+  readonly updatedAt?: string;
+}
+
+/**
+ * What this model request knows from one bound memory resource. The host
+ * resolves it before the render; the shape is the same for every provider.
+ */
+export interface MemoryProjection {
+  readonly text: string;
+  readonly sources: readonly MemorySource[];
+  /** Provider read state the host retains for this request's tools; opaque. */
+  readonly cursor?: string;
+  /** Whether this binding's save tool can commit right now. */
+  readonly writable: boolean;
+}
+
+/**
+ * Implemented by the host that renders the agent. The host renders inside an
+ * isolated worker with a per-render `scope`, sets this object on
+ * `globalThis[Symbol.for("opencomputer.agent-hooks")]`, and clears the scope
+ * when the render returns. The scope fields each hook reads or writes:
+ *
+ * - `useInput()` reads `scope.input`.
+ * - `useSessionData(key)` reads `scope.state[key]`.
+ * - `useTool(id)` adds to `scope.tools`; returned as `enabledTools`.
+ * - `useMemory(id)` reads `scope.memory[id]`, the projection the host
+ *   resolved for the session binding with that resource id (absent when the
+ *   session has no binding for it), and adds the id to
+ *   `scope.selectedMemory`, returned sorted as `selectedMemory` next to
+ *   `enabledTools`. The selection is what routes memory tools and their
+ *   `memory` argument for the model request this render produced.
+ */
 interface AgentHooks {
   useInput(): Readonly<AgentInput>;
   useModel(model: ModelSelection): void;
@@ -312,6 +404,7 @@ interface AgentHooks {
   useSubagent(agent: string | ResourceReference): void;
   useSessionData<T extends DataValue>(key: string): T | undefined;
   useMcpServer(server: string | ResourceReference): void;
+  useMemory(memory: string): MemoryProjection | undefined;
 }
 
 function hooks(): AgentHooks {
@@ -868,6 +961,240 @@ export function defineTool<Output extends DataValue = DataValue>(input: {
     id,
     name: id,
   });
+}
+
+const MEMORY_DEFAULT_MAX_BYTES = 8_192;
+const MEMORY_MAX_BYTES_CEILING = 16_384;
+const MEMORY_ID_MAX_LENGTH = 128;
+const HTTP_MEMORY_DEFAULT_PATH = "/memory";
+const HTTP_MEMORY_MAX_TOOLS = 8;
+const HTTP_MEMORY_TOOL_NAME_PATTERN = /^[a-z0-9_]{1,32}$/;
+/** Injected into every memory tool's model-facing schema to select the resource. */
+const MEMORY_RESERVED_ARGUMENT = "memory";
+
+function memoryMaxBytes(value: number | undefined, label: string): number {
+  if (value === undefined) return MEMORY_DEFAULT_MAX_BYTES;
+  if (
+    !Number.isInteger(value) ||
+    value < 1 ||
+    value > MEMORY_MAX_BYTES_CEILING
+  ) {
+    throw new Error(
+      `${label} maxBytes must be a whole number between 1 and ${MEMORY_MAX_BYTES_CEILING}`,
+    );
+  }
+  return value;
+}
+
+function containsSchemaReference(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsSchemaReference);
+  if (!value || typeof value !== "object") return false;
+  return Object.entries(value as Record<string, unknown>).some(
+    ([key, nested]) => key === "$ref" || containsSchemaReference(nested),
+  );
+}
+
+function httpMemoryToolInput(value: unknown, label: string): ToolInputSchema {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} input must be a JSON Schema object`);
+  }
+  const schema = value as Record<string, unknown>;
+  if (schema.type !== "object") {
+    throw new Error(`${label} input must be a JSON Schema with type "object"`);
+  }
+  if (containsSchemaReference(schema)) {
+    throw new Error(`${label} input cannot use $ref`);
+  }
+  const properties = schema.properties;
+  if (
+    properties !== undefined &&
+    (!properties || typeof properties !== "object" || Array.isArray(properties))
+  ) {
+    throw new Error(`${label} input properties must be an object`);
+  }
+  const required = schema.required;
+  if (
+    required !== undefined &&
+    (!Array.isArray(required) ||
+      required.some((name) => typeof name !== "string"))
+  ) {
+    throw new Error(`${label} input required must be an array of strings`);
+  }
+  if (
+    (properties &&
+      Object.prototype.hasOwnProperty.call(
+        properties,
+        MEMORY_RESERVED_ARGUMENT,
+      )) ||
+    (Array.isArray(required) && required.includes(MEMORY_RESERVED_ARGUMENT))
+  ) {
+    throw new Error(
+      `${label} input cannot declare the reserved ${MEMORY_RESERVED_ARGUMENT} argument; OpenComputer adds it to select the resource`,
+    );
+  }
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(schema);
+  } catch {
+    serialized = undefined;
+  }
+  if (serialized === undefined) {
+    throw new Error(`${label} input must be JSON-compatible`);
+  }
+  return Object.freeze(JSON.parse(serialized) as Record<string, unknown>);
+}
+
+export interface HttpMemoryToolInput {
+  name: string;
+  description: string;
+  access: MemoryToolAccess;
+  idempotent?: boolean;
+  input: ToolInputSchema;
+}
+
+export function documentMemory(
+  input: { maxBytes?: number } = {},
+): DocumentMemoryProvider {
+  return Object.freeze({
+    kind: "document" as const,
+    maxBytes: memoryMaxBytes(input.maxBytes, "documentMemory"),
+  });
+}
+
+export function httpMemory(input: {
+  connection: ConnectionReference;
+  path?: string;
+  maxBytes?: number;
+  tools?: readonly HttpMemoryToolInput[];
+}): HttpMemoryProvider {
+  const connection = input.connection;
+  if (!connection || typeof connection !== "object" || !connection.id) {
+    throw new Error("httpMemory requires a defineConnection() connection");
+  }
+  const path = input.path ?? HTTP_MEMORY_DEFAULT_PATH;
+  if (!/^\/(?!\/)[^?#\s]*$/.test(path)) {
+    throw new Error(
+      "httpMemory path must begin with a single / and contain no query or fragment",
+    );
+  }
+  const policy = connection as Partial<HttpConnectionDefinition>;
+  if (policy.pathPrefix && !path.startsWith(policy.pathPrefix)) {
+    throw new Error(
+      `httpMemory path ${path} is outside connection ${connection.id} pathPrefix ${policy.pathPrefix}`,
+    );
+  }
+  if (policy.methods && !policy.methods.includes("POST")) {
+    throw new Error(
+      `httpMemory requires connection ${connection.id} to allow POST`,
+    );
+  }
+  const tools = input.tools ?? [];
+  if (tools.length > HTTP_MEMORY_MAX_TOOLS) {
+    throw new Error(
+      `httpMemory may declare at most ${HTTP_MEMORY_MAX_TOOLS} tools`,
+    );
+  }
+  const names = new Set<string>();
+  const normalized = tools.map((tool) => {
+    const name = typeof tool.name === "string" ? tool.name.trim() : "";
+    if (!HTTP_MEMORY_TOOL_NAME_PATTERN.test(name)) {
+      throw new Error(
+        "httpMemory tool names must use 1 to 32 lowercase letters, numbers, and underscores",
+      );
+    }
+    const label = `httpMemory tool ${name}`;
+    if (names.has(name)) throw new Error(`${label} is declared more than once`);
+    names.add(name);
+    const description =
+      typeof tool.description === "string" ? tool.description.trim() : "";
+    if (!description) throw new Error(`${label} requires a description`);
+    if (tool.access !== "read" && tool.access !== "write") {
+      throw new Error(`${label} access must be "read" or "write"`);
+    }
+    if (tool.idempotent !== undefined && typeof tool.idempotent !== "boolean") {
+      throw new Error(`${label} idempotent must be true or false`);
+    }
+    return Object.freeze({
+      name,
+      description,
+      access: tool.access,
+      idempotent: tool.idempotent ?? false,
+      input: httpMemoryToolInput(tool.input, label),
+    });
+  });
+  return Object.freeze({
+    kind: "http" as const,
+    connection: connection.id,
+    path,
+    maxBytes: memoryMaxBytes(input.maxBytes, "httpMemory"),
+    tools: Object.freeze(normalized),
+  });
+}
+
+function memoryIdentifier(value: string, kind: string): string {
+  const id = resourceIdentifier(value, kind);
+  if (id.length > MEMORY_ID_MAX_LENGTH) {
+    throw new Error(
+      `${kind} IDs must contain at most ${MEMORY_ID_MAX_LENGTH} characters`,
+    );
+  }
+  return id;
+}
+
+export function defineMemory(input: {
+  id: string;
+  description: string;
+  provider?: MemoryProvider;
+}): MemoryDefinition {
+  const id = memoryIdentifier(input.id, "defineMemory");
+  const description =
+    typeof input.description === "string" ? input.description.trim() : "";
+  if (!description) {
+    throw new Error(`Memory ${id} requires a non-empty description`);
+  }
+  const provider = input.provider ?? documentMemory();
+  if (provider.kind !== "document" && provider.kind !== "http") {
+    throw new Error(
+      `Memory ${id} provider must be documentMemory() or httpMemory()`,
+    );
+  }
+  return Object.freeze({
+    kind: "memory" as const,
+    version: 1 as const,
+    id,
+    description,
+    provider,
+  });
+}
+
+function isMemoryProjection(value: unknown): value is MemoryProjection {
+  if (!value || typeof value !== "object") return false;
+  const projection = value as Record<string, unknown>;
+  return (
+    typeof projection.text === "string" &&
+    Array.isArray(projection.sources) &&
+    typeof projection.writable === "boolean"
+  );
+}
+
+/**
+ * The projection the host recalled for this session's binding of `memory`.
+ * It never fetches: a session without that binding fails the render here,
+ * before inference. Calling it also selects the binding's permitted tools for
+ * this model request; omitting it exposes none of them.
+ */
+export function useMemory(memory: string | ResourceReference): MemoryProjection {
+  const id = memoryIdentifier(
+    typeof memory === "string" ? memory : memory.id,
+    "useMemory",
+  );
+  const projection = hooks().useMemory(id);
+  if (!isMemoryProjection(projection)) {
+    throw new Error(
+      `Memory ${JSON.stringify(id)} is not bound to this session; create the session with a memory binding for it`,
+    );
+  }
+  return projection;
 }
 
 export const useInput = (): Readonly<AgentInput> => hooks().useInput();

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1,5 +1,11 @@
 import { Cron } from "croner";
 
+import {
+  memoryId,
+  memoryProjection,
+  type MemoryProjection,
+} from "./memory.js";
+
 export type DataValue =
   | null
   | boolean
@@ -308,78 +314,23 @@ export interface ToolDefinition<
   run(context: ToolExecutionContext): Output | Promise<Output>;
 }
 
-export interface MemoryReference extends ResourceReference {
-  readonly kind: "memory";
-}
-
-/** Bounded text documents stored by OpenComputer. */
-export interface DocumentMemoryProvider {
-  readonly kind: "document";
-  /** Maximum UTF-8 size of each document's text, for every writer. */
-  readonly maxBytes: number;
-}
-
-export type MemoryToolAccess = "read" | "write";
-
-/**
- * A tool an HTTP memory endpoint executes. The model sees it as
- * `memory_<name>` with the reserved `memory` argument naming the resource, so
- * `input` may not declare a `memory` property of its own.
- */
-export interface HttpMemoryToolDefinition {
-  readonly name: string;
-  readonly description: string;
-  readonly access: MemoryToolAccess;
-  /**
-   * Only an idempotent write is retried after a transport failure or timeout.
-   * Declare it only when the endpoint deduplicates `(partition, operationId)`.
-   */
-  readonly idempotent: boolean;
-  readonly input: ToolInputSchema;
-}
-
-/** Recall and tools served by another service through a declared connection. */
-export interface HttpMemoryProvider {
-  readonly kind: "http";
-  readonly connection: string;
-  readonly path: string;
-  /** Maximum UTF-8 size of recalled text. */
-  readonly maxBytes: number;
-  readonly tools: readonly HttpMemoryToolDefinition[];
-}
-
-export type MemoryProvider = DocumentMemoryProvider | HttpMemoryProvider;
-
-/**
- * A memory resource, registered by the compiler and admitted per session.
- * The same id in every agent of a project names the same resource.
- */
-export interface MemoryDefinition extends MemoryReference {
-  readonly version: 1;
-  /** Model-facing guidance, shown in the resource's tool descriptions. */
-  readonly description: string;
-  readonly provider: MemoryProvider;
-}
-
-export interface MemorySource {
-  readonly id: string;
-  readonly title?: string;
-  readonly revision?: string;
-  readonly updatedAt?: string;
-}
-
-/**
- * What this model request knows from one bound memory resource. The host
- * resolves it before the render; the shape is the same for every provider.
- */
-export interface MemoryProjection {
-  readonly text: string;
-  readonly sources: readonly MemorySource[];
-  /** Provider read state the host retains for this request's tools; opaque. */
-  readonly cursor?: string;
-  /** Whether this binding's save tool can commit right now. */
-  readonly writable: boolean;
-}
+export type {
+  DocumentMemoryInput,
+  DocumentMemoryProvider,
+  HttpMemoryConnection,
+  HttpMemoryInput,
+  HttpMemoryProvider,
+  HttpMemoryToolDefinition,
+  HttpMemoryToolInput,
+  MemoryDefinition,
+  MemoryDefinitionInput,
+  MemoryProjection,
+  MemoryProvider,
+  MemoryReference,
+  MemorySource,
+  MemoryToolAccess,
+} from "./memory.js";
+export { defineMemory, documentMemory, httpMemory } from "./memory.js";
 
 /**
  * Implemented by the host that renders the agent. The host renders inside an
@@ -963,220 +914,6 @@ export function defineTool<Output extends DataValue = DataValue>(input: {
   });
 }
 
-const MEMORY_DEFAULT_MAX_BYTES = 8_192;
-const MEMORY_MAX_BYTES_CEILING = 16_384;
-const MEMORY_ID_MAX_LENGTH = 128;
-const HTTP_MEMORY_DEFAULT_PATH = "/memory";
-const HTTP_MEMORY_MAX_TOOLS = 8;
-const HTTP_MEMORY_TOOL_NAME_PATTERN = /^[a-z0-9_]{1,32}$/;
-/** Injected into every memory tool's model-facing schema to select the resource. */
-const MEMORY_RESERVED_ARGUMENT = "memory";
-
-function memoryMaxBytes(value: number | undefined, label: string): number {
-  if (value === undefined) return MEMORY_DEFAULT_MAX_BYTES;
-  if (
-    !Number.isInteger(value) ||
-    value < 1 ||
-    value > MEMORY_MAX_BYTES_CEILING
-  ) {
-    throw new Error(
-      `${label} maxBytes must be a whole number between 1 and ${MEMORY_MAX_BYTES_CEILING}`,
-    );
-  }
-  return value;
-}
-
-function containsSchemaReference(value: unknown): boolean {
-  if (Array.isArray(value)) return value.some(containsSchemaReference);
-  if (!value || typeof value !== "object") return false;
-  return Object.entries(value as Record<string, unknown>).some(
-    ([key, nested]) => key === "$ref" || containsSchemaReference(nested),
-  );
-}
-
-function httpMemoryToolInput(value: unknown, label: string): ToolInputSchema {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`${label} input must be a JSON Schema object`);
-  }
-  const schema = value as Record<string, unknown>;
-  if (schema.type !== "object") {
-    throw new Error(`${label} input must be a JSON Schema with type "object"`);
-  }
-  if (containsSchemaReference(schema)) {
-    throw new Error(`${label} input cannot use $ref`);
-  }
-  const properties = schema.properties;
-  if (
-    properties !== undefined &&
-    (!properties || typeof properties !== "object" || Array.isArray(properties))
-  ) {
-    throw new Error(`${label} input properties must be an object`);
-  }
-  const required = schema.required;
-  if (
-    required !== undefined &&
-    (!Array.isArray(required) ||
-      required.some((name) => typeof name !== "string"))
-  ) {
-    throw new Error(`${label} input required must be an array of strings`);
-  }
-  if (
-    (properties &&
-      Object.prototype.hasOwnProperty.call(
-        properties,
-        MEMORY_RESERVED_ARGUMENT,
-      )) ||
-    (Array.isArray(required) && required.includes(MEMORY_RESERVED_ARGUMENT))
-  ) {
-    throw new Error(
-      `${label} input cannot declare the reserved ${MEMORY_RESERVED_ARGUMENT} argument; OpenComputer adds it to select the resource`,
-    );
-  }
-  let serialized: string | undefined;
-  try {
-    serialized = JSON.stringify(schema);
-  } catch {
-    serialized = undefined;
-  }
-  if (serialized === undefined) {
-    throw new Error(`${label} input must be JSON-compatible`);
-  }
-  return Object.freeze(JSON.parse(serialized) as Record<string, unknown>);
-}
-
-export interface HttpMemoryToolInput {
-  name: string;
-  description: string;
-  access: MemoryToolAccess;
-  idempotent?: boolean;
-  input: ToolInputSchema;
-}
-
-export function documentMemory(
-  input: { maxBytes?: number } = {},
-): DocumentMemoryProvider {
-  return Object.freeze({
-    kind: "document" as const,
-    maxBytes: memoryMaxBytes(input.maxBytes, "documentMemory"),
-  });
-}
-
-export function httpMemory(input: {
-  connection: ConnectionReference;
-  path?: string;
-  maxBytes?: number;
-  tools?: readonly HttpMemoryToolInput[];
-}): HttpMemoryProvider {
-  const connection = input.connection;
-  if (!connection || typeof connection !== "object" || !connection.id) {
-    throw new Error("httpMemory requires a defineConnection() connection");
-  }
-  const path = input.path ?? HTTP_MEMORY_DEFAULT_PATH;
-  if (!/^\/(?!\/)[^?#\s]*$/.test(path)) {
-    throw new Error(
-      "httpMemory path must begin with a single / and contain no query or fragment",
-    );
-  }
-  const policy = connection as Partial<HttpConnectionDefinition>;
-  if (policy.pathPrefix && !path.startsWith(policy.pathPrefix)) {
-    throw new Error(
-      `httpMemory path ${path} is outside connection ${connection.id} pathPrefix ${policy.pathPrefix}`,
-    );
-  }
-  if (policy.methods && !policy.methods.includes("POST")) {
-    throw new Error(
-      `httpMemory requires connection ${connection.id} to allow POST`,
-    );
-  }
-  const tools = input.tools ?? [];
-  if (tools.length > HTTP_MEMORY_MAX_TOOLS) {
-    throw new Error(
-      `httpMemory may declare at most ${HTTP_MEMORY_MAX_TOOLS} tools`,
-    );
-  }
-  const names = new Set<string>();
-  const normalized = tools.map((tool) => {
-    const name = typeof tool.name === "string" ? tool.name.trim() : "";
-    if (!HTTP_MEMORY_TOOL_NAME_PATTERN.test(name)) {
-      throw new Error(
-        "httpMemory tool names must use 1 to 32 lowercase letters, numbers, and underscores",
-      );
-    }
-    const label = `httpMemory tool ${name}`;
-    if (names.has(name)) throw new Error(`${label} is declared more than once`);
-    names.add(name);
-    const description =
-      typeof tool.description === "string" ? tool.description.trim() : "";
-    if (!description) throw new Error(`${label} requires a description`);
-    if (tool.access !== "read" && tool.access !== "write") {
-      throw new Error(`${label} access must be "read" or "write"`);
-    }
-    if (tool.idempotent !== undefined && typeof tool.idempotent !== "boolean") {
-      throw new Error(`${label} idempotent must be true or false`);
-    }
-    return Object.freeze({
-      name,
-      description,
-      access: tool.access,
-      idempotent: tool.idempotent ?? false,
-      input: httpMemoryToolInput(tool.input, label),
-    });
-  });
-  return Object.freeze({
-    kind: "http" as const,
-    connection: connection.id,
-    path,
-    maxBytes: memoryMaxBytes(input.maxBytes, "httpMemory"),
-    tools: Object.freeze(normalized),
-  });
-}
-
-function memoryIdentifier(value: string, kind: string): string {
-  const id = resourceIdentifier(value, kind);
-  if (id.length > MEMORY_ID_MAX_LENGTH) {
-    throw new Error(
-      `${kind} IDs must contain at most ${MEMORY_ID_MAX_LENGTH} characters`,
-    );
-  }
-  return id;
-}
-
-export function defineMemory(input: {
-  id: string;
-  description: string;
-  provider?: MemoryProvider;
-}): MemoryDefinition {
-  const id = memoryIdentifier(input.id, "defineMemory");
-  const description =
-    typeof input.description === "string" ? input.description.trim() : "";
-  if (!description) {
-    throw new Error(`Memory ${id} requires a non-empty description`);
-  }
-  const provider = input.provider ?? documentMemory();
-  if (provider.kind !== "document" && provider.kind !== "http") {
-    throw new Error(
-      `Memory ${id} provider must be documentMemory() or httpMemory()`,
-    );
-  }
-  return Object.freeze({
-    kind: "memory" as const,
-    version: 1 as const,
-    id,
-    description,
-    provider,
-  });
-}
-
-function isMemoryProjection(value: unknown): value is MemoryProjection {
-  if (!value || typeof value !== "object") return false;
-  const projection = value as Record<string, unknown>;
-  return (
-    typeof projection.text === "string" &&
-    Array.isArray(projection.sources) &&
-    typeof projection.writable === "boolean"
-  );
-}
-
 /**
  * The projection the host recalled for this session's binding of `memory`.
  * It never fetches: a session without that binding fails the render here,
@@ -1184,17 +921,11 @@ function isMemoryProjection(value: unknown): value is MemoryProjection {
  * this model request; omitting it exposes none of them.
  */
 export function useMemory(memory: string | ResourceReference): MemoryProjection {
-  const id = memoryIdentifier(
+  const id = memoryId(
     typeof memory === "string" ? memory : memory.id,
     "useMemory",
   );
-  const projection = hooks().useMemory(id);
-  if (!isMemoryProjection(projection)) {
-    throw new Error(
-      `Memory ${JSON.stringify(id)} is not bound to this session; create the session with a memory binding for it`,
-    );
-  }
-  return projection;
+  return memoryProjection(id, hooks().useMemory(id));
 }
 
 export const useInput = (): Readonly<AgentInput> => hooks().useInput();

--- a/agent/src/memory.ts
+++ b/agent/src/memory.ts
@@ -1,0 +1,420 @@
+/**
+ * The memory declaration contract: what `defineMemory()`, `documentMemory()`
+ * and `httpMemory()` accept and the normalized descriptor they produce.
+ *
+ * This module is shared verbatim by `@opencomputer/agent`
+ * (`agent/src/memory.ts`) and the CLI (`cli/src/memory.ts`), where the
+ * compiler runs it on the literal declarations it extracts from agent source
+ * and inlines its compiled form into the artifact's runtime. The two copies
+ * must stay byte-identical; a CLI test enforces it. Keep the module free of
+ * imports so it can be inlined.
+ */
+
+export const MEMORY_DEFAULT_MAX_BYTES = 8_192;
+export const MEMORY_MAX_BYTES_CEILING = 16_384;
+export const MEMORY_ID_MAX_LENGTH = 128;
+export const HTTP_MEMORY_DEFAULT_PATH = "/memory";
+export const HTTP_MEMORY_MAX_TOOLS = 8;
+/** Injected into every memory tool's model-facing schema to select a resource. */
+export const MEMORY_RESERVED_ARGUMENT = "memory";
+/** The built-in document provider's fixed tools, exposed as `memory_<name>`. */
+export const DOCUMENT_MEMORY_TOOLS: readonly string[] = Object.freeze([
+  "save",
+  "read",
+  "list",
+]);
+
+const MEMORY_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const HTTP_MEMORY_PATH_PATTERN = /^\/(?!\/)[^?#\s]*$/;
+const HTTP_MEMORY_TOOL_NAME_PATTERN = /^[a-z0-9_]{1,32}$/;
+
+export interface MemoryReference {
+  readonly kind: "memory";
+  readonly id: string;
+}
+
+/** Bounded text documents stored by OpenComputer. */
+export interface DocumentMemoryProvider {
+  readonly kind: "document";
+  /** Maximum UTF-8 size of each document's text, for every writer. */
+  readonly maxBytes: number;
+}
+
+export type MemoryToolAccess = "read" | "write";
+
+export type MemoryToolInputSchema = Readonly<Record<string, unknown>>;
+
+/**
+ * A tool an HTTP memory endpoint executes. The model sees it as
+ * `memory_<name>` with the reserved `memory` argument naming the resource, so
+ * `input` may not declare a `memory` property of its own.
+ */
+export interface HttpMemoryToolDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly access: MemoryToolAccess;
+  /**
+   * Only an idempotent write is retried after a transport failure or timeout.
+   * Declare it only when the endpoint deduplicates `(partition, operationId)`.
+   */
+  readonly idempotent: boolean;
+  readonly input: MemoryToolInputSchema;
+}
+
+/** Recall and tools served by another service through a declared connection. */
+export interface HttpMemoryProvider {
+  readonly kind: "http";
+  readonly connection: string;
+  readonly path: string;
+  /** Maximum UTF-8 size of recalled text. */
+  readonly maxBytes: number;
+  readonly tools: readonly HttpMemoryToolDefinition[];
+}
+
+export type MemoryProvider = DocumentMemoryProvider | HttpMemoryProvider;
+
+/**
+ * A memory resource, registered by the compiler and admitted per session.
+ * The same id in every agent of a project names the same resource.
+ */
+export interface MemoryDefinition extends MemoryReference {
+  readonly version: 1;
+  /** Model-facing guidance, shown in the resource's tool descriptions. */
+  readonly description: string;
+  readonly provider: MemoryProvider;
+}
+
+export interface MemorySource {
+  readonly id: string;
+  readonly title?: string;
+  readonly revision?: string;
+  readonly updatedAt?: string;
+}
+
+/**
+ * What this model request knows from one bound memory resource. The host
+ * resolves it before the render; the shape is the same for every provider.
+ * Provider read state stays with the host; it is not part of the projection.
+ */
+export interface MemoryProjection {
+  readonly text: string;
+  readonly sources: readonly MemorySource[];
+  /** Whether this binding's save tool can commit right now. */
+  readonly writable: boolean;
+}
+
+export interface DocumentMemoryInput {
+  maxBytes?: number;
+}
+
+export interface HttpMemoryToolInput {
+  name: string;
+  description: string;
+  access: MemoryToolAccess;
+  idempotent?: boolean;
+  input: MemoryToolInputSchema;
+}
+
+/** A `defineConnection()` result, or the policy the compiler resolved for it. */
+export interface HttpMemoryConnection {
+  readonly kind: "connection";
+  readonly id: string;
+  readonly methods?: readonly string[];
+  readonly pathPrefix?: string;
+}
+
+export interface HttpMemoryInput {
+  connection: HttpMemoryConnection;
+  path?: string;
+  maxBytes?: number;
+  tools?: readonly HttpMemoryToolInput[];
+}
+
+export interface MemoryDefinitionInput {
+  id: string;
+  description: string;
+  provider?: MemoryProvider;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const nested of Object.values(value as Record<string, unknown>)) {
+      deepFreeze(nested);
+    }
+  }
+  return value;
+}
+
+export function memoryId(value: unknown, kind: string): string {
+  const id = typeof value === "string" ? value.trim() : "";
+  if (!id) throw new Error(`${kind} requires a non-empty id`);
+  if (!MEMORY_ID_PATTERN.test(id)) {
+    throw new Error(
+      `${kind} IDs must use lowercase letters, numbers, and single hyphens`,
+    );
+  }
+  if (id.length > MEMORY_ID_MAX_LENGTH) {
+    throw new Error(
+      `${kind} IDs must contain at most ${MEMORY_ID_MAX_LENGTH} characters`,
+    );
+  }
+  return id;
+}
+
+function memoryMaxBytes(value: unknown, label: string): number {
+  if (value === undefined) return MEMORY_DEFAULT_MAX_BYTES;
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    value < 1 ||
+    value > MEMORY_MAX_BYTES_CEILING
+  ) {
+    throw new Error(
+      `${label} maxBytes must be a whole number between 1 and ${MEMORY_MAX_BYTES_CEILING}`,
+    );
+  }
+  return value;
+}
+
+function httpMemoryPath(value: unknown, label: string): string {
+  if (value === undefined) return HTTP_MEMORY_DEFAULT_PATH;
+  if (typeof value !== "string" || !HTTP_MEMORY_PATH_PATTERN.test(value)) {
+    throw new Error(
+      `${label} path must begin with a single / and contain no query or fragment`,
+    );
+  }
+  return value;
+}
+
+function containsSchemaReference(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsSchemaReference);
+  if (!isRecord(value)) return false;
+  return Object.entries(value).some(
+    ([key, nested]) => key === "$ref" || containsSchemaReference(nested),
+  );
+}
+
+function httpMemoryToolInput(
+  value: unknown,
+  label: string,
+): MemoryToolInputSchema {
+  if (!isRecord(value)) {
+    throw new Error(`${label} input must be a JSON Schema object`);
+  }
+  if (value.type !== "object") {
+    throw new Error(`${label} input must be a JSON Schema with type "object"`);
+  }
+  if (containsSchemaReference(value)) {
+    throw new Error(`${label} input cannot use $ref`);
+  }
+  const properties = value.properties;
+  if (properties !== undefined && !isRecord(properties)) {
+    throw new Error(`${label} input properties must be an object`);
+  }
+  const required = value.required;
+  if (
+    required !== undefined &&
+    (!Array.isArray(required) ||
+      required.some((name) => typeof name !== "string"))
+  ) {
+    throw new Error(`${label} input required must be an array of strings`);
+  }
+  if (
+    (properties &&
+      Object.prototype.hasOwnProperty.call(
+        properties,
+        MEMORY_RESERVED_ARGUMENT,
+      )) ||
+    (Array.isArray(required) && required.includes(MEMORY_RESERVED_ARGUMENT))
+  ) {
+    throw new Error(
+      `${label} input cannot declare the reserved ${MEMORY_RESERVED_ARGUMENT} argument; OpenComputer adds it to select the resource`,
+    );
+  }
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    serialized = undefined;
+  }
+  if (serialized === undefined) {
+    throw new Error(`${label} input must be JSON-compatible`);
+  }
+  return deepFreeze(JSON.parse(serialized) as Record<string, unknown>);
+}
+
+function httpMemoryTools(
+  value: unknown,
+  label: string,
+): readonly HttpMemoryToolDefinition[] {
+  if (value === undefined) return Object.freeze([]);
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} tools must be an array`);
+  }
+  if (value.length > HTTP_MEMORY_MAX_TOOLS) {
+    throw new Error(
+      `${label} may declare at most ${HTTP_MEMORY_MAX_TOOLS} tools`,
+    );
+  }
+  const names = new Set<string>();
+  const tools = value.map((tool: unknown): HttpMemoryToolDefinition => {
+    if (!isRecord(tool)) {
+      throw new Error(`${label} tools must contain tool objects`);
+    }
+    const name = typeof tool.name === "string" ? tool.name.trim() : "";
+    if (!HTTP_MEMORY_TOOL_NAME_PATTERN.test(name)) {
+      throw new Error(
+        `${label} tool names must use 1 to 32 lowercase letters, numbers, and underscores`,
+      );
+    }
+    const toolLabel = `${label} tool ${name}`;
+    if (names.has(name)) {
+      throw new Error(`${toolLabel} is declared more than once`);
+    }
+    names.add(name);
+    const description =
+      typeof tool.description === "string" ? tool.description.trim() : "";
+    if (!description) throw new Error(`${toolLabel} requires a description`);
+    if (tool.access !== "read" && tool.access !== "write") {
+      throw new Error(`${toolLabel} access must be "read" or "write"`);
+    }
+    if (tool.idempotent !== undefined && typeof tool.idempotent !== "boolean") {
+      throw new Error(`${toolLabel} idempotent must be true or false`);
+    }
+    return Object.freeze({
+      name,
+      description,
+      access: tool.access,
+      idempotent: tool.idempotent === true,
+      input: httpMemoryToolInput(tool.input, toolLabel),
+    });
+  });
+  return Object.freeze(tools);
+}
+
+/**
+ * Normalizes a provider descriptor. Every descriptor a definition carries
+ * passes through here, whether it came from `documentMemory()`,
+ * `httpMemory()` or was written by hand.
+ */
+function memoryProvider(value: unknown, label: string): MemoryProvider {
+  if (!isRecord(value)) {
+    throw new Error(`${label} provider must be documentMemory() or httpMemory()`);
+  }
+  if (value.kind === "document") {
+    return Object.freeze({
+      kind: "document" as const,
+      maxBytes: memoryMaxBytes(value.maxBytes, label),
+    });
+  }
+  if (value.kind === "http") {
+    const connection =
+      typeof value.connection === "string" ? value.connection.trim() : "";
+    if (!connection) {
+      throw new Error(`${label} requires a defineConnection() connection`);
+    }
+    return Object.freeze({
+      kind: "http" as const,
+      connection,
+      path: httpMemoryPath(value.path, label),
+      maxBytes: memoryMaxBytes(value.maxBytes, label),
+      tools: httpMemoryTools(value.tools, label),
+    });
+  }
+  throw new Error(`${label} provider must be documentMemory() or httpMemory()`);
+}
+
+export function documentMemory(
+  input: DocumentMemoryInput = {},
+): DocumentMemoryProvider {
+  const provider = memoryProvider(
+    { kind: "document", maxBytes: input.maxBytes },
+    "documentMemory",
+  );
+  return provider as DocumentMemoryProvider;
+}
+
+export function httpMemory(input: HttpMemoryInput): HttpMemoryProvider {
+  const connection = input.connection;
+  if (
+    !isRecord(connection) ||
+    typeof connection.id !== "string" ||
+    !connection.id
+  ) {
+    throw new Error("httpMemory requires a defineConnection() connection");
+  }
+  const provider = memoryProvider(
+    {
+      kind: "http",
+      connection: connection.id,
+      path: input.path,
+      maxBytes: input.maxBytes,
+      tools: input.tools,
+    },
+    "httpMemory",
+  ) as HttpMemoryProvider;
+  const policy = connection as HttpMemoryConnection;
+  if (policy.pathPrefix && !provider.path.startsWith(policy.pathPrefix)) {
+    throw new Error(
+      `httpMemory path ${provider.path} is outside connection ${provider.connection} pathPrefix ${policy.pathPrefix}`,
+    );
+  }
+  if (policy.methods && !policy.methods.includes("POST")) {
+    throw new Error(
+      `httpMemory requires connection ${provider.connection} to allow POST`,
+    );
+  }
+  return provider;
+}
+
+export function defineMemory(input: MemoryDefinitionInput): MemoryDefinition {
+  const id = memoryId(input.id, "defineMemory");
+  const description =
+    typeof input.description === "string" ? input.description.trim() : "";
+  if (!description) {
+    throw new Error(`Memory ${id} requires a non-empty description`);
+  }
+  const provider =
+    input.provider === undefined
+      ? documentMemory()
+      : memoryProvider(input.provider, `Memory ${id}`);
+  return Object.freeze({
+    kind: "memory" as const,
+    version: 1 as const,
+    id,
+    description,
+    provider,
+  });
+}
+
+/** The model-facing tool names a provider reserves: `memory_<name>`. */
+export function memoryToolNames(provider: MemoryProvider): string[] {
+  const names =
+    provider.kind === "document"
+      ? DOCUMENT_MEMORY_TOOLS
+      : provider.tools.map((tool) => tool.name);
+  return names.map((name) => `${MEMORY_RESERVED_ARGUMENT}_${name}`);
+}
+
+/**
+ * The projection the host resolved for the session's binding of `id`, or a
+ * render failure when the session has no such binding.
+ */
+export function memoryProjection(id: string, value: unknown): MemoryProjection {
+  if (
+    !isRecord(value) ||
+    typeof value.text !== "string" ||
+    !Array.isArray(value.sources) ||
+    typeof value.writable !== "boolean"
+  ) {
+    throw new Error(
+      `Memory ${JSON.stringify(id)} is not bound to this session; create the session with a memory binding for it`,
+    );
+  }
+  return value as unknown as MemoryProjection;
+}

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.6.8",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/cli",
-      "version": "0.6.8",
+      "version": "0.7.0",
       "dependencies": {
         "@opencode-ai/sdk": "1.18.4",
         "ai": "^7.0.45",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/cli",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "description": "Build, test, deploy, and share OpenComputer agents as code.",
   "type": "module",
   "bin": {

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 
 import type { ResolvedConfig } from "./config.js";
-import type { ProjectResourceManifest } from "./project.js";
+import type { MemoryDeclaration, ProjectResourceManifest } from "./project.js";
 
 export interface OpenComputerIdentity {
   user_id: string | null;
@@ -731,6 +731,7 @@ export class OpenComputerClient {
       pathPrefix?: string;
       redirectOrigins?: Array<{ origin: string; pathPrefix?: string }>;
     }>;
+    memory: MemoryDeclaration[];
     projectDeployment?: {
       id: string;
       digest: string;

--- a/cli/src/dev.test.ts
+++ b/cli/src/dev.test.ts
@@ -143,3 +143,112 @@ test("development publish synchronizes every configured project agent", async ()
     await rm(parent, { recursive: true, force: true });
   }
 });
+
+const WORKSHOP_MEMORY = (maxBytes: string) => `import { defineMemory, documentMemory } from "@opencomputer/agent";
+
+export const requirements = defineMemory({
+  id: "requirements",
+  description: "Verified requirements for a workshop.",
+  provider: documentMemory({ maxBytes: ${maxBytes} }),
+});
+`;
+
+const WORKSHOP_AGENT = `import { useMemory } from "@opencomputer/agent";
+import { requirements } from "./memory";
+
+export default function Agent() {
+  return "Requirements: " + useMemory(requirements).text;
+}
+`;
+
+test("development publish registers memory declarations with the deployment", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-dev-memory-"));
+  try {
+    const initialized = await initializeAgentProject(resolve(parent, "app"), {
+      id: "prj_test",
+      name: "Test project",
+      agentId: "hello-agent",
+    });
+    await writeFile(resolve(initialized.agentRoot, "memory.ts"), WORKSHOP_MEMORY("8_192"));
+    await writeFile(resolve(initialized.agentRoot, "agent.ts"), WORKSHOP_AGENT);
+    let input:
+      | Parameters<
+          Parameters<typeof publishDevelopment>[0]["registerDeployment"]
+        >[0]
+      | undefined;
+    const client = {
+      async registerDeployment(value: NonNullable<typeof input>) {
+        input = value;
+        return {
+          id: `${value.agentId}:${value.source.digest}`,
+          agentId: value.agentId,
+          alias: value.alias,
+          createdAt: new Date(0).toISOString(),
+        };
+      },
+    };
+    await publishDevelopment(client, initialized.agentRoot, "hello-agent");
+    assert.deepEqual(input?.memory, [
+      {
+        id: "requirements",
+        description: "Verified requirements for a workshop.",
+        provider: { kind: "document", maxBytes: 8192 },
+      },
+    ]);
+    assert.deepEqual(JSON.parse(JSON.stringify(input)).memory, input?.memory);
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+test("project publish requires agents to agree on a shared memory resource", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-dev-memory-project-"));
+  try {
+    const initialized = await initializeAgentProject(resolve(parent, "app"));
+    await writeFile(resolve(initialized.agentRoot, "memory.ts"), WORKSHOP_MEMORY("8_192"));
+    await writeFile(resolve(initialized.agentRoot, "agent.ts"), WORKSHOP_AGENT);
+    const echoRoot = resolve(initialized.root, "opencomputer", "agents", "echo");
+    await mkdir(echoRoot, { recursive: true });
+    await writeFile(resolve(echoRoot, "memory.ts"), WORKSHOP_MEMORY("8_192"));
+    await writeFile(resolve(echoRoot, "agent.ts"), WORKSHOP_AGENT);
+    await writeFile(
+      resolve(initialized.root, "opencomputer", "project.ts"),
+      'export default { name: "app", agents: ["hello-world", "echo"] };\n',
+    );
+    const published: string[][] = [];
+    const client = {
+      async registerDeployment(
+        value: Parameters<
+          Parameters<typeof publishDevelopment>[0]["registerDeployment"]
+        >[0],
+      ) {
+        published.push(value.memory.map((declaration) => declaration.id));
+        return {
+          id: `${value.agentId}:${value.source.digest}`,
+          agentId: value.agentId,
+          alias: value.alias,
+          createdAt: new Date(0).toISOString(),
+        };
+      },
+    };
+    const binding = {
+      version: 1 as const,
+      apiUrl: "https://app.opencomputer.dev",
+      projectId: "prj_test",
+      projectName: "Test",
+      agentId: "test-agent",
+    };
+    await publishProjectDevelopment(client, initialized.root, binding);
+    assert.deepEqual(published, [["requirements"], ["requirements"]]);
+
+    await writeFile(resolve(echoRoot, "memory.ts"), WORKSHOP_MEMORY("4_096"));
+    published.length = 0;
+    await assert.rejects(
+      publishProjectDevelopment(client, initialized.root, binding),
+      /Memory "requirements" is declared with different configuration in agent hello-world and agent echo/,
+    );
+    assert.deepEqual(published, []);
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});

--- a/cli/src/dev.ts
+++ b/cli/src/dev.ts
@@ -15,6 +15,7 @@ import {
 import { startGateway } from "./local.js";
 import {
   buildAgentArtifact,
+  mergeMemoryDeclarations,
   readProjectAgents,
   readProjectResources,
   type BuiltAgentArtifact,
@@ -64,6 +65,7 @@ async function registerBuiltDeployment(
     channels: built.channels,
     connections: built.connections,
     httpConnections: built.httpConnections,
+    memory: built.memory,
     ...(projectDeployment ? { projectDeployment } : {}),
     source: {
       digest: built.digest,
@@ -114,6 +116,14 @@ export async function publishProjectDeployment(
       ),
     });
   }
+  // Agents of one project share memory resources by id, so their
+  // declarations must agree before any of them registers.
+  mergeMemoryDeclarations(
+    builtAgents.map(({ source, built }) => ({
+      origin: `agent ${source.localId}`,
+      memory: built.memory,
+    })),
+  );
   const digest = createHash("sha256")
     .update(
       JSON.stringify({

--- a/cli/src/memory.ts
+++ b/cli/src/memory.ts
@@ -1,0 +1,420 @@
+/**
+ * The memory declaration contract: what `defineMemory()`, `documentMemory()`
+ * and `httpMemory()` accept and the normalized descriptor they produce.
+ *
+ * This module is shared verbatim by `@opencomputer/agent`
+ * (`agent/src/memory.ts`) and the CLI (`cli/src/memory.ts`), where the
+ * compiler runs it on the literal declarations it extracts from agent source
+ * and inlines its compiled form into the artifact's runtime. The two copies
+ * must stay byte-identical; a CLI test enforces it. Keep the module free of
+ * imports so it can be inlined.
+ */
+
+export const MEMORY_DEFAULT_MAX_BYTES = 8_192;
+export const MEMORY_MAX_BYTES_CEILING = 16_384;
+export const MEMORY_ID_MAX_LENGTH = 128;
+export const HTTP_MEMORY_DEFAULT_PATH = "/memory";
+export const HTTP_MEMORY_MAX_TOOLS = 8;
+/** Injected into every memory tool's model-facing schema to select a resource. */
+export const MEMORY_RESERVED_ARGUMENT = "memory";
+/** The built-in document provider's fixed tools, exposed as `memory_<name>`. */
+export const DOCUMENT_MEMORY_TOOLS: readonly string[] = Object.freeze([
+  "save",
+  "read",
+  "list",
+]);
+
+const MEMORY_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const HTTP_MEMORY_PATH_PATTERN = /^\/(?!\/)[^?#\s]*$/;
+const HTTP_MEMORY_TOOL_NAME_PATTERN = /^[a-z0-9_]{1,32}$/;
+
+export interface MemoryReference {
+  readonly kind: "memory";
+  readonly id: string;
+}
+
+/** Bounded text documents stored by OpenComputer. */
+export interface DocumentMemoryProvider {
+  readonly kind: "document";
+  /** Maximum UTF-8 size of each document's text, for every writer. */
+  readonly maxBytes: number;
+}
+
+export type MemoryToolAccess = "read" | "write";
+
+export type MemoryToolInputSchema = Readonly<Record<string, unknown>>;
+
+/**
+ * A tool an HTTP memory endpoint executes. The model sees it as
+ * `memory_<name>` with the reserved `memory` argument naming the resource, so
+ * `input` may not declare a `memory` property of its own.
+ */
+export interface HttpMemoryToolDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly access: MemoryToolAccess;
+  /**
+   * Only an idempotent write is retried after a transport failure or timeout.
+   * Declare it only when the endpoint deduplicates `(partition, operationId)`.
+   */
+  readonly idempotent: boolean;
+  readonly input: MemoryToolInputSchema;
+}
+
+/** Recall and tools served by another service through a declared connection. */
+export interface HttpMemoryProvider {
+  readonly kind: "http";
+  readonly connection: string;
+  readonly path: string;
+  /** Maximum UTF-8 size of recalled text. */
+  readonly maxBytes: number;
+  readonly tools: readonly HttpMemoryToolDefinition[];
+}
+
+export type MemoryProvider = DocumentMemoryProvider | HttpMemoryProvider;
+
+/**
+ * A memory resource, registered by the compiler and admitted per session.
+ * The same id in every agent of a project names the same resource.
+ */
+export interface MemoryDefinition extends MemoryReference {
+  readonly version: 1;
+  /** Model-facing guidance, shown in the resource's tool descriptions. */
+  readonly description: string;
+  readonly provider: MemoryProvider;
+}
+
+export interface MemorySource {
+  readonly id: string;
+  readonly title?: string;
+  readonly revision?: string;
+  readonly updatedAt?: string;
+}
+
+/**
+ * What this model request knows from one bound memory resource. The host
+ * resolves it before the render; the shape is the same for every provider.
+ * Provider read state stays with the host; it is not part of the projection.
+ */
+export interface MemoryProjection {
+  readonly text: string;
+  readonly sources: readonly MemorySource[];
+  /** Whether this binding's save tool can commit right now. */
+  readonly writable: boolean;
+}
+
+export interface DocumentMemoryInput {
+  maxBytes?: number;
+}
+
+export interface HttpMemoryToolInput {
+  name: string;
+  description: string;
+  access: MemoryToolAccess;
+  idempotent?: boolean;
+  input: MemoryToolInputSchema;
+}
+
+/** A `defineConnection()` result, or the policy the compiler resolved for it. */
+export interface HttpMemoryConnection {
+  readonly kind: "connection";
+  readonly id: string;
+  readonly methods?: readonly string[];
+  readonly pathPrefix?: string;
+}
+
+export interface HttpMemoryInput {
+  connection: HttpMemoryConnection;
+  path?: string;
+  maxBytes?: number;
+  tools?: readonly HttpMemoryToolInput[];
+}
+
+export interface MemoryDefinitionInput {
+  id: string;
+  description: string;
+  provider?: MemoryProvider;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const nested of Object.values(value as Record<string, unknown>)) {
+      deepFreeze(nested);
+    }
+  }
+  return value;
+}
+
+export function memoryId(value: unknown, kind: string): string {
+  const id = typeof value === "string" ? value.trim() : "";
+  if (!id) throw new Error(`${kind} requires a non-empty id`);
+  if (!MEMORY_ID_PATTERN.test(id)) {
+    throw new Error(
+      `${kind} IDs must use lowercase letters, numbers, and single hyphens`,
+    );
+  }
+  if (id.length > MEMORY_ID_MAX_LENGTH) {
+    throw new Error(
+      `${kind} IDs must contain at most ${MEMORY_ID_MAX_LENGTH} characters`,
+    );
+  }
+  return id;
+}
+
+function memoryMaxBytes(value: unknown, label: string): number {
+  if (value === undefined) return MEMORY_DEFAULT_MAX_BYTES;
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    value < 1 ||
+    value > MEMORY_MAX_BYTES_CEILING
+  ) {
+    throw new Error(
+      `${label} maxBytes must be a whole number between 1 and ${MEMORY_MAX_BYTES_CEILING}`,
+    );
+  }
+  return value;
+}
+
+function httpMemoryPath(value: unknown, label: string): string {
+  if (value === undefined) return HTTP_MEMORY_DEFAULT_PATH;
+  if (typeof value !== "string" || !HTTP_MEMORY_PATH_PATTERN.test(value)) {
+    throw new Error(
+      `${label} path must begin with a single / and contain no query or fragment`,
+    );
+  }
+  return value;
+}
+
+function containsSchemaReference(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsSchemaReference);
+  if (!isRecord(value)) return false;
+  return Object.entries(value).some(
+    ([key, nested]) => key === "$ref" || containsSchemaReference(nested),
+  );
+}
+
+function httpMemoryToolInput(
+  value: unknown,
+  label: string,
+): MemoryToolInputSchema {
+  if (!isRecord(value)) {
+    throw new Error(`${label} input must be a JSON Schema object`);
+  }
+  if (value.type !== "object") {
+    throw new Error(`${label} input must be a JSON Schema with type "object"`);
+  }
+  if (containsSchemaReference(value)) {
+    throw new Error(`${label} input cannot use $ref`);
+  }
+  const properties = value.properties;
+  if (properties !== undefined && !isRecord(properties)) {
+    throw new Error(`${label} input properties must be an object`);
+  }
+  const required = value.required;
+  if (
+    required !== undefined &&
+    (!Array.isArray(required) ||
+      required.some((name) => typeof name !== "string"))
+  ) {
+    throw new Error(`${label} input required must be an array of strings`);
+  }
+  if (
+    (properties &&
+      Object.prototype.hasOwnProperty.call(
+        properties,
+        MEMORY_RESERVED_ARGUMENT,
+      )) ||
+    (Array.isArray(required) && required.includes(MEMORY_RESERVED_ARGUMENT))
+  ) {
+    throw new Error(
+      `${label} input cannot declare the reserved ${MEMORY_RESERVED_ARGUMENT} argument; OpenComputer adds it to select the resource`,
+    );
+  }
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    serialized = undefined;
+  }
+  if (serialized === undefined) {
+    throw new Error(`${label} input must be JSON-compatible`);
+  }
+  return deepFreeze(JSON.parse(serialized) as Record<string, unknown>);
+}
+
+function httpMemoryTools(
+  value: unknown,
+  label: string,
+): readonly HttpMemoryToolDefinition[] {
+  if (value === undefined) return Object.freeze([]);
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} tools must be an array`);
+  }
+  if (value.length > HTTP_MEMORY_MAX_TOOLS) {
+    throw new Error(
+      `${label} may declare at most ${HTTP_MEMORY_MAX_TOOLS} tools`,
+    );
+  }
+  const names = new Set<string>();
+  const tools = value.map((tool: unknown): HttpMemoryToolDefinition => {
+    if (!isRecord(tool)) {
+      throw new Error(`${label} tools must contain tool objects`);
+    }
+    const name = typeof tool.name === "string" ? tool.name.trim() : "";
+    if (!HTTP_MEMORY_TOOL_NAME_PATTERN.test(name)) {
+      throw new Error(
+        `${label} tool names must use 1 to 32 lowercase letters, numbers, and underscores`,
+      );
+    }
+    const toolLabel = `${label} tool ${name}`;
+    if (names.has(name)) {
+      throw new Error(`${toolLabel} is declared more than once`);
+    }
+    names.add(name);
+    const description =
+      typeof tool.description === "string" ? tool.description.trim() : "";
+    if (!description) throw new Error(`${toolLabel} requires a description`);
+    if (tool.access !== "read" && tool.access !== "write") {
+      throw new Error(`${toolLabel} access must be "read" or "write"`);
+    }
+    if (tool.idempotent !== undefined && typeof tool.idempotent !== "boolean") {
+      throw new Error(`${toolLabel} idempotent must be true or false`);
+    }
+    return Object.freeze({
+      name,
+      description,
+      access: tool.access,
+      idempotent: tool.idempotent === true,
+      input: httpMemoryToolInput(tool.input, toolLabel),
+    });
+  });
+  return Object.freeze(tools);
+}
+
+/**
+ * Normalizes a provider descriptor. Every descriptor a definition carries
+ * passes through here, whether it came from `documentMemory()`,
+ * `httpMemory()` or was written by hand.
+ */
+function memoryProvider(value: unknown, label: string): MemoryProvider {
+  if (!isRecord(value)) {
+    throw new Error(`${label} provider must be documentMemory() or httpMemory()`);
+  }
+  if (value.kind === "document") {
+    return Object.freeze({
+      kind: "document" as const,
+      maxBytes: memoryMaxBytes(value.maxBytes, label),
+    });
+  }
+  if (value.kind === "http") {
+    const connection =
+      typeof value.connection === "string" ? value.connection.trim() : "";
+    if (!connection) {
+      throw new Error(`${label} requires a defineConnection() connection`);
+    }
+    return Object.freeze({
+      kind: "http" as const,
+      connection,
+      path: httpMemoryPath(value.path, label),
+      maxBytes: memoryMaxBytes(value.maxBytes, label),
+      tools: httpMemoryTools(value.tools, label),
+    });
+  }
+  throw new Error(`${label} provider must be documentMemory() or httpMemory()`);
+}
+
+export function documentMemory(
+  input: DocumentMemoryInput = {},
+): DocumentMemoryProvider {
+  const provider = memoryProvider(
+    { kind: "document", maxBytes: input.maxBytes },
+    "documentMemory",
+  );
+  return provider as DocumentMemoryProvider;
+}
+
+export function httpMemory(input: HttpMemoryInput): HttpMemoryProvider {
+  const connection = input.connection;
+  if (
+    !isRecord(connection) ||
+    typeof connection.id !== "string" ||
+    !connection.id
+  ) {
+    throw new Error("httpMemory requires a defineConnection() connection");
+  }
+  const provider = memoryProvider(
+    {
+      kind: "http",
+      connection: connection.id,
+      path: input.path,
+      maxBytes: input.maxBytes,
+      tools: input.tools,
+    },
+    "httpMemory",
+  ) as HttpMemoryProvider;
+  const policy = connection as HttpMemoryConnection;
+  if (policy.pathPrefix && !provider.path.startsWith(policy.pathPrefix)) {
+    throw new Error(
+      `httpMemory path ${provider.path} is outside connection ${provider.connection} pathPrefix ${policy.pathPrefix}`,
+    );
+  }
+  if (policy.methods && !policy.methods.includes("POST")) {
+    throw new Error(
+      `httpMemory requires connection ${provider.connection} to allow POST`,
+    );
+  }
+  return provider;
+}
+
+export function defineMemory(input: MemoryDefinitionInput): MemoryDefinition {
+  const id = memoryId(input.id, "defineMemory");
+  const description =
+    typeof input.description === "string" ? input.description.trim() : "";
+  if (!description) {
+    throw new Error(`Memory ${id} requires a non-empty description`);
+  }
+  const provider =
+    input.provider === undefined
+      ? documentMemory()
+      : memoryProvider(input.provider, `Memory ${id}`);
+  return Object.freeze({
+    kind: "memory" as const,
+    version: 1 as const,
+    id,
+    description,
+    provider,
+  });
+}
+
+/** The model-facing tool names a provider reserves: `memory_<name>`. */
+export function memoryToolNames(provider: MemoryProvider): string[] {
+  const names =
+    provider.kind === "document"
+      ? DOCUMENT_MEMORY_TOOLS
+      : provider.tools.map((tool) => tool.name);
+  return names.map((name) => `${MEMORY_RESERVED_ARGUMENT}_${name}`);
+}
+
+/**
+ * The projection the host resolved for the session's binding of `id`, or a
+ * render failure when the session has no such binding.
+ */
+export function memoryProjection(id: string, value: unknown): MemoryProjection {
+  if (
+    !isRecord(value) ||
+    typeof value.text !== "string" ||
+    !Array.isArray(value.sources) ||
+    typeof value.writable !== "boolean"
+  ) {
+    throw new Error(
+      `Memory ${JSON.stringify(id)} is not bound to this session; create the session with a memory binding for it`,
+    );
+  }
+  return value as unknown as MemoryProjection;
+}

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -1167,7 +1167,7 @@ export default function Agent() {
     );
     await assert.rejects(
       build(REQUIREMENTS_MEMORY.replace("export const requirements", "export const memory").replace("8_192", "16_385")),
-      /maxBytes must be a whole number literal between 1 and 16384/,
+      /maxBytes must be a whole number between 1 and 16384/,
     );
     await assert.rejects(
       build(REQUIREMENTS_MEMORY.replace("export const requirements", "export const memory").replace('"requirements"', '"Requirements"')),
@@ -1209,4 +1209,286 @@ export default function Agent() {
   } finally {
     await rm(parent, { recursive: true, force: true });
   }
+});
+
+test("the compiler rejects memory declarations it cannot register as written", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-memory-literal-"));
+  const root = resolve(parent, "app");
+  try {
+    const initialized = await initializeAgentProject(root);
+    await writeFile(
+      resolve(initialized.agentRoot, "agent.ts"),
+      `import { useMemory } from "@opencomputer/agent";
+import { memory } from "./memory";
+
+export default function Agent() {
+  return useMemory(memory).text;
+}
+`,
+    );
+    const build = async (memorySource: string, extra?: [string, string]) => {
+      await writeFile(resolve(initialized.agentRoot, "memory.ts"), memorySource);
+      if (extra) await writeFile(resolve(initialized.agentRoot, extra[0]), extra[1]);
+      return buildAgentArtifact(initialized.agentRoot);
+    };
+    const declaration = (provider: string) =>
+      `  id: "requirements",\n  description: "Requirements.",\n  provider: ${provider},\n`;
+
+    // Review reproduction: an aliased callee executed a definition the
+    // compiler never registered, so the artifact declared no memory.
+    await assert.rejects(
+      build(`import { defineMemory as declareMemory, documentMemory } from "@opencomputer/agent";
+
+export const memory = declareMemory({
+${declaration("documentMemory({ maxBytes: 4_096 })")}});
+`),
+      /memory\.ts imports defineMemory as declareMemory; the compiler registers memory only from a direct defineMemory\(\) call, so keep its name/,
+    );
+    await assert.rejects(
+      build(
+        `import { declareMemory } from "./lib";
+
+export const memory = declareMemory({
+${declaration("undefined")}});
+`,
+        ["lib.ts", 'export { defineMemory as declareMemory } from "@opencomputer/agent";\n'],
+      ),
+      /lib\.ts exports defineMemory as declareMemory; the compiler registers memory only from a direct defineMemory\(\) call/,
+    );
+    await rm(resolve(initialized.agentRoot, "lib.ts"));
+    await assert.rejects(
+      build(`import * as oc from "@opencomputer/agent";
+
+export const memory = oc.defineMemory({
+${declaration("oc.documentMemory({ maxBytes: 4_096 })")}});
+`),
+      /memory\.ts calls oc\.defineMemory\(\); the compiler registers memory only from a direct defineMemory\(\) call, so import defineMemory by name from @opencomputer\/agent/,
+    );
+    await assert.rejects(
+      build(`import { defineMemory } from "@opencomputer/agent";
+
+const declare = defineMemory;
+export const memory = declare({
+${declaration("undefined")}});
+`),
+      /memory\.ts uses defineMemory other than as a direct defineMemory\(\) call; the compiler registers memory only from that call, so do not alias, wrap, or shadow it/,
+    );
+
+    // Review reproduction: spreading options into the provider registered
+    // the default limit while the definition kept 4096.
+    await assert.rejects(
+      build(`import { defineMemory, documentMemory } from "@opencomputer/agent";
+
+const options = { maxBytes: 4_096 };
+export const memory = defineMemory({
+${declaration("documentMemory({ ...options })")}});
+`),
+      /memory\.ts Memory requirements documentMemory\(\) cannot spread options; write each option as a literal property/,
+    );
+
+    // Review reproduction: spreading the provider into the declaration
+    // registered the default provider.
+    await assert.rejects(
+      build(`import { defineMemory, documentMemory } from "@opencomputer/agent";
+
+const provider = { provider: documentMemory({ maxBytes: 4_096 }) };
+export const memory = defineMemory({
+  id: "requirements",
+  description: "Requirements.",
+  ...provider,
+});
+`),
+      /memory\.ts defineMemory\(\) cannot spread provider; write each option as a literal property/,
+    );
+
+    // The same silent default through a shorthand, an accessor, a computed
+    // name, or a non-literal argument.
+    await assert.rejects(
+      build(`import { defineMemory, documentMemory } from "@opencomputer/agent";
+
+const provider = documentMemory({ maxBytes: 4_096 });
+export const memory = defineMemory({ id: "requirements", description: "Requirements.", provider });
+`),
+      /memory\.ts defineMemory\(\) cannot use the shorthand property provider; write provider as a literal property/,
+    );
+    await assert.rejects(
+      build(`import { defineMemory, documentMemory } from "@opencomputer/agent";
+
+export const memory = defineMemory({
+  id: "requirements",
+  description: "Requirements.",
+  get provider() { return documentMemory({ maxBytes: 4_096 }); },
+});
+`),
+      /memory\.ts defineMemory\(\) cannot use methods or accessors/,
+    );
+    await assert.rejects(
+      build(`import { defineMemory, documentMemory } from "@opencomputer/agent";
+
+export const memory = defineMemory({
+  id: "requirements",
+  description: "Requirements.",
+  ["provider"]: documentMemory({ maxBytes: 4_096 }),
+});
+`),
+      /memory\.ts defineMemory\(\) must use static property names/,
+    );
+    await assert.rejects(
+      build(`import { defineMemory } from "@opencomputer/agent";
+
+const options = { id: "requirements", description: "Requirements." };
+export const memory = defineMemory(options);
+`),
+      /memory\.ts defineMemory\(\) requires one object literal argument/,
+    );
+    await assert.rejects(
+      build(`import { defineMemory, documentMemory } from "@opencomputer/agent";
+
+const options = { maxBytes: 4_096 };
+export const memory = defineMemory({
+${declaration("documentMemory(options)")}});
+`),
+      /memory\.ts Memory requirements documentMemory\(\) requires one object literal argument/,
+    );
+    await assert.rejects(
+      build(`import { defineMemory, documentMemory } from "@opencomputer/agent";
+
+const LIMIT = 4_096;
+export const memory = defineMemory({
+${declaration("documentMemory({ maxBytes: LIMIT })")}});
+`),
+      /memory\.ts Memory requirements documentMemory\(\) maxBytes must be a static JSON value/,
+    );
+
+    // Type-only references and unaliased re-exports do not change what runs.
+    await writeFile(
+      resolve(initialized.agentRoot, "lib.ts"),
+      'export { defineMemory, documentMemory } from "@opencomputer/agent";\n',
+    );
+    const built = await build(`import type { MemoryDefinition } from "@opencomputer/agent";
+import { defineMemory, documentMemory } from "./lib";
+
+type Declared = typeof defineMemory;
+export const memory: MemoryDefinition = defineMemory({
+${declaration("documentMemory({ maxBytes: 4_096 })")}});
+export const declared: Declared | undefined = undefined;
+`);
+    assert.deepEqual(built.memory, [
+      {
+        id: "requirements",
+        description: "Requirements.",
+        provider: { kind: "document", maxBytes: 4096 },
+      },
+    ]);
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+test("a registered memory declaration is the definition the artifact executes", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-memory-parity-"));
+  const root = resolve(parent, "app");
+  try {
+    const initialized = await initializeAgentProject(root);
+    await writeFile(resolve(initialized.agentRoot, "knowledge.ts"), KNOWLEDGE_MEMORY);
+    await writeFile(
+      resolve(initialized.agentRoot, "agent.ts"),
+      `import { defineMemory, documentMemory, useMemory } from "@opencomputer/agent";
+export { knowledge } from "./knowledge";
+
+export const requirements = defineMemory({
+  id: "requirements",
+  description: "  Verified requirements and decisions for a workshop, kept for later work.  ",
+  provider: documentMemory({ maxBytes: 8_192 }),
+});
+export const notes = defineMemory({ id: "notes", description: "Notes." });
+
+export default function Agent() {
+  return useMemory(requirements).text;
+}
+`,
+    );
+    const built = await buildAgentArtifact(initialized.agentRoot);
+    const runtime = resolve(initialized.agentRoot, ".opencomputer", "runtime");
+    const module = (await import(
+      `${pathToFileURL(resolve(runtime, "agent.js")).href}?test=${crypto.randomUUID()}`
+    )) as Record<string, { kind: string; version: number; id: string; description: string; provider: unknown }>;
+    const executed = ["knowledge", "notes", "requirements"].map((name) => {
+      const definition = module[name]!;
+      assert.equal(definition.kind, "memory");
+      assert.equal(definition.version, 1);
+      assert.ok(Object.isFrozen(definition));
+      assert.ok(Object.isFrozen(definition.provider));
+      return JSON.parse(
+        JSON.stringify({
+          id: definition.id,
+          description: definition.description,
+          provider: definition.provider,
+        }),
+      ) as unknown;
+    });
+    assert.deepEqual(built.memory, executed);
+    assert.deepEqual(built.memory, [
+      KNOWLEDGE_DECLARATION,
+      { id: "notes", description: "Notes.", provider: { kind: "document", maxBytes: 8192 } },
+      REQUIREMENTS_DECLARATION,
+    ]);
+
+    // The runtime rejects what the compiler rejects: the shim is the same
+    // contract module, so a declaration that would not compile does not run.
+    const shim = (await import(
+      `${pathToFileURL(resolve(runtime, "opencomputer-agent.js")).href}?test=${crypto.randomUUID()}`
+    )) as {
+      defineMemory: (input: unknown) => { provider: { tools?: Array<{ input: Record<string, unknown> }> } };
+      documentMemory: (input?: unknown) => unknown;
+      httpMemory: (input: unknown) => unknown;
+    };
+    assert.throws(
+      () => shim.documentMemory({ maxBytes: 16_385 }),
+      /documentMemory maxBytes must be a whole number between 1 and 16384/,
+    );
+    assert.throws(
+      () => shim.defineMemory({ id: "Requirements", description: "R." }),
+      /defineMemory IDs must use lowercase letters, numbers, and single hyphens/,
+    );
+    assert.throws(
+      () =>
+        shim.httpMemory({
+          connection: { kind: "connection", id: "memory-service", methods: ["GET"] },
+        }),
+      /httpMemory requires connection memory-service to allow POST/,
+    );
+    const definition = shim.defineMemory({
+      id: "knowledge",
+      description: "Facts.",
+      provider: shim.httpMemory({
+        connection: { kind: "connection", id: "memory-service" },
+        tools: [
+          {
+            name: "remember",
+            description: "Save.",
+            access: "write",
+            input: { type: "object", properties: { fact: { type: "string" } } },
+          },
+        ],
+      }),
+    });
+    const schema = definition.provider.tools![0]!.input;
+    assert.ok(Object.isFrozen(schema));
+    assert.ok(Object.isFrozen(schema.properties));
+    assert.ok(Object.isFrozen((schema.properties as Record<string, unknown>).fact));
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+test("the CLI's memory contract is the agent package's module", async () => {
+  const repo = resolve(import.meta.dirname, "..", "..");
+  const packageModule = resolve(repo, "agent", "src", "memory.ts");
+  const cliModule = resolve(repo, "cli", "src", "memory.ts");
+  assert.equal(
+    await readFile(cliModule, "utf8"),
+    await readFile(packageModule, "utf8"),
+    "cli/src/memory.ts must stay byte-identical to agent/src/memory.ts; the compiler, the runtime shim and @opencomputer/agent share it",
+  );
 });

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -348,6 +348,7 @@ export default function Agent() {
         url: string;
         connection?: string;
       }>;
+      memory: unknown[];
       models: Array<{ provider: string; model: string }>;
     };
     assert.deepEqual(manifest, {
@@ -362,6 +363,7 @@ export default function Agent() {
       mcpServerDefinitions: [
         { id: "docs", url: "https://mcp.example.com/" },
       ],
+      memory: [],
       models: [
         {
           provider: "openrouter",
@@ -884,6 +886,325 @@ export default defineChannel({ id: "shop-sms", type: "sms" });
     await assert.rejects(
       readProjectResources(root),
       /unsupported channel type "sms". Supported: slack, twilio, email/,
+    );
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+const REQUIREMENTS_MEMORY = `import { defineMemory, documentMemory } from "@opencomputer/agent";
+
+export const requirements = defineMemory({
+  id: "requirements",
+  description: "Verified requirements and decisions for a workshop, kept for later work.",
+  provider: documentMemory({ maxBytes: 8_192 }),
+});
+`;
+
+const KNOWLEDGE_MEMORY = `import {
+  bearer, defineConnection, defineMemory, httpMemory, useSecret,
+} from "@opencomputer/agent";
+
+const connection = defineConnection({
+  id: "memory-service",
+  origin: "https://memory.example.com",
+  methods: ["POST"],
+  pathPrefix: "/oc-memory",
+  headers: { Authorization: bearer(useSecret("MEMORY_TOKEN")) },
+});
+
+export const knowledge = defineMemory({
+  id: "knowledge",
+  description: "Verified facts needed in later sessions.",
+  provider: httpMemory({
+    connection,
+    path: "/oc-memory",
+    maxBytes: 8_192,
+    tools: [{
+      name: "remember",
+      description: "Save a verified fact for future work.",
+      access: "write",
+      idempotent: false,
+      input: {
+        type: "object",
+        properties: { fact: { type: "string", maxLength: 2_000 } },
+        required: ["fact"],
+        additionalProperties: false,
+      },
+    }],
+  }),
+});
+`;
+
+const KNOWLEDGE_DECLARATION = {
+  id: "knowledge",
+  description: "Verified facts needed in later sessions.",
+  provider: {
+    kind: "http",
+    connection: "memory-service",
+    path: "/oc-memory",
+    maxBytes: 8192,
+    tools: [
+      {
+        name: "remember",
+        description: "Save a verified fact for future work.",
+        access: "write",
+        idempotent: false,
+        input: {
+          type: "object",
+          properties: { fact: { type: "string", maxLength: 2000 } },
+          required: ["fact"],
+          additionalProperties: false,
+        },
+      },
+    ],
+  },
+};
+
+const REQUIREMENTS_DECLARATION = {
+  id: "requirements",
+  description:
+    "Verified requirements and decisions for a workshop, kept for later work.",
+  provider: { kind: "document", maxBytes: 8192 },
+};
+
+test("the compiler registers memory declarations in the artifact manifest", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-memory-"));
+  const root = resolve(parent, "app");
+  try {
+    const initialized = await initializeAgentProject(root);
+    await writeFile(resolve(initialized.agentRoot, "memory.ts"), REQUIREMENTS_MEMORY);
+    await writeFile(resolve(initialized.agentRoot, "knowledge.ts"), KNOWLEDGE_MEMORY);
+    await writeFile(
+      resolve(initialized.agentRoot, "agent.ts"),
+      `import { useInput, useMemory, useModel } from "@opencomputer/agent";
+import { requirements } from "./memory";
+import { knowledge } from "./knowledge";
+
+export default function Agent() {
+  const input = useInput();
+  const saved = useMemory(requirements);
+  if (input.text?.includes("facts")) useMemory(knowledge);
+  useModel("anthropic/claude-sonnet-4.6");
+  return "Saved requirements (JSON string): " + JSON.stringify(saved.text) + " writable=" + String(saved.writable);
+}
+`,
+    );
+
+    const built = await buildAgentArtifact(initialized.agentRoot);
+    assert.deepEqual(built.memory, [KNOWLEDGE_DECLARATION, REQUIREMENTS_DECLARATION]);
+    assert.ok(built.connections.includes("memory-service"));
+    const runtime = resolve(initialized.agentRoot, ".opencomputer", "runtime");
+    const manifest = JSON.parse(
+      await readFile(resolve(runtime, ".opencomputer", "reactive.json"), "utf8"),
+    ) as { memory: unknown; tools: string[] };
+    assert.deepEqual(manifest.memory, built.memory);
+    assert.deepEqual(manifest.tools, []);
+
+    // The compiled agent renders against the host's scope contract: the host
+    // resolves one projection per session binding into scope.memory and
+    // records which ids the render selected.
+    const scope = {
+      input: { source: "user", text: "hello" } as { source: string; text: string },
+      memory: {
+        requirements: {
+          text: "Node.js 22, no paid services.",
+          sources: [{ id: "workshop", title: "Workshop requirements", revision: "r1", updatedAt: "2026-09-10T12:00:00.000Z" }],
+          writable: true,
+        },
+      } as Record<string, unknown>,
+      selectedMemory: new Set<string>(),
+    };
+    (globalThis as Record<PropertyKey, unknown>)[Symbol.for("opencomputer.agent-hooks")] = {
+      useInput: () => scope.input,
+      useModel: () => undefined,
+      useMemory(id: string) {
+        const projection = scope.memory[id];
+        if (projection) scope.selectedMemory.add(id);
+        return projection;
+      },
+    };
+    try {
+      const module = (await import(
+        `${pathToFileURL(resolve(runtime, "agent.js")).href}?test=${crypto.randomUUID()}`
+      )) as { default: () => string };
+      assert.equal(
+        module.default(),
+        'Saved requirements (JSON string): "Node.js 22, no paid services." writable=true',
+      );
+      assert.deepEqual([...scope.selectedMemory], ["requirements"]);
+      scope.input = { source: "user", text: "facts please" };
+      assert.throws(
+        () => module.default(),
+        /Memory "knowledge" is not bound to this session/,
+      );
+    } finally {
+      delete (globalThis as Record<PropertyKey, unknown>)[Symbol.for("opencomputer.agent-hooks")];
+    }
+
+    // The runtime shim normalizes a definition to its manifest entry.
+    const shim = (await import(
+      `${pathToFileURL(resolve(runtime, "opencomputer-agent.js")).href}?test=${crypto.randomUUID()}`
+    )) as {
+      defineMemory: (input: unknown) => unknown;
+      documentMemory: () => unknown;
+    };
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(shim.defineMemory({ id: "notes", description: " Notes. " }))),
+      { kind: "memory", version: 1, id: "notes", description: "Notes.", provider: { kind: "document", maxBytes: 8192 } },
+    );
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+test("the compiler deduplicates identical memory declarations and rejects conflicting ones", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-memory-dup-"));
+  const root = resolve(parent, "app");
+  try {
+    const initialized = await initializeAgentProject(root);
+    await writeFile(resolve(initialized.agentRoot, "memory.ts"), REQUIREMENTS_MEMORY);
+    await writeFile(
+      resolve(initialized.agentRoot, "memory-again.ts"),
+      REQUIREMENTS_MEMORY.replace("export const requirements", "export const again"),
+    );
+    await writeFile(
+      resolve(initialized.agentRoot, "agent.ts"),
+      `import { useMemory } from "@opencomputer/agent";
+import { requirements } from "./memory";
+import { again } from "./memory-again";
+
+export default function Agent() {
+  return useMemory(requirements).text + useMemory(again).text;
+}
+`,
+    );
+    const built = await buildAgentArtifact(initialized.agentRoot);
+    assert.deepEqual(built.memory, [REQUIREMENTS_DECLARATION]);
+
+    await writeFile(
+      resolve(initialized.agentRoot, "memory-again.ts"),
+      REQUIREMENTS_MEMORY.replace("export const requirements", "export const again").replace(
+        "maxBytes: 8_192",
+        "maxBytes: 4_096",
+      ),
+    );
+    await assert.rejects(
+      buildAgentArtifact(initialized.agentRoot),
+      /Memory "requirements" is declared with different configuration in memory-again\.ts and memory\.ts/,
+    );
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+test("the compiler validates memory declarations", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-memory-invalid-"));
+  const root = resolve(parent, "app");
+  try {
+    const initialized = await initializeAgentProject(root);
+    const build = async (memorySource: string, agentSource?: string) => {
+      await writeFile(resolve(initialized.agentRoot, "memory.ts"), memorySource);
+      await writeFile(
+        resolve(initialized.agentRoot, "agent.ts"),
+        agentSource ??
+          `import { useMemory } from "@opencomputer/agent";
+import { memory } from "./memory";
+
+export default function Agent() {
+  return useMemory(memory).text;
+}
+`,
+      );
+      return buildAgentArtifact(initialized.agentRoot);
+    };
+    const http = (tools: string, path = '"/oc-memory"') =>
+      KNOWLEDGE_MEMORY.replace("export const knowledge", "export const memory")
+        .replace('path: "/oc-memory"', `path: ${path}`)
+        .replace(/tools: \[[\s\S]*\],\n  \}\)/, `tools: ${tools},\n  })`);
+    const remember = (extra: string) =>
+      `[{ name: "remember", description: "Save.", access: "write", input: { type: "object", properties: { fact: { type: "string" }${extra} } } }]`;
+
+    await assert.rejects(
+      build(http(remember(', memory: { type: "string" }'))),
+      /tool remember input cannot declare the reserved memory argument/,
+    );
+    await assert.rejects(
+      build(http(`[{ name: "remember", description: "Save.", access: "write", input: { type: "object", required: ["memory"] } }]`)),
+      /tool remember input cannot declare the reserved memory argument/,
+    );
+    await assert.rejects(
+      build(http(`[{ name: "Remember", description: "Save.", access: "write", input: { type: "object" } }]`)),
+      /tool names must use 1 to 32 lowercase letters, numbers, and underscores/,
+    );
+    await assert.rejects(
+      build(http(`[{ name: "remember", description: "Save.", access: "admin", input: { type: "object" } }]`)),
+      /access must be "read" or "write"/,
+    );
+    await assert.rejects(
+      build(http(`[{ name: "remember", description: "Save.", access: "read", input: { type: "object", properties: { a: { $ref: "#/x" } } } }]`)),
+      /input cannot use \$ref/,
+    );
+    await assert.rejects(
+      build(http(`[${Array.from({ length: 9 }, (_, i) => `{ name: "t${i}", description: "T.", access: "read", input: { type: "object" } }`).join(", ")}]`)),
+      /at most 8 tools/,
+    );
+    await assert.rejects(
+      build(http("[]", '"/elsewhere"')),
+      /path \/elsewhere is outside connection memory-service pathPrefix \/oc-memory/,
+    );
+    await assert.rejects(
+      build(http("[]", '"/oc-memory?x=1"')),
+      /path must begin with a single \/ and contain no query or fragment/,
+    );
+    await assert.rejects(
+      build(http("[]").replace('methods: ["POST"]', 'methods: ["GET"]')),
+      /requires connection memory-service to allow POST/,
+    );
+    await assert.rejects(
+      build(http("[]").replace("connection,", "connection: elsewhere,")),
+      /references unknown connection elsewhere/,
+    );
+    await assert.rejects(
+      build(REQUIREMENTS_MEMORY.replace("export const requirements", "export const memory").replace("8_192", "16_385")),
+      /maxBytes must be a whole number literal between 1 and 16384/,
+    );
+    await assert.rejects(
+      build(REQUIREMENTS_MEMORY.replace("export const requirements", "export const memory").replace('"requirements"', '"Requirements"')),
+      /must use lowercase letters, numbers, and single hyphens/,
+    );
+    await assert.rejects(
+      build(REQUIREMENTS_MEMORY.replace("export const requirements", "export const memory").replace("provider: documentMemory({ maxBytes: 8_192 })", "provider: custom")),
+      /provider must be an inline documentMemory\(\) or httpMemory\(\) call/,
+    );
+
+    // A literal useMemory() must name a declared resource, and ordinary tools
+    // cannot take a memory tool's fixed name.
+    await assert.rejects(
+      build(
+        REQUIREMENTS_MEMORY.replace("export const requirements", "export const memory"),
+        `import { useMemory } from "@opencomputer/agent";
+
+export default function Agent() {
+  return useMemory("requirements").text + useMemory("budget").text;
+}
+`,
+      ),
+      /useMemory\("budget"\) references a memory resource this agent does not declare/,
+    );
+    await assert.rejects(
+      build(
+        REQUIREMENTS_MEMORY.replace("export const requirements", "export const memory"),
+        `import { useMemory, useTool } from "@opencomputer/agent";
+import { memory } from "./memory";
+
+export default function Agent() {
+  useTool("memory_save");
+  return useMemory(memory).text;
+}
+`,
+      ),
+      /Tool id "memory_save" collides with the fixed tool name of memory requirements/,
     );
   } finally {
     await rm(parent, { recursive: true, force: true });

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -54,9 +54,9 @@ test("init creates a multi-agent-ready hello-world agent by default", async () =
     assert.equal(packageJSON.scripts.dev, undefined);
     assert.equal(packageJSON.scripts["dev:web"], undefined);
     assert.equal(packageJSON.scripts.deploy, "opencomputer deploy");
-    assert.equal(packageJSON.dependencies["@opencomputer/agent"], "^0.5.0");
+    assert.equal(packageJSON.dependencies["@opencomputer/agent"], "^0.6.0");
     assert.equal(packageJSON.dependencies["@opencomputer/react"], undefined);
-    assert.equal(packageJSON.devDependencies["@opencomputer/cli"], "^0.6.1");
+    assert.equal(packageJSON.devDependencies["@opencomputer/cli"], "^0.7.0");
     assert.equal(packageJSON.devDependencies["@types/node"], undefined);
     assert.match(
       await readFile(resolve(root, "README.md"), "utf8"),
@@ -275,7 +275,7 @@ test("init can explicitly include a separately-run React app", async () => {
     assert.equal(packageJSON.dependencies["@opencomputer/react"], "^0.1.0");
     assert.equal(packageJSON.dependencies.react, "^19.2.0");
     assert.equal(packageJSON.devDependencies.vite, "^8.0.0");
-    assert.equal(packageJSON.devDependencies["@opencomputer/cli"], "^0.6.1");
+    assert.equal(packageJSON.devDependencies["@opencomputer/cli"], "^0.7.0");
     const viteConfig = await readFile(resolve(root, "vite.config.ts"), "utf8");
     assert.match(viteConfig, /npm run deploy -- --watch/);
     assert.deepEqual(initialized.files, [

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -25,9 +25,39 @@ export interface BuiltAgentArtifact {
   channels: string[];
   connections: string[];
   httpConnections: HttpConnectionManifest[];
+  memory: MemoryDeclaration[];
   body: Buffer;
   digest: string;
   elapsedMs: number;
+}
+
+export interface HttpToolDeclaration {
+  name: string;
+  description: string;
+  access: "read" | "write";
+  idempotent: boolean;
+  input: Record<string, unknown>;
+}
+
+export type MemoryProviderDeclaration =
+  | { kind: "document"; maxBytes: number }
+  | {
+      kind: "http";
+      connection: string;
+      path: string;
+      maxBytes: number;
+      tools: HttpToolDeclaration[];
+    };
+
+/**
+ * A memory resource as registered with the deployment. The same id in every
+ * agent of a project names the same resource, so declarations sharing an id
+ * must agree on the provider and its configuration.
+ */
+export interface MemoryDeclaration {
+  id: string;
+  description: string;
+  provider: MemoryProviderDeclaration;
 }
 
 export interface HttpConnectionManifest {
@@ -846,6 +876,305 @@ function definedMcpServers(
   };
   visit(file);
   return definitions.sort((left, right) => left.id.localeCompare(right.id));
+}
+
+const MEMORY_DEFAULT_MAX_BYTES = 8_192;
+const MEMORY_MAX_BYTES_CEILING = 16_384;
+const MEMORY_ID_MAX_LENGTH = 128;
+const HTTP_MEMORY_DEFAULT_PATH = "/memory";
+const HTTP_MEMORY_MAX_TOOLS = 8;
+const HTTP_MEMORY_TOOL_NAME_PATTERN = /^[a-z0-9_]{1,32}$/;
+/** Injected into every memory tool's model-facing schema to select the resource. */
+const MEMORY_RESERVED_ARGUMENT = "memory";
+/** The built-in document provider's fixed tools, exposed as `memory_<name>`. */
+const DOCUMENT_MEMORY_TOOLS = ["save", "read", "list"];
+
+/** The identifier a property references, for `connection: name` and `{ connection }` alike. */
+function objectPropertyIdentifier(
+  object: ts.ObjectLiteralExpression,
+  name: string,
+): string | undefined {
+  for (const property of object.properties) {
+    if (
+      ts.isShorthandPropertyAssignment(property) &&
+      property.name.text === name
+    ) {
+      return property.name.text;
+    }
+  }
+  const expression = objectProperty(object, name);
+  return expression && ts.isIdentifier(expression) ? expression.text : undefined;
+}
+
+function memoryMaxBytesValue(
+  expression: ts.Expression | undefined,
+  label: string,
+): number {
+  if (!expression) return MEMORY_DEFAULT_MAX_BYTES;
+  const value = ts.isNumericLiteral(expression)
+    ? Number(expression.text)
+    : Number.NaN;
+  if (!Number.isInteger(value) || value < 1 || value > MEMORY_MAX_BYTES_CEILING) {
+    throw new Error(
+      `${label} maxBytes must be a whole number literal between 1 and ${MEMORY_MAX_BYTES_CEILING}`,
+    );
+  }
+  return value;
+}
+
+function containsSchemaReference(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsSchemaReference);
+  if (!value || typeof value !== "object") return false;
+  return Object.entries(value as Record<string, unknown>).some(
+    ([key, nested]) => key === "$ref" || containsSchemaReference(nested),
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function httpMemoryTools(value: unknown, label: string): HttpToolDeclaration[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} tools must be an array literal`);
+  }
+  if (value.length > HTTP_MEMORY_MAX_TOOLS) {
+    throw new Error(`${label} may declare at most ${HTTP_MEMORY_MAX_TOOLS} tools`);
+  }
+  const names = new Set<string>();
+  return value.map((entry): HttpToolDeclaration => {
+    if (!isRecord(entry)) {
+      throw new Error(`${label} tools must contain object literals`);
+    }
+    const name = typeof entry.name === "string" ? entry.name.trim() : "";
+    if (!HTTP_MEMORY_TOOL_NAME_PATTERN.test(name)) {
+      throw new Error(
+        `${label} tool names must use 1 to 32 lowercase letters, numbers, and underscores`,
+      );
+    }
+    const toolLabel = `${label} tool ${name}`;
+    if (names.has(name)) {
+      throw new Error(`${toolLabel} is declared more than once`);
+    }
+    names.add(name);
+    const description =
+      typeof entry.description === "string" ? entry.description.trim() : "";
+    if (!description) throw new Error(`${toolLabel} requires a description`);
+    if (entry.access !== "read" && entry.access !== "write") {
+      throw new Error(`${toolLabel} access must be "read" or "write"`);
+    }
+    if (entry.idempotent !== undefined && typeof entry.idempotent !== "boolean") {
+      throw new Error(`${toolLabel} idempotent must be true or false`);
+    }
+    const input = entry.input;
+    if (!isRecord(input)) {
+      throw new Error(`${toolLabel} input must be a JSON Schema object`);
+    }
+    if (input.type !== "object") {
+      throw new Error(
+        `${toolLabel} input must be a JSON Schema with type "object"`,
+      );
+    }
+    if (containsSchemaReference(input)) {
+      throw new Error(`${toolLabel} input cannot use $ref`);
+    }
+    if (input.properties !== undefined && !isRecord(input.properties)) {
+      throw new Error(`${toolLabel} input properties must be an object`);
+    }
+    if (
+      input.required !== undefined &&
+      (!Array.isArray(input.required) ||
+        input.required.some((item) => typeof item !== "string"))
+    ) {
+      throw new Error(`${toolLabel} input required must be an array of strings`);
+    }
+    if (
+      (isRecord(input.properties) &&
+        Object.prototype.hasOwnProperty.call(
+          input.properties,
+          MEMORY_RESERVED_ARGUMENT,
+        )) ||
+      (Array.isArray(input.required) &&
+        input.required.includes(MEMORY_RESERVED_ARGUMENT))
+    ) {
+      throw new Error(
+        `${toolLabel} input cannot declare the reserved ${MEMORY_RESERVED_ARGUMENT} argument; OpenComputer adds it to select the resource`,
+      );
+    }
+    return {
+      name,
+      description,
+      access: entry.access,
+      idempotent: entry.idempotent === true,
+      input,
+    };
+  });
+}
+
+function memoryProviderDeclaration(
+  expression: ts.Expression | undefined,
+  id: string,
+  connectionBindings: ReadonlyMap<string, HttpConnectionManifest>,
+): MemoryProviderDeclaration {
+  const label = `Memory ${id}`;
+  if (!expression) {
+    return { kind: "document", maxBytes: MEMORY_DEFAULT_MAX_BYTES };
+  }
+  if (
+    !ts.isCallExpression(expression) ||
+    !ts.isIdentifier(expression.expression) ||
+    (expression.expression.text !== "documentMemory" &&
+      expression.expression.text !== "httpMemory")
+  ) {
+    throw new Error(
+      `${label} provider must be an inline documentMemory() or httpMemory() call`,
+    );
+  }
+  const provider = expression.expression.text;
+  const input = expression.arguments[0];
+  if (input !== undefined && !ts.isObjectLiteralExpression(input)) {
+    throw new Error(`${label} ${provider}() requires an object literal`);
+  }
+  if (provider === "documentMemory") {
+    return {
+      kind: "document",
+      maxBytes: memoryMaxBytesValue(
+        input && objectProperty(input, "maxBytes"),
+        label,
+      ),
+    };
+  }
+  if (!input) {
+    throw new Error(`${label} httpMemory() requires a connection`);
+  }
+  const connectionName = objectPropertyIdentifier(input, "connection");
+  if (!connectionName) {
+    throw new Error(
+      `${label} connection must reference a defineConnection() binding`,
+    );
+  }
+  const connection = connectionBindings.get(connectionName);
+  if (!connection) {
+    throw new Error(
+      `${label} references unknown connection ${connectionName}`,
+    );
+  }
+  const pathExpression = objectProperty(input, "path");
+  const path = pathExpression
+    ? literalStringValue(pathExpression, `${label} path`)
+    : HTTP_MEMORY_DEFAULT_PATH;
+  if (!/^\/(?!\/)[^?#\s]*$/.test(path)) {
+    throw new Error(
+      `${label} path must begin with a single / and contain no query or fragment`,
+    );
+  }
+  if (connection.pathPrefix && !path.startsWith(connection.pathPrefix)) {
+    throw new Error(
+      `${label} path ${path} is outside connection ${connection.id} pathPrefix ${connection.pathPrefix}`,
+    );
+  }
+  if (connection.methods && !connection.methods.includes("POST")) {
+    throw new Error(
+      `${label} requires connection ${connection.id} to allow POST`,
+    );
+  }
+  const toolsExpression = objectProperty(input, "tools");
+  return {
+    kind: "http",
+    connection: connection.id,
+    path,
+    maxBytes: memoryMaxBytesValue(objectProperty(input, "maxBytes"), label),
+    tools: httpMemoryTools(
+      toolsExpression && staticJsonValue(toolsExpression, `${label} tools`),
+      label,
+    ),
+  };
+}
+
+function definedMemory(
+  source: string,
+  path: string,
+  connectionBindings: ReadonlyMap<string, HttpConnectionManifest>,
+): MemoryDeclaration[] {
+  const file = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true);
+  const declarations: MemoryDeclaration[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "defineMemory"
+    ) {
+      const input = node.arguments[0];
+      if (!input || !ts.isObjectLiteralExpression(input)) {
+        throw new Error(`${path} defineMemory() requires an object literal`);
+      }
+      const id = literalStringValue(objectProperty(input, "id"), "memory id");
+      if (!AGENT_ID_PATTERN.test(id) || id.length > MEMORY_ID_MAX_LENGTH) {
+        throw new Error(
+          `Memory id ${JSON.stringify(id)} must use lowercase letters, numbers, and single hyphens, at most ${MEMORY_ID_MAX_LENGTH} characters`,
+        );
+      }
+      const description = literalStringValue(
+        objectProperty(input, "description"),
+        `Memory ${id} description`,
+      ).trim();
+      if (!description) {
+        throw new Error(`Memory ${id} requires a non-empty description`);
+      }
+      declarations.push({
+        id,
+        description,
+        provider: memoryProviderDeclaration(
+          objectProperty(input, "provider"),
+          id,
+          connectionBindings,
+        ),
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(file);
+  return declarations;
+}
+
+/** The model-facing tool names a declaration reserves. */
+export function memoryToolNames(declaration: MemoryDeclaration): string[] {
+  const names =
+    declaration.provider.kind === "document"
+      ? DOCUMENT_MEMORY_TOOLS
+      : declaration.provider.tools.map((tool) => tool.name);
+  return names.map((name) => `${MEMORY_RESERVED_ARGUMENT}_${name}`);
+}
+
+/**
+ * Deduplicates declarations by id. Declarations sharing an id name the same
+ * resource, so they must agree byte for byte; a difference is a build error
+ * naming both origins.
+ */
+export function mergeMemoryDeclarations(
+  entries: ReadonlyArray<{ origin: string; memory: readonly MemoryDeclaration[] }>,
+): MemoryDeclaration[] {
+  const merged = new Map<string, { origin: string; declaration: MemoryDeclaration }>();
+  for (const { origin, memory } of entries) {
+    for (const declaration of memory) {
+      const existing = merged.get(declaration.id);
+      if (!existing) {
+        merged.set(declaration.id, { origin, declaration });
+        continue;
+      }
+      if (
+        JSON.stringify(existing.declaration) !== JSON.stringify(declaration)
+      ) {
+        throw new Error(
+          `Memory ${JSON.stringify(declaration.id)} is declared with different configuration in ${existing.origin} and ${origin}; declarations sharing an id name the same resource and must agree on the provider and its configuration`,
+        );
+      }
+    }
+  }
+  return [...merged.values()]
+    .map(({ declaration }) => declaration)
+    .sort((left, right) => left.id.localeCompare(right.id));
 }
 
 function objectProperty(
@@ -1850,6 +2179,36 @@ export const publishOutbox = async (outbox, input) => {
   if (!response.ok) throw new Error("Outbox publish failed with status " + response.status);
   return await response.json();
 };
+// Memory declarations are validated by the compiler before this runs; the
+// runtime only normalizes defaults so a definition equals its manifest entry.
+const MEMORY_DEFAULT_MAX_BYTES = 8192;
+export const documentMemory = (input = {}) => Object.freeze({ kind: "document", maxBytes: input.maxBytes ?? MEMORY_DEFAULT_MAX_BYTES });
+export const httpMemory = (input) => Object.freeze({
+  kind: "http",
+  connection: id(input.connection && input.connection.id, "httpMemory connection"),
+  path: input.path || "/memory",
+  maxBytes: input.maxBytes ?? MEMORY_DEFAULT_MAX_BYTES,
+  tools: Object.freeze((input.tools || []).map((tool) => Object.freeze({ ...tool, idempotent: tool.idempotent === true }))),
+});
+export const defineMemory = (input) => Object.freeze({
+  kind: "memory",
+  version: 1,
+  id: id(input.id, "defineMemory"),
+  description: String(input.description).trim(),
+  provider: input.provider || documentMemory(),
+});
+// The host resolves every session binding before the render and exposes the
+// projections on its render scope as scope.memory[id]; the hook returns one
+// and the host records the id in scope.selectedMemory, returned to it as
+// selectedMemory next to enabledTools. An unbound id fails the render here.
+export const useMemory = (memory) => {
+  const memoryId = id(typeof memory === "string" ? memory : memory && memory.id, "useMemory");
+  const projection = hooks().useMemory(memoryId);
+  if (!projection || typeof projection !== "object" || typeof projection.text !== "string" || !Array.isArray(projection.sources) || typeof projection.writable !== "boolean") {
+    throw new Error("Memory " + JSON.stringify(memoryId) + " is not bound to this session; create the session with a memory binding for it");
+  }
+  return projection;
+};
 export const useInput = () => hooks().useInput();
 export const useCurrentInput = useInput;
 export const useModel = (model) => hooks().useModel(model);
@@ -2127,6 +2486,33 @@ the product or support surface presented to users.
       `MCP server id ${JSON.stringify(duplicateMcpServer.id)} is defined more than once`,
     );
   }
+  const memory = mergeMemoryDeclarations(
+    sourceModules.map((module) => ({
+      origin: module.path,
+      memory: definedMemory(module.source, module.path, connectionBindings),
+    })),
+  );
+  const declaredMemory = new Set(memory.map((declaration) => declaration.id));
+  const tools = [
+    ...new Set([...reactiveTools, ...literalHookIds(agentSource, "useTool")]),
+  ].sort();
+  for (const id of literalHookIds(agentSource, "useMemory")) {
+    if (!declaredMemory.has(id)) {
+      throw new Error(
+        `useMemory(${JSON.stringify(id)}) references a memory resource this agent does not declare; import its defineMemory() declaration`,
+      );
+    }
+  }
+  for (const declaration of memory) {
+    const collision = memoryToolNames(declaration).find((name) =>
+      tools.includes(name),
+    );
+    if (collision) {
+      throw new Error(
+        `Tool id ${JSON.stringify(collision)} collides with the fixed tool name of memory ${declaration.id}; rename the tool`,
+      );
+    }
+  }
   await mkdir(resolve(runtime, ".opencomputer"), { recursive: true });
   await writeFile(
     resolve(runtime, ".opencomputer", "reactive.json"),
@@ -2134,12 +2520,7 @@ the product or support surface presented to users.
       {
         version: 2,
         entry: "../agent.js",
-        tools: [
-          ...new Set([
-            ...reactiveTools,
-            ...literalHookIds(agentSource, "useTool"),
-          ]),
-        ].sort(),
+        tools,
         toolModules: toolModules.sort(),
         subagents: literalHookIds(agentSource, "useSubagent"),
         connections: httpConnections.map((connection) => connection.id).sort(),
@@ -2151,6 +2532,7 @@ the product or support surface presented to users.
           ]),
         ].sort(),
         mcpServerDefinitions,
+        memory,
         models: declaredModels,
       },
       null,
@@ -2189,9 +2571,14 @@ export async function buildAgentArtifact(
   const runtime = await prepareAgent(root);
   const reactive = JSON.parse(
     await readFile(resolve(runtime, ".opencomputer", "reactive.json"), "utf8"),
-  ) as { connections?: string[]; httpConnections?: HttpConnectionManifest[] };
+  ) as {
+    connections?: string[];
+    httpConnections?: HttpConnectionManifest[];
+    memory?: MemoryDeclaration[];
+  };
   const connections = [...new Set(reactive.connections ?? [])].sort();
   const httpConnections = reactive.httpConnections ?? [];
+  const memory = reactive.memory ?? [];
   const body = Buffer.from(
     JSON.stringify({
       version: 1,
@@ -2205,6 +2592,7 @@ export async function buildAgentArtifact(
     channels: [],
     connections,
     httpConnections,
+    memory,
     body,
     digest: createHash("sha256").update(body).digest("hex"),
     elapsedMs: Math.round(performance.now() - startedAt),

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -8,10 +8,25 @@ import {
   rm,
   writeFile,
 } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import { basename, dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { Cron } from "croner";
 import { build as bundle } from "esbuild";
 import ts from "typescript";
+
+import {
+  defineMemory,
+  documentMemory,
+  httpMemory,
+  memoryToolNames,
+  type DocumentMemoryInput,
+  type HttpMemoryConnection,
+  type HttpMemoryInput,
+  type MemoryDefinition,
+  type MemoryDefinitionInput,
+  type MemoryProvider,
+} from "./memory.js";
 
 export interface AgentManifest {
   schema: 1;
@@ -31,33 +46,16 @@ export interface BuiltAgentArtifact {
   elapsedMs: number;
 }
 
-export interface HttpToolDeclaration {
-  name: string;
-  description: string;
-  access: "read" | "write";
-  idempotent: boolean;
-  input: Record<string, unknown>;
-}
-
-export type MemoryProviderDeclaration =
-  | { kind: "document"; maxBytes: number }
-  | {
-      kind: "http";
-      connection: string;
-      path: string;
-      maxBytes: number;
-      tools: HttpToolDeclaration[];
-    };
-
 /**
- * A memory resource as registered with the deployment. The same id in every
- * agent of a project names the same resource, so declarations sharing an id
- * must agree on the provider and its configuration.
+ * A memory resource as registered with the deployment: the executable
+ * definition without its `kind` and `version`. The same id in every agent of
+ * a project names the same resource, so declarations sharing an id must agree
+ * on the provider and its configuration.
  */
 export interface MemoryDeclaration {
   id: string;
   description: string;
-  provider: MemoryProviderDeclaration;
+  provider: MemoryProvider;
 }
 
 export interface HttpConnectionManifest {
@@ -878,149 +876,171 @@ function definedMcpServers(
   return definitions.sort((left, right) => left.id.localeCompare(right.id));
 }
 
-const MEMORY_DEFAULT_MAX_BYTES = 8_192;
-const MEMORY_MAX_BYTES_CEILING = 16_384;
-const MEMORY_ID_MAX_LENGTH = 128;
-const HTTP_MEMORY_DEFAULT_PATH = "/memory";
-const HTTP_MEMORY_MAX_TOOLS = 8;
-const HTTP_MEMORY_TOOL_NAME_PATTERN = /^[a-z0-9_]{1,32}$/;
-/** Injected into every memory tool's model-facing schema to select the resource. */
-const MEMORY_RESERVED_ARGUMENT = "memory";
-/** The built-in document provider's fixed tools, exposed as `memory_<name>`. */
-const DOCUMENT_MEMORY_TOOLS = ["save", "read", "list"];
+/**
+ * The memory authoring functions the compiler registers from. A declaration
+ * only counts when one of them is called directly by its own name on literal
+ * arguments: that is what lets the compiler run the same `defineMemory()` the
+ * artifact runs and emit the executable definition itself. Any other use
+ * (an alias, a namespace member, a wrapper, a re-export under another name)
+ * would let the definition execute without being registered, or register
+ * something the definition does not mean, so the build rejects it.
+ */
+const MEMORY_AUTHORING_FUNCTIONS = new Set([
+  "defineMemory",
+  "documentMemory",
+  "httpMemory",
+]);
 
-/** The identifier a property references, for `connection: name` and `{ connection }` alike. */
-function objectPropertyIdentifier(
-  object: ts.ObjectLiteralExpression,
-  name: string,
-): string | undefined {
-  for (const property of object.properties) {
-    if (
-      ts.isShorthandPropertyAssignment(property) &&
-      property.name.text === name
-    ) {
-      return property.name.text;
-    }
-  }
-  const expression = objectProperty(object, name);
-  return expression && ts.isIdentifier(expression) ? expression.text : undefined;
-}
-
-function memoryMaxBytesValue(
-  expression: ts.Expression | undefined,
-  label: string,
-): number {
-  if (!expression) return MEMORY_DEFAULT_MAX_BYTES;
-  const value = ts.isNumericLiteral(expression)
-    ? Number(expression.text)
-    : Number.NaN;
-  if (!Number.isInteger(value) || value < 1 || value > MEMORY_MAX_BYTES_CEILING) {
-    throw new Error(
-      `${label} maxBytes must be a whole number literal between 1 and ${MEMORY_MAX_BYTES_CEILING}`,
-    );
-  }
-  return value;
-}
-
-function containsSchemaReference(value: unknown): boolean {
-  if (Array.isArray(value)) return value.some(containsSchemaReference);
-  if (!value || typeof value !== "object") return false;
-  return Object.entries(value as Record<string, unknown>).some(
-    ([key, nested]) => key === "$ref" || containsSchemaReference(nested),
+function isTypeOnlyContext(node: ts.Node): boolean {
+  return (
+    ts.isTypeNode(node) ||
+    (ts.isImportDeclaration(node) && !!node.importClause?.isTypeOnly) ||
+    (ts.isExportDeclaration(node) && node.isTypeOnly) ||
+    (ts.isImportSpecifier(node) && node.isTypeOnly) ||
+    (ts.isExportSpecifier(node) && node.isTypeOnly)
   );
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
+/**
+ * Rejects every use of a memory authoring function other than an unaliased
+ * import or export and a direct call, so a definition that executes is one
+ * the compiler registered and vice versa.
+ */
+function assertMemoryFunctionsCalledDirectly(
+  file: ts.SourceFile,
+  path: string,
+): void {
+  const visit = (node: ts.Node): void => {
+    if (isTypeOnlyContext(node)) return;
+    if (ts.isIdentifier(node) && MEMORY_AUTHORING_FUNCTIONS.has(node.text)) {
+      const name = node.text;
+      const parent = node.parent;
+      const direct =
+        (ts.isCallExpression(parent) && parent.expression === node) ||
+        ((ts.isImportSpecifier(parent) || ts.isExportSpecifier(parent)) &&
+          parent.name === node &&
+          parent.propertyName === undefined);
+      if (!direct) {
+        if (ts.isImportSpecifier(parent) || ts.isExportSpecifier(parent)) {
+          const verb = ts.isImportSpecifier(parent) ? "imports" : "exports";
+          const imported = (parent.propertyName ?? parent.name).text;
+          throw new Error(
+            `${path} ${verb} ${imported} as ${parent.name.text}; the compiler registers memory only from a direct ${name}() call, so keep its name`,
+          );
+        }
+        if (ts.isPropertyAccessExpression(parent) && parent.name === node) {
+          throw new Error(
+            `${path} calls ${parent.expression.getText(file)}.${name}(); the compiler registers memory only from a direct ${name}() call, so import ${name} by name from @opencomputer/agent`,
+          );
+        }
+        throw new Error(
+          `${path} uses ${name} other than as a direct ${name}() call; the compiler registers memory only from that call, so do not alias, wrap, or shadow it`,
+        );
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(file);
 }
 
-function httpMemoryTools(value: unknown, label: string): HttpToolDeclaration[] {
-  if (value === undefined) return [];
-  if (!Array.isArray(value)) {
-    throw new Error(`${label} tools must be an array literal`);
-  }
-  if (value.length > HTTP_MEMORY_MAX_TOOLS) {
-    throw new Error(`${label} may declare at most ${HTTP_MEMORY_MAX_TOOLS} tools`);
-  }
-  const names = new Set<string>();
-  return value.map((entry): HttpToolDeclaration => {
-    if (!isRecord(entry)) {
-      throw new Error(`${label} tools must contain object literals`);
-    }
-    const name = typeof entry.name === "string" ? entry.name.trim() : "";
-    if (!HTTP_MEMORY_TOOL_NAME_PATTERN.test(name)) {
+/**
+ * The properties of an object literal as name/value pairs, rejecting every
+ * form whose value the compiler cannot read: spreads, shorthand, methods,
+ * accessors and computed names. `identifiers` names properties whose value is
+ * an identifier reference rather than a literal, allowed in shorthand form.
+ */
+function literalObjectEntries(
+  object: ts.ObjectLiteralExpression,
+  label: string,
+  identifiers: readonly string[] = [],
+): Array<[string, ts.Expression]> {
+  return object.properties.map((property): [string, ts.Expression] => {
+    if (ts.isSpreadAssignment(property)) {
       throw new Error(
-        `${label} tool names must use 1 to 32 lowercase letters, numbers, and underscores`,
+        `${label} cannot spread ${property.expression.getText()}; write each option as a literal property`,
       );
     }
-    const toolLabel = `${label} tool ${name}`;
-    if (names.has(name)) {
-      throw new Error(`${toolLabel} is declared more than once`);
-    }
-    names.add(name);
-    const description =
-      typeof entry.description === "string" ? entry.description.trim() : "";
-    if (!description) throw new Error(`${toolLabel} requires a description`);
-    if (entry.access !== "read" && entry.access !== "write") {
-      throw new Error(`${toolLabel} access must be "read" or "write"`);
-    }
-    if (entry.idempotent !== undefined && typeof entry.idempotent !== "boolean") {
-      throw new Error(`${toolLabel} idempotent must be true or false`);
-    }
-    const input = entry.input;
-    if (!isRecord(input)) {
-      throw new Error(`${toolLabel} input must be a JSON Schema object`);
-    }
-    if (input.type !== "object") {
+    if (ts.isShorthandPropertyAssignment(property)) {
+      const name = property.name.text;
+      if (identifiers.includes(name)) return [name, property.name];
       throw new Error(
-        `${toolLabel} input must be a JSON Schema with type "object"`,
+        `${label} cannot use the shorthand property ${name}; write ${name} as a literal property`,
       );
     }
-    if (containsSchemaReference(input)) {
-      throw new Error(`${toolLabel} input cannot use $ref`);
-    }
-    if (input.properties !== undefined && !isRecord(input.properties)) {
-      throw new Error(`${toolLabel} input properties must be an object`);
-    }
-    if (
-      input.required !== undefined &&
-      (!Array.isArray(input.required) ||
-        input.required.some((item) => typeof item !== "string"))
-    ) {
-      throw new Error(`${toolLabel} input required must be an array of strings`);
-    }
-    if (
-      (isRecord(input.properties) &&
-        Object.prototype.hasOwnProperty.call(
-          input.properties,
-          MEMORY_RESERVED_ARGUMENT,
-        )) ||
-      (Array.isArray(input.required) &&
-        input.required.includes(MEMORY_RESERVED_ARGUMENT))
-    ) {
+    if (!ts.isPropertyAssignment(property)) {
       throw new Error(
-        `${toolLabel} input cannot declare the reserved ${MEMORY_RESERVED_ARGUMENT} argument; OpenComputer adds it to select the resource`,
+        `${label} cannot use methods or accessors; write each option as a literal property`,
       );
     }
-    return {
-      name,
-      description,
-      access: entry.access,
-      idempotent: entry.idempotent === true,
-      input,
-    };
+    return [
+      staticPropertyName(property.name, label),
+      property.initializer,
+    ];
   });
 }
 
-function memoryProviderDeclaration(
-  expression: ts.Expression | undefined,
-  id: string,
-  connectionBindings: ReadonlyMap<string, HttpConnectionManifest>,
-): MemoryProviderDeclaration {
-  const label = `Memory ${id}`;
-  if (!expression) {
-    return { kind: "document", maxBytes: MEMORY_DEFAULT_MAX_BYTES };
+/** The single object-literal argument of an authoring call, or none. */
+function literalCallArgument(
+  call: ts.CallExpression,
+  label: string,
+): ts.ObjectLiteralExpression | undefined {
+  if (call.arguments.length === 0) return undefined;
+  const argument = call.arguments[0];
+  if (
+    call.arguments.length !== 1 ||
+    !argument ||
+    !ts.isObjectLiteralExpression(argument)
+  ) {
+    throw new Error(`${label} requires one object literal argument`);
   }
+  return argument;
+}
+
+function memoryConnectionPolicy(
+  expression: ts.Expression,
+  label: string,
+  connectionBindings: ReadonlyMap<string, HttpConnectionManifest>,
+): HttpMemoryConnection {
+  if (!ts.isIdentifier(expression)) {
+    throw new Error(
+      `${label} connection must reference a defineConnection() binding`,
+    );
+  }
+  const connection = connectionBindings.get(expression.text);
+  if (!connection) {
+    throw new Error(
+      `${label} references unknown connection ${expression.text}`,
+    );
+  }
+  return {
+    kind: "connection",
+    id: connection.id,
+    ...(connection.methods ? { methods: connection.methods } : {}),
+    ...(connection.pathPrefix ? { pathPrefix: connection.pathPrefix } : {}),
+  };
+}
+
+/** Runs a contract function on compile-time input, naming the file on error. */
+function inSourceFile<T>(path: string, evaluate: () => T): T {
+  try {
+    return evaluate();
+  } catch (error) {
+    throw new Error(
+      `${path} ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
+ * The provider a declaration names, produced by running `documentMemory()`
+ * or `httpMemory()` on the literal options at the call site.
+ */
+function memoryProviderValue(
+  expression: ts.Expression,
+  path: string,
+  declaration: string,
+  connectionBindings: ReadonlyMap<string, HttpConnectionManifest>,
+): MemoryProvider {
   if (
     !ts.isCallExpression(expression) ||
     !ts.isIdentifier(expression.expression) ||
@@ -1028,68 +1048,43 @@ function memoryProviderDeclaration(
       expression.expression.text !== "httpMemory")
   ) {
     throw new Error(
-      `${label} provider must be an inline documentMemory() or httpMemory() call`,
+      `${path} ${declaration} provider must be an inline documentMemory() or httpMemory() call`,
     );
   }
-  const provider = expression.expression.text;
-  const input = expression.arguments[0];
-  if (input !== undefined && !ts.isObjectLiteralExpression(input)) {
-    throw new Error(`${label} ${provider}() requires an object literal`);
+  const callee = expression.expression.text;
+  const label = `${path} ${declaration} ${callee}()`;
+  const argument = literalCallArgument(expression, label);
+  if (callee === "documentMemory") {
+    const input: Record<string, unknown> = {};
+    for (const [name, value] of argument
+      ? literalObjectEntries(argument, label)
+      : []) {
+      input[name] = staticJsonValue(value, `${label} ${name}`);
+    }
+    return inSourceFile(path, () =>
+      documentMemory(input as DocumentMemoryInput),
+    );
   }
-  if (provider === "documentMemory") {
-    return {
-      kind: "document",
-      maxBytes: memoryMaxBytesValue(
-        input && objectProperty(input, "maxBytes"),
-        label,
-      ),
-    };
+  if (!argument) {
+    throw new Error(`${label} requires a connection`);
   }
-  if (!input) {
-    throw new Error(`${label} httpMemory() requires a connection`);
+  const input: Record<string, unknown> = {};
+  for (const [name, value] of literalObjectEntries(argument, label, [
+    "connection",
+  ])) {
+    input[name] =
+      name === "connection"
+        ? memoryConnectionPolicy(value, label, connectionBindings)
+        : staticJsonValue(value, `${label} ${name}`);
   }
-  const connectionName = objectPropertyIdentifier(input, "connection");
-  if (!connectionName) {
+  if (!input.connection) {
     throw new Error(
       `${label} connection must reference a defineConnection() binding`,
     );
   }
-  const connection = connectionBindings.get(connectionName);
-  if (!connection) {
-    throw new Error(
-      `${label} references unknown connection ${connectionName}`,
-    );
-  }
-  const pathExpression = objectProperty(input, "path");
-  const path = pathExpression
-    ? literalStringValue(pathExpression, `${label} path`)
-    : HTTP_MEMORY_DEFAULT_PATH;
-  if (!/^\/(?!\/)[^?#\s]*$/.test(path)) {
-    throw new Error(
-      `${label} path must begin with a single / and contain no query or fragment`,
-    );
-  }
-  if (connection.pathPrefix && !path.startsWith(connection.pathPrefix)) {
-    throw new Error(
-      `${label} path ${path} is outside connection ${connection.id} pathPrefix ${connection.pathPrefix}`,
-    );
-  }
-  if (connection.methods && !connection.methods.includes("POST")) {
-    throw new Error(
-      `${label} requires connection ${connection.id} to allow POST`,
-    );
-  }
-  const toolsExpression = objectProperty(input, "tools");
-  return {
-    kind: "http",
-    connection: connection.id,
-    path,
-    maxBytes: memoryMaxBytesValue(objectProperty(input, "maxBytes"), label),
-    tools: httpMemoryTools(
-      toolsExpression && staticJsonValue(toolsExpression, `${label} tools`),
-      label,
-    ),
-  };
+  return inSourceFile(path, () =>
+    httpMemory(input as unknown as HttpMemoryInput),
+  );
 }
 
 function definedMemory(
@@ -1098,6 +1093,7 @@ function definedMemory(
   connectionBindings: ReadonlyMap<string, HttpConnectionManifest>,
 ): MemoryDeclaration[] {
   const file = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true);
+  assertMemoryFunctionsCalledDirectly(file, path);
   const declarations: MemoryDeclaration[] = [];
   const visit = (node: ts.Node): void => {
     if (
@@ -1105,46 +1101,38 @@ function definedMemory(
       ts.isIdentifier(node.expression) &&
       node.expression.text === "defineMemory"
     ) {
-      const input = node.arguments[0];
-      if (!input || !ts.isObjectLiteralExpression(input)) {
-        throw new Error(`${path} defineMemory() requires an object literal`);
+      const label = `${path} defineMemory()`;
+      const argument = literalCallArgument(node, label);
+      if (!argument) {
+        throw new Error(`${label} requires one object literal argument`);
       }
-      const id = literalStringValue(objectProperty(input, "id"), "memory id");
-      if (!AGENT_ID_PATTERN.test(id) || id.length > MEMORY_ID_MAX_LENGTH) {
-        throw new Error(
-          `Memory id ${JSON.stringify(id)} must use lowercase letters, numbers, and single hyphens, at most ${MEMORY_ID_MAX_LENGTH} characters`,
-        );
+      const input: Record<string, unknown> = {};
+      const entries = literalObjectEntries(argument, label);
+      const idEntry = entries.find(([name]) => name === "id");
+      const id = idEntry
+        ? staticJsonValue(idEntry[1], `${label} id`)
+        : undefined;
+      const declaration =
+        typeof id === "string" && id ? `Memory ${id}` : "defineMemory()";
+      for (const [name, value] of entries) {
+        input[name] =
+          name === "provider"
+            ? memoryProviderValue(value, path, declaration, connectionBindings)
+            : staticJsonValue(value, `${label} ${name}`);
       }
-      const description = literalStringValue(
-        objectProperty(input, "description"),
-        `Memory ${id} description`,
-      ).trim();
-      if (!description) {
-        throw new Error(`Memory ${id} requires a non-empty description`);
-      }
+      const definition: MemoryDefinition = inSourceFile(path, () =>
+        defineMemory(input as unknown as MemoryDefinitionInput),
+      );
       declarations.push({
-        id,
-        description,
-        provider: memoryProviderDeclaration(
-          objectProperty(input, "provider"),
-          id,
-          connectionBindings,
-        ),
+        id: definition.id,
+        description: definition.description,
+        provider: definition.provider,
       });
     }
     ts.forEachChild(node, visit);
   };
   visit(file);
   return declarations;
-}
-
-/** The model-facing tool names a declaration reserves. */
-export function memoryToolNames(declaration: MemoryDeclaration): string[] {
-  const names =
-    declaration.provider.kind === "document"
-      ? DOCUMENT_MEMORY_TOOLS
-      : declaration.provider.tools.map((tool) => tool.name);
-  return names.map((name) => `${MEMORY_RESERVED_ARGUMENT}_${name}`);
 }
 
 /**
@@ -2085,8 +2073,18 @@ function staticModelSelections(
   );
 }
 
+/**
+ * The compiled memory contract, inlined into the runtime so the artifact's
+ * defineMemory() is the same code the compiler ran on the declaration.
+ */
+const MEMORY_CONTRACT_SOURCE = readFileSync(
+  fileURLToPath(new URL("./memory.js", import.meta.url)),
+  "utf8",
+).replace(/^\/\/# sourceMappingURL=.*$/m, "");
+
 function agentApiRuntimeSource(): string {
-  return `function hooks() {
+  return `${MEMORY_CONTRACT_SOURCE}
+function hooks() {
   const value = globalThis[Symbol.for("opencomputer.agent-hooks")];
   if (!value) throw new Error("OpenComputer hooks can only run while rendering an agent");
   return value;
@@ -2179,35 +2177,13 @@ export const publishOutbox = async (outbox, input) => {
   if (!response.ok) throw new Error("Outbox publish failed with status " + response.status);
   return await response.json();
 };
-// Memory declarations are validated by the compiler before this runs; the
-// runtime only normalizes defaults so a definition equals its manifest entry.
-const MEMORY_DEFAULT_MAX_BYTES = 8192;
-export const documentMemory = (input = {}) => Object.freeze({ kind: "document", maxBytes: input.maxBytes ?? MEMORY_DEFAULT_MAX_BYTES });
-export const httpMemory = (input) => Object.freeze({
-  kind: "http",
-  connection: id(input.connection && input.connection.id, "httpMemory connection"),
-  path: input.path || "/memory",
-  maxBytes: input.maxBytes ?? MEMORY_DEFAULT_MAX_BYTES,
-  tools: Object.freeze((input.tools || []).map((tool) => Object.freeze({ ...tool, idempotent: tool.idempotent === true }))),
-});
-export const defineMemory = (input) => Object.freeze({
-  kind: "memory",
-  version: 1,
-  id: id(input.id, "defineMemory"),
-  description: String(input.description).trim(),
-  provider: input.provider || documentMemory(),
-});
 // The host resolves every session binding before the render and exposes the
 // projections on its render scope as scope.memory[id]; the hook returns one
 // and the host records the id in scope.selectedMemory, returned to it as
 // selectedMemory next to enabledTools. An unbound id fails the render here.
 export const useMemory = (memory) => {
-  const memoryId = id(typeof memory === "string" ? memory : memory && memory.id, "useMemory");
-  const projection = hooks().useMemory(memoryId);
-  if (!projection || typeof projection !== "object" || typeof projection.text !== "string" || !Array.isArray(projection.sources) || typeof projection.writable !== "boolean") {
-    throw new Error("Memory " + JSON.stringify(memoryId) + " is not bound to this session; create the session with a memory binding for it");
-  }
-  return projection;
+  const resource = memoryId(typeof memory === "string" ? memory : memory && memory.id, "useMemory");
+  return memoryProjection(resource, hooks().useMemory(resource));
 };
 export const useInput = () => hooks().useInput();
 export const useCurrentInput = useInput;
@@ -2504,7 +2480,7 @@ the product or support surface presented to users.
     }
   }
   for (const declaration of memory) {
-    const collision = memoryToolNames(declaration).find((name) =>
+    const collision = memoryToolNames(declaration.provider).find((name) =>
       tools.includes(name),
     );
     if (collision) {

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -463,7 +463,7 @@ export default function Agent() {
           deploy: "opencomputer deploy",
         },
         dependencies: {
-          "@opencomputer/agent": "^0.5.0",
+          "@opencomputer/agent": "^0.6.0",
           ...(spa
             ? {
                 "@opencomputer/react": "^0.1.0",
@@ -473,7 +473,7 @@ export default function Agent() {
             : {}),
         },
         devDependencies: {
-          "@opencomputer/cli": "^0.6.1",
+          "@opencomputer/cli": "^0.7.0",
           ...(spa
             ? {
                 "@types/node": "^24.0.0",

--- a/cli/src/template.ts
+++ b/cli/src/template.ts
@@ -2,9 +2,11 @@ import { readFile, stat } from "node:fs/promises";
 import { resolve } from "node:path";
 import {
   buildAgentArtifact,
+  mergeMemoryDeclarations,
   readProjectAgents,
   readProjectResources,
   type HttpConnectionManifest,
+  type MemoryDeclaration,
   type ProjectResourceManifest,
 } from "./project.js";
 
@@ -47,6 +49,7 @@ export interface TemplateBuildArtifact {
   body: string;
   connections: string[];
   httpConnections: HttpConnectionManifest[];
+  memory: MemoryDeclaration[];
 }
 
 export interface TemplateBuildBundle {
@@ -323,6 +326,7 @@ export async function buildTemplateProject(
       body: built.body.toString("utf8"),
       connections: built.connections,
       httpConnections: built.httpConnections,
+      memory: built.memory,
     });
     for (const connection of built.connections)
       compiledConnections.add(connection);
@@ -366,6 +370,12 @@ export async function buildTemplateProject(
       );
     }
   }
+  mergeMemoryDeclarations(
+    artifacts.map((artifact) => ({
+      origin: `agent ${artifact.localAgentId}`,
+      memory: artifact.memory,
+    })),
+  );
   if (
     template.template.firstRun &&
     !sources.some(

--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -1407,6 +1407,13 @@ describe("managed agents proxy", () => {
                 },
               },
             ],
+            memory: [
+              {
+                id: "requirements",
+                description: "Verified requirements.",
+                provider: { kind: "document", maxBytes: 8192 },
+              },
+            ],
             source: {
               digest,
               size: source.length,
@@ -1444,6 +1451,13 @@ describe("managed agents proxy", () => {
           id: "github-api",
           origin: "https://api.github.com",
         }),
+      ],
+      memory: [
+        {
+          id: "requirements",
+          description: "Verified requirements.",
+          provider: { kind: "document", maxBytes: 8192 },
+        },
       ],
     });
     expect(JSON.stringify(await response.json())).not.toMatch(

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -1102,6 +1102,7 @@ async function deploySourceAgent(
       httpConnections: Array.isArray(body.httpConnections)
         ? body.httpConnections
         : [],
+      memory: Array.isArray(body.memory) ? body.memory : [],
       ...(body.projectDeployment && typeof body.projectDeployment === "object"
         ? { projectDeployment: body.projectDeployment }
         : {}),

--- a/create-start/package.json
+++ b/create-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/create-start",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "description": "Create a hello-world OpenComputer agent application.",
   "type": "module",
   "bin": {
@@ -18,7 +18,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@opencomputer/cli": "0.6.9"
+    "@opencomputer/cli": "0.7.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Stream S3 of the project-memory build (serverless-agents-ws work 026): the authoring surface in `@opencomputer/agent` and the compiler/registration path in `@opencomputer/cli`, implementing contract C3 and the behaviour documented on `docs/memory` (#719).

## `@opencomputer/agent` 0.5.3 -> 0.6.0

```ts
defineMemory({ id, description, provider? }): MemoryDefinition
  // frozen { kind: "memory", version: 1, id, description, provider }; provider defaults to documentMemory()
documentMemory({ maxBytes? } = {}): DocumentMemoryProvider
  // { kind: "document", maxBytes } — default 8192, ceiling 16384, validated at definition time
httpMemory({ connection, path?, maxBytes?, tools? }): HttpMemoryProvider
  // { kind: "http", connection: connection.id, path (default "/memory"), maxBytes, tools }
  // validates: path shape and connection pathPrefix/POST, tool names /^[a-z0-9_]{1,32}$/ and <= 8, unique,
  // access "read" | "write", idempotent default false, input = object JSON Schema without $ref,
  // reserved `memory` argument rejected in properties/required
useMemory(definition | id): MemoryProjection
  // { text, sources: [{ id, title?, revision?, updatedAt? }], cursor?, writable }
  // throws `Memory "<id>" is not bound to this session` when the host provides no projection
ToolExecutionContext.toolCallId: string
```

Ids use the framework's resource identifier rules (lowercase, digits, single hyphens; <= 128 chars). The same id across agents names the same resource, so there is no per-agent namespacing.

## Compiler and registration (`@opencomputer/cli` 0.6.9 -> 0.7.0, `create-start` in lockstep)

`reactive.json` and `BuiltAgentArtifact` gain `memory: MemoryDeclaration[]` (contract C3 shape, sorted by id), collected from every bundled source module like connections and MCP servers. Duplicate ids within an agent are deduplicated when identical and fail the build when they differ; a project publish applies the same rule across agents before any of them registers. `registerDeployment` sends `memory` next to `connections`/`httpConnections`; api-edge forwards it (the edge rebuilds the body field by field, so this one line is what makes the array reach the backend — flagging for S4 since api-edge is otherwise theirs).

Extra build-time checks: a literal `useMemory("id")` must name a declared resource; an ordinary tool may not take a memory tool's fixed name (`memory_save`/`memory_read`/`memory_list`, or `memory_<tool>` for an HTTP provider).

## Render scope contract for the host (S5)

The host's render worker owns the hooks object. `useMemory(id)` calls `hooks().useMemory(id)`, which must return `scope.memory[id]` — the projection the host resolved for the session binding with that resource id (absent when unbound) — and add the id to `scope.selectedMemory`, returned as `selectedMemory: string[]` (sorted) next to `enabledTools`. The agent-side wrapper throws for an unbound id, so the host hook can be:

```js
useMemory(id) { const projection = scope.memory[id]; if (projection) scope.selectedMemory.add(id); return projection; }
```

Documented on `AgentHooks` in `agent/src/index.ts` and in the CLI runtime shim.

## Tests

- agent: 10 (new `node --test` suite; the publish workflow now runs `npm test` for the package)
- cli: 65 (5 new: manifest emission incl. an end-to-end render of the compiled `agent.js` against a fake host scope, dedupe/conflict, declaration validation incl. the reserved argument, registration payload, cross-agent agreement)
- api-edge: 173 (memory forwarded in the deployment registration test)

## Docs

No change needed on `docs/memory` for the behaviour implemented. One note: the projection type carries an optional `cursor` (per contract C1 and the task brief) while the product note says provider cursors are host-private; `document-memory.mdx` ("The hook returns text, sources and writable") stays accurate either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKjbUpydN8ju2ZLxukbWLQ
