### PR TITLE
Memory DX: useAgent attaches to server-created sessions; start a session on a new document in one call

### DIFF
--- a/.github/workflows/publish-opencomputer-packages.yml
+++ b/.github/workflows/publish-opencomputer-packages.yml
@@ -59,11 +59,11 @@ jobs:
           npm ci
           npm test
 
-      - name: Install and build React package
+      - name: Install and test React package
         working-directory: react
         run: |
           npm ci
-          npm run build
+          npm test
 
       - name: Install and test starter package
         working-directory: create-start

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -280,7 +280,19 @@ export interface MemoryDocumentRead {
   etag: string;
 }
 
-interface CreateSessionResult {
+/**
+ * A session's memory binding (docs/agents/document-memory.mdx, "Session
+ * bindings"), keyed by resource id in the session create body.
+ */
+export type MemoryBinding =
+  | { scope: "document"; id: string; access?: "read" | "read-write" }
+  | { scope: "collection"; access?: "read" };
+
+export type MemoryBindings = Record<string, MemoryBinding>;
+
+export interface CreateSessionResult {
+  /** 201 created the session; 200 replayed an earlier create under the same Idempotency-Key. */
+  created: boolean;
   session: ManagedSessionSnapshot;
   deployment?: ManagedAgentDeployment;
 }
@@ -974,11 +986,21 @@ export class OpenComputerClient {
     );
   }
 
-  createSession(agentId: string) {
-    return this.request<CreateSessionResult>("/api/managed-agents/sessions", {
+  async createSession(
+    agentId: string,
+    options: { memory?: MemoryBindings } = {},
+  ): Promise<CreateSessionResult> {
+    const response = await this.response("/api/managed-agents/sessions", {
       method: "POST",
-      body: JSON.stringify({ agentId }),
+      body: JSON.stringify({
+        agentId,
+        ...(options.memory && Object.keys(options.memory).length
+          ? { memory: options.memory }
+          : {}),
+      }),
     });
+    const body = (await response.json()) as Omit<CreateSessionResult, "created">;
+    return { created: response.status === 201, ...body };
   }
 
   async sessions(): Promise<ManagedSessionSnapshot[]> {

--- a/cli/src/commands.ts
+++ b/cli/src/commands.ts
@@ -3,6 +3,7 @@ import {
   type ManagedAgentEvent,
   type ManagedAgentLog,
   type ManagedSessionSnapshot,
+  type MemoryBindings,
   type MemoryDocument,
   type MemoryDocumentMeta,
 } from "./api.js";
@@ -49,8 +50,11 @@ import { createInterface } from "node:readline/promises";
 import { doctorProject, type DoctorResult } from "./doctor.js";
 import { CLIError } from "./errors.js";
 import {
+  createSessionWithMemory,
+  ensureMemoryDocuments,
   memoryResources,
   saveMemoryEdit,
+  type EnsuredMemoryDocument,
   type MemoryEditDraft,
   type MemoryResourceSummary,
 } from "./memory-commands.js";
@@ -613,8 +617,9 @@ async function runAgent(
   json: boolean,
   verbose: boolean,
   idempotencyKey?: string,
+  memory?: MemoryBindings,
 ): Promise<unknown> {
-  const created = await client.createSession(agent);
+  const created = await createSessionWithMemory(client, agent, memory);
   process.stderr.write(`Starting ${agent}…\n`);
   const connected = await waitForEvent(
     client,
@@ -667,9 +672,29 @@ async function runAgent(
     turnId: turn.turnId,
     agentId: created.deployment?.agentId ?? agent,
     deploymentId: created.deployment?.id,
+    ...(memory ? { memory } : {}),
     status: "completed",
     output: streamedText || completedText || undefined,
   };
+}
+
+function printMemoryBindings(
+  memory: MemoryBindings | undefined,
+  documents: EnsuredMemoryDocument[],
+): string {
+  if (!memory) return "";
+  return Object.entries(memory)
+    .map(([resource, binding]) => {
+      if (binding.scope === "collection") {
+        return `Memory:     ${resource} (collection, read)\n`;
+      }
+      const ensured = documents.find(
+        (document) => document.resource === resource && document.id === binding.id,
+      );
+      const state = ensured ? (ensured.created ? ", created" : ", existing") : "";
+      return `Memory:     ${resource}/${binding.id} (${binding.access ?? "read-write"}${state})\n`;
+    })
+    .join("");
 }
 
 export async function runCommand(
@@ -1953,6 +1978,14 @@ export async function runCommand(
         session.agent,
       );
       const agent = developmentAgentReference(agentId);
+      // Sessions from the CLI run on Development, so its memory is bound.
+      const documents = session.createDocuments && session.memory
+        ? await ensureMemoryDocuments(client, {
+            projectId: project.projectId,
+            environment: "development",
+            bindings: session.memory,
+          })
+        : [];
       if (prompt) {
         const result = await runAgent(
           client,
@@ -1962,11 +1995,22 @@ export async function runCommand(
           globals.json,
           globals.verbose === true,
           globals.idempotencyKey,
+          session.memory,
         );
-        if (globals.json) printJSON(result);
+        if (globals.json) {
+          printJSON(
+            documents.length
+              ? { ...(result as Record<string, unknown>), documents }
+              : result,
+          );
+        }
         return;
       }
-      const created = await client.createSession(agent);
+      const created = await createSessionWithMemory(
+        client,
+        agent,
+        session.memory,
+      );
       const connected = await waitForEvent(
         client,
         created.session.id,
@@ -1980,17 +2024,21 @@ export async function runCommand(
       }
       const result = {
         sessionId: created.session.id,
+        created: created.created,
         agentId: created.deployment?.agentId ?? agent,
         deploymentId: created.deployment?.id,
+        ...(session.memory ? { memory: session.memory } : {}),
+        ...(documents.length ? { documents } : {}),
         status: session.keep ? "running" : "suspended",
         cursor: connected.cursor,
       };
       if (globals.json) printJSON(result);
       else {
         process.stdout.write(
-          `Session:    ${result.sessionId}\n` +
+          `Session:    ${result.sessionId}${created.created ? "" : " (existing)"}\n` +
             `Agent:      ${result.agentId}\n` +
             `Deployment: ${result.deploymentId ?? "—"}\n` +
+            printMemoryBindings(session.memory, documents) +
             `Runtime:    ${result.status}\n`,
         );
       }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -60,6 +60,10 @@ Usage:
   opencomputer dev [--project <id|slug> | --create-project <name>]  (legacy alias)
   opencomputer session [prompt] [--agent <project-agent>] [--keep]
   opencomputer session create [prompt] [--agent <project-agent>] [--keep]
+      [--memory <resource>=<documentId>[:read|read-write] | --memory <resource>]... [--create-document]
+      --memory binds a document (read-write by default) or a collection; --create-document
+      creates each bound document that does not exist yet; with --idempotency-key a retry
+      returns the same session
   opencomputer session list
   opencomputer session inspect <session-id>
   opencomputer session attach <session-id>

--- a/cli/src/memory-commands.test.ts
+++ b/cli/src/memory-commands.test.ts
@@ -6,7 +6,12 @@ import test from "node:test";
 
 import { OpenComputerClient } from "./api.js";
 import { CLIError } from "./errors.js";
-import { memoryResources, saveMemoryEdit } from "./memory-commands.js";
+import {
+  createSessionWithMemory,
+  ensureMemoryDocuments,
+  memoryResources,
+  saveMemoryEdit,
+} from "./memory-commands.js";
 
 const config = { apiUrl: "https://app.opencomputer.dev", apiKey: "test" };
 
@@ -283,4 +288,91 @@ test("a saved edit discards its draft", async (context) => {
   } finally {
     await draft.cleanup();
   }
+});
+
+test("--create-document creates missing bound documents, keeps existing ones, and refuses deleted ids", async (context) => {
+  const requests: Array<{ method: string; path: string; ifNoneMatch: string | null }> = [];
+  context.mock.method(globalThis, "fetch", async (input: string | URL | Request, init?: RequestInit) => {
+    const request = new Request(input, init);
+    const path = route(request);
+    requests.push({ method: request.method, path, ifNoneMatch: request.headers.get("if-none-match") });
+    const document = (id: string, revision: string) =>
+      Response.json({ id, title: id, text: "", summary: "", agentWrites: "enabled", revision, bytes: 0, maxBytes: 8192, updatedAt: "2026-09-10T00:00:00.000Z", writer: { kind: "owner" } }, { status: request.method === "PUT" ? 201 : 200, headers: { etag: `"${revision}"` } });
+    if (path.includes("/documents/fresh?")) return document("fresh", "r1");
+    if (path.includes("/documents/kept?")) {
+      return request.method === "PUT"
+        ? Response.json({ error: { code: "precondition_failed", message: "used" } }, { status: 412 })
+        : document("kept", "r9");
+    }
+    if (path.includes("/documents/gone?")) {
+      return request.method === "PUT"
+        ? Response.json({ error: { code: "precondition_failed", message: "used" } }, { status: 412 })
+        : Response.json({ error: { code: "not_found", message: "deleted" } }, { status: 404 });
+    }
+    throw new Error(`unexpected ${request.method} ${path}`);
+  });
+  const client = new OpenComputerClient(config);
+
+  const ensured = await ensureMemoryDocuments(client, {
+    projectId: "prj_1",
+    environment: "development",
+    bindings: {
+      topics: { scope: "document", id: "fresh", access: "read-write" },
+      profile: { scope: "document", id: "kept", access: "read" },
+      archive: { scope: "collection" },
+    },
+  });
+  assert.deepEqual(ensured, [
+    { resource: "topics", id: "fresh", created: true, revision: "r1" },
+    { resource: "profile", id: "kept", created: false, revision: "r9" },
+  ]);
+  assert.deepEqual(requests.map((request) => `${request.method} ${request.path.split("?")[0]} ${request.ifNoneMatch ?? ""}`.trim()), [
+    "PUT /api/managed-agents/projects/prj_1/memory/topics/documents/fresh *",
+    "PUT /api/managed-agents/projects/prj_1/memory/profile/documents/kept *",
+    "GET /api/managed-agents/projects/prj_1/memory/profile/documents/kept",
+  ]);
+
+  await assert.rejects(
+    ensureMemoryDocuments(client, {
+      projectId: "prj_1",
+      environment: "development",
+      bindings: { topics: { scope: "document", id: "gone" } },
+    }),
+    (error: unknown) => error instanceof CLIError && error.code === "memory_document_deleted" && /reserved/.test(error.message),
+  );
+});
+
+test("session create sends bindings, reports replay, and names a reused key's conflict", async (context) => {
+  const bodies: Array<Record<string, unknown>> = [];
+  let status = 201;
+  context.mock.method(globalThis, "fetch", async (input: string | URL | Request, init?: RequestInit) => {
+    const request = new Request(input, init);
+    assert.equal(route(request), "/api/managed-agents/sessions");
+    bodies.push((await request.json()) as Record<string, unknown>);
+    if (status === 409) {
+      return Response.json({ error: { code: "idempotency_conflict", message: "Idempotency-Key was already used with different session input" } }, { status });
+    }
+    return Response.json({ session: { id: "ses-1", status: "connecting" }, deployment: { id: "muse:dev", agentId: "muse", alias: "development" } }, { status });
+  });
+  const client = new OpenComputerClient(config, "topic/workshop/1");
+  const memory = { topics: { scope: "document" as const, id: "workshop", access: "read-write" as const } };
+
+  const created = await createSessionWithMemory(client, "muse@development", memory);
+  assert.equal(created.created, true);
+  assert.equal(created.session.id, "ses-1");
+  assert.deepEqual(bodies[0], { agentId: "muse@development", memory });
+
+  status = 200;
+  const replayed = await createSessionWithMemory(client, "muse@development", memory);
+  assert.equal(replayed.created, false);
+
+  status = 201;
+  await createSessionWithMemory(client, "muse@development");
+  assert.deepEqual(bodies[2], { agentId: "muse@development" });
+
+  status = 409;
+  await assert.rejects(
+    createSessionWithMemory(client, "muse@development", memory),
+    (error: unknown) => error instanceof CLIError && error.code === "session_idempotency_conflict" && /different agent, deployment, environment or memory bindings/.test(error.message),
+  );
 });

--- a/cli/src/memory-commands.ts
+++ b/cli/src/memory-commands.ts
@@ -1,5 +1,7 @@
 import {
   APIError,
+  type CreateSessionResult,
+  type MemoryBindings,
   type MemoryDocument,
   type MemoryEnvironment,
   type MemoryResource,
@@ -173,4 +175,88 @@ function writerLabel(document: MemoryDocument): string {
   return document.writer.kind === "agent"
     ? `agent ${document.writer.sessionId}`
     : "owner";
+}
+
+/** One bound document after `--create-document`: created now, or already there. */
+export interface EnsuredMemoryDocument {
+  resource: string;
+  id: string;
+  created: boolean;
+  revision: string;
+}
+
+/**
+ * Creates every document a session's bindings name that does not exist yet
+ * (title = its id, empty text), and reports each with whether it was created.
+ * A deleted id is reserved and a binding to it would fail admission, so it
+ * fails here, before any session is created.
+ */
+export async function ensureMemoryDocuments(
+  client: OpenComputerClient,
+  input: {
+    projectId: string;
+    environment: MemoryEnvironment;
+    bindings: MemoryBindings;
+  },
+): Promise<EnsuredMemoryDocument[]> {
+  const ensured: EnsuredMemoryDocument[] = [];
+  for (const [resource, binding] of Object.entries(input.bindings)) {
+    if (binding.scope !== "document") continue;
+    const target = {
+      projectId: input.projectId,
+      resource,
+      id: binding.id,
+      environment: input.environment,
+    };
+    try {
+      const { document } = await client.createMemoryDocument({
+        ...target,
+        title: binding.id,
+        text: "",
+      });
+      ensured.push({ resource, id: binding.id, created: true, revision: document.revision });
+      continue;
+    } catch (error) {
+      if (!(error instanceof APIError && error.status === 412)) throw error;
+    }
+    try {
+      const { document } = await client.memoryDocument(target);
+      ensured.push({ resource, id: binding.id, created: false, revision: document.revision });
+    } catch (error) {
+      if (error instanceof APIError && error.status === 404) {
+        throw new CLIError(
+          "memory_document_deleted",
+          `${resource}/${binding.id} was deleted and its id is reserved; a session cannot bind it.`,
+          "Bind a new document id, or create one with `opencomputer memory create`.",
+          { resource, id: binding.id },
+        );
+      }
+      throw error;
+    }
+  }
+  return ensured;
+}
+
+/**
+ * Creates a session, with bindings when given. A reused `--idempotency-key`
+ * whose earlier session had different inputs is a 409; name the cause.
+ */
+export async function createSessionWithMemory(
+  client: OpenComputerClient,
+  agent: string,
+  memory?: MemoryBindings,
+): Promise<CreateSessionResult> {
+  try {
+    return await client.createSession(agent, memory ? { memory } : {});
+  } catch (error) {
+    if (error instanceof APIError && error.status === 409) {
+      throw new CLIError(
+        "session_idempotency_conflict",
+        "This --idempotency-key already created a session with a different agent, deployment, environment or memory bindings.",
+        "Pass a new --idempotency-key to start another session, or repeat the earlier command unchanged to get the existing one.",
+        { status: 409, ...(memory ? { memory } : {}) },
+      );
+    }
+    throw error;
+  }
 }

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -272,7 +272,7 @@ test("init can explicitly include a separately-run React app", async () => {
       session: "opencomputer session",
       deploy: "opencomputer deploy",
     });
-    assert.equal(packageJSON.dependencies["@opencomputer/react"], "^0.1.0");
+    assert.equal(packageJSON.dependencies["@opencomputer/react"], "^0.2.0");
     assert.equal(packageJSON.dependencies.react, "^19.2.0");
     assert.equal(packageJSON.devDependencies.vite, "^8.0.0");
     assert.equal(packageJSON.devDependencies["@opencomputer/cli"], "^0.7.0");

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -464,7 +464,7 @@ export default function Agent() {
           "@opencomputer/agent": "^0.6.0",
           ...(spa
             ? {
-                "@opencomputer/react": "^0.1.0",
+                "@opencomputer/react": "^0.2.0",
                 react: "^19.2.0",
                 "react-dom": "^19.2.0",
               }

--- a/cli/src/session-command.test.ts
+++ b/cli/src/session-command.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   developmentAgentReference,
+  parseMemoryBinding,
   parseSessionCommand,
   resolveProjectAgent,
 } from "./session-command.js";
@@ -78,4 +79,45 @@ test("session rejects equals-form deprecated routing options", () => {
     () => parseSessionCommand(["Hello", "--alias=production"]),
     /--alias is no longer supported/,
   );
+});
+
+test("session create binds memory documents and collections", () => {
+  assert.deepEqual(
+    parseSessionCommand([
+      "create",
+      "--memory",
+      "topics=workshop",
+      "--memory=profile=owner:read",
+      "--memory",
+      "archive",
+      "--create-document",
+      "Plan the workshop",
+    ]),
+    {
+      action: "create",
+      args: ["Plan the workshop"],
+      keep: false,
+      memory: {
+        topics: { scope: "document", id: "workshop", access: "read-write" },
+        profile: { scope: "document", id: "owner", access: "read" },
+        archive: { scope: "collection" },
+      },
+      createDocuments: true,
+    },
+  );
+  assert.deepEqual(parseMemoryBinding("notes=work_shop-1:read-write"), {
+    resource: "notes",
+    binding: { scope: "document", id: "work_shop-1", access: "read-write" },
+  });
+});
+
+test("session create rejects malformed memory bindings", () => {
+  assert.throws(() => parseSessionCommand(["--memory"]), /--memory requires a value/);
+  assert.throws(() => parseSessionCommand(["--memory", "Notes=workshop"]), /is not a resource id/);
+  assert.throws(() => parseSessionCommand(["--memory", "notes=work shop"]), /is not a document id/);
+  assert.throws(() => parseSessionCommand(["--memory", "notes=workshop:write"]), /access must be read or read-write/);
+  assert.throws(() => parseSessionCommand(["--memory", "notes=a", "--memory", "notes=b"]), /names resource notes twice/);
+  assert.throws(() => parseSessionCommand(["send", "ses-1", "hi", "--memory", "notes=a"]), /only supported when creating/);
+  assert.throws(() => parseSessionCommand(["--create-document"]), /needs at least one --memory/);
+  assert.throws(() => parseSessionCommand(["--memory", "notes", "--create-document"]), /applies to document bindings/);
 });

--- a/cli/src/session-command.ts
+++ b/cli/src/session-command.ts
@@ -6,12 +6,80 @@ export type SessionAction =
   | "send"
   | "end";
 
+import type { MemoryBindings } from "./api.js";
+
 export type SessionCommand = {
   action: SessionAction;
   args: string[];
   keep: boolean;
   agent?: string;
+  /** `--memory` bindings for `create`, keyed by resource. */
+  memory?: MemoryBindings;
+  /** `--create-document`: create each bound document that does not exist yet. */
+  createDocuments?: boolean;
 };
+
+const RESOURCE_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const DOCUMENT_ID = /^[A-Za-z0-9_-]{1,128}$/;
+
+/**
+ * One `--memory` value: `<resource>=<documentId>[:read|read-write]` binds a
+ * document (read-write by default), `<resource>` alone binds the collection.
+ */
+export function parseMemoryBinding(
+  value: string,
+): { resource: string; binding: MemoryBindings[string] } {
+  const usage =
+    "--memory takes <resource>=<documentId>[:read|read-write] or <resource> for a collection";
+  const equals = value.indexOf("=");
+  const resource = equals < 0 ? value : value.slice(0, equals);
+  if (!RESOURCE_ID.test(resource) || resource.length > 128) {
+    throw new Error(`${usage}; ${JSON.stringify(resource)} is not a resource id`);
+  }
+  if (equals < 0) return { resource, binding: { scope: "collection" } };
+  const target = value.slice(equals + 1);
+  const colon = target.lastIndexOf(":");
+  const id = colon < 0 ? target : target.slice(0, colon);
+  const access = colon < 0 ? "read-write" : target.slice(colon + 1);
+  if (!DOCUMENT_ID.test(id)) {
+    throw new Error(`${usage}; ${JSON.stringify(id)} is not a document id`);
+  }
+  if (access !== "read" && access !== "read-write") {
+    throw new Error(`${usage}; access must be read or read-write`);
+  }
+  return { resource, binding: { scope: "document", id, access } };
+}
+
+function takeMemoryOptions(args: string[]): MemoryBindings | undefined {
+  const bindings: MemoryBindings = {};
+  let count = 0;
+  for (;;) {
+    const equalsIndex = args.findIndex((argument) =>
+      argument.startsWith("--memory="),
+    );
+    const index = equalsIndex >= 0 ? equalsIndex : args.indexOf("--memory");
+    if (index < 0) break;
+    let value: string;
+    if (equalsIndex >= 0) {
+      value = args[index]!.slice("--memory=".length);
+      args.splice(index, 1);
+    } else {
+      value = args[index + 1] ?? "";
+      if (!value || value.startsWith("--")) {
+        throw new Error("--memory requires a value");
+      }
+      args.splice(index, 2);
+    }
+    if (!value) throw new Error("--memory requires a value");
+    const { resource, binding } = parseMemoryBinding(value);
+    if (bindings[resource]) {
+      throw new Error(`--memory names resource ${resource} twice`);
+    }
+    bindings[resource] = binding;
+    count += 1;
+  }
+  return count ? bindings : undefined;
+}
 
 export function developmentAgentReference(agentId: string): string {
   return `${agentId}@development`;
@@ -86,6 +154,10 @@ export function parseSessionCommand(rawArgs: string[]): SessionCommand {
 
   const args = [...rawArgs];
   const agent = takeAgentOption(args);
+  const memory = takeMemoryOptions(args);
+  const createDocumentsIndex = args.indexOf("--create-document");
+  const createDocuments = createDocumentsIndex >= 0;
+  if (createDocuments) args.splice(createDocumentsIndex, 1);
   const keepIndex = args.indexOf("--keep");
   const keep = keepIndex >= 0;
   if (keep) args.splice(keepIndex, 1);
@@ -98,5 +170,24 @@ export function parseSessionCommand(rawArgs: string[]): SessionCommand {
   if (agent && action !== "create") {
     throw new Error("--agent is only supported when creating a session.");
   }
-  return { action, args, keep, ...(agent ? { agent } : {}) };
+  if (memory && action !== "create") {
+    throw new Error("--memory is only supported when creating a session.");
+  }
+  if (createDocuments && !memory) {
+    throw new Error("--create-document needs at least one --memory <resource>=<documentId>.");
+  }
+  if (
+    createDocuments &&
+    !Object.values(memory ?? {}).some((binding) => binding.scope === "document")
+  ) {
+    throw new Error("--create-document applies to document bindings; --memory <resource> binds a collection.");
+  }
+  return {
+    action,
+    args,
+    keep,
+    ...(agent ? { agent } : {}),
+    ...(memory ? { memory } : {}),
+    ...(createDocuments ? { createDocuments } : {}),
+  };
 }

--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -1790,6 +1790,42 @@ describe("managed agents proxy", () => {
     });
   });
 
+  it("interrupts a session's running turn and returns the sanitized snapshot", async () => {
+    const fetchSpy = vi.fn(async () =>
+      Response.json({
+        id: "session-1",
+        status: "idle",
+        executionMode: "workerd",
+        accountId: "org_test",
+        runtimeToken: "internal-runtime-token",
+        turns: [{ id: "turn-1", status: "cancelled" }],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const response = await proxyManagedAgents(
+      new Request(
+        "https://app.opencomputer.dev/api/managed-agents/sessions/session-1/interrupt",
+        { method: "POST" },
+      ),
+      {
+        OC_MANAGED_AGENTS_SECRET: "test-secret",
+        MANAGED_AGENTS_API_URL: "https://managedagents.test",
+      },
+      { orgID: "org_test", userID: "user_test" },
+      "/api/managed-agents",
+    );
+
+    expect(response.status).toBe(200);
+    const [target] = fetchSpy.mock.calls[0] as unknown as [URL];
+    expect(String(target)).toBe(
+      "https://managedagents.test/v1/sessions/session-1/interrupt",
+    );
+    const serialized = JSON.stringify(await response.json());
+    expect(serialized).toContain('"status":"cancelled"');
+    expect(serialized).not.toMatch(/runtimeToken|accountId|org_test/);
+  });
+
   it("removes backend artifact and runtime fields from successful responses", async () => {
     vi.stubGlobal(
       "fetch",

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -1150,7 +1150,7 @@ function publicSuccessBody(
   if (
     (method === "GET" && /^\/sessions(?:\/[^/]+)?$/.test(suffix)) ||
     (method === "POST" &&
-      /^\/sessions\/[^/]+\/(resume|end|terminate)$/.test(suffix))
+      /^\/sessions\/[^/]+\/(resume|end|terminate|interrupt)$/.test(suffix))
   ) {
     return stripPrivateValues(body);
   }
@@ -1409,7 +1409,9 @@ function isAllowedManagedAgentsRoute(method: string, suffix: string): boolean {
   }
   return (
     method === "POST" &&
-    /^\/sessions\/[^/]+\/(turns|suspend|resume|end|terminate)$/.test(suffix)
+    /^\/sessions\/[^/]+\/(turns|suspend|resume|end|terminate|interrupt)$/.test(
+      suffix,
+    )
   );
 }
 

--- a/docs/agents/document-memory.mdx
+++ b/docs/agents/document-memory.mdx
@@ -87,6 +87,56 @@ for read-only bindings, frozen/deleted documents and ended sessions.
 Reusing a session-create `Idempotency-Key` requires identical agent, deployment,
 environment and bindings; incompatible inputs return `409 conflict`.
 
+### Start a session on a new document
+
+A document and a session are separate objects: the document is owner data
+with its own lifetime, the binding is that session's admission to it, and
+neither is created as a side effect of the other. Opening a topic in an
+application still means "these notes, this session", so the SDK and the CLI
+do the two steps in order and make the pair converge on retry.
+
+```ts
+import { startSessionOnDocument } from "@opencomputer/sdk";
+
+const { document, session } = await startSessionOnDocument({
+  apiKey: process.env.OPENCOMPUTER_API_KEY!,
+  projectId: "<project-id>",
+  environment: "development",
+  agent: "<agent-id>",
+  resource: "notes",
+  documentId: "workshop",
+  document: { title: "Workshop notes" },
+  idempotencyKey: "topic/workshop/1",
+});
+// document.created and session.created are false when they already existed.
+```
+
+- The document is created with `If-None-Match: *`. An existing document is
+  left as it is; `document` is ignored then. A deleted id is reserved and
+  fails before any session is created.
+- The session is created with an `Idempotency-Key` derived from
+  `idempotencyKey`. The same key with the same agent, deployment, environment
+  and bindings returns the existing session; anything else under that key is
+  a conflict error naming the cause. `access` (default `read-write`),
+  `memory` for further bindings and `source` are passed through.
+
+The CLI does the same for a Development session:
+
+```bash
+opencomputer session create --memory notes=workshop --create-document --idempotency-key topic/workshop/1
+```
+
+`--memory <resource>=<documentId>[:read|read-write]` binds a document
+(read-write by default); `--memory <resource>` binds a collection.
+`--create-document` creates each bound document that does not exist yet,
+titled after its id, and reports it as created or existing. Add a prompt to
+run the first turn at once, and `--json` for the ids.
+
+Over HTTP, send `PUT .../documents/<id>` with `If-None-Match: *`, treat `412`
+as "exists" (then `GET` it; `404` means the id was deleted), and `POST
+/api/managed-agents/sessions` with an `Idempotency-Key`; `201` created the
+session, `200` returned the one that key had already created.
+
 ## Reading
 
 The hook is synchronous; pass the definition or its ID:

--- a/docs/agents/react.mdx
+++ b/docs/agents/react.mdx
@@ -1,11 +1,160 @@
 ---
 title: "React integration"
-description: "Stream agent sessions from a React application with useAgent"
+description: "Attach a React application to agent sessions with useAgent"
 ---
 
-An independently developed React application can use `@opencomputer/react`.
-The package owns session creation, multi-turn reuse, and streamed assistant
-messages. React is not part of the default agent scaffold.
+`@opencomputer/react` provides one hook, `useAgent`. It renders a session's
+messages, streams new turns and sends input. The session comes from one of
+two places:
+
+- **Attach** to a session your server created. This is the pattern for any
+  application that keeps its API key on the server and chooses what a session
+  may do there, including every application that binds
+  [memory](/agents/memory).
+- **Create** a session from the browser during development, through the
+  authenticated development bridge.
+
+```bash
+npm install @opencomputer/react
+```
+
+## Attach to a server-created session
+
+Three pieces: your server creates the session, your server proxies three
+routes under its own authentication, and the browser attaches with the
+session id.
+
+### 1. Create the session on the server
+
+Create the session where the API key lives. With memory, that is also where
+the bindings are chosen; the browser can neither see the key nor change what
+the session may read or write. `startSessionOnDocument` from
+`@opencomputer/sdk` creates the document if it does not exist yet, then the
+session bound to it, both converging under one idempotency key
+([details](/agents/document-memory#start-a-session-on-a-new-document)):
+
+```ts
+import { startSessionOnDocument } from "@opencomputer/sdk";
+
+const { session } = await startSessionOnDocument({
+  apiKey: process.env.OPENCOMPUTER_API_KEY!,
+  projectId: process.env.OPENCOMPUTER_PROJECT_ID!,
+  environment: "development",
+  agent: "topic-worker",
+  resource: "topics",
+  documentId: topicId,
+  document: { title },
+  idempotencyKey: `topic/${topicId}/${user.id}`,
+});
+// Store session.id with the topic; the browser attaches to it.
+```
+
+Without memory, `POST /api/managed-agents/sessions` with `x-api-key` and
+`{ "agentId": "<agent-id>@development" }` returns `{ session: { id } }`.
+
+### 2. Proxy three routes
+
+The hook needs exactly these, relative to its `basePath`:
+
+| Route | Purpose |
+| --- | --- |
+| `GET /sessions/<id>/events?after=<seq>` | The durable event log from a cursor; history and live turns |
+| `POST /sessions/<id>/turns` | A new turn: `{ input, idempotencyKey }` |
+| `POST /sessions/<id>/interrupt` | Stop the running turn |
+
+Expose them under your own authentication, check that the signed-in user may
+use that session, and forward to OpenComputer with the API key. A Next.js
+route handler that serves all three:
+
+```ts
+// app/api/agent/sessions/[id]/[action]/route.ts
+const allowed: Record<string, string[]> = { GET: ["events"], POST: ["turns", "interrupt"] };
+
+async function proxy(request: Request, { params }: { params: Promise<{ id: string; action: string }> }) {
+  const { id, action } = await params;
+  const user = await requireUser(request); // your session cookie or token
+  if (!allowed[request.method]?.includes(action) || !(await userOwnsSession(user, id))) {
+    return new Response(null, { status: 404 });
+  }
+  const upstream = await fetch(
+    `https://app.opencomputer.dev/api/managed-agents/sessions/${encodeURIComponent(id)}/${action}${new URL(request.url).search}`,
+    {
+      method: request.method,
+      headers: { "x-api-key": process.env.OPENCOMPUTER_API_KEY!, "content-type": "application/json" },
+      body: request.method === "POST" ? await request.text() : undefined,
+    },
+  );
+  return new Response(upstream.body, { status: upstream.status, headers: { "content-type": "application/json" } });
+}
+
+export const GET = proxy;
+export const POST = proxy;
+```
+
+The turn body carries an `idempotencyKey` the hook generates per send, so a
+retried request does not start a second turn. Forward request bodies and
+responses unchanged; the hook reads `{ events }`, `{ turnId }` and the error
+envelope `{ error: { message } }`.
+
+### 3. Attach in the browser
+
+```tsx
+import { useAgent } from "@opencomputer/react";
+
+export function TopicChat({ sessionId, onNotesChanged }: { sessionId: string; onNotesChanged: () => void }) {
+  const { messages, send, stop, isReplaying, isRunning, error } = useAgent({
+    sessionId,
+    basePath: "/api/agent",
+    onMemorySaved: onNotesChanged,
+  });
+
+  return (
+    <section>
+      {isReplaying ? <p>Loading the conversation…</p> : null}
+      {messages.map((message) => (
+        <p key={message.id}>
+          <strong>{message.role}:</strong> {message.text}
+        </p>
+      ))}
+      <button disabled={isRunning} onClick={() => void send("Book the venue")}>Send</button>
+      <button disabled={!isRunning} onClick={() => void stop()}>Stop</button>
+      {error ? <p role="alert">{error}</p> : null}
+    </section>
+  );
+}
+```
+
+On mount the hook reads the whole event log from `after` (default `0`) and
+reduces it to messages, so a reopened page shows the conversation as it
+stands, including turns that ran while the tab was closed. It then keeps
+polling from its cursor. A failed poll sets `error`, backs off, and resumes
+from the same cursor; nothing is replayed twice, and `error` clears when the
+log answers again. Changing `sessionId` replays the new session.
+
+`send` starts a turn and shows the input at once; the log's own record of it
+confirms that message rather than adding a second one. Turns sent while one
+is running are queued by the platform. `stop` interrupts the running turn
+without spending a model turn.
+
+The hook never suspends, resumes or ends an attached session. Its lifecycle
+belongs to the server that created it.
+
+### Refresh notes on save
+
+Every `memory.saved` event the session records
+([document memory](/agents/document-memory#saving)) is appended to
+`memorySaves` and passed to `onMemorySaved` with its `resource`,
+`documentId`, `revision` and `bytes`. Re-read the document through your own
+owner route when one arrives. Saves are reported best-effort: a document
+can change without an event, so also refresh when the user opens the panel.
+
+Any other event is available through `onEvent`, for example tool activity for
+an activity view.
+
+## Create a session from the browser
+
+For a local application against Development, pass `agent-id@alias` and the
+first `send` creates the session through the development bridge:
 
 ```tsx
 import { useAgent } from "@opencomputer/react";
@@ -35,36 +184,8 @@ export default function Chat() {
 }
 ```
 
-## Hook result
-
-| Value | Purpose |
-| --- | --- |
-| `messages` | User and assistant messages accumulated by this hook instance |
-| `send(text)` | Starts or continues the session and streams the response |
-| `sessionId` | Current cloud session after the first message |
-| `isRunning` | Whether a turn is active |
-| `error` | Most recent request error |
-
-## Select the target
-
-Pass `agent-id@alias` to choose the agent and environment:
-
-```tsx
-useAgent("support@development");
-useAgent("support@production");
-```
-
-An options object can also set the input source, API base path, or fetch
-implementation:
-
-```tsx
-useAgent({
-  agent: "support@development",
-  source: "customer-portal",
-});
-```
-
-## Development
+Each `send` resumes the session, streams one turn and suspends it again.
+Sessions created this way have no memory bindings.
 
 Run the watched agent deployment and the web application separately:
 
@@ -74,8 +195,35 @@ npm run dev:web
 ```
 
 The first command deploys agent changes and provides the authenticated
-development bridge. The second starts only the web application. The web app
-can also be deployed through its own lifecycle; credentials are not bundled
-into browser code.
+development bridge at the hook's default `basePath`. The second starts only
+the web application. Credentials are not bundled into browser code.
+
+## Hook result
+
+| Value | Purpose |
+| --- | --- |
+| `messages` | User and assistant messages, in log order |
+| `send(text)` | Starts a turn; in create mode the first call creates the session |
+| `stop()` | Interrupts the running turn |
+| `sessionId` | The attached session, or the created one after the first send |
+| `isRunning` | Whether a turn is active |
+| `isReplaying` | Attach mode: true until the existing history has been read |
+| `error` | The most recent request or turn failure |
+| `memorySaves` | `memory.saved` events seen so far |
+| `cursor` | The last event position applied |
+
+## Options
+
+| Option | Purpose |
+| --- | --- |
+| `sessionId` | Attach to this session |
+| `agent` | Create mode: `agent-id@alias` |
+| `basePath` | Route prefix for the three routes; default `/api/opencomputer/managed-agents` |
+| `fetch` | A fetch implementation, for example one that adds a CSRF header |
+| `after` | Attach mode: replay from this cursor instead of the start |
+| `pollIntervalMs` | Attach mode: interval between empty polls; default 1000, 500 while a turn runs |
+| `onEvent` | Every applied event, including replayed history |
+| `onMemorySaved` | Each `memory.saved` event |
+| `source` | Create mode: the session's input source |
 
 For the durable conversation model, see [Sessions and turns](/agents/sessions).

--- a/docs/agents/sessions.mdx
+++ b/docs/agents/sessions.mdx
@@ -56,6 +56,13 @@ npm run session -- send <session-id> "Continue"
 npm run session -- end <session-id>
 ```
 
+Bind [memory](/agents/memory) documents when creating a session; add
+`--create-document` to create the ones that do not exist yet:
+
+```bash
+npm run session -- create --memory notes=workshop --create-document "Plan the workshop"
+```
+
 Follow the durable event log directly. With `--json`, each event is one NDJSON
 record suitable for a coding agent or log processor:
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -40,6 +40,7 @@
             "pages": [
               "agents/reactive-agents",
               "agents/sessions",
+              "agents/react",
               "agents/memory",
               "agents/schedules",
               "agents/webhooks",

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,6 +11,7 @@
 - [Deployments and environments](https://docs.opencomputer.dev/agents/deployments.md): Understand development, production, immutable deployments, and aliases.
 - [Reactive agents](https://docs.opencomputer.dev/agents/reactive-agents.md): Render instructions, models, tools, subagents, and MCP servers from code.
 - [Sessions and turns](https://docs.opencomputer.dev/agents/sessions.md): Create and inspect durable conversations.
+- [React integration](https://docs.opencomputer.dev/agents/react.md): Attach a React application to server-created sessions with useAgent, proxying three routes under your own authentication.
 - [Agent capabilities](https://docs.opencomputer.dev/agents/capabilities.md): Choose between tools, MCP servers, skills, subagents, and outbound connections.
 - [Secrets and outbound requests](https://docs.opencomputer.dev/agents/secrets.md): Store scoped secrets and inject them only into declared outbound requests.
 - [Agent hooks](https://docs.opencomputer.dev/agents/hooks.md): Compose agent capabilities with reactive hooks.

--- a/react/README.md
+++ b/react/README.md
@@ -2,11 +2,26 @@
 
 React hooks for applications that interact with OpenComputer agents.
 
+Create a session from the browser during development:
+
 ```tsx
 import { useAgent } from "@opencomputer/react";
 
 const agent = useAgent("support@development");
 ```
+
+Attach to a session your server created, for example one bound to
+[memory](https://opencomputer.dev/agents/memory):
+
+```tsx
+const chat = useAgent({ sessionId, basePath: "/api/agent" });
+```
+
+The hook replays the session's history, streams new turns, and reports
+`memory.saved` events. It only needs the session's events, turns and
+interrupt routes, which your server proxies under its own authentication; the
+API key never reaches the browser. See the
+[React integration guide](https://opencomputer.dev/agents/react).
 
 Run `npm run deploy -- --watch` for the agent project to configure the local
 authenticated bridge, then start the React application separately with its own

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -1,15 +1,20 @@
 {
   "name": "@opencomputer/react",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencomputer/react",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "^24.13.4",
         "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.0",
+        "jsdom": "^26.1.0",
         "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "typescript": "^5.9.0"
       },
       "engines": {
@@ -19,14 +24,206 @@
         "react": ">=19.0.0"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.4.tgz",
+      "integrity": "sha512-YJ7EqCstVTzIr0fMr7qul/977en+pQHrfmuKIo6Zr9i75Be21dr3MovcfvGtyvi2HAUrRerWps5sMO9I7WaxDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/@types/react": {
-      "version": "19.2.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
-      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.3.0.tgz",
+      "integrity": "sha512-N0rFCuH9YoxG9/m61l9MfpJKfmLOVU0em7ipIz6TRgSSkvReLB9vL85GB+yr8Bs5leqpvg96JSwF4ZS1s4viQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.3.0.tgz",
+      "integrity": "sha512-ZI7bU42mZXXKHn/qNLEw2IrbiINU7X5+vfgdixBHkCNpYWXjKgfQ/P+uyGb5CjOLB9UcnTeg3rylQtV2hym44Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.3.0"
+      }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/csstype": {
@@ -36,14 +233,311 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.27.tgz",
+      "integrity": "sha512-gQPNF78qebCQ6tvVFBYrvJdBNOrYZm90ZlXgpIFm06p6qHDHq/XC4TnJftN6OMbxVE0UTBAoRgcsDeJBBooITw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
-      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.3.0.tgz",
+      "integrity": "sha512-E8LUcbtBWt20bbl2YoHfx4ZDBdxVTfOKtCZn9cDSJ4l6/nuoApcpIBcj47t2wZoVX8g2ZHuMHbiShgCR1T5Sog==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.3.0.tgz",
+      "integrity": "sha512-JDk8dgif51OjFoDE70+OT9ICyYr+69HlmihNwp1+Nsfbna3t5sIiCa9ZJktDmQ4/1b/rn26hIAR2uYXDMr5r0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": "^19.3.0"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.28.0.tgz",
+      "integrity": "sha512-juorfCmIkIw8tT+p5BXSm6PJjQF/ycEYmKyzURCIt/RaZIhL+PulbQ9Yu2z1HdOJDdqDTlxA1+xKBmHXJsczAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/typescript": {
@@ -59,6 +553,113 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencomputer/react",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "React hooks for OpenComputer agents.",
   "type": "module",
   "main": "./dist/index.js",
@@ -17,7 +17,8 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "prepack": "npm run build"
+    "prepack": "npm run build",
+    "test": "npm run build && node --test dist/*.test.js"
   },
   "engines": {
     "node": ">=22.0.0"
@@ -26,8 +27,13 @@
     "react": ">=19.0.0"
   },
   "devDependencies": {
+    "@types/jsdom": "^21.1.7",
+    "@types/node": "^24.13.4",
     "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.0",
+    "jsdom": "^26.1.0",
     "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "typescript": "^5.9.0"
   },
   "publishConfig": {

--- a/react/src/events.test.ts
+++ b/react/src/events.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applyEvents,
+  emptyTimeline,
+  failureMessage,
+  inputMessageId,
+  memorySaveFromEvent,
+  type AgentEvent,
+} from "./events.js";
+
+const turn: AgentEvent[] = [
+  { seq: 1, turnId: "t1", type: "message.received", data: { input: "hi" } },
+  { seq: 2, turnId: "t1", type: "turn.started", data: {} },
+  { seq: 3, turnId: "t1", type: "message.delta", data: { text: "hel" } },
+  { seq: 4, turnId: "t1", type: "message.delta", data: { text: "lo" } },
+  {
+    seq: 5,
+    turnId: "t1",
+    type: "memory.saved",
+    timestamp: "2026-09-10T12:00:00.000Z",
+    data: { resource: "notes", documentId: "workshop", revision: "r2", bytes: 12 },
+  },
+  { seq: 6, turnId: "t1", type: "message.completed", data: { text: "hello" } },
+  { seq: 7, turnId: "t1", type: "turn.completed", data: {} },
+];
+
+test("a turn reduces to one user and one assistant message", () => {
+  const partial = applyEvents(emptyTimeline(), turn.slice(0, 4));
+  assert.equal(partial.isRunning, true);
+  assert.deepEqual(partial.messages, [
+    { id: inputMessageId("t1"), role: "user", text: "hi", turnId: "t1" },
+    { id: "turn:t1:reply", role: "assistant", text: "hello", turnId: "t1", streaming: true },
+  ]);
+
+  const complete = applyEvents(partial, turn.slice(4));
+  assert.equal(complete.isRunning, false);
+  assert.equal(complete.cursor, 7);
+  assert.deepEqual(complete.messages, [
+    { id: inputMessageId("t1"), role: "user", text: "hi", turnId: "t1" },
+    { id: "turn:t1:reply", role: "assistant", text: "hello", turnId: "t1", streaming: false },
+  ]);
+  assert.deepEqual(complete.memorySaves, [
+    {
+      seq: 5,
+      turnId: "t1",
+      timestamp: "2026-09-10T12:00:00.000Z",
+      resource: "notes",
+      documentId: "workshop",
+      revision: "r2",
+      bytes: 12,
+    },
+  ]);
+});
+
+test("a completed message without deltas is still one message", () => {
+  const timeline = applyEvents(emptyTimeline(), [turn[0], turn[1], turn[5], turn[6]]);
+  assert.deepEqual(
+    timeline.messages.map((message) => [message.role, message.text, message.streaming]),
+    [["user", "hi", undefined], ["assistant", "hello", false]],
+  );
+});
+
+test("events at or below the cursor are ignored, so overlapping pages do not duplicate", () => {
+  const once = applyEvents(emptyTimeline(), turn);
+  const twice = applyEvents(once, turn);
+  assert.deepEqual(twice, once);
+  assert.equal(twice.messages.length, 2);
+  assert.equal(twice.memorySaves.length, 1);
+});
+
+test("a message sent locally is confirmed, not duplicated, by its message.received", () => {
+  const optimistic = {
+    ...emptyTimeline(),
+    messages: [{ id: inputMessageId("t1"), role: "user" as const, text: "hi", turnId: "t1" }],
+  };
+  const timeline = applyEvents(optimistic, turn.slice(0, 2));
+  assert.equal(timeline.messages.length, 1);
+  assert.equal(timeline.isRunning, true);
+});
+
+test("cancelled and failed turns stop running and settle the streaming reply", () => {
+  for (const type of ["turn.failed", "turn.cancelled"]) {
+    const timeline = applyEvents(emptyTimeline(), [
+      ...turn.slice(0, 4),
+      { seq: 5, turnId: "t1", type, data: { message: "stopped" } },
+    ]);
+    assert.equal(timeline.isRunning, false);
+    assert.equal(timeline.messages[1]?.streaming, false);
+  }
+  assert.equal(
+    failureMessage({ seq: 5, turnId: "t1", type: "turn.failed", data: { message: "boom" } }),
+    "boom",
+  );
+  assert.equal(
+    failureMessage({ seq: 5, type: "runtime.disconnected", data: {} }),
+    "runtime disconnected",
+  );
+  assert.equal(failureMessage(turn[6]), undefined);
+});
+
+test("session end is terminal", () => {
+  const timeline = applyEvents(emptyTimeline(), [
+    ...turn.slice(0, 2),
+    { seq: 3, type: "session.ended", data: {} },
+  ]);
+  assert.equal(timeline.ended, true);
+  assert.equal(timeline.isRunning, false);
+});
+
+test("only memory.saved events describe a save", () => {
+  assert.equal(memorySaveFromEvent(turn[0]), undefined);
+  assert.deepEqual(memorySaveFromEvent({ seq: 9, type: "memory.saved", data: {} }), {
+    seq: 9,
+    resource: "",
+    documentId: "",
+    revision: "",
+    bytes: 0,
+  });
+});

--- a/react/src/events.ts
+++ b/react/src/events.ts
@@ -1,0 +1,189 @@
+// The durable session event log as the hook reads it, and the pure reduction
+// of that log into what a chat renders. No React and no network here: the
+// same function replays history and applies live events, so a reconnect that
+// resumes from a cursor produces the same messages as an uninterrupted stream.
+
+/** One entry of `GET /sessions/<id>/events`. */
+export interface AgentEvent {
+  id?: string;
+  /** Position in the session log; `after=<seq>` resumes past it. */
+  seq: number;
+  timestamp?: string;
+  turnId?: string;
+  type: string;
+  data: Record<string, unknown>;
+}
+
+export interface AgentMessage {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  /** The turn that carried the message; absent on messages the hook created locally. */
+  turnId?: string;
+  /** Set on an assistant message while its turn is still producing text. */
+  streaming?: boolean;
+}
+
+/** A `memory.saved` event: a save the session observed succeeding. */
+export interface MemorySave {
+  seq: number;
+  turnId?: string;
+  timestamp?: string;
+  resource: string;
+  documentId: string;
+  revision: string;
+  bytes: number;
+}
+
+export interface SessionTimeline {
+  messages: AgentMessage[];
+  memorySaves: MemorySave[];
+  /** The highest `seq` applied so far. */
+  cursor: number;
+  isRunning: boolean;
+  ended: boolean;
+}
+
+export function emptyTimeline(): SessionTimeline {
+  return {
+    messages: [],
+    memorySaves: [],
+    cursor: 0,
+    isRunning: false,
+    ended: false,
+  };
+}
+
+/** The id of the user message that starts a turn; `send` uses the same id, so the event upserts it. */
+export function inputMessageId(turnId: string): string {
+  return `turn:${turnId}:input`;
+}
+
+function replyMessageId(event: AgentEvent): string {
+  return event.turnId ? `turn:${event.turnId}:reply` : `event:${String(event.seq)}`;
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/** The save a `memory.saved` event reports; undefined for any other event. */
+export function memorySaveFromEvent(event: AgentEvent): MemorySave | undefined {
+  if (event.type !== "memory.saved") return undefined;
+  const data = event.data ?? {};
+  return {
+    seq: event.seq,
+    ...(event.turnId ? { turnId: event.turnId } : {}),
+    ...(event.timestamp ? { timestamp: event.timestamp } : {}),
+    resource: text(data.resource),
+    documentId: text(data.documentId),
+    revision: text(data.revision),
+    bytes: typeof data.bytes === "number" ? data.bytes : 0,
+  };
+}
+
+function upsert(
+  messages: AgentMessage[],
+  message: AgentMessage,
+): AgentMessage[] {
+  const index = messages.findIndex((candidate) => candidate.id === message.id);
+  if (index < 0) return [...messages, message];
+  const next = [...messages];
+  next[index] = { ...next[index], ...message };
+  return next;
+}
+
+/**
+ * Applies one event. Events at or below the cursor are ignored, so a page
+ * that overlaps an earlier one is harmless.
+ */
+export function applyEvent(
+  timeline: SessionTimeline,
+  event: AgentEvent,
+): SessionTimeline {
+  if (event.seq <= timeline.cursor) return timeline;
+  const next: SessionTimeline = { ...timeline, cursor: event.seq };
+  const data = event.data ?? {};
+  switch (event.type) {
+    case "message.received": {
+      next.messages = upsert(timeline.messages, {
+        id: event.turnId ? inputMessageId(event.turnId) : `event:${String(event.seq)}`,
+        role: "user",
+        text: text(data.input),
+        ...(event.turnId ? { turnId: event.turnId } : {}),
+      });
+      return next;
+    }
+    case "turn.started":
+      next.isRunning = true;
+      return next;
+    case "message.delta": {
+      const id = replyMessageId(event);
+      const existing = timeline.messages.find((message) => message.id === id);
+      next.messages = upsert(timeline.messages, {
+        id,
+        role: "assistant",
+        text: (existing?.text ?? "") + text(data.text),
+        ...(event.turnId ? { turnId: event.turnId } : {}),
+        streaming: true,
+      });
+      return next;
+    }
+    case "message.completed": {
+      next.messages = upsert(timeline.messages, {
+        id: replyMessageId(event),
+        role: "assistant",
+        text: text(data.text),
+        ...(event.turnId ? { turnId: event.turnId } : {}),
+        streaming: false,
+      });
+      return next;
+    }
+    case "turn.completed":
+    case "turn.failed":
+    case "turn.cancelled":
+      next.isRunning = false;
+      next.messages = timeline.messages.map((message) =>
+        message.streaming && message.turnId === event.turnId
+          ? { ...message, streaming: false }
+          : message,
+      );
+      return next;
+    case "memory.saved": {
+      const save = memorySaveFromEvent(event);
+      if (save) next.memorySaves = [...timeline.memorySaves, save];
+      return next;
+    }
+    case "session.ended":
+      next.isRunning = false;
+      next.ended = true;
+      return next;
+    case "session.failed":
+    case "runtime.disconnected":
+      next.isRunning = false;
+      return next;
+    default:
+      return next;
+  }
+}
+
+export function applyEvents(
+  timeline: SessionTimeline,
+  events: readonly AgentEvent[],
+): SessionTimeline {
+  return events.reduce(applyEvent, timeline);
+}
+
+/** The message a failed turn or a lost runtime reports, if the event carries one. */
+export function failureMessage(event: AgentEvent): string | undefined {
+  if (
+    event.type !== "turn.failed" &&
+    event.type !== "session.failed" &&
+    event.type !== "runtime.disconnected"
+  ) {
+    return undefined;
+  }
+  const data = event.data ?? {};
+  const message = text(data.message) || text(data.reason);
+  return message || `${event.type.replace(".", " ")}`;
+}

--- a/react/src/index.ts
+++ b/react/src/index.ts
@@ -158,13 +158,14 @@ export function useAgent(
   );
 
   // Applies a page of events to the timeline and runs the callbacks once per
-  // event. Events the timeline already holds fire nothing.
+  // event. Events the timeline already holds fire nothing. Returns how many
+  // were new.
   const ingest = useCallback(
-    (events: AgentEvent[]) => {
+    (events: AgentEvent[]): number => {
       const fresh = events.filter(
         (event) => event.seq > timelineRef.current.cursor,
       );
-      if (!fresh.length) return;
+      if (!fresh.length) return 0;
       commit(applyEvents(timelineRef.current, fresh));
       for (const event of fresh) {
         cursorRef.current = Math.max(cursorRef.current, event.seq);
@@ -178,6 +179,7 @@ export function useAgent(
         const failure = failureMessage(event);
         if (failure) setError(failure);
       }
+      return fresh.length;
     },
     [commit],
   );
@@ -205,10 +207,8 @@ export function useAgent(
           if (signal.aborted) return;
           if (failures) setError(undefined);
           failures = 0;
-          if (page.events.length) {
-            ingest(page.events);
-            continue;
-          }
+          // A full page means more may follow: read on without waiting.
+          if (ingest(page.events) > 0) continue;
           setIsReplaying(false);
         } catch (cause) {
           if (signal.aborted) return;

--- a/react/src/index.ts
+++ b/react/src/index.ts
@@ -1,84 +1,304 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  applyEvents,
+  emptyTimeline,
+  failureMessage,
+  inputMessageId,
+  memorySaveFromEvent,
+  type AgentEvent,
+  type AgentMessage,
+  type MemorySave,
+  type SessionTimeline,
+} from "./events.js";
 
-export interface AgentMessage {
-  id: string;
-  role: "user" | "assistant";
-  text: string;
-}
+export {
+  applyEvent,
+  applyEvents,
+  emptyTimeline,
+  type AgentEvent,
+  type AgentMessage,
+  type MemorySave,
+  type SessionTimeline,
+} from "./events.js";
 
-export interface UseAgentOptions {
-  agent: string;
-  source?: string;
+interface CommonOptions {
+  /**
+   * Where the hook sends its requests; the app's own route prefix when the
+   * app proxies them, the development bridge otherwise. Default
+   * `/api/opencomputer/managed-agents`.
+   */
   basePath?: string;
   fetch?: typeof globalThis.fetch;
+  /** Every event the hook applies, in order, including replayed history. */
+  onEvent?: (event: AgentEvent) => void;
+  /** A save the session observed succeeding; refresh the document it names. */
+  onMemorySaved?: (save: MemorySave) => void;
 }
 
-interface AgentEvent {
-  seq: number;
-  type: string;
-  data: Record<string, unknown>;
+/** Create mode: the first `send` creates a session for `agent`. */
+export interface CreateAgentOptions extends CommonOptions {
+  /** `agent-id@alias`. */
+  agent: string;
+  source?: string;
+  sessionId?: undefined;
 }
 
-export function useAgent(agentOrOptions: string | UseAgentOptions) {
-  const options =
+/**
+ * Attach mode: the session already exists, created by trusted code with the
+ * API key. The hook replays its history, streams new turns and never
+ * changes its lifecycle.
+ */
+export interface AttachAgentOptions extends CommonOptions {
+  sessionId: string;
+  agent?: undefined;
+  /** Replay from this event cursor instead of the start of the log. */
+  after?: number;
+  /** Polling interval between empty pages in milliseconds. Default 1000; 500 while a turn runs. */
+  pollIntervalMs?: number;
+}
+
+export type UseAgentOptions = CreateAgentOptions | AttachAgentOptions;
+
+export interface UseAgentResult {
+  messages: AgentMessage[];
+  /** Starts a turn. In create mode the first call creates the session. */
+  send: (value: string) => Promise<void>;
+  /** Interrupts the running turn. */
+  stop: () => Promise<void>;
+  sessionId: string | undefined;
+  isRunning: boolean;
+  /** Attach mode: true until the existing history has been replayed. */
+  isReplaying: boolean;
+  error: string | undefined;
+  /** `memory.saved` events in log order. */
+  memorySaves: MemorySave[];
+  /** The last event position applied; resume from it with `after`. */
+  cursor: number;
+}
+
+const DEFAULT_BASE_PATH = "/api/opencomputer/managed-agents";
+
+function delay(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(done, ms);
+    function done() {
+      signal.removeEventListener("abort", done);
+      clearTimeout(timer);
+      resolve();
+    }
+    signal.addEventListener("abort", done);
+  });
+}
+
+function upsert(
+  messages: AgentMessage[],
+  message: AgentMessage,
+): AgentMessage[] {
+  const index = messages.findIndex((candidate) => candidate.id === message.id);
+  if (index < 0) return [...messages, message];
+  const next = [...messages];
+  next[index] = { ...next[index], ...message };
+  return next;
+}
+
+export function useAgent(
+  agentOrOptions: string | UseAgentOptions,
+): UseAgentResult {
+  const options: UseAgentOptions =
     typeof agentOrOptions === "string"
       ? { agent: agentOrOptions }
       : agentOrOptions;
-  const basePath = options.basePath ?? "/api/opencomputer/managed-agents";
-  const requestFetch = options.fetch ?? globalThis.fetch;
-  const [messages, setMessages] = useState<AgentMessage[]>([]);
-  const [sessionId, setSessionId] = useState<string>();
-  const sessionRef = useRef<string | undefined>(undefined);
+  const basePath = options.basePath ?? DEFAULT_BASE_PATH;
+  const attachedSessionId = options.sessionId;
+  const after = options.sessionId ? (options.after ?? 0) : 0;
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const [timeline, setTimeline] = useState<SessionTimeline>(emptyTimeline);
+  const timelineRef = useRef(timeline);
+  const [sessionId, setSessionId] = useState<string | undefined>(
+    attachedSessionId,
+  );
+  const sessionRef = useRef<string | undefined>(attachedSessionId);
   const cursorRef = useRef(0);
-  const [isRunning, setIsRunning] = useState(false);
+  const [isReplaying, setIsReplaying] = useState(Boolean(attachedSessionId));
   const [error, setError] = useState<string>();
+
+  const commit = useCallback((next: SessionTimeline) => {
+    timelineRef.current = next;
+    setTimeline(next);
+  }, []);
 
   const request = useCallback(
     async <T>(path: string, init?: RequestInit): Promise<T> => {
+      const requestFetch = optionsRef.current.fetch ?? globalThis.fetch;
       const response = await requestFetch(`${basePath}${path}`, {
         ...init,
         headers: { "content-type": "application/json", ...init?.headers },
       });
-      const body: unknown = await response.json();
+      const body: unknown =
+        response.status === 204 ? undefined : await response.json();
       if (!response.ok) {
-        const problem = body as { error?: { message?: string } };
+        const problem = body as { error?: { message?: string } | string };
+        const message =
+          typeof problem?.error === "string"
+            ? problem.error
+            : problem?.error?.message;
         throw new Error(
-          problem?.error?.message ??
-            `Agent request failed (${String(response.status)})`,
+          message ?? `Agent request failed (${String(response.status)})`,
         );
       }
       return body as T;
     },
-    [basePath, requestFetch],
+    [basePath],
   );
 
-  const send = useCallback(
-    async (value: string) => {
-      const prompt = value.trim();
-      if (!prompt || isRunning) return;
+  // Applies a page of events to the timeline and runs the callbacks once per
+  // event. Events the timeline already holds fire nothing.
+  const ingest = useCallback(
+    (events: AgentEvent[]) => {
+      const fresh = events.filter(
+        (event) => event.seq > timelineRef.current.cursor,
+      );
+      if (!fresh.length) return;
+      commit(applyEvents(timelineRef.current, fresh));
+      for (const event of fresh) {
+        cursorRef.current = Math.max(cursorRef.current, event.seq);
+        optionsRef.current.onEvent?.(event);
+        if (event.type === "memory.saved") {
+          const save = timelineRef.current.memorySaves.find(
+            (candidate) => candidate.seq === event.seq,
+          );
+          if (save) optionsRef.current.onMemorySaved?.(save);
+        }
+        const failure = failureMessage(event);
+        if (failure) setError(failure);
+      }
+    },
+    [commit],
+  );
+
+  // Attach mode: one polling loop per session, resumed from the cursor after
+  // every failure, so a reconnect continues where it stopped.
+  useEffect(() => {
+    if (!attachedSessionId) return;
+    const controller = new AbortController();
+    const { signal } = controller;
+    sessionRef.current = attachedSessionId;
+    setSessionId(attachedSessionId);
+    setError(undefined);
+    setIsReplaying(true);
+    cursorRef.current = after;
+    commit({ ...emptyTimeline(), cursor: after });
+    void (async () => {
+      let failures = 0;
+      while (!signal.aborted) {
+        try {
+          const page = await request<{ events: AgentEvent[] }>(
+            `/sessions/${encodeURIComponent(attachedSessionId)}/events?after=${String(cursorRef.current)}`,
+            { signal },
+          );
+          if (signal.aborted) return;
+          if (failures) setError(undefined);
+          failures = 0;
+          if (page.events.length) {
+            ingest(page.events);
+            continue;
+          }
+          setIsReplaying(false);
+        } catch (cause) {
+          if (signal.aborted) return;
+          failures += 1;
+          setError(cause instanceof Error ? cause.message : String(cause));
+        }
+        const idle =
+          (optionsRef.current as AttachAgentOptions).pollIntervalMs ?? 1000;
+        const base = timelineRef.current.isRunning ? Math.min(idle, 500) : idle;
+        await delay(
+          failures ? Math.min(base * 2 ** failures, 10_000) : base,
+          signal,
+        );
+      }
+    })();
+    return () => {
+      controller.abort();
+    };
+  }, [attachedSessionId, after, basePath, commit, ingest, request]);
+
+  const sendAttached = useCallback(
+    async (activeSession: string, prompt: string) => {
+      setError(undefined);
+      try {
+        const result = await request<{ turnId: string }>(
+          `/sessions/${encodeURIComponent(activeSession)}/turns`,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              input: prompt,
+              idempotencyKey: crypto.randomUUID(),
+            }),
+          },
+        );
+        // The log's message.received for this turn carries the same id, so
+        // it confirms this message instead of duplicating it.
+        const current = timelineRef.current;
+        commit({
+          ...current,
+          isRunning: true,
+          messages: upsert(current.messages, {
+            id: inputMessageId(result.turnId),
+            role: "user",
+            text: prompt,
+            turnId: result.turnId,
+          }),
+        });
+      } catch (cause) {
+        setError(cause instanceof Error ? cause.message : String(cause));
+      }
+    },
+    [commit, request],
+  );
+
+  const sendCreated = useCallback(
+    async (prompt: string) => {
+      if (timelineRef.current.isRunning) return;
       const userMessage: AgentMessage = {
         id: crypto.randomUUID(),
         role: "user",
         text: prompt,
       };
       const assistantId = crypto.randomUUID();
-      setMessages((current) => [
-        ...current,
-        userMessage,
-        { id: assistantId, role: "assistant", text: "" },
-      ]);
-      setIsRunning(true);
+      const updateMessages = (
+        update: (messages: AgentMessage[]) => AgentMessage[],
+        patch: Partial<SessionTimeline> = {},
+      ) => {
+        const current = timelineRef.current;
+        commit({ ...current, ...patch, messages: update(current.messages) });
+      };
+      updateMessages(
+        (current) => [
+          ...current,
+          userMessage,
+          { id: assistantId, role: "assistant", text: "" },
+        ],
+        { isRunning: true },
+      );
       setError(undefined);
       try {
         let activeSession = sessionRef.current;
         if (!activeSession) {
+          const create = optionsRef.current as CreateAgentOptions;
           const created = await request<{ session: { id: string } }>(
             "/sessions",
             {
               method: "POST",
               body: JSON.stringify({
-                agentId: options.agent,
-                source: options.source ?? "local-react",
+                agentId: create.agent,
+                source: create.source ?? "local-react",
               }),
             },
           );
@@ -101,9 +321,10 @@ export function useAgent(agentOrOptions: string | UseAgentOptions) {
             );
             for (const event of result.events) {
               cursorRef.current = Math.max(cursorRef.current, event.seq);
+              optionsRef.current.onEvent?.(event);
               if (event.type === "message.delta") {
                 streamed += String(event.data.text ?? "");
-                setMessages((current) =>
+                updateMessages((current) =>
                   current.map((message) =>
                     message.id === assistantId
                       ? { ...message, text: streamed }
@@ -112,13 +333,26 @@ export function useAgent(agentOrOptions: string | UseAgentOptions) {
                 );
               } else if (event.type === "message.completed" && !streamed) {
                 const text = String(event.data.text ?? "");
-                setMessages((current) =>
+                updateMessages((current) =>
                   current.map((message) =>
                     message.id === assistantId ? { ...message, text } : message,
                   ),
                 );
+              } else {
+                const save = memorySaveFromEvent(event);
+                if (save) {
+                  const current = timelineRef.current;
+                  commit({
+                    ...current,
+                    memorySaves: [...current.memorySaves, save],
+                  });
+                  optionsRef.current.onMemorySaved?.(save);
+                }
               }
               if (terminal(event)) return event;
+            }
+            if (result.events.length) {
+              commit({ ...timelineRef.current, cursor: cursorRef.current });
             }
             await new Promise((done) => setTimeout(done, 500));
           }
@@ -133,7 +367,9 @@ export function useAgent(agentOrOptions: string | UseAgentOptions) {
         });
         const completed = await waitFor(
           (event) =>
-            event.type === "turn.completed" || event.type === "turn.failed",
+            event.type === "turn.completed" ||
+            event.type === "turn.failed" ||
+            event.type === "turn.cancelled",
         );
         if (completed.type === "turn.failed") {
           throw new Error(String(completed.data.message ?? "Agent failed"));
@@ -147,7 +383,7 @@ export function useAgent(agentOrOptions: string | UseAgentOptions) {
       } catch (cause) {
         const message = cause instanceof Error ? cause.message : String(cause);
         setError(message);
-        setMessages((current) =>
+        updateMessages((current) =>
           current.map((item) =>
             item.id === assistantId && !item.text
               ? { ...item, text: "I couldn't complete that request." }
@@ -155,11 +391,48 @@ export function useAgent(agentOrOptions: string | UseAgentOptions) {
           ),
         );
       } finally {
-        setIsRunning(false);
+        commit({
+          ...timelineRef.current,
+          cursor: Math.max(timelineRef.current.cursor, cursorRef.current),
+          isRunning: false,
+        });
       }
     },
-    [isRunning, options.agent, options.source, request],
+    [commit, request],
   );
 
-  return { messages, send, sessionId, isRunning, error };
+  const send = useCallback(
+    async (value: string) => {
+      const prompt = value.trim();
+      if (!prompt) return;
+      if (attachedSessionId) await sendAttached(attachedSessionId, prompt);
+      else await sendCreated(prompt);
+    },
+    [attachedSessionId, sendAttached, sendCreated],
+  );
+
+  const stop = useCallback(async () => {
+    const activeSession = sessionRef.current;
+    if (!activeSession) return;
+    try {
+      await request(
+        `/sessions/${encodeURIComponent(activeSession)}/interrupt`,
+        { method: "POST" },
+      );
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    }
+  }, [request]);
+
+  return {
+    messages: timeline.messages,
+    send,
+    stop,
+    sessionId,
+    isRunning: timeline.isRunning,
+    isReplaying,
+    error,
+    memorySaves: timeline.memorySaves,
+    cursor: timeline.cursor,
+  };
 }

--- a/react/src/use-agent.test.ts
+++ b/react/src/use-agent.test.ts
@@ -217,6 +217,34 @@ test("attach resumes from its cursor after a failed poll instead of replaying", 
   await view.unmount();
 });
 
+test("attach waits between polls when a page brings nothing new", async (t) => {
+  let polls = 0;
+  const stale: AgentEvent[] = [
+    { seq: 1, turnId: "t0", type: "message.received", data: { input: "hello" } },
+    { seq: 2, turnId: "t0", type: "turn.completed", data: {} },
+  ];
+  // A relay that ignores `after` and repeats the same page.
+  const view = mount(t, {
+    sessionId: "ses-stale",
+    basePath: "/app/agent",
+    fetch: async () => {
+      polls += 1;
+      return Response.json({ events: stale });
+    },
+    pollIntervalMs: 20,
+  });
+  await view.render();
+  const replayed = await view.until((result) => result.cursor === 2, "replay");
+  assert.equal(replayed.messages.length, 1);
+  const before = polls;
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  });
+  assert.ok(polls - before <= 8, `polled ${String(polls - before)} times in 100ms at a 20ms interval`);
+  assert.equal(view.result().messages.length, 1);
+  await view.unmount();
+});
+
 test("attach sends turns and interrupts through the app's routes without duplicating the input", async (t) => {
   const session = fakeSession("ses-3");
   const view = mount(t, { sessionId: "ses-3", basePath: "/app/agent", fetch: session.fetch, pollIntervalMs: 5 });

--- a/react/src/use-agent.test.ts
+++ b/react/src/use-agent.test.ts
@@ -1,0 +1,343 @@
+import assert from "node:assert/strict";
+import test, { type TestContext } from "node:test";
+import { JSDOM } from "jsdom";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import {
+  useAgent,
+  type AgentEvent,
+  type UseAgentOptions,
+  type UseAgentResult,
+} from "./index.js";
+
+// React DOM needs a document; the hook itself needs only fetch and timers.
+const dom = new JSDOM("<!doctype html><html><body></body></html>");
+Object.assign(globalThis, {
+  window: dom.window,
+  document: dom.window.document,
+  IS_REACT_ACT_ENVIRONMENT: true,
+});
+
+interface Call {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  body?: Record<string, unknown>;
+}
+
+// A fake of the three routes the hook proxies: the event log paged by
+// `after`, turn creation that appends the input to the log, and interrupt.
+function fakeSession(sessionId: string) {
+  const log: AgentEvent[] = [];
+  const calls: Call[] = [];
+  let failNext = 0;
+  let turns = 0;
+  const append = (event: Omit<AgentEvent, "seq">) => {
+    log.push({ ...event, seq: log.length + 1 });
+  };
+  const fetch: typeof globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input), "http://app.test");
+    const headers = Object.fromEntries(new Headers(init?.headers).entries());
+    const call: Call = {
+      method: init?.method ?? "GET",
+      path: `${url.pathname}${url.search}`,
+      headers,
+      ...(typeof init?.body === "string"
+        ? { body: JSON.parse(init.body) as Record<string, unknown> }
+        : {}),
+    };
+    calls.push(call);
+    if (failNext > 0) {
+      failNext -= 1;
+      throw new TypeError("network down");
+    }
+    const prefix = `/app/agent/sessions/${sessionId}`;
+    if (call.method === "GET" && url.pathname === `${prefix}/events`) {
+      const after = Number(url.searchParams.get("after") ?? "0");
+      return Response.json({
+        events: log.filter((event) => event.seq > after).slice(0, 3),
+      });
+    }
+    if (call.method === "POST" && url.pathname === `${prefix}/turns`) {
+      turns += 1;
+      const turnId = `turn-${String(turns)}`;
+      append({
+        turnId,
+        type: "message.received",
+        data: { input: call.body?.input, mode: "queue" },
+      });
+      append({ turnId, type: "turn.started", data: {} });
+      return Response.json({ turnId, status: "queued", duplicate: false }, { status: 202 });
+    }
+    if (call.method === "POST" && url.pathname === `${prefix}/interrupt`) {
+      return Response.json({ id: sessionId, status: "idle" });
+    }
+    return Response.json(
+      { error: { code: "not_found", message: `no route ${call.method} ${url.pathname}` } },
+      { status: 404 },
+    );
+  };
+  return {
+    log,
+    calls,
+    fetch,
+    append,
+    failNext: (count: number) => {
+      failNext = count;
+    },
+  };
+}
+
+function mount(context: TestContext, options: UseAgentOptions | string) {
+  const container = dom.window.document.createElement("div");
+  const root: Root = createRoot(container);
+  const renders: UseAgentResult[] = [];
+  let latest: UseAgentResult | undefined;
+  function Harness() {
+    latest = useAgent(options);
+    renders.push(latest);
+    return null;
+  }
+  let mounted = true;
+  const unmount = async () => {
+    if (!mounted) return;
+    mounted = false;
+    await act(async () => {
+      root.unmount();
+    });
+  };
+  // A failed assertion must not leave the polling loop running.
+  context.after(unmount);
+  return {
+    async render() {
+      await act(async () => {
+        root.render(createElement(Harness));
+      });
+    },
+    result: () => latest!,
+    first: () => renders[0]!,
+    async until(predicate: (result: UseAgentResult) => boolean, label: string) {
+      for (let attempt = 0; attempt < 200; attempt += 1) {
+        if (latest && predicate(latest)) return latest;
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        });
+      }
+      throw new Error(`timed out waiting for ${label}`);
+    },
+    unmount,
+  };
+}
+
+test("attach replays the session's history, then reports memory saves and new turns", async (t) => {
+  const session = fakeSession("ses-1");
+  session.append({ turnId: "t0", type: "message.received", data: { input: "What do you know?" } });
+  session.append({ turnId: "t0", type: "turn.started", data: {} });
+  session.append({ turnId: "t0", type: "message.delta", data: { text: "Notes " } });
+  session.append({ turnId: "t0", type: "message.delta", data: { text: "say Node 22." } });
+  session.append({
+    turnId: "t0",
+    type: "memory.saved",
+    data: { resource: "notes", documentId: "workshop", revision: "r1", bytes: 40 },
+  });
+  session.append({ turnId: "t0", type: "message.completed", data: { text: "Notes say Node 22." } });
+  session.append({ turnId: "t0", type: "turn.completed", data: {} });
+
+  const seen: string[] = [];
+  const saves: string[] = [];
+  const view = mount(t, {
+    sessionId: "ses-1",
+    basePath: "/app/agent",
+    fetch: session.fetch,
+    pollIntervalMs: 5,
+    onEvent: (event) => seen.push(event.type),
+    onMemorySaved: (save) => saves.push(`${save.resource}/${save.documentId}@${save.revision}`),
+  });
+  await view.render();
+  // The first render is attached but has nothing yet; the fake replies at once.
+  assert.equal(view.first().isReplaying, true);
+  assert.equal(view.first().sessionId, "ses-1");
+  assert.deepEqual(view.first().messages, []);
+
+  const replayed = await view.until((result) => !result.isReplaying, "history replay");
+  assert.deepEqual(
+    replayed.messages.map((message) => [message.role, message.text, message.streaming]),
+    [["user", "What do you know?", undefined], ["assistant", "Notes say Node 22.", false]],
+  );
+  assert.equal(replayed.isRunning, false);
+  assert.equal(replayed.cursor, 7);
+  assert.deepEqual(saves, ["notes/workshop@r1"]);
+  assert.equal(replayed.memorySaves.length, 1);
+  assert.equal(seen.length, 7);
+  // History is paged by the server; every page resumes from the cursor.
+  assert.deepEqual(
+    session.calls.filter((call) => call.method === "GET").slice(0, 4).map((call) => call.path),
+    [
+      "/app/agent/sessions/ses-1/events?after=0",
+      "/app/agent/sessions/ses-1/events?after=3",
+      "/app/agent/sessions/ses-1/events?after=6",
+      "/app/agent/sessions/ses-1/events?after=7",
+    ],
+  );
+
+  // A live save on a later turn reaches the list and the callback once.
+  session.append({ turnId: "t1", type: "turn.started", data: {} });
+  session.append({
+    turnId: "t1",
+    type: "memory.saved",
+    data: { resource: "notes", documentId: "workshop", revision: "r2", bytes: 44 },
+  });
+  const live = await view.until((result) => result.memorySaves.length === 2, "live save");
+  assert.equal(live.isRunning, true);
+  assert.deepEqual(saves, ["notes/workshop@r1", "notes/workshop@r2"]);
+  await view.unmount();
+});
+
+test("attach resumes from its cursor after a failed poll instead of replaying", async (t) => {
+  const session = fakeSession("ses-2");
+  session.append({ turnId: "t0", type: "message.received", data: { input: "hello" } });
+  session.append({ turnId: "t0", type: "turn.started", data: {} });
+  const view = mount(t, { sessionId: "ses-2", basePath: "/app/agent", fetch: session.fetch, pollIntervalMs: 5 });
+  await view.render();
+  await view.until((result) => !result.isReplaying, "history replay");
+
+  session.failNext(1);
+  await view.until((result) => result.error === "network down", "the failed poll");
+  session.append({ turnId: "t0", type: "message.completed", data: { text: "hi" } });
+  session.append({ turnId: "t0", type: "turn.completed", data: {} });
+  const recovered = await view.until((result) => result.cursor === 4, "recovery");
+  assert.equal(recovered.error, undefined);
+  assert.equal(recovered.messages.length, 2);
+  assert.equal(recovered.isRunning, false);
+  const afters = session.calls
+    .filter((call) => call.method === "GET")
+    .map((call) => call.path.replace(/.*after=/, ""));
+  assert.ok(!afters.slice(1).includes("0"), `no poll restarted from 0: ${afters.join(",")}`);
+  await view.unmount();
+});
+
+test("attach sends turns and interrupts through the app's routes without duplicating the input", async (t) => {
+  const session = fakeSession("ses-3");
+  const view = mount(t, { sessionId: "ses-3", basePath: "/app/agent", fetch: session.fetch, pollIntervalMs: 5 });
+  await view.render();
+  await view.until((result) => !result.isReplaying, "empty history");
+
+  await act(async () => {
+    await view.result().send("  Book the venue  ");
+  });
+  const sent = view.result();
+  assert.equal(sent.isRunning, true);
+  assert.deepEqual(sent.messages, [
+    { id: "turn:turn-1:input", role: "user", text: "Book the venue", turnId: "turn-1" },
+  ]);
+  const turn = session.calls.find((call) => call.method === "POST" && call.path.endsWith("/turns"));
+  assert.equal(turn?.body?.input, "Book the venue");
+  assert.equal(typeof turn?.body?.idempotencyKey, "string");
+  assert.equal(turn?.headers["content-type"], "application/json");
+
+  const confirmed = await view.until((result) => result.cursor === 2, "message.received");
+  assert.equal(confirmed.messages.length, 1);
+
+  await act(async () => {
+    await view.result().stop();
+  });
+  assert.ok(
+    session.calls.some((call) => call.method === "POST" && call.path === "/app/agent/sessions/ses-3/interrupt"),
+  );
+  session.append({ turnId: "turn-1", type: "turn.cancelled", data: { reason: "interrupted" } });
+  const stopped = await view.until((result) => !result.isRunning, "cancellation");
+  assert.equal(stopped.error, undefined);
+  await view.unmount();
+});
+
+test("attach reports a failed turn and a rejected send", async (t) => {
+  const session = fakeSession("ses-4");
+  const view = mount(t, { sessionId: "ses-4", basePath: "/app/agent", fetch: session.fetch, pollIntervalMs: 5 });
+  await view.render();
+  session.append({ turnId: "t0", type: "turn.started", data: {} });
+  session.append({ turnId: "t0", type: "turn.failed", data: { message: "model unavailable" } });
+  const failed = await view.until((result) => result.error !== undefined, "turn failure");
+  assert.equal(failed.error, "model unavailable");
+  assert.equal(failed.isRunning, false);
+
+  const rejecting = mount(t, {
+    sessionId: "ses-5",
+    basePath: "/app/agent",
+    fetch: async () =>
+      Response.json({ error: { code: "session_ended", message: "Session has ended" } }, { status: 409 }),
+    pollIntervalMs: 5,
+  });
+  await rejecting.render();
+  await act(async () => {
+    await rejecting.result().send("anything");
+  });
+  assert.equal(rejecting.result().error, "Session has ended");
+  assert.deepEqual(rejecting.result().messages, []);
+  await rejecting.unmount();
+  await view.unmount();
+});
+
+test("create mode still creates the session on the first send and streams the reply", async (t) => {
+  const calls: Call[] = [];
+  const log: AgentEvent[] = [
+    { seq: 1, type: "runtime.connected", data: {} },
+    { seq: 2, turnId: "t1", type: "message.delta", data: { text: "Hello " } },
+    { seq: 3, turnId: "t1", type: "message.delta", data: { text: "there" } },
+    { seq: 4, turnId: "t1", type: "turn.completed", data: {} },
+  ];
+  let created = false;
+  let turned = false;
+  const fetch: typeof globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input), "http://app.test");
+    calls.push({
+      method: init?.method ?? "GET",
+      path: `${url.pathname}${url.search}`,
+      headers: Object.fromEntries(new Headers(init?.headers).entries()),
+      ...(typeof init?.body === "string" ? { body: JSON.parse(init.body) as Record<string, unknown> } : {}),
+    });
+    if (url.pathname === "/api/opencomputer/managed-agents/sessions" && init?.method === "POST") {
+      created = true;
+      return Response.json({ session: { id: "ses-new" } }, { status: 201 });
+    }
+    if (url.pathname.endsWith("/turns")) {
+      turned = true;
+      return Response.json({ turnId: "t1", status: "queued", duplicate: false }, { status: 202 });
+    }
+    if (url.pathname.endsWith("/events")) {
+      const after = Number(url.searchParams.get("after"));
+      const visible = log.filter((event) => event.seq > after && (turned || event.seq === 1));
+      return Response.json({ events: created ? visible : [] });
+    }
+    return Response.json({ id: "ses-new", status: "suspended" });
+  };
+  const view = mount(t, { agent: "hello-world@development", fetch });
+  await view.render();
+  assert.equal(view.result().isReplaying, false);
+  assert.equal(view.result().sessionId, undefined);
+
+  await act(async () => {
+    await view.result().send("Hi");
+  });
+  const result = view.result();
+  assert.equal(result.sessionId, "ses-new");
+  assert.equal(result.isRunning, false);
+  assert.equal(result.error, undefined);
+  assert.deepEqual(
+    result.messages.map((message) => [message.role, message.text]),
+    [["user", "Hi"], ["assistant", "Hello there"]],
+  );
+  assert.equal(result.cursor, 4);
+  assert.deepEqual(
+    calls.map((call) => `${call.method} ${call.path}`),
+    [
+      "POST /api/opencomputer/managed-agents/sessions",
+      "GET /api/opencomputer/managed-agents/sessions/ses-new/events?after=0",
+      "POST /api/opencomputer/managed-agents/sessions/ses-new/turns",
+      "GET /api/opencomputer/managed-agents/sessions/ses-new/events?after=1",
+      "POST /api/opencomputer/managed-agents/sessions/ses-new/suspend",
+    ],
+  );
+  assert.deepEqual(calls[0].body, { agentId: "hello-world@development", source: "local-react" });
+  await view.unmount();
+});

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -170,6 +170,22 @@ await oc.credentials.delete(creds[0].id);
 
 Or reference one by id when creating an agent: `oc.agents.create({ …, credential: "cred_…" })`. A key isn't required — `credential: "managed"` needs none; a session fails with `422 no_credential` only when it resolves to neither Managed nor a usable key. Full guide: [Credentials](https://docs.opencomputer.dev/agent-sessions/credentials).
 
+### Serverless Agents memory
+
+Serverless Agents (`opencomputer deploy`) keep notes in [memory](https://opencomputer.dev/agents/memory). This package types its management API and ships one helper for the moment an application opens a topic: create the document if it is new, then create a session bound to it, both converging under one key on retry:
+
+```typescript
+import { startSessionOnDocument } from "@opencomputer/sdk";
+
+const { document, session } = await startSessionOnDocument({
+  apiKey: process.env.OPENCOMPUTER_API_KEY!,
+  projectId: "prj_…", environment: "development", agent: "topic-worker",
+  resource: "topics", documentId: "workshop", document: { title: "Workshop" },
+  idempotencyKey: `topic/workshop/${deploymentId}`,
+});
+// document.created, session.created: false when they already existed.
+```
+
 ## Sandbox webhooks (Preview)
 
 Subscribe to sandbox lifecycle events (`sandbox.ready`, `sandbox.stopped`, …) — signed, retried, and redeliverable. The same `verifyWebhook` helper verifies both session and sandbox deliveries. **Preview: newly available; the surface may change.**

--- a/sdks/typescript/src/agents/index.ts
+++ b/sdks/typescript/src/agents/index.ts
@@ -54,6 +54,8 @@ export type {
 } from "./schedules.js";
 export { verifyWebhook, WebhookVerificationError } from "./webhooks.js";
 export type { WebhookDelivery, VerifyWebhookOptions } from "./webhooks.js";
+export { startSessionOnDocument, sessionIdempotencyKey } from "./memory-sessions.js";
+export type { StartSessionOnDocumentParams, StartSessionOnDocumentResult } from "./memory-sessions.js";
 export type {
   MemoryEnvironment, MemoryAccess, MemoryAgentWrites, MemoryBinding, MemoryBindings,
   SessionMemoryBinding, MemoryWriter, MemoryDocumentMeta, MemoryDocument, MemoryDocumentPage,

--- a/sdks/typescript/src/agents/memory-sessions.test.ts
+++ b/sdks/typescript/src/agents/memory-sessions.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { ConflictError, NotFoundError } from "./errors.js";
+import { sessionIdempotencyKey, startSessionOnDocument } from "./memory-sessions.js";
+
+interface Call { method: string; url: string; headers: Record<string, string>; body?: Record<string, unknown> }
+
+const document = (id: string, revision: string) => ({
+  id, title: "Workshop", text: "", summary: "", agentWrites: "enabled", revision,
+  bytes: 0, maxBytes: 8192, updatedAt: "2026-09-10T12:00:00.000Z", writer: { kind: "owner" },
+});
+
+// The two routes the helper touches, with a switchable document state and a
+// session store keyed by Idempotency-Key.
+function fakeApi(state: { document: "absent" | "present" | "deleted"; sessions?: Map<string, string> }) {
+  const calls: Call[] = [];
+  const sessions = state.sessions ?? new Map<string, string>();
+  const fetch: typeof globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    const headers: Record<string, string> = {};
+    new Headers(init?.headers).forEach((value, name) => { headers[name] = value; });
+    const call: Call = { method: init?.method ?? "GET", url: `${url.pathname}${url.search}`, headers };
+    if (typeof init?.body === "string") call.body = JSON.parse(init.body) as Record<string, unknown>;
+    calls.push(call);
+    if (url.pathname.endsWith("/documents/workshop")) {
+      if (call.method === "PUT") {
+        if (state.document === "absent") { state.document = "present"; return Response.json(document("workshop", "r1"), { status: 201 }); }
+        return Response.json({ error: { code: "precondition_failed", message: "id already used" } }, { status: 412 });
+      }
+      if (state.document === "present") return Response.json(document("workshop", "r7"));
+      return Response.json({ error: { code: "not_found", message: "deleted" } }, { status: 404 });
+    }
+    if (url.pathname === "/api/managed-agents/sessions" && call.method === "POST") {
+      const key = headers["idempotency-key"];
+      const existing = sessions.get(key);
+      if (existing === "other-bindings") {
+        return Response.json({ error: { code: "idempotency_conflict", message: "Idempotency-Key was already used with different session input" } }, { status: 409 });
+      }
+      if (existing) return Response.json({ session: { id: existing, status: "idle", executionMode: "workerd" } }, { status: 200 });
+      const id = `ses-${sessions.size + 1}`;
+      sessions.set(key, id);
+      return Response.json({ session: { id, status: "connecting", executionMode: "workerd" } }, { status: 201 });
+    }
+    return Response.json({ error: { code: "not_found", message: "no route" } }, { status: 404 });
+  };
+  return { calls, fetch, sessions };
+}
+
+const params = {
+  apiKey: "osb_test", projectId: "prj_1", environment: "development" as const, agent: "openmuse-dev--topic-worker",
+  resource: "topics", documentId: "workshop", document: { title: "Workshop" }, idempotencyKey: "topic/workshop/1",
+};
+
+describe("startSessionOnDocument", () => {
+  it("creates the document, then the session bound to it, under derived keys", async () => {
+    const api = fakeApi({ document: "absent" });
+    const result = await startSessionOnDocument({ ...params, fetch: api.fetch });
+
+    expect(result).toEqual({
+      document: { id: "workshop", created: true, revision: "r1", title: "Workshop" },
+      session: { id: "ses-1", created: true, status: "connecting", executionMode: "workerd" },
+    });
+    expect(api.calls.map((call) => `${call.method} ${call.url}`)).toEqual([
+      "PUT /api/managed-agents/projects/prj_1/memory/topics/documents/workshop?environment=development",
+      "POST /api/managed-agents/sessions",
+    ]);
+    const [create, session] = api.calls;
+    expect(create.headers["if-none-match"]).toBe("*");
+    expect(create.headers["x-api-key"]).toBe("osb_test");
+    expect(create.body).toEqual({ title: "Workshop", text: "" });
+    expect(session.headers["idempotency-key"]).toBe(await sessionIdempotencyKey("topic/workshop/1"));
+    expect(session.body).toEqual({
+      agentId: "openmuse-dev--topic-worker@development",
+      source: "api",
+      memory: { topics: { scope: "document", id: "workshop", access: "read-write" } },
+    });
+  });
+
+  it("converges on a retry: the document and the session both already exist", async () => {
+    const api = fakeApi({ document: "absent" });
+    await startSessionOnDocument({ ...params, fetch: api.fetch });
+    const retry = await startSessionOnDocument({ ...params, fetch: api.fetch });
+
+    expect(retry.document).toEqual({ id: "workshop", created: false, revision: "r7", title: "Workshop" });
+    expect(retry.session).toMatchObject({ id: "ses-1", created: false });
+    // The retry read the existing document after its conditional create was refused.
+    expect(api.calls.slice(2).map((call) => `${call.method} ${call.url.split("?")[0]}`)).toEqual([
+      "PUT /api/managed-agents/projects/prj_1/memory/topics/documents/workshop",
+      "GET /api/managed-agents/projects/prj_1/memory/topics/documents/workshop",
+      "POST /api/managed-agents/sessions",
+    ]);
+  });
+
+  it("keeps different keys apart and carries extra bindings, access and source", async () => {
+    const api = fakeApi({ document: "present" });
+    const first = await startSessionOnDocument({ ...params, fetch: api.fetch, idempotencyKey: "a" });
+    const second = await startSessionOnDocument({
+      ...params, fetch: api.fetch, idempotencyKey: "b", access: "read", source: "openmuse",
+      memory: { profile: { scope: "document", id: "owner", access: "read" } },
+    });
+    expect(first.session.id).not.toBe(second.session.id);
+    expect(api.calls.at(-1)?.body).toEqual({
+      agentId: "openmuse-dev--topic-worker@development",
+      source: "openmuse",
+      memory: {
+        profile: { scope: "document", id: "owner", access: "read" },
+        topics: { scope: "document", id: "workshop", access: "read" },
+      },
+    });
+    expect(await sessionIdempotencyKey("a")).not.toBe(await sessionIdempotencyKey("b"));
+    expect(await sessionIdempotencyKey("a")).toBe(await sessionIdempotencyKey("a"));
+  });
+
+  it("reports a reused key with different bindings as a conflict", async () => {
+    const sessions = new Map([[await sessionIdempotencyKey("topic/workshop/1"), "other-bindings"]]);
+    const api = fakeApi({ document: "present", sessions });
+    await expect(startSessionOnDocument({ ...params, fetch: api.fetch })).rejects.toThrow(ConflictError);
+    await expect(startSessionOnDocument({ ...params, fetch: api.fetch })).rejects.toThrow(/different agent, deployment, environment or memory bindings/);
+  });
+
+  it("refuses a deleted document id instead of creating a session that cannot bind it", async () => {
+    const api = fakeApi({ document: "deleted" });
+    await expect(startSessionOnDocument({ ...params, fetch: api.fetch })).rejects.toThrow(NotFoundError);
+    expect(api.calls.some((call) => call.url === "/api/managed-agents/sessions")).toBe(false);
+  });
+});

--- a/sdks/typescript/src/agents/memory-sessions.ts
+++ b/sdks/typescript/src/agents/memory-sessions.ts
@@ -1,0 +1,201 @@
+// Start a session on a memory document in one call (docs/agents/document-memory.mdx,
+// "Start a session on a new document"). The management API keeps the two
+// objects separate on purpose: a document is owner data with its own
+// lifetime, a session binding is admission to it, and nothing creates one as
+// a side effect of the other. What an application wants at the moment it
+// opens a topic is still "these notes, this session", so this helper does the
+// two calls in order and makes the pair converge under one key.
+//
+// This helper speaks to the project-scoped Serverless Agents surface
+// (`/api/managed-agents/...`) with an API key, not to the Durable Agent
+// Sessions client in this package. Use it from trusted server code only.
+
+import { ConflictError, errorFromResponse, NotFoundError, OpenComputerError, type ApiErrorBody } from "./errors.js";
+import type { MemoryAccess, MemoryAgentWrites, MemoryBindings, MemoryDocument, MemoryEnvironment } from "./memory.js";
+
+const DEFAULT_MANAGED_AGENTS_URL = "https://app.opencomputer.dev";
+
+export interface StartSessionOnDocumentParams {
+  /** An OpenComputer API key with access to the project. Server-side only. */
+  apiKey: string;
+  /** The project whose memory holds the document. */
+  projectId: string;
+  /** Development and Production have separate memory; the session runs in the same environment. */
+  environment: MemoryEnvironment;
+  /** The deployed agent's id (not `agent@alias`; the environment above supplies the alias). */
+  agent: string;
+  /** The declared memory resource and the document id to bind. */
+  resource: string;
+  documentId: string;
+  /** What to create when the document does not exist yet. Ignored when it does. */
+  document: {
+    title: string;
+    /** Default `""`. */
+    text?: string;
+    /** Default `""`. */
+    summary?: string;
+    /** Default `"enabled"`. */
+    agentWrites?: MemoryAgentWrites;
+  };
+  /** The binding's access. Default `read-write`. */
+  access?: MemoryAccess;
+  /** Further bindings for the session, keyed by resource id. */
+  memory?: MemoryBindings;
+  /**
+   * One key for the whole operation. A retry with the same key returns the
+   * same session; the document converges on its id regardless.
+   */
+  idempotencyKey: string;
+  /** The session's `source`. Default `api`. */
+  source?: string;
+  /** The Serverless Agents API. Default `https://app.opencomputer.dev`. */
+  baseUrl?: string;
+  /** Override fetch (runtimes without a global, or testing). */
+  fetch?: typeof fetch;
+  signal?: AbortSignal;
+}
+
+export interface StartSessionOnDocumentResult {
+  document: {
+    id: string;
+    /** False when the document already existed; its content was left as it was. */
+    created: boolean;
+    /** The current revision, for a later conditional owner write. */
+    revision: string;
+    title: string;
+  };
+  session: {
+    id: string;
+    /** False when the key had already created this session. */
+    created: boolean;
+    status?: string;
+    executionMode?: string;
+  };
+}
+
+/**
+ * The session-create `Idempotency-Key` derived from the caller's key: stable
+ * for a retry, distinct from any other use of the same caller key.
+ */
+export async function sessionIdempotencyKey(idempotencyKey: string): Promise<string> {
+  const bytes = new TextEncoder().encode(`opencomputer.memory.session\0${idempotencyKey}`);
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+  let hex = "";
+  for (const byte of digest) hex += byte.toString(16).padStart(2, "0");
+  return hex;
+}
+
+async function readBody(response: Response): Promise<unknown> {
+  try { return await response.json(); } catch { return undefined; }
+}
+
+function errorBody(body: unknown): ApiErrorBody | undefined {
+  if (!body || typeof body !== "object") return undefined;
+  const error = (body as { error?: unknown }).error;
+  if (typeof error === "string") return { message: error };
+  if (error && typeof error === "object") return error as ApiErrorBody;
+  return undefined;
+}
+
+/**
+ * Creates the document if it does not exist, then creates the session bound
+ * to it, and reports both ids and whether each already existed.
+ *
+ * - The document is created with `If-None-Match: *`; an existing document is
+ *   kept as it is and reported with `created: false`. An id that was deleted
+ *   is reserved and fails with a `NotFoundError`, since a binding to it would
+ *   fail admission.
+ * - The session is created with an `Idempotency-Key` derived from
+ *   `idempotencyKey`; the same key with the same agent, deployment,
+ *   environment and bindings returns the existing session with
+ *   `created: false`. Anything else under the same key is a `ConflictError`.
+ */
+export async function startSessionOnDocument(
+  params: StartSessionOnDocumentParams,
+): Promise<StartSessionOnDocumentResult> {
+  const doFetch = params.fetch ?? (typeof fetch !== "undefined" ? fetch : undefined);
+  if (!doFetch) throw new Error("global fetch is unavailable — pass { fetch }.");
+  const base = (params.baseUrl ?? DEFAULT_MANAGED_AGENTS_URL).replace(/\/+$/, "");
+  const headers = { "x-api-key": params.apiKey, accept: "application/json", "content-type": "application/json" };
+  const documentUrl =
+    `${base}/api/managed-agents/projects/${encodeURIComponent(params.projectId)}` +
+    `/memory/${encodeURIComponent(params.resource)}/documents/${encodeURIComponent(params.documentId)}` +
+    `?environment=${encodeURIComponent(params.environment)}`;
+
+  const createResponse = await doFetch(documentUrl, {
+    method: "PUT",
+    headers: { ...headers, "if-none-match": "*" },
+    body: JSON.stringify({
+      title: params.document.title,
+      text: params.document.text ?? "",
+      ...(params.document.summary !== undefined ? { summary: params.document.summary } : {}),
+      ...(params.document.agentWrites ? { agentWrites: params.document.agentWrites } : {}),
+    }),
+    signal: params.signal,
+  });
+  let document: MemoryDocument;
+  let documentCreated: boolean;
+  if (createResponse.status === 201) {
+    document = (await createResponse.json()) as MemoryDocument;
+    documentCreated = true;
+  } else if (createResponse.status === 412) {
+    const readResponse = await doFetch(documentUrl, { method: "GET", headers, signal: params.signal });
+    if (readResponse.status === 404) {
+      throw new NotFoundError(
+        404,
+        {
+          code: "memory_document_deleted",
+          message:
+            `Document ${params.resource}/${params.documentId} was deleted and its id is reserved; ` +
+            "a session cannot bind it. Use a new document id.",
+        },
+        "document deleted",
+      );
+    }
+    if (!readResponse.ok) throw errorFromResponse(readResponse.status, errorBody(await readBody(readResponse)));
+    document = (await readResponse.json()) as MemoryDocument;
+    documentCreated = false;
+  } else {
+    throw errorFromResponse(createResponse.status, errorBody(await readBody(createResponse)));
+  }
+
+  const sessionResponse = await doFetch(`${base}/api/managed-agents/sessions`, {
+    method: "POST",
+    headers: { ...headers, "idempotency-key": await sessionIdempotencyKey(params.idempotencyKey) },
+    body: JSON.stringify({
+      agentId: `${params.agent}@${params.environment}`,
+      source: params.source ?? "api",
+      memory: {
+        ...params.memory,
+        [params.resource]: { scope: "document", id: params.documentId, access: params.access ?? "read-write" },
+      },
+    }),
+    signal: params.signal,
+  });
+  const sessionBody = await readBody(sessionResponse);
+  if (sessionResponse.status === 409) {
+    throw new ConflictError(
+      409,
+      {
+        code: "idempotency_key_reused",
+        message:
+          `Idempotency key ${JSON.stringify(params.idempotencyKey)} already created a session with a different ` +
+          "agent, deployment, environment or memory bindings. Use a new key to start another session; " +
+          "the document was left as it is.",
+      },
+      "idempotency key reused",
+    );
+  }
+  if (!sessionResponse.ok) throw errorFromResponse(sessionResponse.status, errorBody(sessionBody));
+  const session = (sessionBody as { session?: { id?: string; status?: string; executionMode?: string } })?.session;
+  if (!session?.id) throw new OpenComputerError(sessionResponse.status, undefined, "session create returned no session id");
+  return {
+    document: { id: document.id, created: documentCreated, revision: document.revision, title: document.title },
+    session: {
+      id: session.id,
+      created: sessionResponse.status === 201,
+      ...(session.status ? { status: session.status } : {}),
+      ...(session.executionMode ? { executionMode: session.executionMode } : {}),
+    },
+  };
+}


### PR DESCRIPTION
Two DX gaps found while building the OpenMuse example on project memory (work 026, "Findings from the first real runs"). Stacked on `feat/project-memory` (#722).

## 1. `useAgent` attaches to a server-created session

Every application that binds memory creates its sessions server-side (the API key and the bindings live there), so a hook that only creates sessions could not be used by exactly those applications; OpenMuse wrote its own server-side SSE relay over the events API.

`@opencomputer/react` 0.2.0:

- `useAgent({ sessionId, basePath, fetch, after?, pollIntervalMs?, onEvent?, onMemorySaved? })` attaches to an existing session: replays the event log from a cursor (pages are followed without waiting), resumes from that cursor after a failed poll (nothing replayed twice, `error` clears on recovery), streams new turns, `send` starts a turn (the input is shown at once and confirmed, not duplicated, by the log's `message.received`), `stop` interrupts, `memorySaves` and `onMemorySaved` carry `memory.saved` events. Result surface: `messages, send, stop, sessionId, isRunning, isReplaying, error, memorySaves, cursor`.
- The hook only needs three routes relative to `basePath`: `GET /sessions/<id>/events?after=`, `POST /sessions/<id>/turns`, `POST /sessions/<id>/interrupt`. The app's server proxies them under its own auth; the API key never reaches the browser. It never suspends, resumes or ends an attached session.
- Create-on-first-send (`useAgent("agent@alias")`) is unchanged, apart from gaining `stop()` and no longer stalling on a cancelled turn.
- The event reduction is a pure module (`react/src/events.ts`) shared by replay and live streaming. Tests: reducer tests plus hook tests against a fake of the three routes (react-dom under jsdom), in the sibling packages' `node --test` style; the publish workflow now runs `npm test` for react.
- `api-edge` passes `POST /sessions/<id>/interrupt` through (backend route from blue #64), returning the sanitized snapshot like `resume`/`end`.
- `docs/agents/react.mdx` is rewritten as the walkthrough (server creates, server proxies, browser attaches, refresh notes on save) and returns to the navigation and `llms.txt`. Placed under Concepts after Sessions; move it if you prefer another group.
- The scaffold's web template depends on `@opencomputer/react ^0.2.0`.

## 2. Start a session on a new document in one call

Starting a topic was two calls with two idempotency keys. The model stays honest (no cross-object transaction, no `create: true` in the binding); the helper does the two steps in order and makes the pair converge under one key.

- SDK: `startSessionOnDocument({ apiKey, projectId, environment, agent, resource, documentId, document: { title, text?, summary?, agentWrites? }, access?, memory?, idempotencyKey, source?, baseUrl?, fetch?, signal? })` returns `{ document: { id, created, revision, title }, session: { id, created, status?, executionMode? } }`. Document create is `If-None-Match: *` (412 = exists, then read; 404 on read = deleted/reserved id, `NotFoundError` before any session is created). Session create sends an `Idempotency-Key` derived from the caller's key (`sessionIdempotencyKey`); 409 becomes a `ConflictError` naming the cause. Version already bumped on this branch (1.1.1).
- CLI: `opencomputer session create [prompt] --memory <resource>=<documentId>[:read|read-write] [--memory <resource>] [--create-document]`. `--create-document` creates each bound document that does not exist yet (title = id) and reports created/existing; the global `--idempotency-key` already derives one key per request, so a retry returns the same session; a 409 is reported as `session_idempotency_conflict` with the reason. Version already bumped on this branch (0.7.1).
- Docs: `document-memory.mdx` "Start a session on a new document" (SDK, CLI, HTTP sequence); `sessions.mdx` shows the flag; CLI help lists it.

## Checks

Package contract, agent (13), cli (80), react (13), create-start (2), sdk (lint + 56), api-edge (185), web (220 + tsc) all green locally on Node 22.

## What OpenMuse can now delete

`lib/http/sse.ts`, `app/api/conversation/stream/route.ts`, `app/api/topics/[id]/stream/route.ts`, the `useLiveTimeline` hook and `EventSource` handling in `app/ui/OpenMuse.tsx`, the message part of `lib/events/messages.ts` (keep the activity reducer over `onEvent` if the activity view stays), the interrupt-mode Stop turn in `lib/topics/service.ts` / `app/api/conversation/stop` (call `interrupt`), and the document-then-session sequence in `startTopic` (`lib/topics/service.ts`) once memory bindings replace the recall block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKjbUpydN8ju2ZLxukbWLQ
