### PR TITLE
docs: management API and session events reference for Serverless Agents

### DIFF
--- a/docs/agents/api.mdx
+++ b/docs/agents/api.mdx
@@ -173,7 +173,7 @@ To read a whole log, start at `after=0` and repeat with the last `seq` you
 received until a page is empty. A full page means more may follow; read on
 without waiting. To follow a live session, keep polling from the last
 `seq`; the CLI's `sessions tail` and `useAgent` do exactly this. The log is
-durable, so a consumer that stops can resume from its cursor without gaps.
+durable, so a consumer that stops can resume from its cursor and miss nothing.
 Event types and their `data` are listed on [Session events](/agents/events).
 
 ## Memory

--- a/docs/agents/api.mdx
+++ b/docs/agents/api.mdx
@@ -1,0 +1,254 @@
+---
+title: "Management API"
+description: "Create sessions, send turns, read the event log and manage projects over HTTP"
+---
+
+The management API is the HTTP surface behind the CLI, the dashboard, the
+SDK helpers and the React hook's proxy routes. Use it from trusted server
+code to run agents from your own application.
+
+## Base URL and authentication
+
+```text
+https://app.opencomputer.dev/api/managed-agents
+```
+
+Every request carries an API key in the `x-api-key` header. A key belongs to
+an organization and reaches every project, agent and session in it. Keep it
+on the server; the [React integration](/agents/react) shows how a browser
+attaches through your own routes without seeing the key.
+
+Request and response bodies are JSON. Paths below are relative to the base
+URL; `<p>` is a project ID and `<r>` a memory resource ID.
+
+## Errors
+
+Error bodies are `{ error: { code, message } }`. The `code` is stable and is
+what to branch on; the `message` is short and safe to show.
+
+| Status | Meaning |
+| --- | --- |
+| `400` | Invalid body, query or header |
+| `401` | Missing or invalid API key |
+| `402` | `insufficient_credits`: prepaid credits are exhausted |
+| `403` | The key may not perform this operation |
+| `404` | The route or the target does not exist |
+| `409` | The request conflicts with current state, for example a reused `Idempotency-Key` |
+| `429` | Too many requests; retry after `Retry-After` |
+| `5xx` | Temporary failure; retry with the same idempotency key |
+
+A missing key and an unknown route return `{ "error": "<text>" }` without a
+code.
+
+## Sessions
+
+A session is a durable conversation with one deployed agent. It pins the
+deployment it was created on; see [Sessions and turns](/agents/sessions).
+
+| Operation | Method and path | Success |
+| --- | --- | --- |
+| Create | `POST /sessions` | `201` with the session, `200` when the key had already created it |
+| Get | `GET /sessions/<id>` | `200` with the session |
+| List | `GET /sessions` | `200` with `{ sessions }` |
+| End | `POST /sessions/<id>/end` | `200` with the ended session |
+| Interrupt | `POST /sessions/<id>/interrupt` | `200` with the session |
+
+### Create
+
+```bash
+curl -X POST 'https://app.opencomputer.dev/api/managed-agents/sessions' \
+  -H 'x-api-key: <api-key>' \
+  -H 'Content-Type: application/json' \
+  -H 'Idempotency-Key: topic/workshop/1' \
+  -d '{
+    "agentId": "<agent-id>@development",
+    "memory": {
+      "notes": { "scope": "document", "id": "workshop", "access": "read-write" }
+    }
+  }'
+```
+
+| Field | Meaning |
+| --- | --- |
+| `agentId` | `<agent-id>@development` or `<agent-id>@production`. The alias selects the environment and the deployment active in it. A bare agent ID means `production`. |
+| `deploymentId` | Pin one deployment instead of resolving an alias. Send `environment` with it; it may be omitted only when the deployment is promoted to exactly one environment. |
+| `environment` | `development` or `production`. Optional with `agentId`; it must agree with the alias. |
+| `memory` | Bindings keyed by resource ID, at most eight. Needs a deployed agent and an environment. Shapes on [Document memory](/agents/document-memory#session-bindings). |
+| `source` | `api` (default), `playground`, `channel` or `webhook`. The dashboard groups sessions by it. |
+
+The response is `{ session: { id, executionMode, status, createdAt }, deployment }`.
+The session starts without a turn; send one with the turns route.
+
+`Idempotency-Key` (at most 256 characters) makes a retry safe. The key
+identifies the session within your organization:
+
+- The same key with the same agent, deployment, environment and memory
+  bindings returns the existing session with `200`.
+- Anything else under that key is `409 idempotency_conflict`. The deployment
+  is part of the identity, so after a redeploy the same key conflicts:
+  a session pins its deployment, and new code needs a new session under a
+  new key.
+- `503 memory_admission_unconfirmed` means the memory grants were not
+  confirmed in time. Retry with the same key; the retry resumes the wait.
+
+Other codes: `400 invalid_environment`, `400 invalid_memory_binding`,
+`404 deployment_not_found`, `409 deployment_not_promoted` (a pinned
+deployment is not active in the named environment), `402
+insufficient_credits`.
+
+### Get and list
+
+`GET /sessions/<id>` returns the session:
+
+| Field | Meaning |
+| --- | --- |
+| `id`, `agentId`, `deploymentId` | The session and the deployment it pins |
+| `environment` | `development` or `production`, when the request named one |
+| `status` | `new`, `connecting`, `idle`, `running`, `waiting_runtime`, `suspending`, `suspended`, `resuming`, `failed` or `ended` |
+| `source` | The `source` given at creation |
+| `memory` | Bindings with `resource`, `scope`, `id`, `access` and `writable`; present when the session was created with bindings |
+| `turns` | Every turn: `id`, `input`, `mode`, `status`, `createdAt`, `updatedAt` |
+| `createdAt`, `updatedAt` | Timestamps |
+
+`GET /sessions` returns `{ sessions }`: the fifty most recently updated
+sessions of the organization, newest first, in the same shape. There are no
+filters or paging parameters; keep your own index of session IDs.
+
+### End and interrupt
+
+`POST /sessions/<id>/end` ends the session. Queued and running turns are
+cancelled and memory write access is revoked; do not send further turns to
+it. `503 session_end_unconfirmed` means the session is ended but the memory
+revocation was not acknowledged; retry, or
+[freeze the document](/agents/document-memory#disable-agent-writes). Ending an
+ended session returns it unchanged.
+
+`POST /sessions/<id>/interrupt` stops the running turn without spending a
+model turn. The turn settles as `cancelled` with reason `interrupted`, the
+runtime is told to stop, and the next queued turn starts. An idle session is
+returned unchanged.
+
+## Turns
+
+```bash
+curl -X POST 'https://app.opencomputer.dev/api/managed-agents/sessions/<session-id>/turns' \
+  -H 'x-api-key: <api-key>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "input": "Plan the workshop.",
+    "idempotencyKey": "message-42",
+    "mode": "queue"
+  }'
+```
+
+| Field | Meaning |
+| --- | --- |
+| `input` | The user text for this turn. Required, not empty. |
+| `idempotencyKey` | Optional. The same key returns the existing turn; without one every request starts a turn. |
+| `mode` | `queue` (default): run after earlier turns. `steer`: deliver into the running turn when the runtime supports it, otherwise queue. `interrupt`: cancel running turns and run next. |
+
+The response is `202 { turnId, status, duplicate }` for a new turn and
+`200` with `duplicate: true` when the key had already created one. `status`
+is `queued` or `running`. Follow the turn in the event log; the response
+does not wait for it.
+
+Codes: `400 invalid_turn`, `402 insufficient_credits`,
+`409 memory_admission_pending` (retry the session creation with its key
+first), `409 memory_admission_rejected` (the session is ended; create a new
+one).
+
+## Events
+
+```bash
+curl 'https://app.opencomputer.dev/api/managed-agents/sessions/<session-id>/events?after=0' \
+  -H 'x-api-key: <api-key>'
+```
+
+`GET /sessions/<id>/events?after=<seq>` returns `{ events }`: up to 500
+events with `seq` greater than `after`, in ascending order. Each event is
+`{ id, seq, timestamp, sessionId, turnId, type, data }`; `turnId` is absent
+on session-level events.
+
+To read a whole log, start at `after=0` and repeat with the last `seq` you
+received until a page is empty. A full page means more may follow; read on
+without waiting. To follow a live session, keep polling from the last
+`seq`; the CLI's `sessions tail` and `useAgent` do exactly this. The log is
+durable, so a consumer that stops can resume from its cursor without gaps.
+Event types and their `data` are listed on [Session events](/agents/events).
+
+## Memory
+
+Document memory belongs to a project and an environment. Every route takes
+`?environment=development` or `?environment=production`. Bodies, conditional
+headers, the document object and the error codes are on
+[Document memory](/agents/document-memory#management-api).
+
+| Operation | Method and path | Success |
+| --- | --- | --- |
+| Resource inventory | `GET /projects/<p>/memory` | `200` with `{ resources }` |
+| List documents | `GET /projects/<p>/memory/<r>/documents` | `200` with `{ documents, nextCursor }` |
+| Read | `GET /projects/<p>/memory/<r>/documents/<id>` | `200` with the document and `ETag` |
+| Create | `PUT /projects/<p>/memory/<r>/documents/<id>` with `If-None-Match: *` | `201` |
+| Replace text or summary | `PUT /projects/<p>/memory/<r>/documents/<id>` with `If-Match` | `200` |
+| Change title or policy | `PATCH /projects/<p>/memory/<r>/documents/<id>` with `If-Match` | `200` |
+| Delete | `DELETE /projects/<p>/memory/<r>/documents/<id>` with `If-Match` | `204` |
+
+```bash
+curl -X PUT 'https://app.opencomputer.dev/api/managed-agents/projects/<project-id>/memory/notes/documents/workshop?environment=development' \
+  -H 'x-api-key: <api-key>' \
+  -H 'Content-Type: application/json' \
+  -H 'If-None-Match: *' \
+  -d '{ "title": "Workshop notes" }'
+```
+
+`startSessionOnDocument` in the
+[TypeScript SDK](/reference/typescript-sdk#serverless-agents-helpers) does
+this create and the session create in one call.
+
+## Webhooks
+
+Webhook configuration lives under the project; invocation uses the separate
+`/api/agent-webhooks/<id>/<token>` URL described on
+[Agent webhooks](/agents/webhooks).
+
+| Operation | Method and path | Body or query | Success |
+| --- | --- | --- | --- |
+| List | `GET /projects/<p>/webhooks` | Optional `?environment=` and `?agentId=` | `200` with `{ webhooks }`, URLs without tokens |
+| Create | `POST /projects/<p>/webhooks` | `{ name, agentId, environment, identity? }` | `201` with `{ webhook }`; `token` and the full `invocationUrl` appear once |
+| Update | `PATCH /projects/<p>/webhooks/<id>` | Any of `name`, `enabled`, `identity` (`null` removes it) | `200` with `{ webhook }` |
+| Rotate token | `POST /projects/<p>/webhooks/<id>/rotate-token` | None | `200` with `{ webhook }` carrying the new token |
+| Delete | `DELETE /projects/<p>/webhooks/<id>` | None | `204` |
+| Request ledger | `GET /projects/<p>/webhooks/<id>/requests` | None | `200` with `{ requests }` |
+
+`identity` is `header:<name>` or `body:<json-pointer>`. Creating a webhook
+for an agent that is not deployed in the environment is
+`409 webhook_target_unavailable`.
+
+```bash
+curl 'https://app.opencomputer.dev/api/managed-agents/projects/<project-id>/webhooks/<webhook-id>/requests' \
+  -H 'x-api-key: <api-key>'
+```
+
+## Projects, agents and deployments
+
+| Operation | Method and path | Success |
+| --- | --- | --- |
+| List projects | `GET /projects` | `200` with `{ projects }` |
+| Create project | `POST /projects` with `{ name, slug? }` | `201` with the project |
+| Get project | `GET /projects/<p>` | `200` with `{ project, deployments, sessions, connections, channels, schedules }` |
+| List agents | `GET /agents` | `200` with `{ agents }`: `id`, `name`, `activeAlias`, `activeDeploymentId`, `deploymentCount` |
+| List deployments | `GET /deployments?agentId=<agent-id>` | `200` with `{ deployments }` |
+| Get deployment | `GET /deployments/<id>` | `200` with `id`, `agentId`, `alias`, `memory` declarations, `createdAt` |
+
+A project is `{ id, slug, name, environments, agents, createdAt, updatedAt }`;
+`agents` carries each agent's `id` and `name`. See
+[Projects and agents](/agents/projects) for how projects are created and
+linked from the CLI.
+
+```bash
+curl 'https://app.opencomputer.dev/api/managed-agents/projects' \
+  -H 'x-api-key: <api-key>'
+```
+
+Secrets, runtime variables, schedules, channels, outboxes and logs are managed
+with the CLI and the dashboard; see their pages under Concepts.

--- a/docs/agents/document-memory.mdx
+++ b/docs/agents/document-memory.mdx
@@ -85,7 +85,8 @@ Session inspection returns a `memory` array. Entries contain `resource`,
 for read-only bindings, frozen/deleted documents and ended sessions.
 
 Reusing a session-create `Idempotency-Key` requires identical agent, deployment,
-environment and bindings; incompatible inputs return `409 conflict`.
+environment and bindings; incompatible inputs return `409 idempotency_conflict`.
+The [management API](/agents/api#create) page has the full rules.
 
 ### Start a session on a new document
 
@@ -135,7 +136,9 @@ run the first turn at once, and `--json` for the ids.
 Over HTTP, send `PUT .../documents/<id>` with `If-None-Match: *`, treat `412`
 as "exists" (then `GET` it; `404` means the id was deleted), and `POST
 /api/managed-agents/sessions` with an `Idempotency-Key`; `201` created the
-session, `200` returned the one that key had already created.
+session, `200` returned the one that key had already created. The helper's
+signature and errors are in the
+[TypeScript SDK reference](/reference/typescript-sdk#serverless-agents-helpers).
 
 ## Reading
 
@@ -243,10 +246,10 @@ A committed save whose reply was lost can conflict on retry. Read current
 content before writing again. Separately, **model-generation retries can
 render again using newer memory**; they do not preserve the same projection.
 
-Observed saves produce `memory.saved` events with `resource`, `documentId`,
-`revision`, `bytes`. Delivery is best-effort: a write can commit without a
-reply or event. Refresh documents when attaching, reconnecting and completing
-work.
+Observed saves produce `memory.saved` [session events](/agents/events#memory)
+with `resource`, `documentId`, `revision`, `bytes`. Delivery is best-effort: a
+write can commit without a reply or event. Refresh documents when attaching,
+reconnecting and completing work.
 
 ## Owner access
 
@@ -339,7 +342,8 @@ and exports remain. Use a new ID for new notes.
 
 ## Management API
 
-Use `x-api-key: <api-key>` and project access. Every route requires
+Use `x-api-key: <api-key>` on `https://app.opencomputer.dev`, as for the rest
+of the [management API](/agents/api). Every route requires
 `environment=development` or `environment=production` as a query parameter.
 Below, `<p>` is the project ID and `<r>` the resource ID.
 

--- a/docs/agents/events.mdx
+++ b/docs/agents/events.mdx
@@ -1,0 +1,151 @@
+---
+title: "Session events"
+description: "The durable event log every session keeps and every consumer reads"
+---
+
+Every session appends what happens to one durable log: the turns it
+accepted, the text the model produced, the tools it called, the memory it
+saved and the runtime that ran it. The log is what `opencomputer sessions
+tail --json` prints, what [`useAgent`](/agents/react) reduces to messages,
+what the dashboard's session view shows, and what
+[`GET /sessions/<id>/events`](/agents/api#events) returns.
+
+## Shape and ordering
+
+Each event is one JSON object:
+
+| Field | Meaning |
+| --- | --- |
+| `seq` | Position in the log, starting at 1 and increasing with every event |
+| `id` | A unique event ID |
+| `timestamp` | When the event was recorded |
+| `sessionId` | The session |
+| `turnId` | The turn the event belongs to; absent on session-level events |
+| `type` | One of the types below |
+| `data` | Fields specific to the type |
+
+`seq` is the cursor. A read with `after=<seq>` returns events with a greater
+`seq`, in ascending order, up to 500 at a time; repeat from the last `seq`
+you received until a page is empty, and keep polling from there to follow a
+live session. Because the log is durable and `seq` only grows, a consumer
+that stops can resume from its cursor without missing anything, and a page
+that overlaps one already read is harmless: apply events whose `seq` is
+greater than what you have applied. The React hook and the CLI work this
+way.
+
+Events at or below the cursor never change. New types can appear; treat an
+unknown type as informational and keep reading.
+
+## Event types
+
+### Session lifecycle
+
+| Type | When | `data` |
+| --- | --- | --- |
+| `session.created` | The session exists. Always the first event. | `agentId`, `deploymentId` |
+| `session.status_changed` | The session moved between `new`, `connecting`, `idle`, `running`, `waiting_runtime`, `suspending`, `suspended`, `resuming`, `failed` and `ended` | `from`, `to` |
+| `session.ended` | The owner ended the session. Queued and running turns were cancelled and memory writes revoked. | none |
+| `session.failed` | The session cannot continue | `message`: a sanitized reason |
+
+### Turns
+
+| Type | When | `data` |
+| --- | --- | --- |
+| `message.received` | A turn was accepted; its input is recorded before anything runs | `input`: the user text; `mode`: `queue`, `steer` or `interrupt` |
+| `turn.queued` | The turn waits for earlier turns | `mode` |
+| `turn.steered` | The input was delivered into the running turn | `activeTurnId` |
+| `turn.interrupted` | This turn cancelled the turns that were running | `interruptedTurnIds` |
+| `turn.started` | The runtime began the turn | none |
+| `turn.completed` | The turn finished and the session is idle again | none |
+| `turn.failed` | The turn stopped with an error | `message`: the runtime's reason, sanitized |
+| `turn.cancelled` | The turn was stopped by an interrupt | `reason`: `interrupted`; `replacementTurnId` when an interrupt-mode turn replaced it |
+
+A failed turn's `message` is the runtime's own error, for example a rejected
+model or a tool that is not available. Stack frames, URLs, file paths and
+credential-shaped values are removed and the text is capped at 500
+characters; when nothing readable remains, a generic sentence is sent.
+
+### Messages
+
+| Type | When | `data` |
+| --- | --- | --- |
+| `message.delta` | The model produced a fragment of its reply | `text`: the fragment; concatenate deltas of one turn |
+| `message.completed` | The reply is complete | `text`: the whole reply |
+| `reasoning.delta` | The model produced a fragment of reasoning, when the model exposes it | `text` |
+| `reasoning.completed` | The reasoning is complete | `text` |
+
+### Tools
+
+| Type | When | `data` |
+| --- | --- | --- |
+| `tool.started` | The model called a tool | `tool`: its name; `callId`; `title`; `input` |
+| `tool.progress` | The tool reported progress | runtime-defined |
+| `tool.completed` | The tool returned | `tool`, `callId`, `title`, `output` |
+| `tool.failed` | The tool raised an error | `tool`, `callId`, `message` |
+
+The exact fields come from the runtime's tool record; read them as optional
+and key a tool call on `callId` when it is present. The memory tools
+(`memory_save`, `memory_read`, `memory_list`) appear here like any other
+tool; the save itself is reported separately.
+
+### Memory
+
+| Type | When | `data` |
+| --- | --- | --- |
+| `memory.saved` | A `memory_save` the session observed succeeding | `resource`, `documentId`, `revision`, `bytes` |
+
+Delivery is best-effort. A save commits independently of the event: a
+runtime that loses its connection can commit without ever reporting it, and
+the same event can be reported once or twice after a reconnect. Treat the
+event as a hint to re-read the document, and also re-read when attaching,
+reconnecting and completing work. See
+[Document memory](/agents/document-memory#saving).
+
+### Model and usage
+
+| Type | When | `data` |
+| --- | --- | --- |
+| `model.route_resolved` | A model call is about to be sent | `providerCallId`; `requested` and `effective` as `{ provider, model }`; `runtime`; `access` |
+| `model.access_fallback` | A call planned on a connected model account fell back to managed access | `providerCallId`, `requested`, `from`, `reason` |
+| `usage.recorded` | A model call finished | `provider`, `model`, `inputTokens`, `outputTokens`, `reasoningTokens`, `cachedTokens`, `cacheWriteTokens`, `costUsd`, `payer` |
+
+### Outbound requests
+
+| Type | When | `data` |
+| --- | --- | --- |
+| `egress.request` | A [declared connection](/agents/secrets) sent a request | `connectionId`, `method`, `path` |
+| `egress.response` | The destination answered | `connectionId`, `method`, `path`, `status`, `durationMs` |
+| `egress.failed` | The request did not complete | `connectionId`, `method`, `path`, `message` |
+
+### Runtime
+
+| Type | When | `data` |
+| --- | --- | --- |
+| `runtime.connected` | An agent runtime attached to the session | none |
+| `runtime.disconnected` | The runtime went away; a running turn is queued again and resumes on the next runtime | none |
+| `runtime.suspended` | The runtime was suspended between turns | none |
+| `runtime.resumed` | The runtime was resumed | none |
+| `runtime.log` | A line of runtime output or a platform milestone | `level`, `stream`, `message` for output; `phase` and `message` for milestones such as the runtime starting |
+
+### Agent renders
+
+| Type | When | `data` |
+| --- | --- | --- |
+| `agent.rendered` | Your agent function was rendered for a model step | `renderId`, `instructions`, `model`, `enabledTools`, `enabledSubagents`, `enabledMcpServers`, `requiredConnections`, `input`, `tools`, `renderedAt` |
+
+One turn can carry several renders, one per model step. The debug inspector
+in the [playground](/agents/playground) shows the same data.
+
+## Reading the log
+
+From the CLI, with one NDJSON record per event:
+
+```bash
+opencomputer sessions tail <session-id> --after 0 --json
+```
+
+From an application, poll the [events route](/agents/api#events) or attach
+[`useAgent`](/agents/react), which turns `message.received`,
+`message.delta` and `message.completed` into messages, `turn.*` and
+`session.*` into `isRunning` and `ended`, and `memory.saved` into
+`memorySaves`; every event, these included, also reaches `onEvent`.

--- a/docs/agents/memory-providers.mdx
+++ b/docs/agents/memory-providers.mdx
@@ -260,5 +260,6 @@ consumes model context.
 - **Ownership:** the provider supplies retention, backups, inspection, export
   and deletion. OpenComputer document editing/freezing applies only to
   `documentMemory`; deleting a project does not delete remote data.
-- **Inspection:** the proposed Memory page identifies the provider. Session
-  inspection exposes namespace and partition so owners can locate remote data.
+- **Inspection:** the [resource inventory](/agents/document-memory#resource-inventory)
+  identifies each resource's provider. Session inspection would expose
+  namespace and partition so owners can locate remote data.

--- a/docs/agents/memory.mdx
+++ b/docs/agents/memory.mdx
@@ -56,7 +56,7 @@ Treat saved text as data the model reads, not as instructions it follows.
 ## Bind a document to a session
 
 Include `memory` when creating a [session](/agents/sessions) with
-`POST /api/managed-agents/sessions`:
+`POST /api/managed-agents/sessions` ([management API](/agents/api#create)):
 
 ```json
 {
@@ -82,6 +82,11 @@ credentials nor permission to select another document. A
 [collection binding](/agents/document-memory#session-bindings) instead lets it
 browse documents with `memory_list` and `memory_read`.
 
+The document must exist before the session binds it. `startSessionOnDocument`
+in the [TypeScript SDK](/reference/typescript-sdk#serverless-agents-helpers)
+creates it if needed and then the session, and the CLI's
+`session create --memory notes=workshop --create-document` does the same.
+
 ## Save and reuse notes
 
 Saving is explicit: the model calls `memory_save({ text })`. Each save replaces
@@ -90,7 +95,9 @@ Conversation history is not automatically extracted into memory.
 
 Sessions bound to the same document share its latest saved text. Each model
 step reads it again; [revision checks](/agents/document-memory#saving) prevent
-an agent from overwriting changes made since its read.
+an agent from overwriting changes made since its read. A successful save is
+reported as a `memory.saved` [session event](/agents/events#memory), delivered
+best-effort.
 
 Memory belongs to a **project and environment**. It survives session end,
 sandbox loss, conversation compaction and new deployments. Development and

--- a/docs/agents/mental-model.mdx
+++ b/docs/agents/mental-model.mdx
@@ -105,6 +105,10 @@ Every session remains pinned to the immutable deployment it started with. A
 new development sync or production deployment affects new sessions, not code
 already running inside an existing session.
 
+[Memory](/agents/memory) is what outlives a session: project-scoped documents
+that the agent function reads at render with `useMemory`, that the model saves
+through memory tools, and that the owner reads, edits and exports.
+
 ## Capabilities are selected, not executed, during render
 
 Use the narrowest capability that fits the work:
@@ -115,6 +119,7 @@ Use the narrowest capability that fits the work:
 | `useMcpServer(server)` | A collection of tools advertised by a remote MCP server |
 | `useSubagent(agent)` | Another project agent available for delegation |
 | A skill under `skills/` | Reusable instructions and supporting resources |
+| `useMemory(memory)` | The bound documents' text and the tools that save to them |
 
 The model decides whether to request an available tool. The harness remains
 responsible for validating the request, executing it, and recording the

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -23,7 +23,9 @@ export default function Agent() {
 The exported function is a reactive description of the agent. OpenComputer
 renders it for the current input and uses its return value as instructions for
 the managed agent loop. Hooks attach the model, tools, MCP servers, and
-subagents needed for that render.
+subagents needed for that render. [Memory](/agents/memory) gives an agent
+notes that outlive a session: project-scoped documents read at render, saved
+by the model through memory tools, and owned by you.
 
 <CardGroup cols={2}>
   <Card title="Projects" icon="folder" href="/agents/projects">
@@ -72,7 +74,7 @@ URL, and syncs every configured agent to `development`.
 
 - TypeScript projects containing one or more agents
 - reactive instructions, model selection, tools, subagents, MCP
-  servers, input metadata, and session data reads
+  servers, input metadata, session data reads, and document memory
 - cloud development with file watching and automatic synchronization
 - dashboard and CLI playground sessions
 - immutable deployments promoted through aliases such as `production`

--- a/docs/agents/react.mdx
+++ b/docs/agents/react.mdx
@@ -40,21 +40,23 @@ const { session } = await startSessionOnDocument({
   apiKey: process.env.OPENCOMPUTER_API_KEY!,
   projectId: process.env.OPENCOMPUTER_PROJECT_ID!,
   environment: "development",
-  agent: "topic-worker",
-  resource: "topics",
-  documentId: topicId,
-  document: { title },
-  idempotencyKey: `topic/${topicId}/${user.id}`,
+  agent: "<agent-id>",
+  resource: "notes",
+  documentId: "workshop",
+  document: { title: "Workshop notes" },
+  idempotencyKey: `workshop/${user.id}`,
 });
-// Store session.id with the topic; the browser attaches to it.
+// Store session.id with the workshop; the browser attaches to it.
 ```
 
 Without memory, `POST /api/managed-agents/sessions` with `x-api-key` and
-`{ "agentId": "<agent-id>@development" }` returns `{ session: { id } }`.
+`{ "agentId": "<agent-id>@development" }` returns `{ session: { id } }`. Both
+are [management API](/agents/api#sessions) calls.
 
 ### 2. Proxy three routes
 
-The hook needs exactly these, relative to its `basePath`:
+The hook needs exactly these [management API](/agents/api) routes, relative
+to its `basePath`:
 
 | Route | Purpose |
 | --- | --- |
@@ -101,7 +103,7 @@ envelope `{ error: { message } }`.
 ```tsx
 import { useAgent } from "@opencomputer/react";
 
-export function TopicChat({ sessionId, onNotesChanged }: { sessionId: string; onNotesChanged: () => void }) {
+export function WorkshopChat({ sessionId, onNotesChanged }: { sessionId: string; onNotesChanged: () => void }) {
   const { messages, send, stop, isReplaying, isRunning, error } = useAgent({
     sessionId,
     basePath: "/api/agent",
@@ -148,8 +150,8 @@ Every `memory.saved` event the session records
 owner route when one arrives. Saves are reported best-effort: a document
 can change without an event, so also refresh when the user opens the panel.
 
-Any other event is available through `onEvent`, for example tool activity for
-an activity view.
+Every event is available through `onEvent`, for example tool activity for an
+activity view; the types are listed on [Session events](/agents/events).
 
 ## Create a session from the browser
 

--- a/docs/agents/sessions.mdx
+++ b/docs/agents/sessions.mdx
@@ -5,7 +5,15 @@ description: "Understand durable conversations and multi-turn agent work"
 
 A session is a durable conversation with a deployed agent. Each turn appends
 input and streamed runtime events to the session, allowing clients to resume a
-conversation without rebuilding its history locally.
+conversation without rebuilding its history locally. The events are listed on
+[Session events](/agents/events).
+
+A session pins the deployment it was created on. Advancing Development or
+promoting to Production changes which deployment new sessions get; turns sent
+to an existing session keep running the code it started with, including its
+declared tools and memory resources. To run new code, start a new session.
+Memory documents are not pinned: they belong to the project and environment,
+so a new session bound to the same document reads what the old one saved.
 
 ## Agent playground
 
@@ -81,6 +89,16 @@ npx --package @opencomputer/cli opencomputer session "Draft a response"
 
 Use `--keep` on supported commands when the session should remain active after
 the command exits.
+
+## From an application
+
+Applications create sessions with the [management API](/agents/api): `POST
+/api/managed-agents/sessions` with an API key, then turns and the event log
+under that session. `startSessionOnDocument` in the
+[TypeScript SDK](/reference/typescript-sdk#serverless-agents-helpers) creates
+a memory document and a session bound to it in one call. In the browser, the
+[`useAgent`](/agents/react) hook attaches to a session your server created
+and renders its messages.
 
 ## Input sources
 

--- a/docs/agents/webhooks.mdx
+++ b/docs/agents/webhooks.mdx
@@ -75,8 +75,8 @@ with your API key; the session id there is authoritative, since a retried
 start can use a different session than the one first announced:
 
 ```bash
-curl 'https://app.opencomputer.dev/api/managed-agents/projects/<project-id>/webhooks/<webhook-id>/requests?environment=production' \
-  -H 'Authorization: Bearer <api-key>'
+curl 'https://app.opencomputer.dev/api/managed-agents/projects/<project-id>/webhooks/<webhook-id>/requests' \
+  -H 'x-api-key: <api-key>'
 ```
 
 Each delivery needs an identity so that a retry does not start a second
@@ -159,3 +159,5 @@ identity source to the field that names the delivery, for example
 
 Development and Production webhooks have separate URLs, tokens, and sessions.
 Disable or remove a webhook when its caller should no longer start sessions.
+The webhook routes are listed on the [management API](/agents/api#webhooks)
+page.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -40,6 +40,8 @@
             "pages": [
               "agents/reactive-agents",
               "agents/sessions",
+              "agents/api",
+              "agents/events",
               "agents/react",
               "agents/memory",
               "agents/schedules",

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,6 +11,8 @@
 - [Deployments and environments](https://docs.opencomputer.dev/agents/deployments.md): Understand development, production, immutable deployments, and aliases.
 - [Reactive agents](https://docs.opencomputer.dev/agents/reactive-agents.md): Render instructions, models, tools, subagents, and MCP servers from code.
 - [Sessions and turns](https://docs.opencomputer.dev/agents/sessions.md): Create and inspect durable conversations.
+- [Management API](https://docs.opencomputer.dev/agents/api.md): Create sessions, send turns, read the event log and manage memory, webhooks and projects over HTTP with an API key.
+- [Session events](https://docs.opencomputer.dev/agents/events.md): Every event type in the durable session log, its data fields, and the seq cursor rules.
 - [React integration](https://docs.opencomputer.dev/agents/react.md): Attach a React application to server-created sessions with useAgent, proxying three routes under your own authentication.
 - [Agent capabilities](https://docs.opencomputer.dev/agents/capabilities.md): Choose between tools, MCP servers, skills, subagents, and outbound connections.
 - [Secrets and outbound requests](https://docs.opencomputer.dev/agents/secrets.md): Store scoped secrets and inject them only into declared outbound requests.

--- a/docs/reference/typescript-sdk.mdx
+++ b/docs/reference/typescript-sdk.mdx
@@ -875,3 +875,125 @@ const apiResult = await sandbox.commands.run(
 | `allowedHosts` | `string[]` | Host restrictions for this secret |
 | `createdAt` | `string` | ISO 8601 timestamp |
 | `updatedAt` | `string` | ISO 8601 timestamp |
+
+---
+
+## Serverless Agents helpers
+
+`Sandbox` and the `OpenComputer` client wrap the sandbox API and the `/v3`
+Durable Agent Sessions API. The helpers in this section are different: they
+call the Serverless Agents [management API](/agents/api) under
+`/api/managed-agents` with an OpenComputer API key. Use them from trusted
+server code only; the key must not reach a browser.
+
+```typescript
+import { startSessionOnDocument, sessionIdempotencyKey } from "@opencomputer/sdk";
+```
+
+### `startSessionOnDocument(params): Promise<StartSessionOnDocumentResult>`
+
+Creates a [memory document](/agents/document-memory) if it does not exist,
+then a session bound to it, and reports both IDs and whether each already
+existed. The two objects stay separate on the API; this helper does the two
+calls in order and makes the pair converge on retry.
+
+```typescript
+const { document, session } = await startSessionOnDocument({
+  apiKey: process.env.OPENCOMPUTER_API_KEY!,
+  projectId: "<project-id>",
+  environment: "development",
+  agent: "<agent-id>",
+  resource: "notes",
+  documentId: "workshop",
+  document: { title: "Workshop notes" },
+  idempotencyKey: "topic/workshop/1",
+});
+```
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `apiKey` | string | required | API key with access to the project |
+| `projectId` | string | required | Project whose memory holds the document |
+| `environment` | `"development"` \| `"production"` | required | Memory store and session environment |
+| `agent` | string | required | Agent ID; the environment supplies the alias |
+| `resource` | string | required | Declared memory resource ID |
+| `documentId` | string | required | Document to bind |
+| `document` | `{ title, text?, summary?, agentWrites? }` | required | What to create when the document does not exist; ignored when it does |
+| `access` | `"read"` \| `"read-write"` | `"read-write"` | The binding's access |
+| `memory` | `MemoryBindings` | none | Further bindings keyed by resource ID |
+| `idempotencyKey` | string | required | One key for the whole operation |
+| `source` | string | `"api"` | The session's `source` |
+| `baseUrl` | string | `https://app.opencomputer.dev` | The management API origin |
+| `fetch` | typeof fetch | global | Override for runtimes without a global `fetch`, or tests |
+| `signal` | AbortSignal | none | Aborts both requests |
+
+The steps, in order:
+
+1. `PUT /projects/<projectId>/memory/<resource>/documents/<documentId>` with
+   `If-None-Match: *` and the `document` body. `201` means the document was
+   created. `412` means it exists; the helper reads it with `GET` and leaves
+   its content as it is. A `404` on that read means the ID was deleted and is
+   reserved, which is an error, since a binding to it would fail admission.
+2. `POST /sessions` with `agentId: "<agent>@<environment>"`, `source`, and
+   `memory` set to your further bindings plus
+   `{ [resource]: { scope: "document", id: documentId, access } }`. The
+   `Idempotency-Key` header is `sessionIdempotencyKey(idempotencyKey)`.
+   `201` created the session; `200` means the key had already created it.
+
+The result:
+
+| Field | Description |
+| --- | --- |
+| `document.id` | The document |
+| `document.created` | `false` when it already existed |
+| `document.revision` | Current revision, for a later conditional owner write |
+| `document.title` | Its title |
+| `session.id` | The session |
+| `session.created` | `false` when the key had already created this session |
+| `session.status`, `session.executionMode` | As the create response reported them |
+
+Errors:
+
+| Error | When |
+| --- | --- |
+| `NotFoundError` with code `memory_document_deleted` | The document ID was deleted and is reserved; use a new ID |
+| `ConflictError` with code `idempotency_key_reused` | The key already created a session with a different agent, deployment, environment or bindings; the document was left as it is. Use a new key |
+| `AuthError` | `401` or `403` from the API |
+| `RateLimitError` | `429`; `retryAfter` carries the wait in seconds |
+| `OpenComputerError` | Any other failure; `status` and `code` carry the API's error envelope |
+| `Error` | No global `fetch` and none passed |
+
+A retry with the same `idempotencyKey` after a redeploy is a
+`ConflictError`: the deployment is part of the session's identity. Start
+the new session under a new key.
+
+### `sessionIdempotencyKey(idempotencyKey): Promise<string>`
+
+The `Idempotency-Key` the helper sends when creating the session: the
+SHA-256 hex digest of `opencomputer.memory.session`, a NUL byte and your
+key. Stable for a retry and distinct from any other use of the same caller
+key. Use it to recognize the session-create key in your own requests or logs.
+
+### Memory types
+
+The package exports the shapes of the memory management routes as types, for
+typing your own requests, the CLI's `--json` output and `opencomputer memory
+export` files. They carry no behavior.
+
+| Type | Shape |
+| --- | --- |
+| `MemoryEnvironment` | `"development" \| "production"` |
+| `MemoryAccess` | `"read" \| "read-write"` |
+| `MemoryAgentWrites` | `"enabled" \| "disabled"` |
+| `MemoryBinding` | One session binding: `{ scope: "document", id, access? }` or `{ scope: "collection", access?: "read" }` |
+| `MemoryBindings` | `Record<string, MemoryBinding>`, keyed by resource ID, at most eight |
+| `SessionMemoryBinding` | One entry of a session's `memory` array, with `resource` and `writable` |
+| `MemoryWriter` | `{ kind: "owner" }` or `{ kind: "agent", sessionId }` |
+| `MemoryDocumentMeta` | A document without `text`, as the list route returns it |
+| `MemoryDocument` | A full document, as read, create, replace and patch return it |
+| `MemoryDocumentPage` | `{ documents, nextCursor }` |
+| `MemoryResource`, `MemoryResourceInventory` | One entry, and the whole, of `GET /projects/<id>/memory` |
+| `CreateMemoryDocumentBody`, `ReplaceMemoryDocumentBody`, `PatchMemoryDocumentBody` | Bodies of `PUT` with `If-None-Match`, `PUT` with `If-Match`, and `PATCH` |
+| `MemorySavedEvent` | The `data` of a `memory.saved` [session event](/agents/events) |
+| `MemoryErrorCode` | The codes the memory routes return in `{ error: { code, message } }` |
+| `StartSessionOnDocumentParams`, `StartSessionOnDocumentResult` | The helper's parameters and result |

--- a/docs/reference/typescript-sdk/overview.mdx
+++ b/docs/reference/typescript-sdk/overview.mdx
@@ -54,4 +54,7 @@ import { Image, Snapshots } from "@opencomputer/sdk/node";
   <Card title="Secret Stores" icon="key" href="/reference/typescript-sdk/secrets">
     Manage secrets and egress control
   </Card>
+  <Card title="Serverless Agents helpers" icon="robot" href="/reference/typescript-sdk#serverless-agents-helpers">
+    Start a session on a memory document; memory types for the management API
+  </Card>
 </CardGroup>


### PR DESCRIPTION
Reference pages for the surfaces the project-memory branch relies on, plus a consistency pass over the pages it touched. Docs only.

## New pages

- **Management API** (`docs/agents/api.mdx`, Concepts after Sessions): base URL, `x-api-key` auth and what a key scopes to, the error envelope; sessions (create with `agentId` alias or a pinned `deploymentId` plus `environment`, `memory` bindings, `source`, the `Idempotency-Key` rules with the 409 conflict and the redeploy note; get; list; end; interrupt), turns (`mode` queue|steer|interrupt, `idempotencyKey`), events (`after=` cursor paging and how to follow), memory routes, webhook routes, projects/agents/deployments. One curl per group.
- **Session events** (`docs/agents/events.mdx`): every public event type with when it occurs and its `data` fields, grouped (session lifecycle, turns, messages, tools, memory, model and usage, outbound requests, runtime, agent renders); `seq`/`after` rules; `memory.saved` is best-effort; failed turns carry a sanitized `message`.

Both wired into `docs.json` and `llms.txt`.

## Touched pages

- `sessions.mdx`: a session pins its deployment and what that means across deploys; "From an application" pointing at the API page, the SDK helper and `useAgent`.
- `mental-model.mdx`, `overview.mdx`: one sentence each placing memory among the concepts.
- `reference/typescript-sdk.mdx`: "Serverless Agents helpers" (`startSessionOnDocument` signature, steps, derived idempotency key, errors, exported memory types); states the client wraps the sandbox and `/v3` APIs while the helpers call the management API. Card on the SDK overview.
- Consistency fixes: webhooks curl used `Authorization: Bearer` (the edge accepts `x-api-key` only); document-memory named the conflict code `conflict` (it is `idempotency_conflict`); react example now uses `notes`/`workshop` like every other page; memory-providers no longer calls the Memory page "proposed"; cross-links between memory, document-memory, react, api and events.

## Verification

Routes checked against `cloudflare-workers/api-edge/src/managed_agents.ts` (`isAllowedManagedAgentsRoute`, `publicSuccessBody`, `publicEventData`, `publicMemory*`, `publicErrorResponse`) and the backend session handlers; event types against the backend `AgentEventType` union and emit sites. Interrupt is verified against the edge passthrough on this branch and the backend `interrupt()` on the branch that carries it.

`mint broken-links` in `docs/`: no broken links. Every `docs.json` page path exists; every relative link and anchor in the touched pages resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKjbUpydN8ju2ZLxukbWLQ
