### PR TITLE
Public review round 2: typed failures, fenced sends, bound declarations, event subscriptions

### DIFF
--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -6,9 +6,12 @@ import {
   defineMemory,
   documentMemory,
   httpMemory,
+  useInput,
   useMemory,
   useSecret,
+  type AgentInput,
   type MemoryProjection,
+  type OutcomeEvent,
 } from "./index.js";
 
 const HOOKS = Symbol.for("opencomputer.agent-hooks");
@@ -401,4 +404,50 @@ test("useMemory fails a render whose session has no binding for the resource", (
     () => useMemory("requirements"),
     /hooks can only run while rendering an agent/,
   );
+});
+
+// Public delivery slice: the input an event subscription delivers. This is
+// the authoring contract the review found missing; the narrowing below is
+// what has to type-check for an agent to read the event.
+test("useInput narrows a delivered turn outcome to its typed event", () => {
+  const event: OutcomeEvent = {
+    id: "event_9",
+    type: "turn.completed",
+    sessionId: "ses_worker",
+    turnId: "turn-1",
+    agentId: "worker",
+    occurredAt: "2026-09-10T12:00:00.000Z",
+    result: { text: "Guide reproduced; the fix is in step 3.", truncated: false },
+  };
+  const input: AgentInput = {
+    source: "event",
+    text: "Outcome event turn.completed from worker.",
+    event,
+  };
+  const globals = globalThis as Record<PropertyKey, unknown>;
+  globals[HOOKS] = { useInput: () => input };
+  try {
+    const read = useInput();
+    assert.equal(read.source, "event");
+    if (read.source === "event") {
+      assert.equal(read.event.type, "turn.completed");
+      assert.equal(read.event.sessionId, "ses_worker");
+      assert.equal(read.event.result?.text, "Guide reproduced; the fix is in step 3.");
+      assert.equal(read.event.error, undefined);
+    }
+    // A failed outcome carries the reason and the bounded message instead.
+    const failed: AgentInput = {
+      source: "event",
+      event: { ...event, type: "turn.failed", reason: "runtime_lost", error: "The agent runtime stopped reporting" },
+    };
+    if (failed.source === "event" && failed.event.type === "turn.failed") {
+      assert.equal(failed.event.reason, "runtime_lost");
+      assert.equal(failed.event.error, "The agent runtime stopped reporting");
+    }
+    // The other sources have no event.
+    const user: AgentInput = { source: "user", text: "hi" };
+    assert.equal("event" in user, false);
+  } finally {
+    delete globals[HOOKS];
+  }
 });

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -20,7 +20,8 @@ export type InputSource =
   | "schedule"
   | "webhook"
   | "subagent"
-  | "system";
+  | "system"
+  | "event";
 
 export interface ScheduleRunContext {
   readonly id: string;
@@ -37,6 +38,33 @@ export interface WebhookRequestContext {
   readonly receivedAt: string;
 }
 
+/** The turn outcomes an event subscription delivers. */
+export type OutcomeEventType = "turn.completed" | "turn.failed" | "turn.cancelled";
+
+/**
+ * A recorded turn outcome of another session in the project, delivered by
+ * an event subscription as the input of a new turn. The platform attests
+ * where it came from through `source: "event"`; the included agent output
+ * is data to reason about, not instructions to follow.
+ */
+export interface OutcomeEvent {
+  /** The source session's own id for its terminal `turn.*` event. */
+  readonly id: string;
+  readonly type: OutcomeEventType;
+  /** The session and turn whose outcome this is. */
+  readonly sessionId: string;
+  readonly turnId: string;
+  /** The agent that ran the source turn. */
+  readonly agentId: string;
+  readonly occurredAt: string;
+  /** Why the turn failed or was cancelled, when the source recorded a reason. */
+  readonly reason?: string;
+  /** The failure message, bounded, when the turn failed. */
+  readonly error?: string;
+  /** The final assistant message of a completed turn; `truncated` when it was cut to fit. */
+  readonly result?: { readonly text: string; readonly truncated?: boolean };
+}
+
 interface BasicAgentInput {
   readonly text?: string;
   readonly payload?: DataValue;
@@ -44,7 +72,7 @@ interface BasicAgentInput {
 
 export type AgentInput =
   | (BasicAgentInput & {
-      readonly source: Exclude<InputSource, "schedule" | "webhook">;
+      readonly source: Exclude<InputSource, "schedule" | "webhook" | "event">;
     })
   | (BasicAgentInput & {
       readonly source: "schedule";
@@ -53,6 +81,10 @@ export type AgentInput =
   | (BasicAgentInput & {
       readonly source: "webhook";
       readonly webhook: Readonly<WebhookRequestContext>;
+    })
+  | (BasicAgentInput & {
+      readonly source: "event";
+      readonly event: Readonly<OutcomeEvent>;
     });
 
 export interface ResourceReference {

--- a/cli/src/api.test.ts
+++ b/cli/src/api.test.ts
@@ -3,12 +3,16 @@ import test from "node:test";
 
 import { APIError, OpenComputerClient } from "./api.js";
 
-test("mutations derive stable, operation-specific idempotency headers", async (context) => {
+// Review reproduction (U6): the header names the operation the caller's key
+// stands for, not the request it was sent with. The body is the backend's
+// to compare; hashing it here turned a retry with different inputs into a
+// second resource instead of the conflict the key promises.
+test("mutations derive idempotency headers from the caller's key and the target only", async (context) => {
   const requests: Request[] = [];
   context.mock.method(globalThis, "fetch", async (input: string | URL | Request, init?: RequestInit) => {
     const request = new Request(input, init);
     requests.push(request);
-    return Response.json({ id: "project", agents: [], environments: [] });
+    return Response.json({ id: "project", agents: [], environments: [], session: { id: "ses" } });
   });
   const client = new OpenComputerClient(
     { apiUrl: "https://app.opencomputer.dev", apiKey: "test" },
@@ -18,11 +22,15 @@ test("mutations derive stable, operation-specific idempotency headers", async (c
   await client.createProject("Agent", "agent");
   await client.createProject("Agent", "agent");
   await client.createProject("Different", "different");
+  await client.createSession("muse@development");
+  await client.projects();
 
   const keys = requests.map((request) => request.headers.get("idempotency-key"));
   assert.ok(keys[0]);
   assert.equal(keys[0], keys[1]);
-  assert.notEqual(keys[0], keys[2]);
+  assert.equal(keys[0], keys[2], "a different body is the same operation");
+  assert.notEqual(keys[0], keys[3], "a different target is a different operation");
+  assert.equal(keys[4], null, "reads carry no key");
   assert.equal(keys[0]?.includes("retry-42"), false);
 });
 

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -356,6 +356,10 @@ export class OpenComputerClient {
       headers.set("x-api-key", this.config.apiKey);
     }
     const method = (init.method ?? "GET").toUpperCase();
+    // The caller's key names an operation on a target; the body is what the
+    // backend compares under that key. Hashing the body in would make a
+    // retry with different inputs a new operation instead of the conflict
+    // the key promises.
     if (this.idempotencyKey && method !== "GET" && method !== "HEAD") {
       headers.set(
         "idempotency-key",
@@ -365,8 +369,6 @@ export class OpenComputerClient {
           .update(method)
           .update("\0")
           .update(path)
-          .update("\0")
-          .update(typeof init.body === "string" ? init.body : "")
           .digest("hex"),
       );
     }

--- a/cli/src/memory-commands.test.ts
+++ b/cli/src/memory-commands.test.ts
@@ -236,7 +236,9 @@ test("an over-limit save keeps the edited draft and says where it is", async (co
   }
 });
 
-test("a save that never reaches the API keeps the edited draft", async (context) => {
+// Review reproduction (U8): no answer from the API is not proof that
+// nothing was written.
+test("a save whose response is lost keeps the draft and is reported as unconfirmed", async (context) => {
   context.mock.method(globalThis, "fetch", async () => {
     throw new TypeError("fetch failed");
   });
@@ -248,13 +250,51 @@ test("a save that never reaches the API keeps the edited draft", async (context)
     }).catch((error: unknown) => error);
 
     assert.ok(error instanceof CLIError);
-    assert.equal(error.code, "command_failed");
-    assert.match(error.message, /was not saved: fetch failed/);
+    assert.equal(error.code, "memory_save_unconfirmed");
+    assert.match(error.message, /may or may not have been saved: fetch failed/);
+    assert.doesNotMatch(error.message, /was not saved/);
+    assert.match(
+      error.hint,
+      /Run `opencomputer memory show requirements workshop --project prj_1 --environment development` to see whether the revision changed/,
+    );
     assert.match(error.hint, new RegExp(`kept at ${draft.path}`));
-    assert.deepEqual(error.details, { editedTextPath: draft.path });
+    assert.deepEqual(error.details, { editedTextPath: draft.path, expectedRevision: '"rev-1"' });
     await access(draft.path);
   } finally {
     await draft.cleanup();
+  }
+});
+
+// Review reproduction (U8): the recovery command targets what the edit
+// targeted, carries the summary, and quotes what the shell would split.
+test("the draft recovery command keeps project, environment, summary and shell quoting", async (context) => {
+  context.mock.method(globalThis, "fetch", async () =>
+    Response.json(
+      { error: { code: "memory_limit_exceeded", message: "Text is 9000 bytes; the limit is 8192." } },
+      { status: 413 },
+    ),
+  );
+  const directory = await mkdtemp(join(tmpdir(), "opencomputer memory test-"));
+  const path = join(directory, "requirements--workshop.md");
+  await writeFile(path, "text", "utf8");
+  try {
+    const error = await saveMemoryEdit(new OpenComputerClient(config), {
+      ...target,
+      projectId: "prj_other",
+      environment: "production",
+      summary: "Workshop's requirements",
+      draft: { path, discard: async () => undefined },
+    }).catch((error: unknown) => error);
+
+    assert.ok(error instanceof CLIError);
+    assert.equal(error.code, "memory_too_large");
+    const command = error.hint.match(/`(opencomputer memory edit [^`]+)`/)?.[1];
+    assert.equal(
+      command,
+      `opencomputer memory edit requirements workshop --project prj_other --environment production --summary 'Workshop'\\''s requirements' --text-file '${path}'`,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
   }
 });
 

--- a/cli/src/memory-commands.test.ts
+++ b/cli/src/memory-commands.test.ts
@@ -342,6 +342,53 @@ test("--create-document creates missing bound documents, keeps existing ones, an
   );
 });
 
+// Review reproduction (U6): a backend keyed like the real one, by account
+// and Idempotency-Key header, comparing the inputs it stored under it.
+test("one caller key with different bindings is a conflict, not a second session", async (context) => {
+  const receipts = new Map<string, { body: string; id: string }>();
+  let created = 0;
+  context.mock.method(globalThis, "fetch", async (input: string | URL | Request, init?: RequestInit) => {
+    const request = new Request(input, init);
+    assert.equal(route(request), "/api/managed-agents/sessions");
+    const key = request.headers.get("idempotency-key");
+    assert.ok(key, "the CLI sends the header");
+    const body = await request.text();
+    const receipt = receipts.get(key);
+    if (receipt && receipt.body !== body) {
+      return Response.json(
+        { error: { code: "idempotency_conflict", message: "Idempotency-Key was already used with different session input" } },
+        { status: 409 },
+      );
+    }
+    if (receipt) {
+      return Response.json({ session: { id: receipt.id, status: "idle" } }, { status: 200 });
+    }
+    created += 1;
+    const id = `ses-${String(created)}`;
+    receipts.set(key, { body, id });
+    return Response.json({ session: { id, status: "connecting" } }, { status: 201 });
+  });
+  const client = new OpenComputerClient(config, "topic/workshop/1");
+  const workshop = { topics: { scope: "document" as const, id: "workshop", access: "read-write" as const } };
+  const other = { topics: { scope: "document" as const, id: "other", access: "read-write" as const } };
+
+  const first = await createSessionWithMemory(client, "muse@development", workshop);
+  assert.equal(first.created, true);
+  const replayed = await createSessionWithMemory(client, "muse@development", workshop);
+  assert.equal(replayed.created, false);
+  assert.equal(replayed.session.id, first.session.id);
+  await assert.rejects(
+    createSessionWithMemory(client, "muse@development", other),
+    (error: unknown) => error instanceof CLIError && error.code === "session_idempotency_conflict",
+  );
+  await assert.rejects(
+    createSessionWithMemory(client, "muse@development"),
+    (error: unknown) => error instanceof CLIError && error.code === "session_idempotency_conflict",
+  );
+  assert.equal(created, 1);
+  assert.equal(receipts.size, 1);
+});
+
 test("session create sends bindings, reports replay, and names a reused key's conflict", async (context) => {
   const bodies: Array<Record<string, unknown>> = [];
   let status = 201;

--- a/cli/src/memory-commands.ts
+++ b/cli/src/memory-commands.ts
@@ -106,10 +106,49 @@ export interface MemoryEditDraft {
   discard: () => Promise<void>;
 }
 
+/** A word as a POSIX shell reads it back unchanged. */
+export function shellWord(value: string): string {
+  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value)
+    ? value
+    : `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+/**
+ * The command that retries an edit from its kept draft: the same target
+ * (project and environment included, so it never lands on the linked
+ * project's Development by default), the same summary, and a path the
+ * shell reads back whatever it contains.
+ */
+export function memoryEditResumeCommand(input: {
+  projectId: string;
+  resource: string;
+  id: string;
+  environment: MemoryEnvironment;
+  summary?: string;
+  draftPath: string;
+}): string {
+  return [
+    "opencomputer memory edit",
+    shellWord(input.resource),
+    shellWord(input.id),
+    "--project",
+    shellWord(input.projectId),
+    "--environment",
+    input.environment,
+    ...(input.summary !== undefined
+      ? ["--summary", shellWord(input.summary)]
+      : []),
+    "--text-file",
+    shellWord(input.draftPath),
+  ].join(" ");
+}
+
 /**
  * Replaces a document's text at the revision that was read. On success the
  * draft file goes; on any failure it stays and the error names it, so an
- * over-limit, unreachable or failing save costs no work.
+ * over-limit, unreachable or failing save costs no work. An answer from the
+ * API is a verdict; no answer at all (the request never arrived, or its
+ * response was lost) is not, and is reported as an unconfirmed write.
  */
 export async function saveMemoryEdit(
   client: OpenComputerClient,
@@ -135,9 +174,19 @@ export async function saveMemoryEdit(
       : {};
     const resume = draft
       ? ` Your edited text is kept at ${draft.path}; save it with ` +
-        `\`opencomputer memory edit ${input.resource} ${input.id} --text-file ${draft.path}\`.`
+        `\`${memoryEditResumeCommand({ ...input, draftPath: draft.path })}\`.`
       : "";
-    if (error instanceof APIError && error.status === 412) {
+    if (!(error instanceof APIError)) {
+      const failure = structuredError(error);
+      throw new CLIError(
+        "memory_save_unconfirmed",
+        `${input.resource}/${input.id} may or may not have been saved: ${failure.message}`,
+        `Run \`opencomputer memory show ${shellWord(input.resource)} ${shellWord(input.id)} --project ${shellWord(input.projectId)} --environment ${input.environment}\` to see whether the revision changed before saving again.` +
+          resume,
+        { ...kept, expectedRevision: input.etag },
+      );
+    }
+    if (error.status === 412) {
       const latest = await client
         .memoryDocument(input)
         .catch(() => null);

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -1360,6 +1360,49 @@ ${declaration("documentMemory({ maxBytes: LIMIT })")}});
       /memory\.ts Memory requirements documentMemory\(\) maxBytes must be a static JSON value/,
     );
 
+    // Review reproduction (U5): a namespace member reached through bracket
+    // access executed a definition the compiler never registered.
+    await assert.rejects(
+      build(`import * as oc from "@opencomputer/agent";
+
+export const memory = oc["defineMemory"]({ id: "notes", description: "Notes." });
+`),
+      /memory\.ts calls oc\["defineMemory"\]\(\); the compiler registers memory only from a direct defineMemory\(\) call, so import defineMemory by name from @opencomputer\/agent/,
+    );
+    await assert.rejects(
+      build(`import * as oc from "@opencomputer/agent";
+
+const name = "defineMemory";
+export const memory = oc[name]({ id: "notes", description: "Notes." });
+`),
+      /memory\.ts accesses oc\[\.\.\.\] with a computed key; the compiler cannot tell whether that names a memory authoring function, so import what you need by name from @opencomputer\/agent/,
+    );
+    await assert.rejects(
+      build(`import * as oc from "@opencomputer/agent";
+
+const agent = oc;
+export const memory = agent.defineMemory({ id: "notes", description: "Notes." });
+`),
+      /memory\.ts uses the namespace import oc other than as oc\.<name>; the compiler registers memory only from a direct defineMemory\(\) call, so import defineMemory by name from @opencomputer\/agent/,
+    );
+    await assert.rejects(
+      build(`export const memory = (await import("@opencomputer/agent")).defineMemory({ id: "notes", description: "Notes." });
+`),
+      /memory\.ts imports @opencomputer\/agent dynamically; the compiler registers memory only from a static import, so import defineMemory by name/,
+    );
+    // The same reach through a module that re-exports the package.
+    await assert.rejects(
+      build(
+        `import * as lib from "./lib";
+
+export const memory = lib.defineMemory({ id: "notes", description: "Notes." });
+`,
+        ["lib.ts", 'export * from "@opencomputer/agent";\n'],
+      ),
+      /memory\.ts calls lib\.defineMemory\(\); the compiler registers memory only from a direct defineMemory\(\) call/,
+    );
+    await rm(resolve(initialized.agentRoot, "lib.ts"));
+
     // Type-only references and unaliased re-exports do not change what runs.
     await writeFile(
       resolve(initialized.agentRoot, "lib.ts"),
@@ -1380,6 +1423,52 @@ export const declared: Declared | undefined = undefined;
         provider: { kind: "document", maxBytes: 4096 },
       },
     ]);
+
+    // A star re-export and a re-export of an imported binding are chains the
+    // compiler follows; the namespace import stays usable for other members.
+    await writeFile(
+      resolve(initialized.agentRoot, "lib.ts"),
+      'import { documentMemory } from "@opencomputer/agent";\nexport * from "@opencomputer/agent";\nexport { documentMemory };\n',
+    );
+    const chained = await build(`import * as oc from "@opencomputer/agent";
+import { defineMemory, documentMemory } from "./lib";
+
+export const memory = defineMemory({
+${declaration("documentMemory({ maxBytes: 2_048 })")}});
+export const secret = oc.useSecret;
+`);
+    assert.deepEqual(chained.memory, [
+      {
+        id: "requirements",
+        description: "Requirements.",
+        provider: { kind: "document", maxBytes: 2048 },
+      },
+    ]);
+    await rm(resolve(initialized.agentRoot, "lib.ts"));
+
+    // Review reproduction (U5): the spelling alone is not a declaration. A
+    // property, a string and a local function of that name are unrelated to
+    // the package's defineMemory; they neither register memory nor fail the
+    // build.
+    await writeFile(
+      resolve(initialized.agentRoot, "agent.ts"),
+      `import { useInput } from "@opencomputer/agent";
+import { labels, config } from "./memory";
+
+export default function Agent() {
+  return \`\${labels.defineMemory}: \${config.id} \${useInput().text ?? ""}\`;
+}
+`,
+    );
+    const unrelated = await build(`export const labels = { defineMemory: "Memory settings" };
+
+function defineMemory(input: { id: string }) {
+  return { ...input, defineMemory: true };
+}
+export const config = defineMemory({ id: "settings" });
+export const spelled = "defineMemory";
+`);
+    assert.deepEqual(unrelated.memory, []);
   } finally {
     await rm(parent, { recursive: true, force: true });
   }

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -9,7 +9,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { readFileSync } from "node:fs";
-import { basename, dirname, relative, resolve } from "node:path";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Cron } from "croner";
 import { build as bundle } from "esbuild";
@@ -880,18 +880,181 @@ function definedMcpServers(
 
 /**
  * The memory authoring functions the compiler registers from. A declaration
- * only counts when one of them is called directly by its own name on literal
- * arguments: that is what lets the compiler run the same `defineMemory()` the
- * artifact runs and emit the executable definition itself. Any other use
- * (an alias, a namespace member, a wrapper, a re-export under another name)
- * would let the definition execute without being registered, or register
- * something the definition does not mean, so the build rejects it.
+ * only counts when one of them is called directly, through a binding that
+ * the compiler can trace to `@opencomputer/agent` (a named import, or a
+ * re-export chain through the project's own modules), on literal arguments:
+ * that is what lets the compiler run the same `defineMemory()` the artifact
+ * runs and emit the executable definition itself. Any other reach (an alias,
+ * a namespace member, a wrapper, a dynamic import) would let the definition
+ * execute without being registered, or register something the definition
+ * does not mean, so the build rejects it. A property, string or local
+ * function that merely spells one of these names is unrelated to them.
  */
-const MEMORY_AUTHORING_FUNCTIONS = new Set([
+type MemoryAuthoringFunction = "defineMemory" | "documentMemory" | "httpMemory";
+
+const MEMORY_AUTHORING_FUNCTIONS: ReadonlySet<string> = new Set<MemoryAuthoringFunction>([
   "defineMemory",
   "documentMemory",
   "httpMemory",
 ]);
+
+const AGENT_PACKAGE = "@opencomputer/agent";
+
+/** What a module makes available to importers, as far as memory authoring goes. */
+interface MemoryModuleExports {
+  /** Exported name -> the authoring function it is. */
+  functions: Map<string, MemoryAuthoringFunction>;
+  /** Exported names that are a namespace exposing the authoring functions. */
+  namespaces: Set<string>;
+}
+
+/** The local identifiers of one module that reach the authoring functions. */
+interface MemoryModuleBindings {
+  functions: Map<string, MemoryAuthoringFunction>;
+  namespaces: Set<string>;
+}
+
+const AGENT_PACKAGE_EXPORTS: MemoryModuleExports = {
+  functions: new Map(
+    [...MEMORY_AUTHORING_FUNCTIONS].map((name) => [
+      name,
+      name as MemoryAuthoringFunction,
+    ]),
+  ),
+  namespaces: new Set(),
+};
+
+const EMPTY_MEMORY_EXPORTS: MemoryModuleExports = {
+  functions: new Map(),
+  namespaces: new Set(),
+};
+
+/**
+ * Resolves, across the agent's own source modules, which identifiers are
+ * bound to the memory authoring functions of `@opencomputer/agent`. Third
+ * party packages are opaque: an import from one binds nothing here.
+ */
+class MemorySourceResolver {
+  private readonly files = new Map<string, ts.SourceFile>();
+  private readonly exports = new Map<string, MemoryModuleExports>();
+  private readonly resolving = new Set<string>();
+
+  constructor(private readonly modules: readonly AgentSourceModule[]) {}
+
+  file(path: string): ts.SourceFile {
+    let file = this.files.get(path);
+    if (!file) {
+      const module = this.modules.find((candidate) => candidate.path === path);
+      if (!module) throw new Error(`Agent source module ${path} is not in the build`);
+      file = ts.createSourceFile(path, module.source, ts.ScriptTarget.Latest, true);
+      this.files.set(path, file);
+    }
+    return file;
+  }
+
+  /** The module a specifier names from `from`: the agent package, one of ours, or neither. */
+  target(from: string, specifier: string): string | "package" | undefined {
+    if (specifier === AGENT_PACKAGE) return "package";
+    if (!specifier.startsWith("./") && !specifier.startsWith("../")) {
+      return undefined;
+    }
+    const base = join(dirname(from), specifier).split("\\").join("/");
+    const stem = base.replace(/\.[cm]?jsx?$/, "");
+    const candidates = [
+      base,
+      ...["ts", "tsx", "mts", "cts"].map((extension) => `${stem}.${extension}`),
+      ...["ts", "tsx", "js", "jsx", "mts", "mjs", "cts", "cjs"].map(
+        (extension) => `${base}.${extension}`,
+      ),
+      ...["ts", "tsx", "js", "jsx"].map((extension) => `${base}/index.${extension}`),
+    ];
+    return candidates.find((candidate) =>
+      this.modules.some((module) => module.path === candidate),
+    );
+  }
+
+  exportsOf(target: string | "package" | undefined): MemoryModuleExports {
+    if (target === "package") return AGENT_PACKAGE_EXPORTS;
+    if (target === undefined) return EMPTY_MEMORY_EXPORTS;
+    const cached = this.exports.get(target);
+    if (cached) return cached;
+    // A cycle contributes nothing on the way round; the first pass wins.
+    if (this.resolving.has(target)) return EMPTY_MEMORY_EXPORTS;
+    this.resolving.add(target);
+    const result: MemoryModuleExports = {
+      functions: new Map(),
+      namespaces: new Set(),
+    };
+    const bindings = this.bindingsOf(target);
+    for (const statement of this.file(target).statements) {
+      if (!ts.isExportDeclaration(statement) || statement.isTypeOnly) continue;
+      const source = statement.moduleSpecifier;
+      const from =
+        source && ts.isStringLiteral(source)
+          ? this.exportsOf(this.target(target, source.text))
+          : undefined;
+      if (!statement.exportClause) {
+        // export * from "..."
+        for (const [name, fn] of from?.functions ?? []) result.functions.set(name, fn);
+        for (const name of from?.namespaces ?? []) result.namespaces.add(name);
+        continue;
+      }
+      if (ts.isNamespaceExport(statement.exportClause)) {
+        // export * as ns from "..."
+        if (from && (from.functions.size || from.namespaces.size)) {
+          result.namespaces.add(statement.exportClause.name.text);
+        }
+        continue;
+      }
+      for (const specifier of statement.exportClause.elements) {
+        if (specifier.isTypeOnly) continue;
+        const local = (specifier.propertyName ?? specifier.name).text;
+        const exported = specifier.name.text;
+        if (from) {
+          const fn = from.functions.get(local);
+          if (fn) result.functions.set(exported, fn);
+          if (from.namespaces.has(local)) result.namespaces.add(exported);
+        } else {
+          const fn = bindings.functions.get(local);
+          if (fn) result.functions.set(exported, fn);
+          if (bindings.namespaces.has(local)) result.namespaces.add(exported);
+        }
+      }
+    }
+    this.resolving.delete(target);
+    this.exports.set(target, result);
+    return result;
+  }
+
+  bindingsOf(path: string): MemoryModuleBindings {
+    const bindings: MemoryModuleBindings = {
+      functions: new Map(),
+      namespaces: new Set(),
+    };
+    for (const statement of this.file(path).statements) {
+      if (!ts.isImportDeclaration(statement)) continue;
+      const clause = statement.importClause;
+      if (!clause || clause.isTypeOnly || !ts.isStringLiteral(statement.moduleSpecifier)) {
+        continue;
+      }
+      const from = this.exportsOf(this.target(path, statement.moduleSpecifier.text));
+      if (!from.functions.size && !from.namespaces.size) continue;
+      const named = clause.namedBindings;
+      if (named && ts.isNamespaceImport(named)) {
+        bindings.namespaces.add(named.name.text);
+      } else if (named) {
+        for (const specifier of named.elements) {
+          if (specifier.isTypeOnly) continue;
+          const imported = (specifier.propertyName ?? specifier.name).text;
+          const fn = from.functions.get(imported);
+          if (fn) bindings.functions.set(specifier.name.text, fn);
+          if (from.namespaces.has(imported)) bindings.namespaces.add(specifier.name.text);
+        }
+      }
+    }
+    return bindings;
+  }
+}
 
 function isTypeOnlyContext(node: ts.Node): boolean {
   return (
@@ -903,46 +1066,136 @@ function isTypeOnlyContext(node: ts.Node): boolean {
   );
 }
 
+/** An identifier that names a property, not a binding: `a.name`, `{ name: 1 }`, `{ name() {} }`. */
+function isPropertyNamePosition(node: ts.Identifier): boolean {
+  const parent = node.parent;
+  return (
+    (ts.isPropertyAccessExpression(parent) && parent.name === node) ||
+    (ts.isPropertyAssignment(parent) && parent.name === node) ||
+    (ts.isPropertySignature(parent) && parent.name === node) ||
+    (ts.isPropertyDeclaration(parent) && parent.name === node) ||
+    (ts.isMethodDeclaration(parent) && parent.name === node) ||
+    (ts.isMethodSignature(parent) && parent.name === node) ||
+    (ts.isGetAccessorDeclaration(parent) && parent.name === node) ||
+    (ts.isSetAccessorDeclaration(parent) && parent.name === node) ||
+    (ts.isEnumMember(parent) && parent.name === node) ||
+    (ts.isBindingElement(parent) && parent.propertyName === node) ||
+    (ts.isQualifiedName(parent) && parent.right === node)
+  );
+}
+
+const DIRECT_CALL_HINT = (name: string) =>
+  `the compiler registers memory only from a direct ${name}() call, so import ${name} by name from ${AGENT_PACKAGE}`;
+
 /**
- * Rejects every use of a memory authoring function other than an unaliased
+ * Rejects every reach to a memory authoring function other than an unaliased
  * import or export and a direct call, so a definition that executes is one
  * the compiler registered and vice versa.
  */
 function assertMemoryFunctionsCalledDirectly(
-  file: ts.SourceFile,
+  resolver: MemorySourceResolver,
   path: string,
-): void {
+): MemoryModuleBindings {
+  const file = resolver.file(path);
+  const bindings = resolver.bindingsOf(path);
   const visit = (node: ts.Node): void => {
     if (isTypeOnlyContext(node)) return;
-    if (ts.isIdentifier(node) && MEMORY_AUTHORING_FUNCTIONS.has(node.text)) {
-      const name = node.text;
-      const parent = node.parent;
-      const direct =
-        (ts.isCallExpression(parent) && parent.expression === node) ||
-        ((ts.isImportSpecifier(parent) || ts.isExportSpecifier(parent)) &&
-          parent.name === node &&
-          parent.propertyName === undefined);
-      if (!direct) {
-        if (ts.isImportSpecifier(parent) || ts.isExportSpecifier(parent)) {
-          const verb = ts.isImportSpecifier(parent) ? "imports" : "exports";
-          const imported = (parent.propertyName ?? parent.name).text;
+    if (ts.isExportDeclaration(node) && node.moduleSpecifier && node.exportClause &&
+        ts.isNamedExports(node.exportClause) && ts.isStringLiteral(node.moduleSpecifier)) {
+      // export { a as b } from "...": an aliased re-export of an authoring
+      // function would let importers call it under a name the compiler does
+      // not register from.
+      const from = resolver.exportsOf(resolver.target(path, node.moduleSpecifier.text));
+      for (const specifier of node.exportClause.elements) {
+        if (specifier.isTypeOnly || !specifier.propertyName) continue;
+        const imported = specifier.propertyName.text;
+        const fn = from.functions.get(imported);
+        if (fn && specifier.name.text !== imported) {
           throw new Error(
-            `${path} ${verb} ${imported} as ${parent.name.text}; the compiler registers memory only from a direct ${name}() call, so keep its name`,
+            `${path} exports ${imported} as ${specifier.name.text}; the compiler registers memory only from a direct ${fn}() call, so keep its name`,
           );
         }
-        if (ts.isPropertyAccessExpression(parent) && parent.name === node) {
+      }
+      return;
+    }
+    if (
+      ts.isCallExpression(node) &&
+      (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) && node.expression.text === "require"))
+    ) {
+      const argument = node.arguments[0];
+      if (argument && ts.isStringLiteralLike(argument)) {
+        const from = resolver.exportsOf(resolver.target(path, argument.text));
+        if (from.functions.size || from.namespaces.size) {
           throw new Error(
-            `${path} calls ${parent.expression.getText(file)}.${name}(); the compiler registers memory only from a direct ${name}() call, so import ${name} by name from @opencomputer/agent`,
+            `${path} imports ${argument.text} dynamically; the compiler registers memory only from a static import, so import defineMemory by name`,
           );
+        }
+      }
+    }
+    if (ts.isIdentifier(node) && !isPropertyNamePosition(node)) {
+      const parent = node.parent;
+      const fn = bindings.functions.get(node.text);
+      if (fn) {
+        const direct =
+          (ts.isCallExpression(parent) && parent.expression === node) ||
+          ((ts.isImportSpecifier(parent) || ts.isExportSpecifier(parent)) &&
+            parent.name === node &&
+            parent.propertyName === undefined);
+        if (!direct) {
+          if (ts.isImportSpecifier(parent) || ts.isExportSpecifier(parent)) {
+            const verb = ts.isImportSpecifier(parent) ? "imports" : "exports";
+            const imported = (parent.propertyName ?? parent.name).text;
+            throw new Error(
+              `${path} ${verb} ${imported} as ${parent.name.text}; the compiler registers memory only from a direct ${fn}() call, so keep its name`,
+            );
+          }
+          throw new Error(
+            `${path} uses ${node.text} other than as a direct ${node.text}() call; the compiler registers memory only from that call, so do not alias, wrap, or shadow it`,
+          );
+        }
+      }
+      if (bindings.namespaces.has(node.text) && !ts.isNamespaceImport(parent) &&
+          !(ts.isImportSpecifier(parent) && parent.name === node)) {
+        const namespace = node.text;
+        if (ts.isPropertyAccessExpression(parent) && parent.expression === node) {
+          const member = parent.name.text;
+          if (MEMORY_AUTHORING_FUNCTIONS.has(member)) {
+            const called = ts.isCallExpression(parent.parent) && parent.parent.expression === parent;
+            throw new Error(
+              called
+                ? `${path} calls ${namespace}.${member}(); ${DIRECT_CALL_HINT(member)}`
+                : `${path} uses ${namespace}.${member} other than as a direct ${member}() call; ${DIRECT_CALL_HINT(member)}`,
+            );
+          }
+          return;
+        }
+        if (ts.isElementAccessExpression(parent) && parent.expression === node) {
+          const key = parent.argumentExpression;
+          if (!ts.isStringLiteralLike(key)) {
+            throw new Error(
+              `${path} accesses ${namespace}[...] with a computed key; the compiler cannot tell whether that names a memory authoring function, so import what you need by name from ${AGENT_PACKAGE}`,
+            );
+          }
+          if (MEMORY_AUTHORING_FUNCTIONS.has(key.text)) {
+            const called = ts.isCallExpression(parent.parent) && parent.parent.expression === parent;
+            throw new Error(
+              called
+                ? `${path} calls ${namespace}[${JSON.stringify(key.text)}](); ${DIRECT_CALL_HINT(key.text)}`
+                : `${path} uses ${namespace}[${JSON.stringify(key.text)}] other than as a direct ${key.text}() call; ${DIRECT_CALL_HINT(key.text)}`,
+            );
+          }
+          return;
         }
         throw new Error(
-          `${path} uses ${name} other than as a direct ${name}() call; the compiler registers memory only from that call, so do not alias, wrap, or shadow it`,
+          `${path} uses the namespace import ${namespace} other than as ${namespace}.<name>; the compiler registers memory only from a direct defineMemory() call, so import defineMemory by name from ${AGENT_PACKAGE}`,
         );
       }
     }
     ts.forEachChild(node, visit);
   };
   visit(file);
+  return bindings;
 }
 
 /**
@@ -1041,19 +1294,21 @@ function memoryProviderValue(
   expression: ts.Expression,
   path: string,
   declaration: string,
+  bindings: MemoryModuleBindings,
   connectionBindings: ReadonlyMap<string, HttpConnectionManifest>,
 ): MemoryProvider {
+  const callee =
+    ts.isCallExpression(expression) && ts.isIdentifier(expression.expression)
+      ? bindings.functions.get(expression.expression.text)
+      : undefined;
   if (
     !ts.isCallExpression(expression) ||
-    !ts.isIdentifier(expression.expression) ||
-    (expression.expression.text !== "documentMemory" &&
-      expression.expression.text !== "httpMemory")
+    (callee !== "documentMemory" && callee !== "httpMemory")
   ) {
     throw new Error(
       `${path} ${declaration} provider must be an inline documentMemory() or httpMemory() call`,
     );
   }
-  const callee = expression.expression.text;
   const label = `${path} ${declaration} ${callee}()`;
   const argument = literalCallArgument(expression, label);
   if (callee === "documentMemory") {
@@ -1090,18 +1345,18 @@ function memoryProviderValue(
 }
 
 function definedMemory(
-  source: string,
+  resolver: MemorySourceResolver,
   path: string,
   connectionBindings: ReadonlyMap<string, HttpConnectionManifest>,
 ): MemoryDeclaration[] {
-  const file = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true);
-  assertMemoryFunctionsCalledDirectly(file, path);
+  const file = resolver.file(path);
+  const bindings = assertMemoryFunctionsCalledDirectly(resolver, path);
   const declarations: MemoryDeclaration[] = [];
   const visit = (node: ts.Node): void => {
     if (
       ts.isCallExpression(node) &&
       ts.isIdentifier(node.expression) &&
-      node.expression.text === "defineMemory"
+      bindings.functions.get(node.expression.text) === "defineMemory"
     ) {
       const label = `${path} defineMemory()`;
       const argument = literalCallArgument(node, label);
@@ -1119,7 +1374,13 @@ function definedMemory(
       for (const [name, value] of entries) {
         input[name] =
           name === "provider"
-            ? memoryProviderValue(value, path, declaration, connectionBindings)
+            ? memoryProviderValue(
+                value,
+                path,
+                declaration,
+                bindings,
+                connectionBindings,
+              )
             : staticJsonValue(value, `${label} ${name}`);
       }
       const definition: MemoryDefinition = inSourceFile(path, () =>
@@ -2464,10 +2725,11 @@ the product or support surface presented to users.
       `MCP server id ${JSON.stringify(duplicateMcpServer.id)} is defined more than once`,
     );
   }
+  const memoryResolver = new MemorySourceResolver(sourceModules);
   const memory = mergeMemoryDeclarations(
     sourceModules.map((module) => ({
       origin: module.path,
-      memory: definedMemory(module.source, module.path, connectionBindings),
+      memory: definedMemory(memoryResolver, module.path, connectionBindings),
     })),
   );
   const declaredMemory = new Set(memory.map((declaration) => declaration.id));

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -607,7 +607,9 @@ export default function App() {
     event.preventDefault();
     const prompt = input;
     setInput("");
-    void send(prompt);
+    // send rejects when no turn was admitted; the hook shows the error and
+    // the draft comes back.
+    send(prompt).catch(() => setInput(prompt));
   }
 
   return (
@@ -621,7 +623,7 @@ export default function App() {
       <section className="chat" aria-label="Agent conversation">
         <div className="messages">
           {messages.length === 0 ? (
-            <button className="suggestion" onClick={() => void send("Say hello and tell me what you can do.")}>
+            <button className="suggestion" onClick={() => send("Say hello and tell me what you can do.").catch(() => undefined)}>
               Say hello and tell me what you can do →
             </button>
           ) : (

--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -6,7 +6,7 @@ import {
   hasBYOKPlanAccess,
   mintManagedAgentsAssertion,
   proxyManagedAgents,
-  publicFailureMessage,
+  publicFailure,
 } from "./managed_agents";
 
 function legacyPlanEnv(plan: string) {
@@ -2312,9 +2312,10 @@ describe("managed agents proxy", () => {
     });
   });
 
-  // A failed turn carries its reason so the user can act on it; the reason is
-  // an operator-facing Error message, so paths, URLs and credentials go.
-  it("passes a sanitized turn failure reason through the event stream", async () => {
+  // A failed turn carries a typed public failure: a stable code, a fixed
+  // sentence and validated parameters. The runtime's own error text is an
+  // operator message and never leaves the edge, whatever it contains.
+  it("projects a turn failure as a typed public failure through the event stream", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () =>
@@ -2338,6 +2339,19 @@ describe("managed agents proxy", () => {
               seq: 10,
               timestamp: "2026-09-10T00:00:01.000Z",
               sessionId: "session-1",
+              turnId: "turn-2",
+              type: "turn.failed",
+              data: {
+                message:
+                  "The agent runtime stopped reporting on this turn and its lease expired",
+                reason: "runtime_lost",
+              },
+            },
+            {
+              id: "event_3",
+              seq: 11,
+              timestamp: "2026-09-10T00:00:02.000Z",
+              sessionId: "session-1",
               type: "session.failed",
               data: {},
             },
@@ -2359,49 +2373,158 @@ describe("managed agents proxy", () => {
     };
 
     expect(body.events[0].data).toEqual({
-      message:
-        "The Workerd runtime rejects any useModel other than anthropic/claude-sonnet-4.6 (requested openai/gpt-5)",
+      code: "model_unavailable",
+      message: "The model openai/gpt-5 is not available to this agent.",
+      model: "openai/gpt-5",
     });
     expect(body.events[1].data).toEqual({
+      code: "runtime_lost",
+      message:
+        "The agent runtime stopped responding and the turn was abandoned.",
+    });
+    expect(body.events[2].data).toEqual({
+      code: "agent_failed",
       message: "The agent could not complete this request.",
     });
     expect(JSON.stringify(body)).not.toContain("never-return-this");
+    expect(JSON.stringify(body)).not.toContain("Workerd");
   });
 
-  it("strips paths, URLs, credentials and stack frames from failure reasons", () => {
-    expect(
-      publicFailureMessage({
-        message: [
-          "ENOENT: no such file or directory, open '/Users/dev/app/.opencomputer/agent.js'",
-          "    at Object.openSync (node:fs:581:3)",
-          "    at /home/runner/work/index.js:12:5",
-        ].join("\n"),
-      }),
-    ).toBe("ENOENT: no such file or directory, open '<path>'");
-    expect(
-      publicFailureMessage({
-        message:
-          "fetch to http://127.0.0.1:4096/session/ses_1/message?token=abc failed: Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abcdefghijklmnopqrstuvwxyz",
-      }),
-    ).toBe("fetch to <url> failed: Authorization: Bearer <redacted>");
-    expect(
-      publicFailureMessage({
-        message:
-          "provider rejected api_key=sk-ant-api03-0123456789abcdefghijklmnop and osb_0123456789abcdef; retry",
-      }),
-    ).toBe("provider rejected api_key=<redacted> and <redacted>; retry");
-    expect(
-      publicFailureMessage({
-        reason: "Runtime harness is not ready\u0007",
-      }),
-    ).toBe("Runtime harness is not ready");
-    const long = publicFailureMessage({
-      message: "The turn exceeded its budget. ".repeat(40),
+  it("classifies known runtime failures into typed public failures", () => {
+    expect(publicFailure({ reason: "interrupted" })).toEqual({
+      code: "interrupted",
+      message: "The turn was interrupted before it finished.",
     });
-    expect(long).toHaveLength(500);
-    expect(long.endsWith("\u2026")).toBe(true);
-    expect(publicFailureMessage(undefined)).toBe(
-      "The agent could not complete this request.",
-    );
+    expect(
+      publicFailure({
+        message: "OpenCode execution was interrupted",
+        reason: "runtime_interrupted",
+      }),
+    ).toEqual({
+      code: "interrupted",
+      message: "The turn was interrupted before it finished.",
+    });
+    expect(publicFailure({ reason: "session_ended" })).toEqual({
+      code: "session_ended",
+      message: "The session ended before the turn finished.",
+    });
+    expect(
+      publicFailure({ message: "Model unavailable: openai/gpt-5-mini" }),
+    ).toEqual({
+      code: "model_unavailable",
+      message: "The model openai/gpt-5-mini is not available to this agent.",
+      model: "openai/gpt-5-mini",
+    });
+    // A model id that is not a model id is not echoed.
+    expect(
+      publicFailure({ message: "Model unavailable: sk-ant-api03-0123456789abcdefghijklmnop/x" }),
+    ).toEqual({
+      code: "model_unavailable",
+      message: "The requested model is not available to this agent.",
+    });
+    expect(
+      publicFailure({
+        message:
+          "AI_APICallError: 401 Unauthorized: invalid x-api-key sk-ant-api03-0123456789abcdefghijklmnop",
+      }),
+    ).toEqual({
+      code: "model_rejected",
+      message: "The model provider rejected the request.",
+    });
+    expect(
+      publicFailure({ message: "Rate limit exceeded; retry after 20s" }),
+    ).toEqual({
+      code: "model_rejected",
+      message: "The model provider rejected the request.",
+    });
+    expect(
+      publicFailure({
+        message: "prompt is too long: 214000 tokens > 200000 maximum context length",
+      }),
+    ).toEqual({
+      code: "context_too_long",
+      message: "The conversation is too long for the model's context window.",
+    });
+    expect(
+      publicFailure({ message: "Tool module exported an unregistered tool: lookup_venue" }),
+    ).toEqual({
+      code: "tool_failed",
+      message: "Tool lookup_venue failed.",
+      tool: "lookup_venue",
+    });
+    expect(publicFailure({ message: "The tool has no edge implementation" })).toEqual({
+      code: "tool_failed",
+      message: "A tool failed.",
+    });
+    expect(publicFailure({ message: "Sandbox operation timed out" })).toEqual({
+      code: "sandbox_timeout",
+      message: "A sandbox command did not finish in time.",
+    });
+    expect(
+      publicFailure({
+        message: "Sandbox acquisition returned 503: {\"error\":\"no capacity in us-east\"}",
+      }),
+    ).toEqual({
+      code: "sandbox_failed",
+      message: "The sandbox could not run this turn.",
+    });
+    expect(publicFailure({ reason: "Runtime harness is not ready\u0007" })).toEqual({
+      code: "runtime_failed",
+      message: "The agent runtime failed before the turn finished.",
+    });
+    expect(publicFailure({ message: "The Workerd runtime stream ended before the turn did" })).toEqual({
+      code: "runtime_failed",
+      message: "The agent runtime failed before the turn finished.",
+    });
+    expect(
+      publicFailure({ message: "The deployment is missing tool module \"tools/x.js\"" }),
+    ).toEqual({
+      code: "deployment_invalid",
+      message: "The deployment could not be loaded by the runtime.",
+    });
+    expect(publicFailure(undefined)).toEqual({
+      code: "agent_failed",
+      message: "The agent could not complete this request.",
+    });
+  });
+
+  // Review reproductions: text the label-and-length redaction used to let
+  // through. None of it is public now, because no runtime text is.
+  it("never publishes unclassified runtime error text", () => {
+    const leaks = [
+      'provider rejected {"api_key":"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"} for org 42',
+      "fetch failed: Authorization: Basic dXNlcjpwYXNz was refused",
+      "connect to db: password=hunter2 host=10.0.0.5",
+      [
+        "ENOENT: no such file or directory, open '/Users/dev/app/.opencomputer/agent.js'",
+        "    at Object.openSync (node:fs:581:3)",
+      ].join("\n"),
+      "fetch to http://127.0.0.1:4096/session/ses_1/message?token=abc failed",
+      "The turn exceeded its budget. ".repeat(40),
+    ];
+    expect(publicFailure({ message: leaks[3] })).toEqual({
+      code: "agent_failed",
+      message: "The agent could not complete this request.",
+    });
+    for (const message of leaks) {
+      const failure = publicFailure({ message });
+      // Whatever the classification, nothing but a fixed sentence goes out.
+      expect(Object.keys(failure).sort()).toEqual(["code", "message"]);
+      expect(failure.message).toMatch(/^[A-Z][a-z' ]+\.$/);
+      const serialized = JSON.stringify(failure);
+      expect(serialized).not.toContain("a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6");
+      expect(serialized).not.toContain("dXNlcjpwYXNz");
+      expect(serialized).not.toContain("hunter2");
+      expect(serialized).not.toContain("/Users/dev");
+      expect(serialized).not.toContain("127.0.0.1");
+    }
+    // Parameters are the only runtime-derived text, and they are validated:
+    // a credential in a model or tool position is dropped.
+    expect(
+      publicFailure({
+        message:
+          "Tool module exported an unregistered tool: sk-ant-api03-0123456789abcdefghijklmnop",
+      }),
+    ).toEqual({ code: "tool_failed", message: "A tool failed." });
   });
 });

--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -1826,6 +1826,282 @@ describe("managed agents proxy", () => {
     expect(serialized).not.toMatch(/runtimeToken|accountId|org_test/);
   });
 
+  // Public delivery slice (work 025): event subscriptions are managed under
+  // the project and pass through the edge one-to-one; the backend owns the
+  // body's validation, so fields this edge does not know (the environment
+  // scope, for one) reach it and come back untouched.
+  describe("event subscriptions", () => {
+    const env = {
+      OC_MANAGED_AGENTS_SECRET: "test-secret",
+      MANAGED_AGENTS_API_URL: "https://managedagents.test",
+    };
+    const caller = { orgID: "org_test", userID: "user_test" };
+    const subscription = {
+      id: "evs_1",
+      projectId: "prj_1",
+      agentId: "worker",
+      environment: "development",
+      events: ["turn.completed", "turn.failed"],
+      destination: { type: "session", sessionId: "ses_coordinator" },
+      createdBy: "user_private",
+      createdAt: "2026-09-10T12:00:00.000Z",
+    };
+    const publicSubscription = {
+      id: "evs_1",
+      projectId: "prj_1",
+      agentId: "worker",
+      environment: "development",
+      events: ["turn.completed", "turn.failed"],
+      destination: { type: "session", sessionId: "ses_coordinator" },
+      createdAt: "2026-09-10T12:00:00.000Z",
+    };
+
+    it("creates a subscription, forwarding the body as sent", async () => {
+      const fetchSpy = vi.fn(async () =>
+        Response.json({ subscription }, { status: 201 }),
+      );
+      vi.stubGlobal("fetch", fetchSpy);
+      const body = {
+        agentId: "worker",
+        events: ["turn.completed", "turn.failed"],
+        destination: { type: "session", sessionId: "ses_coordinator" },
+        environment: "development",
+      };
+
+      const response = await proxyManagedAgents(
+        new Request(
+          "https://app.opencomputer.dev/api/managed-agents/projects/prj_1/event-subscriptions",
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(body),
+          },
+        ),
+        env,
+        caller,
+        "/api/managed-agents",
+      );
+
+      expect(response.status).toBe(201);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      const [target, init] = fetchSpy.mock.calls[0] as unknown as [
+        URL,
+        RequestInit,
+      ];
+      expect(String(target)).toBe(
+        "https://managedagents.test/v1/projects/prj_1/event-subscriptions",
+      );
+      expect(init.method).toBe("POST");
+      expect(await new Response(init.body).json()).toEqual(body);
+      expect(await response.json()).toEqual({ subscription: publicSubscription });
+    });
+
+    it("lists, reads and deletes subscriptions", async () => {
+      const fetchSpy = vi.fn(async (input: URL | string, init?: RequestInit) => {
+        const url = String(input);
+        if (init?.method === "DELETE") return new Response(null, { status: 204 });
+        if (url.endsWith("/event-subscriptions")) {
+          return Response.json({ subscriptions: [subscription] });
+        }
+        return Response.json({ subscription });
+      });
+      vi.stubGlobal("fetch", fetchSpy);
+      const call = (path: string, method = "GET") =>
+        proxyManagedAgents(
+          new Request(`https://app.opencomputer.dev/api/managed-agents${path}`, {
+            method,
+          }),
+          env,
+          caller,
+          "/api/managed-agents",
+        );
+
+      const listed = await call("/projects/prj_1/event-subscriptions");
+      expect(listed.status).toBe(200);
+      expect(await listed.json()).toEqual({
+        subscriptions: [publicSubscription],
+      });
+
+      const read = await call("/projects/prj_1/event-subscriptions/evs_1");
+      expect(read.status).toBe(200);
+      expect(await read.json()).toEqual({ subscription: publicSubscription });
+
+      const deleted = await call(
+        "/projects/prj_1/event-subscriptions/evs_1",
+        "DELETE",
+      );
+      expect(deleted.status).toBe(204);
+      expect(
+        fetchSpy.mock.calls.map((call) => String((call as unknown[])[0])),
+      ).toEqual([
+        "https://managedagents.test/v1/projects/prj_1/event-subscriptions",
+        "https://managedagents.test/v1/projects/prj_1/event-subscriptions/evs_1",
+        "https://managedagents.test/v1/projects/prj_1/event-subscriptions/evs_1",
+      ]);
+      expect(JSON.stringify(fetchSpy.mock.results)).not.toContain("user_test");
+    });
+
+    it("keeps the backend's error codes for a rejected subscription", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          Response.json(
+            {
+              error: {
+                code: "destination_session_ended",
+                message: "Destination session has ended",
+              },
+            },
+            { status: 409 },
+          ),
+        ),
+      );
+      const response = await proxyManagedAgents(
+        new Request(
+          "https://app.opencomputer.dev/api/managed-agents/projects/prj_1/event-subscriptions",
+          { method: "POST", body: "{}" },
+        ),
+        env,
+        caller,
+        "/api/managed-agents",
+      );
+      expect(response.status).toBe(409);
+      expect(((await response.json()) as { error: { code: string } }).error.code).toBe(
+        "destination_session_ended",
+      );
+    });
+
+    it("does not admit other methods on subscription routes", async () => {
+      const fetchSpy = vi.fn();
+      vi.stubGlobal("fetch", fetchSpy);
+      for (const [path, method] of [
+        ["/projects/prj_1/event-subscriptions", "DELETE"],
+        ["/projects/prj_1/event-subscriptions/evs_1", "PATCH"],
+        ["/projects/prj_1/event-subscriptions/evs_1", "POST"],
+      ] as const) {
+        const response = await proxyManagedAgents(
+          new Request(`https://app.opencomputer.dev/api/managed-agents${path}`, {
+            method,
+          }),
+          env,
+          caller,
+          "/api/managed-agents",
+        );
+        expect(response.status).toBe(404);
+      }
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("projects a turn's deliveries on the session snapshot with typed errors only", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          Response.json({
+            id: "ses_worker",
+            status: "idle",
+            accountId: "org_test",
+            turns: [
+              {
+                id: "turn-1",
+                input: "Reproduce the guide",
+                mode: "queue",
+                status: "completed",
+                createdAt: "2026-09-10T12:00:00.000Z",
+                updatedAt: "2026-09-10T12:01:00.000Z",
+                deliveries: [
+                  {
+                    id: "evs_1:event_9",
+                    subscriptionId: "evs_1",
+                    eventId: "event_9",
+                    eventType: "turn.completed",
+                    destination: { type: "session", sessionId: "ses_coordinator" },
+                    status: "delivered",
+                    attempt: 1,
+                    receipt: { sessionId: "ses_coordinator", turnId: "turn-7" },
+                    updatedAt: "2026-09-10T12:01:01.000Z",
+                  },
+                  {
+                    id: "evs_2:event_9",
+                    subscriptionId: "evs_2",
+                    eventId: "event_9",
+                    eventType: "turn.completed",
+                    destination: { type: "session", sessionId: "ses_gone" },
+                    status: "failed",
+                    attempt: 1,
+                    error: "target_ended",
+                    updatedAt: "2026-09-10T12:01:01.000Z",
+                  },
+                  {
+                    id: "evs_3:event_9",
+                    subscriptionId: "evs_3",
+                    eventId: "event_9",
+                    eventType: "turn.completed",
+                    destination: { type: "session", sessionId: "ses_slow" },
+                    status: "pending",
+                    attempt: 2,
+                    nextAttemptAt: "2026-09-10T12:05:00.000Z",
+                    error:
+                      "Target session returned 500 at https://internal.do/sessions/ses_slow with token osb_0123456789abcdef",
+                    updatedAt: "2026-09-10T12:01:01.000Z",
+                  },
+                ],
+              },
+            ],
+          }),
+        ),
+      );
+
+      const response = await proxyManagedAgents(
+        new Request(
+          "https://app.opencomputer.dev/api/managed-agents/sessions/ses_worker",
+        ),
+        env,
+        caller,
+        "/api/managed-agents",
+      );
+      const body = (await response.json()) as {
+        turns: Array<{ deliveries: Array<Record<string, unknown>> }>;
+      };
+      expect(body.turns[0].deliveries).toEqual([
+        {
+          id: "evs_1:event_9",
+          subscriptionId: "evs_1",
+          eventId: "event_9",
+          eventType: "turn.completed",
+          destination: { type: "session", sessionId: "ses_coordinator" },
+          status: "delivered",
+          attempt: 1,
+          receipt: { sessionId: "ses_coordinator", turnId: "turn-7" },
+          updatedAt: "2026-09-10T12:01:01.000Z",
+        },
+        {
+          id: "evs_2:event_9",
+          subscriptionId: "evs_2",
+          eventId: "event_9",
+          eventType: "turn.completed",
+          destination: { type: "session", sessionId: "ses_gone" },
+          status: "failed",
+          attempt: 1,
+          error: "target_ended",
+          updatedAt: "2026-09-10T12:01:01.000Z",
+        },
+        {
+          id: "evs_3:event_9",
+          subscriptionId: "evs_3",
+          eventId: "event_9",
+          eventType: "turn.completed",
+          destination: { type: "session", sessionId: "ses_slow" },
+          status: "pending",
+          attempt: 2,
+          nextAttemptAt: "2026-09-10T12:05:00.000Z",
+          error: "delivery_failed",
+          updatedAt: "2026-09-10T12:01:01.000Z",
+        },
+      ]);
+      expect(JSON.stringify(body)).not.toMatch(/internal\.do|osb_|accountId/);
+    });
+  });
+
   it("removes backend artifact and runtime fields from successful responses", async () => {
     vi.stubGlobal(
       "fetch",

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -655,6 +655,79 @@ function publicWebhookRequest(value: unknown): Record<string, unknown> {
   };
 }
 
+// Event subscriptions (docs/agents/api.mdx, "Event subscriptions"): the
+// backend owns the body and the object, so both pass through as written,
+// less who created it. Fields the edge does not know (the environment scope,
+// for one) are the backend's to validate and are kept.
+const EVENT_SUBSCRIPTIONS_ROUTE = /^\/projects\/[^/]+\/event-subscriptions$/;
+const EVENT_SUBSCRIPTION_ROUTE =
+  /^\/projects\/[^/]+\/event-subscriptions\/[^/]+$/;
+
+function isEventSubscriptionRoute(method: string, suffix: string): boolean {
+  return (
+    ((method === "GET" || method === "POST") &&
+      EVENT_SUBSCRIPTIONS_ROUTE.test(suffix)) ||
+    ((method === "GET" || method === "DELETE") &&
+      EVENT_SUBSCRIPTION_ROUTE.test(suffix))
+  );
+}
+
+function publicEventSubscription(value: unknown): unknown {
+  const subscription = record(stripPrivateValues(value));
+  if (!subscription) return value;
+  const { createdBy: _createdBy, ...rest } = subscription;
+  return rest;
+}
+
+// A delivery's `error` is the backend's terminal verdict when it is one of
+// its codes; any other text is an operator message and is not public.
+const DELIVERY_ERROR_CODES = new Set([
+  "subscription_unavailable",
+  "target_missing",
+  "target_ended",
+]);
+
+function publicDelivery(value: unknown): Record<string, unknown> {
+  const delivery = record(value) ?? {};
+  const receipt = record(delivery.receipt);
+  return {
+    id: delivery.id,
+    subscriptionId: delivery.subscriptionId,
+    eventId: delivery.eventId,
+    eventType: delivery.eventType,
+    destination: stripPrivateValues(delivery.destination),
+    status: delivery.status,
+    attempt: delivery.attempt,
+    ...(receipt
+      ? { receipt: { sessionId: receipt.sessionId, turnId: receipt.turnId } }
+      : {}),
+    ...(typeof delivery.nextAttemptAt === "string"
+      ? { nextAttemptAt: delivery.nextAttemptAt }
+      : {}),
+    ...(typeof delivery.error === "string"
+      ? {
+          error: DELIVERY_ERROR_CODES.has(delivery.error)
+            ? delivery.error
+            : "delivery_failed",
+        }
+      : {}),
+    updatedAt: delivery.updatedAt,
+  };
+}
+
+function publicSessionSnapshot(value: unknown): unknown {
+  const session = record(stripPrivateValues(value));
+  if (!session || !Array.isArray(session.turns)) return session ?? value;
+  return {
+    ...session,
+    turns: session.turns.map((entry) => {
+      const turn = record(entry);
+      if (!turn || !Array.isArray(turn.deliveries)) return entry;
+      return { ...turn, deliveries: turn.deliveries.map(publicDelivery) };
+    }),
+  };
+}
+
 const PRIVATE_EVENT_KEYS = new Set([
   "accountId",
   "account_id",
@@ -1026,6 +1099,19 @@ function publicSuccessBody(
         : [],
     };
   }
+  if (method === "GET" && EVENT_SUBSCRIPTIONS_ROUTE.test(suffix)) {
+    return {
+      subscriptions: Array.isArray(body.subscriptions)
+        ? body.subscriptions.map(publicEventSubscription)
+        : [],
+    };
+  }
+  if (
+    (method === "POST" && EVENT_SUBSCRIPTIONS_ROUTE.test(suffix)) ||
+    (method === "GET" && EVENT_SUBSCRIPTION_ROUTE.test(suffix))
+  ) {
+    return { subscription: publicEventSubscription(body.subscription) };
+  }
   if (
     (method === "GET" || method === "PUT") &&
     /^\/projects\/[^/]+\/runtime-variables(?:\/[^/]+)?$/.test(suffix)
@@ -1267,12 +1353,20 @@ function publicSuccessBody(
       updatedAt: body.updatedAt,
     };
   }
+  if (method === "GET" && suffix === "/sessions") {
+    return {
+      ...(record(stripPrivateValues(body)) ?? {}),
+      sessions: Array.isArray(body.sessions)
+        ? body.sessions.map(publicSessionSnapshot)
+        : [],
+    };
+  }
   if (
-    (method === "GET" && /^\/sessions(?:\/[^/]+)?$/.test(suffix)) ||
+    (method === "GET" && /^\/sessions\/[^/]+$/.test(suffix)) ||
     (method === "POST" &&
       /^\/sessions\/[^/]+\/(resume|end|terminate|interrupt)$/.test(suffix))
   ) {
-    return stripPrivateValues(body);
+    return publicSessionSnapshot(body);
   }
   throw new Error("Unsupported managed agents response");
 }
@@ -1288,7 +1382,9 @@ async function publicSuccessResponse(
   const headers = new Headers({ "content-type": "application/json" });
   const cacheControl = upstream.headers.get("cache-control");
   if (cacheControl) headers.set("cache-control", cacheControl);
-  if (suffix.includes("/webhooks")) headers.set("cache-control", "no-store");
+  if (suffix.includes("/webhooks") || suffix.includes("/event-subscriptions")) {
+    headers.set("cache-control", "no-store");
+  }
   return new Response(
     JSON.stringify(
       publicSuccessBody(
@@ -1469,6 +1565,7 @@ function isAllowedManagedAgentsRoute(method: string, suffix: string): boolean {
     return true;
   }
   if (isMemoryRoute(method, suffix)) return true;
+  if (isEventSubscriptionRoute(method, suffix)) return true;
   if (
     (method === "GET" || method === "PUT" || method === "DELETE") &&
     /^\/projects\/[^/]+\/runtime-variables(?:\/[^/]+)?$/.test(suffix)

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -678,50 +678,170 @@ const PRIVATE_EVENT_KEYS = new Set([
   "platform_instructions",
 ]);
 
-const GENERIC_FAILURE_MESSAGE = "The agent could not complete this request.";
-const FAILURE_MESSAGE_LIMIT = 500;
+export type PublicFailureCode =
+  | "interrupted"
+  | "session_ended"
+  | "runtime_lost"
+  | "runtime_failed"
+  | "deployment_invalid"
+  | "model_unavailable"
+  | "model_rejected"
+  | "context_too_long"
+  | "tool_failed"
+  | "sandbox_timeout"
+  | "sandbox_failed"
+  | "agent_failed";
 
-// A turn or session failure reason is an Error message from the runtime,
-// written for operators: it names what went wrong (a rejected model, a tool
-// that is not available, a harness that never became ready) and the user
-// needs that to act. It can also carry what the user must not see: absolute
-// paths, internal URLs, credentials, stack frames. Keep the sentence, drop
-// those.
-export function publicFailureMessage(value: unknown): string {
+/**
+ * What a `turn.failed` or `session.failed` event says in public: a stable
+ * code, a fixed sentence, and at most one validated parameter. The runtime's
+ * own error text is written for operators and can carry anything (paths,
+ * internal URLs, credentials, stack frames), so it is classified here and
+ * never forwarded. A failure no rule recognizes is `agent_failed`.
+ */
+export interface PublicFailure {
+  code: PublicFailureCode;
+  message: string;
+  /** The model the agent asked for, when the runtime rejected it by id. */
+  model?: string;
+  /** The tool that failed, when the runtime named it. */
+  tool?: string;
+}
+
+const GENERIC_FAILURE_MESSAGE = "The agent could not complete this request.";
+
+const PUBLIC_FAILURE_MESSAGES: Record<PublicFailureCode, string> = {
+  interrupted: "The turn was interrupted before it finished.",
+  session_ended: "The session ended before the turn finished.",
+  runtime_lost:
+    "The agent runtime stopped responding and the turn was abandoned.",
+  runtime_failed: "The agent runtime failed before the turn finished.",
+  deployment_invalid: "The deployment could not be loaded by the runtime.",
+  model_unavailable: "The requested model is not available to this agent.",
+  model_rejected: "The model provider rejected the request.",
+  context_too_long:
+    "The conversation is too long for the model's context window.",
+  tool_failed: "A tool failed.",
+  sandbox_timeout: "A sandbox command did not finish in time.",
+  sandbox_failed: "The sandbox could not run this turn.",
+  agent_failed: GENERIC_FAILURE_MESSAGE,
+};
+
+// The typed reasons the session records itself, ahead of any runtime text.
+const FAILURE_REASON_CODES: Record<string, PublicFailureCode> = {
+  interrupted: "interrupted",
+  runtime_interrupted: "interrupted",
+  session_ended: "session_ended",
+  runtime_lost: "runtime_lost",
+};
+
+// A parameter is the only runtime-derived text a public failure carries, so
+// it must look like what it claims to be; anything else is dropped.
+const MODEL_ID =
+  /^(?:[a-z][a-z0-9-]{0,31}\/)?[a-z0-9][a-z0-9._:-]{0,63}$/i;
+const TOOL_ID = /^[a-z0-9_][a-z0-9_.-]{0,63}$/i;
+const CREDENTIAL_SHAPED =
+  /^(?:sk|osb|ghp|gho|ghs|ghu|ghr|github_pat|xox[abprs]|key|token|secret)[-_]/i;
+
+function validParameter(pattern: RegExp, value: string | undefined) {
+  return value !== undefined &&
+    pattern.test(value) &&
+    !CREDENTIAL_SHAPED.test(value)
+    ? value
+    : undefined;
+}
+
+// Message rules, first match wins. Each names the runtime error family it
+// recognizes; the captured group, if any, is the parameter.
+const FAILURE_MESSAGE_RULES: ReadonlyArray<{
+  code: PublicFailureCode;
+  pattern: RegExp;
+  parameter?: "model" | "tool";
+}> = [
+  {
+    code: "model_unavailable",
+    pattern: /rejects any useModel other than \S+ \(requested (\S+)\)/,
+    parameter: "model",
+  },
+  {
+    code: "model_unavailable",
+    pattern: /^Model unavailable: (\S+?)\.?(?:\s|$)/,
+    parameter: "model",
+  },
+  {
+    code: "model_unavailable",
+    pattern: /\bmodel (?:is )?not (?:found|available|supported)\b|ModelNotFound/i,
+  },
+  {
+    code: "context_too_long",
+    pattern:
+      /context (?:length|window|overflow)|too long|exceeds? the (?:maximum )?(?:context|token)|ContextOverflow/i,
+  },
+  {
+    code: "model_rejected",
+    pattern:
+      /\b(?:401|403|429)\b|unauthori[sz]ed|invalid (?:x-)?api[ _-]?key|authentication|rate limit|quota|overloaded|insufficient(?: |_)(?:credits|quota)|APICallError|provider (?:rejected|error)/i,
+  },
+  {
+    code: "tool_failed",
+    pattern:
+      /^Tool (?:module exported an unregistered tool|is defined more than once): (\S+)$/,
+    parameter: "tool",
+  },
+  {
+    code: "tool_failed",
+    pattern: /^(?:Unknown tool|Tool) "?([A-Za-z0-9_.-]+)"? (?:failed|is not (?:available|registered)|threw)/,
+    parameter: "tool",
+  },
+  { code: "tool_failed", pattern: /^The tool has no edge implementation/ },
+  { code: "sandbox_timeout", pattern: /^Sandbox operation timed out/ },
+  {
+    code: "sandbox_failed",
+    pattern: /^(?:Sandbox|The sandbox|Cannot terminate the sandbox)\b/,
+  },
+  {
+    code: "deployment_invalid",
+    pattern:
+      /^(?:The deployment is missing|The Workerd agent artifact|The Workerd session has no pinned deployment|This Workerd slice requires|Agent must return instructions|Invalid artifact module path|The (?:private artifact service|Dynamic Worker Loader) is not configured|Artifact service returned)/,
+  },
+  {
+    code: "runtime_failed",
+    pattern:
+      /^(?:Runtime harness|OpenCode|The (?:Workerd|reactive) (?:runtime|harness)|Prestarted OpenCode|Workerd runtime|Agent (?:render|tool metadata) returned|Render commit returned|Session state returned|Agent selected an unregistered)/,
+  },
+];
+
+export function publicFailure(value: unknown): PublicFailure {
   const data = record(value) ?? {};
-  const raw =
-    typeof data.message === "string"
-      ? data.message
-      : typeof data.reason === "string"
-        ? data.reason
-        : "";
-  const message = raw
-    .split(/\r?\n/)
-    // Stack frames and their "Caused by" chains.
-    .filter((line) => !/^\s+at\s|^\s*caused by:/i.test(line))
-    .join(" ")
-    // Internal topology: URLs, then absolute filesystem paths. A bare name
-    // such as a model id (`anthropic/claude-sonnet-4.6`) is not a path.
-    .replace(/\b[a-z][a-z0-9+.-]*:\/\/[^\s"'`)\]]+/gi, "<url>")
-    .replace(/(?<![\w@:.-])\/(?:[\w@.+-]+\/)+[\w@.+-]*/g, "<path>")
-    // Credentials by label, by prefix, then anything long enough to be one.
-    .replace(/\bBearer\s+\S+/gi, "Bearer <redacted>")
-    .replace(
-      /\b((?:api[_-]?key|token|secret|password|authorization))\s*[=:]\s*"?[^\s"',;]{16,}/gi,
-      "$1=<redacted>",
-    )
-    .replace(
-      /\b(?:sk|osb|ghp|gho|ghs|ghu|ghr|github_pat|xox[abprs])[-_][A-Za-z0-9_-]{8,}/g,
-      "<redacted>",
-    )
-    .replace(/\b[A-Za-z0-9+/_-]{40,}={0,2}\b/g, "<redacted>")
-    .replace(/[\u0000-\u001f\u007f]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  if (!message) return GENERIC_FAILURE_MESSAGE;
-  return message.length > FAILURE_MESSAGE_LIMIT
-    ? `${message.slice(0, FAILURE_MESSAGE_LIMIT - 1)}\u2026`
-    : message;
+  const reason = typeof data.reason === "string" ? data.reason : "";
+  const known = FAILURE_REASON_CODES[reason];
+  if (known) return { code: known, message: PUBLIC_FAILURE_MESSAGES[known] };
+  const message = typeof data.message === "string" ? data.message : reason;
+  // Classification reads only the first line: the sentence the runtime
+  // wrote, before any stack frame or cause chain.
+  const firstLine = message.split(/\r?\n/, 1)[0].trim();
+  for (const rule of FAILURE_MESSAGE_RULES) {
+    const match = firstLine.match(rule.pattern);
+    if (!match) continue;
+    if (rule.parameter === "model") {
+      const model = validParameter(MODEL_ID, match[1]);
+      if (model) {
+        return {
+          code: rule.code,
+          message: `The model ${model} is not available to this agent.`,
+          model,
+        };
+      }
+    }
+    if (rule.parameter === "tool") {
+      const tool = validParameter(TOOL_ID, match[1]);
+      if (tool) {
+        return { code: rule.code, message: `Tool ${tool} failed.`, tool };
+      }
+    }
+    return { code: rule.code, message: PUBLIC_FAILURE_MESSAGES[rule.code] };
+  }
+  return { code: "agent_failed", message: GENERIC_FAILURE_MESSAGE };
 }
 
 function publicEventData(
@@ -730,7 +850,7 @@ function publicEventData(
 ): Record<string, unknown> {
   if (type.startsWith("runtime.") && type !== "runtime.log") return {};
   if (type === "session.failed" || type === "turn.failed") {
-    return { message: publicFailureMessage(value) };
+    return { ...publicFailure(value) };
   }
   const data = record(value) ?? {};
   return Object.fromEntries(

--- a/docs/agents/api.mdx
+++ b/docs/agents/api.mdx
@@ -107,7 +107,7 @@ insufficient_credits`.
 | `status` | `new`, `connecting`, `idle`, `running`, `waiting_runtime`, `suspending`, `suspended`, `resuming`, `failed` or `ended` |
 | `source` | The `source` given at creation |
 | `memory` | Bindings with `resource`, `scope`, `id`, `access` and `writable`; present when the session was created with bindings |
-| `turns` | Every turn: `id`, `input`, `mode`, `status`, `createdAt`, `updatedAt` |
+| `turns` | Every turn: `id`, `input`, `mode`, `status`, `createdAt`, `updatedAt`, and `deliveries` when an [event subscription](#event-subscriptions) selected its outcome |
 | `createdAt`, `updatedAt` | Timestamps |
 
 `GET /sessions` returns `{ sessions }`: the fifty most recently updated
@@ -228,6 +228,74 @@ for an agent that is not deployed in the environment is
 curl 'https://app.opencomputer.dev/api/managed-agents/projects/<project-id>/webhooks/<webhook-id>/requests' \
   -H 'x-api-key: <api-key>'
 ```
+
+## Event subscriptions
+
+An event subscription delivers the recorded outcome of turns run by agents
+in a project to a session in the same project, as a new turn of that
+session. It is how one agent learns that another finished: a coordinator
+subscribes to its workers' outcomes and reasons about them when they arrive.
+Destinations are sessions only; there is no public HTTPS destination, and
+this is not the [outbound webhooks](/agents/webhooks) feature.
+
+| Operation | Method and path | Success |
+| --- | --- | --- |
+| Create | `POST /projects/<p>/event-subscriptions` | `201` with `{ subscription }` |
+| List | `GET /projects/<p>/event-subscriptions` | `200` with `{ subscriptions }` |
+| Get | `GET /projects/<p>/event-subscriptions/<id>` | `200` with `{ subscription }` |
+| Delete | `DELETE /projects/<p>/event-subscriptions/<id>` | `204`; pending deliveries stop |
+
+```bash
+curl -X POST 'https://app.opencomputer.dev/api/managed-agents/projects/<project-id>/event-subscriptions' \
+  -H 'x-api-key: <api-key>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "agentId": "worker",
+    "events": ["turn.completed", "turn.failed"],
+    "destination": { "type": "session", "sessionId": "<coordinator-session-id>" },
+    "environment": "development"
+  }'
+```
+
+| Field | Meaning |
+| --- | --- |
+| `agentId` | Optional. Outcomes of this agent only; omitted, every agent in the project. |
+| `events` | One or more of `turn.completed`, `turn.failed`, `turn.cancelled`. Turn outcomes, not session ends. |
+| `destination` | `{ type: "session", sessionId }`: a session of an agent in this project that can still take turns. |
+| `environment` | `development` or `production`. A subscription is scoped to one environment: it selects outcomes recorded there and its destination session runs there. |
+
+A subscription is immutable; `{ subscription }` carries `id`, `projectId`,
+the fields above and `createdAt`. Codes: `400 invalid_event_subscription`,
+`403 project_scope_violation` (the agent is outside the project),
+`404 destination_session_not_found`, `409 destination_session_ended`,
+`404 event_subscription_not_found`.
+
+### Delivery and receipts
+
+When a selected turn settles, the source session records one delivery per
+matching subscription and starts a turn on the destination session with
+`source: "event"` input; the receiving agent reads it with `useInput()`
+([Event input](/agents/inputs#event-input)). The destination turn's
+idempotency key is `<subscription-id>:<event-id>`, so a retried delivery
+never starts a second turn. Deliveries are retried with backoff and stop
+when the subscription is deleted or the destination has ended.
+
+`GET /sessions/<id>` on the source session lists each turn's `deliveries`:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | `<subscription-id>:<event-id>` |
+| `subscriptionId`, `eventId`, `eventType` | What was delivered, to which subscription |
+| `destination` | The subscription's destination |
+| `status` | `pending`, `delivered` or `failed` |
+| `attempt` | Delivery attempts so far |
+| `receipt` | `{ sessionId, turnId }`: the turn the destination admitted, once delivered |
+| `nextAttemptAt` | When a pending delivery is retried |
+| `error` | `subscription_unavailable`, `target_missing`, `target_ended`, or `delivery_failed` |
+
+The delivered event names identifiers and the outcome; a completed turn's
+final message is included, bounded to 16 KB. The receiving agent should
+treat that text as data about another agent's work, not as instructions.
 
 ## Projects, agents and deployments
 

--- a/docs/agents/events.mdx
+++ b/docs/agents/events.mdx
@@ -45,7 +45,7 @@ unknown type as informational and keep reading.
 | `session.created` | The session exists. Always the first event. | `agentId`, `deploymentId` |
 | `session.status_changed` | The session moved between `new`, `connecting`, `idle`, `running`, `waiting_runtime`, `suspending`, `suspended`, `resuming`, `failed` and `ended` | `from`, `to` |
 | `session.ended` | The owner ended the session. Queued and running turns were cancelled and memory writes revoked. | none |
-| `session.failed` | The session cannot continue | `message`: a sanitized reason |
+| `session.failed` | The session cannot continue | `code`, `message`: a [public failure](#public-failures) |
 
 ### Turns
 
@@ -57,13 +57,29 @@ unknown type as informational and keep reading.
 | `turn.interrupted` | This turn cancelled the turns that were running | `interruptedTurnIds` |
 | `turn.started` | The runtime began the turn | none |
 | `turn.completed` | The turn finished and the session is idle again | none |
-| `turn.failed` | The turn stopped with an error | `message`: the runtime's reason, sanitized |
+| `turn.failed` | The turn stopped with an error | `code`, `message`, and `model` or `tool` when named: a [public failure](#public-failures) |
 | `turn.cancelled` | The turn was stopped by an interrupt | `reason`: `interrupted`; `replacementTurnId` when an interrupt-mode turn replaced it |
 
-A failed turn's `message` is the runtime's own error, for example a rejected
-model or a tool that is not available. Stack frames, URLs, file paths and
-credential-shaped values are removed and the text is capped at 500
-characters; when nothing readable remains, a generic sentence is sent.
+#### Public failures
+
+A failure's `data` is a stable `code`, a fixed `message` for that code, and
+at most one parameter. The runtime's own error text is never sent; a failure
+no rule recognizes is `agent_failed`.
+
+| `code` | Meaning | Parameter |
+| --- | --- | --- |
+| `interrupted` | The turn was stopped before it finished | |
+| `session_ended` | The session ended while the turn ran | |
+| `runtime_lost` | The runtime stopped responding and the turn was abandoned | |
+| `runtime_failed` | The runtime failed before the turn finished | |
+| `deployment_invalid` | The runtime could not load the deployment | |
+| `model_unavailable` | The requested model is not available to this agent | `model`: the requested model id |
+| `model_rejected` | The model provider rejected the request: credentials, rate limit or quota | |
+| `context_too_long` | The conversation exceeds the model's context window | |
+| `tool_failed` | A tool failed | `tool`: the tool id, when the runtime named it |
+| `sandbox_timeout` | A sandbox command did not finish in time | |
+| `sandbox_failed` | The sandbox could not run the turn | |
+| `agent_failed` | Any other failure | |
 
 ### Messages
 

--- a/docs/agents/inputs.mdx
+++ b/docs/agents/inputs.mdx
@@ -32,7 +32,7 @@ interface AgentInput {
 
 | Field | Meaning |
 | --- | --- |
-| `source` | How the work entered the session |
+| `source` | How the work entered the session: `user`, `channel`, `schedule`, `webhook`, `subagent`, `system` or `event` |
 | `text` | Optional human-readable message |
 | `payload` | Optional structured JSON value supplied by the source |
 
@@ -81,6 +81,44 @@ export default function Agent() {
 ```
 
 Validate untrusted payloads in a tool before performing side effects.
+
+## Event input
+
+When an [event subscription](/agents/api#event-subscriptions) delivers
+another session's turn outcome to this one, the turn's input has
+`source: "event"` and an `event`:
+
+```tsx
+import { useInput } from "@opencomputer/agent";
+
+export default function Agent() {
+  const input = useInput();
+  if (input.source === "event") {
+    const { event } = input;
+    if (event.type === "turn.completed") {
+      return `Worker ${event.agentId} finished turn ${event.turnId}. Its final message: ${event.result?.text ?? "(none)"}. Decide what happens next.`;
+    }
+    return `Worker ${event.agentId}'s turn ${event.type === "turn.failed" ? "failed" : "was cancelled"} (${event.reason ?? "no reason"}). ${event.error ?? ""}`;
+  }
+  return `Help with: ${input.text ?? "the current request"}`;
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `event.id` | The source session's event id for its terminal `turn.*` event |
+| `event.type` | `turn.completed`, `turn.failed` or `turn.cancelled` |
+| `event.sessionId`, `event.turnId`, `event.agentId` | Whose outcome this is |
+| `event.occurredAt` | When the source turn settled |
+| `event.reason` | Why it failed or was cancelled, when recorded |
+| `event.error` | The failure message, bounded, when it failed |
+| `event.result` | `{ text, truncated }`: the final assistant message of a completed turn, bounded to 16 KB |
+
+An event input carries no `text`; read `event`. The turn's recorded input in
+the [event log](/agents/events) is a text description of the same outcome.
+The platform attests where the input came from through `source`; the
+included message is another agent's output and is data to reason about, not
+instructions to follow.
 
 ## Input is not a prompt UI
 

--- a/docs/agents/memory.mdx
+++ b/docs/agents/memory.mdx
@@ -26,9 +26,12 @@ before binding it to a session.
 
 `notes` is an application-defined resource name. It can contain many documents;
 this example calls one `workshop`. Neither name is built into OpenComputer.
-Declare with a direct `defineMemory({...})` on a literal object; the compiler
-rejects aliases, spreads and variables so that what it registers is exactly
-what runs.
+Declare with a direct `defineMemory({...})` on a literal object, calling the
+function imported by name from `@opencomputer/agent` (or re-exported under
+that name by one of your own modules); the compiler rejects aliases,
+namespace members such as `agent.defineMemory`, spreads and variables so
+that what it registers is exactly what runs. Anything else that merely
+spells `defineMemory`, such as a property of your own, is unrelated to it.
 
 ## Read it in the render
 

--- a/docs/agents/react.mdx
+++ b/docs/agents/react.mdx
@@ -101,6 +101,7 @@ envelope `{ error: { message } }`.
 ### 3. Attach in the browser
 
 ```tsx
+import { useState } from "react";
 import { useAgent } from "@opencomputer/react";
 
 export function WorkshopChat({ sessionId, onNotesChanged }: { sessionId: string; onNotesChanged: () => void }) {
@@ -109,6 +110,12 @@ export function WorkshopChat({ sessionId, onNotesChanged }: { sessionId: string;
     basePath: "/api/agent",
     onMemorySaved: onNotesChanged,
   });
+  const [draft, setDraft] = useState("");
+
+  async function submit() {
+    await send(draft); // rejects when no turn was admitted
+    setDraft(""); // clear only once the platform has the input
+  }
 
   return (
     <section>
@@ -118,7 +125,8 @@ export function WorkshopChat({ sessionId, onNotesChanged }: { sessionId: string;
           <strong>{message.role}:</strong> {message.text}
         </p>
       ))}
-      <button disabled={isRunning} onClick={() => void send("Book the venue")}>Send</button>
+      <input value={draft} onChange={(event) => setDraft(event.target.value)} />
+      <button onClick={() => submit().catch(() => undefined)}>Send</button>
       <button disabled={!isRunning} onClick={() => void stop()}>Stop</button>
       {error ? <p role="alert">{error}</p> : null}
     </section>
@@ -131,12 +139,41 @@ reduces it to messages, so a reopened page shows the conversation as it
 stands, including turns that ran while the tab was closed. It then keeps
 polling from its cursor. A failed poll sets `error`, backs off, and resumes
 from the same cursor; nothing is replayed twice, and `error` clears when the
-log answers again. Changing `sessionId` replays the new session.
+log answers again. Changing `sessionId` replays the new session; a `send`
+still in flight for the previous session settles for its caller but never
+changes what the new session shows.
 
-`send` starts a turn and shows the input at once; the log's own record of it
-confirms that message rather than adding a second one. Turns sent while one
-is running are queued by the platform. `stop` interrupts the running turn
-without spending a model turn.
+`after` is a position, not a snapshot: the hook applies only events after
+it, so messages and running state from before that position are not
+reconstructed. Pass `after` to skip history you have already rendered from
+your own store, otherwise start at `0`.
+
+Turns sent while one is running are queued by the platform. `stop`
+interrupts the running turn without spending a model turn.
+
+### What `send` returns
+
+`send(text)` resolves once the platform has admitted the input as a turn,
+with a receipt `{ sessionId, turnId, status }` where `status` is `queued`
+or `running`. The input appears in `messages` at that point; the log's own
+record of it confirms that message rather than adding a second one.
+`isRunning` is true from admission until the log settles the turn, and a
+reply that arrives after the log has already shown the turn completed
+changes nothing.
+
+`send` rejects with a `SendError` when no turn was admitted, so a composer
+can keep the draft:
+
+| `code` | Cause | `status` |
+| --- | --- | --- |
+| The platform's error code, for example `session_ended`, `memory_admission_unconfirmed` or `insufficient_credits` | The request was answered with an error | The HTTP status |
+| `network_error` | The request was not answered | none |
+| `empty_input` | The text was blank; nothing was sent | none |
+| `busy` | Create mode only: a turn is already running | none |
+
+The hook's `error` is set to the same message either way. A turn that fails
+after admission is not a rejection: the receipt was returned, the failure
+arrives through the log as a `turn.failed` event and sets `error`.
 
 The hook never suspends, resumes or ends an attached session. Its lifecycle
 belongs to the server that created it.
@@ -175,7 +212,7 @@ export default function Chat() {
       ))}
       <button
         disabled={isRunning}
-        onClick={() => void send("Hello")}
+        onClick={() => send("Hello").catch(() => undefined)}
       >
         Send
       </button>
@@ -186,8 +223,9 @@ export default function Chat() {
 }
 ```
 
-Each `send` resumes the session, streams one turn and suspends it again.
-Sessions created this way have no memory bindings.
+Each `send` resumes the session, streams one turn and suspends it again; the
+promise settles when the turn ends, with the same receipt and rejections as
+in attach mode. Sessions created this way have no memory bindings.
 
 Run the watched agent deployment and the web application separately:
 
@@ -205,10 +243,10 @@ the web application. Credentials are not bundled into browser code.
 | Value | Purpose |
 | --- | --- |
 | `messages` | User and assistant messages, in log order |
-| `send(text)` | Starts a turn; in create mode the first call creates the session |
+| `send(text)` | Starts a turn; resolves with `{ sessionId, turnId, status }` or rejects with a `SendError`. In create mode the first call creates the session |
 | `stop()` | Interrupts the running turn |
 | `sessionId` | The attached session, or the created one after the first send |
-| `isRunning` | Whether a turn is active |
+| `isRunning` | A turn is admitted and not yet settled by the log |
 | `isReplaying` | Attach mode: true until the existing history has been read |
 | `error` | The most recent request or turn failure |
 | `memorySaves` | `memory.saved` events seen so far |
@@ -222,7 +260,7 @@ the web application. Credentials are not bundled into browser code.
 | `agent` | Create mode: `agent-id@alias` |
 | `basePath` | Route prefix for the three routes; default `/api/opencomputer/managed-agents` |
 | `fetch` | A fetch implementation, for example one that adds a CSRF header |
-| `after` | Attach mode: replay from this cursor instead of the start |
+| `after` | Attach mode: apply only events after this position; earlier history is not reconstructed |
 | `pollIntervalMs` | Attach mode: interval between empty polls; default 1000, 500 while a turn runs |
 | `onEvent` | Every applied event, including replayed history |
 | `onMemorySaved` | Each `memory.saved` event |

--- a/docs/reference/typescript-sdk.mdx
+++ b/docs/reference/typescript-sdk.mdx
@@ -997,3 +997,19 @@ export` files. They carry no behavior.
 | `MemorySavedEvent` | The `data` of a `memory.saved` [session event](/agents/events) |
 | `MemoryErrorCode` | The codes the memory routes return in `{ error: { code, message } }` |
 | `StartSessionOnDocumentParams`, `StartSessionOnDocumentResult` | The helper's parameters and result |
+
+### Event subscription types
+
+The shapes of the [event subscription](/agents/api#event-subscriptions)
+routes and of the input they deliver, as types only.
+
+| Type | Shape |
+| --- | --- |
+| `OutcomeEventType` | `"turn.completed" \| "turn.failed" \| "turn.cancelled"` |
+| `SessionDestination` | `{ type: "session", sessionId }` |
+| `CreateEventSubscriptionBody` | Body of `POST /projects/<id>/event-subscriptions`: `agentId?`, `events`, `destination`, `environment?` |
+| `EventSubscription` | A subscription as the routes return it |
+| `OutcomeEvent` | The delivered outcome: `id`, `type`, `sessionId`, `turnId`, `agentId`, `occurredAt`, `reason?`, `error?`, `result?` |
+| `EventInput` | `{ source: "event", text?, event }`, what the receiving agent's `useInput()` returns |
+| `TurnOutcomeDelivery` | One entry of a turn's `deliveries` on `GET /sessions/<id>` |
+| `EventSubscriptionErrorCode` | The codes the subscription routes return in `{ error: { code, message } }` |

--- a/react/src/events.test.ts
+++ b/react/src/events.test.ts
@@ -6,6 +6,7 @@ import {
   emptyTimeline,
   failureMessage,
   inputMessageId,
+  isSettledTurn,
   memorySaveFromEvent,
   type AgentEvent,
 } from "./events.js";
@@ -27,8 +28,12 @@ const turn: AgentEvent[] = [
 ];
 
 test("a turn reduces to one user and one assistant message", () => {
+  const queued = applyEvents(emptyTimeline(), turn.slice(0, 1));
+  assert.deepEqual(queued.turns, { t1: "queued" });
+  assert.equal(isSettledTurn(queued, "t1"), false);
   const partial = applyEvents(emptyTimeline(), turn.slice(0, 4));
   assert.equal(partial.isRunning, true);
+  assert.deepEqual(partial.turns, { t1: "running" });
   assert.deepEqual(partial.messages, [
     { id: inputMessageId("t1"), role: "user", text: "hi", turnId: "t1" },
     { id: "turn:t1:reply", role: "assistant", text: "hello", turnId: "t1", streaming: true },
@@ -37,6 +42,9 @@ test("a turn reduces to one user and one assistant message", () => {
   const complete = applyEvents(partial, turn.slice(4));
   assert.equal(complete.isRunning, false);
   assert.equal(complete.cursor, 7);
+  assert.deepEqual(complete.turns, { t1: "completed" });
+  assert.equal(isSettledTurn(complete, "t1"), true);
+  assert.equal(isSettledTurn(complete, "t2"), false);
   assert.deepEqual(complete.messages, [
     { id: inputMessageId("t1"), role: "user", text: "hi", turnId: "t1" },
     { id: "turn:t1:reply", role: "assistant", text: "hello", turnId: "t1", streaming: false },

--- a/react/src/events.ts
+++ b/react/src/events.ts
@@ -35,11 +35,20 @@ export interface MemorySave {
   bytes: number;
 }
 
+export type TurnStatus =
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
 export interface SessionTimeline {
   messages: AgentMessage[];
   memorySaves: MemorySave[];
   /** The highest `seq` applied so far. */
   cursor: number;
+  /** Every turn the log has recorded, by id, with its status as of the cursor. */
+  turns: Record<string, TurnStatus>;
   isRunning: boolean;
   ended: boolean;
 }
@@ -49,9 +58,19 @@ export function emptyTimeline(): SessionTimeline {
     messages: [],
     memorySaves: [],
     cursor: 0,
+    turns: {},
     isRunning: false,
     ended: false,
   };
+}
+
+/** Whether the log has settled the turn: completed, failed or cancelled. */
+export function isSettledTurn(
+  timeline: SessionTimeline,
+  turnId: string,
+): boolean {
+  const status = timeline.turns[turnId];
+  return status === "completed" || status === "failed" || status === "cancelled";
 }
 
 /** The id of the user message that starts a turn; `send` uses the same id, so the event upserts it. */
@@ -112,10 +131,16 @@ export function applyEvent(
         text: text(data.input),
         ...(event.turnId ? { turnId: event.turnId } : {}),
       });
+      if (event.turnId && !timeline.turns[event.turnId]) {
+        next.turns = { ...timeline.turns, [event.turnId]: "queued" };
+      }
       return next;
     }
     case "turn.started":
       next.isRunning = true;
+      if (event.turnId) {
+        next.turns = { ...timeline.turns, [event.turnId]: "running" };
+      }
       return next;
     case "message.delta": {
       const id = replyMessageId(event);
@@ -143,6 +168,17 @@ export function applyEvent(
     case "turn.failed":
     case "turn.cancelled":
       next.isRunning = false;
+      if (event.turnId) {
+        next.turns = {
+          ...timeline.turns,
+          [event.turnId]:
+            event.type === "turn.completed"
+              ? "completed"
+              : event.type === "turn.failed"
+                ? "failed"
+                : "cancelled",
+        };
+      }
       next.messages = timeline.messages.map((message) =>
         message.streaming && message.turnId === event.turnId
           ? { ...message, streaming: false }

--- a/react/src/index.ts
+++ b/react/src/index.ts
@@ -4,6 +4,7 @@ import {
   emptyTimeline,
   failureMessage,
   inputMessageId,
+  isSettledTurn,
   memorySaveFromEvent,
   type AgentEvent,
   type AgentMessage,
@@ -15,10 +16,12 @@ export {
   applyEvent,
   applyEvents,
   emptyTimeline,
+  isSettledTurn,
   type AgentEvent,
   type AgentMessage,
   type MemorySave,
   type SessionTimeline,
+  type TurnStatus,
 } from "./events.js";
 
 interface CommonOptions {
@@ -59,13 +62,46 @@ export interface AttachAgentOptions extends CommonOptions {
 
 export type UseAgentOptions = CreateAgentOptions | AttachAgentOptions;
 
+/** What `send` resolves with: the platform admitted the input as a turn. */
+export interface SendReceipt {
+  sessionId: string;
+  turnId: string;
+  /** `queued` behind earlier turns, or `running` at once. */
+  status: "queued" | "running";
+}
+
+/**
+ * What `send` rejects with. `code` is the platform's error code when the
+ * request was answered (`session_ended`, `memory_admission_unconfirmed`,
+ * `insufficient_credits`), `network_error` when it was not, `empty_input`
+ * and `busy` when nothing was sent. `status` is the HTTP status when there
+ * was one. The hook's `error` is set to the same message.
+ */
+export class SendError extends Error {
+  readonly code: string;
+  readonly status: number | undefined;
+
+  constructor(message: string, code: string, status?: number) {
+    super(message);
+    this.name = "SendError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
 export interface UseAgentResult {
   messages: AgentMessage[];
-  /** Starts a turn. In create mode the first call creates the session. */
-  send: (value: string) => Promise<void>;
+  /**
+   * Starts a turn. Resolves with the admission receipt; rejects with a
+   * `SendError` when no turn was admitted, so a draft can be kept. In create
+   * mode the first call creates the session and the promise settles when the
+   * turn ends.
+   */
+  send: (value: string) => Promise<SendReceipt>;
   /** Interrupts the running turn. */
   stop: () => Promise<void>;
   sessionId: string | undefined;
+  /** A turn is admitted and not yet settled by the log. */
   isRunning: boolean;
   /** Attach mode: true until the existing history has been replayed. */
   isReplaying: boolean;
@@ -105,6 +141,19 @@ function upsert(
   return next;
 }
 
+function asSendError(cause: unknown): SendError {
+  if (cause instanceof SendError) return cause;
+  return new SendError(
+    cause instanceof Error ? cause.message : String(cause),
+    "network_error",
+  );
+}
+
+interface TurnAdmission {
+  turnId: string;
+  status: "queued" | "running";
+}
+
 export function useAgent(
   agentOrOptions: string | UseAgentOptions,
 ): UseAgentResult {
@@ -124,13 +173,25 @@ export function useAgent(
     attachedSessionId,
   );
   const sessionRef = useRef<string | undefined>(attachedSessionId);
+  // Bumped by every attach, so work started against an earlier attachment
+  // of the same session id is fenced too.
+  const attachmentRef = useRef(0);
   const cursorRef = useRef(0);
   const [isReplaying, setIsReplaying] = useState(Boolean(attachedSessionId));
   const [error, setError] = useState<string>();
+  // Admission state, apart from the log: turns the platform admitted whose
+  // settlement the log has not shown yet. The log's word wins as soon as it
+  // arrives, and an admission the log already settled never counts.
+  const [admitted, setAdmitted] = useState<string[]>([]);
 
   const commit = useCallback((next: SessionTimeline) => {
     timelineRef.current = next;
     setTimeline(next);
+    setAdmitted((current) =>
+      current.some((turnId) => isSettledTurn(next, turnId))
+        ? current.filter((turnId) => !isSettledTurn(next, turnId))
+        : current,
+    );
   }, []);
 
   const request = useCallback(
@@ -143,13 +204,22 @@ export function useAgent(
       const body: unknown =
         response.status === 204 ? undefined : await response.json();
       if (!response.ok) {
-        const problem = body as { error?: { message?: string } | string };
+        const problem = body as {
+          error?: { code?: string; message?: string } | string;
+        };
         const message =
           typeof problem?.error === "string"
             ? problem.error
             : problem?.error?.message;
-        throw new Error(
+        const code =
+          typeof problem?.error === "object" &&
+          typeof problem.error?.code === "string"
+            ? problem.error.code
+            : "request_failed";
+        throw new SendError(
           message ?? `Agent request failed (${String(response.status)})`,
+          code,
+          response.status,
         );
       }
       return body as T;
@@ -190,10 +260,12 @@ export function useAgent(
     if (!attachedSessionId) return;
     const controller = new AbortController();
     const { signal } = controller;
+    attachmentRef.current += 1;
     sessionRef.current = attachedSessionId;
     setSessionId(attachedSessionId);
     setError(undefined);
     setIsReplaying(true);
+    setAdmitted([]);
     cursorRef.current = after;
     commit({ ...emptyTimeline(), cursor: after });
     void (async () => {
@@ -229,43 +301,77 @@ export function useAgent(
     };
   }, [attachedSessionId, after, basePath, commit, ingest, request]);
 
+  const admitTurn = useCallback(
+    async (activeSession: string, prompt: string): Promise<SendReceipt> => {
+      const admission = await request<TurnAdmission>(
+        `/sessions/${encodeURIComponent(activeSession)}/turns`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            input: prompt,
+            idempotencyKey: crypto.randomUUID(),
+          }),
+        },
+      );
+      return {
+        sessionId: activeSession,
+        turnId: admission.turnId,
+        status: admission.status === "running" ? "running" : "queued",
+      };
+    },
+    [request],
+  );
+
   const sendAttached = useCallback(
-    async (activeSession: string, prompt: string) => {
+    async (activeSession: string, prompt: string): Promise<SendReceipt> => {
+      // The target is fixed here. Whatever the hook is attached to when the
+      // response arrives, this response belongs to that session and that
+      // attachment only; if they have changed, the caller still gets the
+      // outcome and the hook's state stays with the current session.
+      const attachment = attachmentRef.current;
+      const current = () =>
+        sessionRef.current === activeSession &&
+        attachmentRef.current === attachment;
       setError(undefined);
       try {
-        const result = await request<{ turnId: string }>(
-          `/sessions/${encodeURIComponent(activeSession)}/turns`,
-          {
-            method: "POST",
-            body: JSON.stringify({
-              input: prompt,
-              idempotencyKey: crypto.randomUUID(),
+        const receipt = await admitTurn(activeSession, prompt);
+        if (current()) {
+          // The log's message.received for this turn carries the same id,
+          // so it confirms this message instead of duplicating it. Whether
+          // the turn is still running is the log's call, not this reply's.
+          const timeline = timelineRef.current;
+          commit({
+            ...timeline,
+            messages: upsert(timeline.messages, {
+              id: inputMessageId(receipt.turnId),
+              role: "user",
+              text: prompt,
+              turnId: receipt.turnId,
             }),
-          },
-        );
-        // The log's message.received for this turn carries the same id, so
-        // it confirms this message instead of duplicating it.
-        const current = timelineRef.current;
-        commit({
-          ...current,
-          isRunning: true,
-          messages: upsert(current.messages, {
-            id: inputMessageId(result.turnId),
-            role: "user",
-            text: prompt,
-            turnId: result.turnId,
-          }),
-        });
+          });
+          if (!isSettledTurn(timelineRef.current, receipt.turnId)) {
+            setAdmitted((pending) =>
+              pending.includes(receipt.turnId)
+                ? pending
+                : [...pending, receipt.turnId],
+            );
+          }
+        }
+        return receipt;
       } catch (cause) {
-        setError(cause instanceof Error ? cause.message : String(cause));
+        const failure = asSendError(cause);
+        if (current()) setError(failure.message);
+        throw failure;
       }
     },
-    [commit, request],
+    [admitTurn, commit],
   );
 
   const sendCreated = useCallback(
-    async (prompt: string) => {
-      if (timelineRef.current.isRunning) return;
+    async (prompt: string): Promise<SendReceipt> => {
+      if (timelineRef.current.isRunning) {
+        throw new SendError("A turn is already running.", "busy");
+      }
       const userMessage: AgentMessage = {
         id: crypto.randomUUID(),
         role: "user",
@@ -288,6 +394,7 @@ export function useAgent(
         { isRunning: true },
       );
       setError(undefined);
+      let receipt: SendReceipt | undefined;
       try {
         let activeSession = sessionRef.current;
         if (!activeSession) {
@@ -358,13 +465,7 @@ export function useAgent(
           }
         };
         await waitFor((event) => event.type === "runtime.connected");
-        await request(`/sessions/${encodeURIComponent(activeSession)}/turns`, {
-          method: "POST",
-          body: JSON.stringify({
-            input: prompt,
-            idempotencyKey: crypto.randomUUID(),
-          }),
-        });
+        receipt = await admitTurn(activeSession, prompt);
         const completed = await waitFor(
           (event) =>
             event.type === "turn.completed" ||
@@ -383,6 +484,18 @@ export function useAgent(
       } catch (cause) {
         const message = cause instanceof Error ? cause.message : String(cause);
         setError(message);
+        if (!receipt) {
+          // Nothing was admitted: the input was never sent, so it is not
+          // part of the conversation, and the caller keeps it.
+          updateMessages(
+            (current) =>
+              current.filter(
+                (item) => item.id !== userMessage.id && item.id !== assistantId,
+              ),
+            { isRunning: false },
+          );
+          throw asSendError(cause);
+        }
         updateMessages((current) =>
           current.map((item) =>
             item.id === assistantId && !item.text
@@ -397,16 +510,19 @@ export function useAgent(
           isRunning: false,
         });
       }
+      if (!receipt) throw new SendError("No turn was admitted.", "busy");
+      return receipt;
     },
-    [commit, request],
+    [admitTurn, commit, request],
   );
 
   const send = useCallback(
-    async (value: string) => {
+    async (value: string): Promise<SendReceipt> => {
       const prompt = value.trim();
-      if (!prompt) return;
-      if (attachedSessionId) await sendAttached(attachedSessionId, prompt);
-      else await sendCreated(prompt);
+      if (!prompt) throw new SendError("Nothing to send.", "empty_input");
+      return attachedSessionId
+        ? sendAttached(attachedSessionId, prompt)
+        : sendCreated(prompt);
     },
     [attachedSessionId, sendAttached, sendCreated],
   );
@@ -429,7 +545,7 @@ export function useAgent(
     send,
     stop,
     sessionId,
-    isRunning: timeline.isRunning,
+    isRunning: timeline.isRunning || admitted.length > 0,
     isReplaying,
     error,
     memorySaves: timeline.memorySaves,

--- a/react/src/use-agent.test.ts
+++ b/react/src/use-agent.test.ts
@@ -5,8 +5,10 @@ import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 
 import {
+  SendError,
   useAgent,
   type AgentEvent,
+  type SendReceipt,
   type UseAgentOptions,
   type UseAgentResult,
 } from "./index.js";
@@ -33,6 +35,9 @@ function fakeSession(sessionId: string) {
   const calls: Call[] = [];
   let failNext = 0;
   let turns = 0;
+  // While set, turn admissions are recorded in the log at once but their
+  // responses wait until released: the reply is what arrives late.
+  let held: Array<() => void> | undefined;
   const append = (event: Omit<AgentEvent, "seq">) => {
     log.push({ ...event, seq: log.length + 1 });
   };
@@ -68,7 +73,11 @@ function fakeSession(sessionId: string) {
         data: { input: call.body?.input, mode: "queue" },
       });
       append({ turnId, type: "turn.started", data: {} });
-      return Response.json({ turnId, status: "queued", duplicate: false }, { status: 202 });
+      const reply = () =>
+        Response.json({ turnId, status: "queued", duplicate: false }, { status: 202 });
+      if (!held) return reply();
+      const gate = new Promise<void>((release) => held!.push(release));
+      return gate.then(reply);
     }
     if (call.method === "POST" && url.pathname === `${prefix}/interrupt`) {
       return Response.json({ id: sessionId, status: "idle" });
@@ -85,6 +94,14 @@ function fakeSession(sessionId: string) {
     append,
     failNext: (count: number) => {
       failNext = count;
+    },
+    holdTurns: () => {
+      held = [];
+      return () => {
+        const pending = held ?? [];
+        held = undefined;
+        for (const release of pending) release();
+      };
     },
   };
 }
@@ -251,9 +268,11 @@ test("attach sends turns and interrupts through the app's routes without duplica
   await view.render();
   await view.until((result) => !result.isReplaying, "empty history");
 
+  let receipt: SendReceipt | undefined;
   await act(async () => {
-    await view.result().send("  Book the venue  ");
+    receipt = await view.result().send("  Book the venue  ");
   });
+  assert.deepEqual(receipt, { sessionId: "ses-3", turnId: "turn-1", status: "queued" });
   const sent = view.result();
   assert.equal(sent.isRunning, true);
   assert.deepEqual(sent.messages, [
@@ -297,13 +316,216 @@ test("attach reports a failed turn and a rejected send", async (t) => {
     pollIntervalMs: 5,
   });
   await rejecting.render();
+  let rejection: unknown;
   await act(async () => {
-    await rejecting.result().send("anything");
+    rejection = await rejecting.result().send("anything").catch((cause: unknown) => cause);
   });
+  assert.ok(rejection instanceof SendError);
+  assert.equal(rejection.status, 409);
+  assert.equal(rejection.code, "session_ended");
+  assert.equal(rejection.message, "Session has ended");
   assert.equal(rejecting.result().error, "Session has ended");
   assert.deepEqual(rejecting.result().messages, []);
   await rejecting.unmount();
   await view.unmount();
+});
+
+// Review reproduction (U3): a send whose response arrives after the hook
+// moved to another session must not land in that session.
+test("a send admitted by one session never lands in the session attached later", async (t) => {
+  const a = fakeSession("ses-a");
+  const b = fakeSession("ses-b");
+  b.append({ turnId: "b0", type: "message.received", data: { input: "B's own history" } });
+  b.append({ turnId: "b0", type: "turn.completed", data: {} });
+  const routes: typeof globalThis.fetch = (input, init) =>
+    String(input).includes("/sessions/ses-b/") ? b.fetch(input, init) : a.fetch(input, init);
+  const container = dom.window.document.createElement("div");
+  const root: Root = createRoot(container);
+  let latest: UseAgentResult | undefined;
+  function Harness({ sessionId }: { sessionId: string }) {
+    latest = useAgent({ sessionId, basePath: "/app/agent", fetch: routes, pollIntervalMs: 5 });
+    return null;
+  }
+  t.after(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+  });
+  const tick = () =>
+    act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    });
+  const until = async (predicate: () => boolean, label: string) => {
+    for (let attempt = 0; attempt < 200; attempt += 1) {
+      if (predicate()) return;
+      await tick();
+    }
+    throw new Error(`timed out waiting for ${label}`);
+  };
+
+  await act(async () => {
+    root.render(createElement(Harness, { sessionId: "ses-a" }));
+  });
+  await until(() => latest?.isReplaying === false, "A's replay");
+
+  const release = a.holdTurns();
+  let sent: Promise<SendReceipt> | undefined;
+  await act(async () => {
+    sent = latest!.send("Plan A's workshop");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  // Switch to B while A's admission response is still outstanding.
+  await act(async () => {
+    root.render(createElement(Harness, { sessionId: "ses-b" }));
+  });
+  await until(() => latest?.isReplaying === false && latest.sessionId === "ses-b", "B's replay");
+  assert.deepEqual(
+    latest!.messages.map((message) => message.text),
+    ["B's own history"],
+  );
+
+  // A's response lands now: A's caller gets A's receipt, B is untouched.
+  release();
+  const receipt = await sent!;
+  assert.deepEqual(receipt, { sessionId: "ses-a", turnId: "turn-1", status: "queued" });
+  await tick();
+  await tick();
+  assert.equal(latest!.sessionId, "ses-b");
+  assert.deepEqual(
+    latest!.messages.map((message) => message.text),
+    ["B's own history"],
+  );
+  assert.equal(latest!.isRunning, false);
+  assert.equal(latest!.error, undefined);
+
+  // The same fence covers a late failure: it is not B's error.
+  await act(async () => {
+    root.render(createElement(Harness, { sessionId: "ses-a" }));
+  });
+  await until(() => latest?.isReplaying === false && latest.sessionId === "ses-a", "A again");
+  let failed: Promise<SendReceipt> | undefined;
+  const gate = new Promise<void>((resolve) => setTimeout(resolve, 20));
+  const slowFailure: typeof globalThis.fetch = async (input, init) => {
+    if (init?.method === "POST") {
+      await gate;
+      throw new TypeError("network down");
+    }
+    return routes(input, init);
+  };
+  function Slow({ sessionId }: { sessionId: string }) {
+    latest = useAgent({ sessionId, basePath: "/app/agent", fetch: slowFailure, pollIntervalMs: 5 });
+    return null;
+  }
+  await act(async () => {
+    root.render(createElement(Slow, { sessionId: "ses-a" }));
+  });
+  await until(() => latest?.isReplaying === false, "A on the slow transport");
+  await act(async () => {
+    failed = latest!.send("This one fails late");
+    failed.catch(() => undefined);
+  });
+  await act(async () => {
+    root.render(createElement(Slow, { sessionId: "ses-b" }));
+  });
+  await until(() => latest?.isReplaying === false && latest.sessionId === "ses-b", "B again");
+  const cause = await failed!.catch((error: unknown) => error);
+  assert.ok(cause instanceof SendError);
+  assert.equal(cause.code, "network_error");
+  await tick();
+  assert.equal(latest!.error, undefined);
+  assert.equal(latest!.sessionId, "ses-b");
+});
+
+// Review reproduction (U4): the admission reply says nothing about
+// execution; a turn the log already settled stays settled.
+test("a late admission reply does not turn a completed turn back into a running one", async (t) => {
+  const session = fakeSession("ses-late");
+  const view = mount(t, { sessionId: "ses-late", basePath: "/app/agent", fetch: session.fetch, pollIntervalMs: 5 });
+  await view.render();
+  await view.until((result) => !result.isReplaying, "empty history");
+
+  const release = session.holdTurns();
+  let sent: Promise<SendReceipt> | undefined;
+  await act(async () => {
+    sent = view.result().send("Quick question");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  // The admitted turn runs to completion in the log while the reply is held.
+  session.append({ turnId: "turn-1", type: "message.completed", data: { text: "Quick answer" } });
+  session.append({ turnId: "turn-1", type: "turn.completed", data: {} });
+  const settled = await view.until((result) => result.cursor === 4, "the completed turn");
+  assert.equal(settled.isRunning, false);
+  assert.deepEqual(
+    settled.messages.map((message) => [message.role, message.text]),
+    [["user", "Quick question"], ["assistant", "Quick answer"]],
+  );
+
+  release();
+  const receipt = await sent!;
+  assert.equal(receipt.turnId, "turn-1");
+  // Several empty polls later the hook still reports the log's verdict.
+  for (let i = 0; i < 6; i += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    });
+    assert.equal(view.result().isRunning, false);
+  }
+  assert.equal(view.result().messages.length, 2);
+  await view.unmount();
+});
+
+// Review reproduction (U9): an admission failure is a rejection the caller
+// can act on, in attach and in create mode; the hook's error is set too.
+test("send rejects on an unconfirmed admission and leaves nothing of the draft in the timeline", async (t) => {
+  const unconfirmed = () =>
+    Response.json(
+      { error: { code: "memory_admission_unconfirmed", message: "Memory admission was not confirmed" } },
+      { status: 503 },
+    );
+  const attached = mount(t, {
+    sessionId: "ses-503",
+    basePath: "/app/agent",
+    fetch: async (_input, init) =>
+      init?.method === "POST" ? unconfirmed() : Response.json({ events: [] }),
+    pollIntervalMs: 5,
+  });
+  await attached.render();
+  await attached.until((result) => !result.isReplaying, "empty history");
+  let rejection: unknown;
+  await act(async () => {
+    rejection = await attached.result().send("Keep this draft").catch((cause: unknown) => cause);
+  });
+  assert.ok(rejection instanceof SendError);
+  assert.equal(rejection.status, 503);
+  assert.equal(rejection.code, "memory_admission_unconfirmed");
+  assert.equal(attached.result().error, "Memory admission was not confirmed");
+  assert.deepEqual(attached.result().messages, []);
+  assert.equal(attached.result().isRunning, false);
+  await attached.unmount();
+
+  const created = mount(t, {
+    agent: "hello-world@development",
+    fetch: async (_input, init) =>
+      init?.method === "POST" ? unconfirmed() : Response.json({ events: [] }),
+  });
+  await created.render();
+  await act(async () => {
+    rejection = await created.result().send("Keep this draft too").catch((cause: unknown) => cause);
+  });
+  assert.ok(rejection instanceof SendError);
+  assert.equal(rejection.status, 503);
+  assert.equal(rejection.code, "memory_admission_unconfirmed");
+  assert.equal(created.result().error, "Memory admission was not confirmed");
+  assert.deepEqual(created.result().messages, []);
+  assert.equal(created.result().sessionId, undefined);
+  assert.equal(created.result().isRunning, false);
+
+  // Nothing to send is a rejection as well, without a request.
+  const empty = await created.result().send("   ").catch((cause: unknown) => cause);
+  assert.ok(empty instanceof SendError);
+  assert.equal(empty.code, "empty_input");
+  assert.equal(empty.status, undefined);
+  await created.unmount();
 });
 
 test("create mode still creates the session on the first send and streams the reply", async (t) => {
@@ -344,9 +566,11 @@ test("create mode still creates the session on the first send and streams the re
   assert.equal(view.result().isReplaying, false);
   assert.equal(view.result().sessionId, undefined);
 
+  let receipt: SendReceipt | undefined;
   await act(async () => {
-    await view.result().send("Hi");
+    receipt = await view.result().send("Hi");
   });
+  assert.deepEqual(receipt, { sessionId: "ses-new", turnId: "t1", status: "queued" });
   const result = view.result();
   assert.equal(result.sessionId, "ses-new");
   assert.equal(result.isRunning, false);

--- a/sdks/typescript/src/agents/event-subscriptions.test.ts
+++ b/sdks/typescript/src/agents/event-subscriptions.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import type {
+  CreateEventSubscriptionBody,
+  EventInput,
+  EventSubscription,
+  OutcomeEvent,
+  TurnOutcomeDelivery,
+} from "./index.js";
+
+// Types only: what has to compile for a caller to type a subscription
+// request, its response, a turn's deliveries, and the delivered input.
+describe("event subscription types", () => {
+  it("shape a subscription request and its response", () => {
+    const body: CreateEventSubscriptionBody = {
+      agentId: "worker",
+      events: ["turn.completed", "turn.failed"],
+      destination: { type: "session", sessionId: "ses_coordinator" },
+      environment: "development",
+    };
+    const subscription: EventSubscription = {
+      id: "evs_1",
+      projectId: "prj_1",
+      ...body,
+      createdAt: "2026-09-10T12:00:00.000Z",
+    };
+    expectTypeOf(subscription.destination.type).toEqualTypeOf<"session">();
+    expect(subscription.events).toContain("turn.failed");
+    // @ts-expect-error a public HTTPS destination is not a destination type.
+    const https: CreateEventSubscriptionBody["destination"] = { type: "https", url: "https://example.com" };
+    expect(https.type).toBe("https");
+  });
+
+  it("narrow a delivered outcome from the agent's input", () => {
+    const event: OutcomeEvent = {
+      id: "event_9",
+      type: "turn.completed",
+      sessionId: "ses_worker",
+      turnId: "turn-1",
+      agentId: "worker",
+      occurredAt: "2026-09-10T12:00:00.000Z",
+      result: { text: "Done.", truncated: false },
+    };
+    const input: EventInput = { source: "event", event };
+    expectTypeOf(input.source).toEqualTypeOf<"event">();
+    expect(input.event.result?.text).toBe("Done.");
+    const delivery: TurnOutcomeDelivery = {
+      id: "evs_1:event_9",
+      subscriptionId: "evs_1",
+      eventId: "event_9",
+      eventType: "turn.completed",
+      destination: { type: "session", sessionId: "ses_coordinator" },
+      status: "delivered",
+      attempt: 1,
+      receipt: { sessionId: "ses_coordinator", turnId: "turn-7" },
+      updatedAt: "2026-09-10T12:01:01.000Z",
+    };
+    expectTypeOf(delivery.error).toEqualTypeOf<
+      "subscription_unavailable" | "target_missing" | "target_ended" | "delivery_failed" | undefined
+    >();
+    expect(delivery.receipt?.turnId).toBe("turn-7");
+  });
+});

--- a/sdks/typescript/src/agents/event-subscriptions.ts
+++ b/sdks/typescript/src/agents/event-subscriptions.ts
@@ -1,0 +1,102 @@
+// Event subscription types — the shapes of the management API documented at
+// docs/agents/api.mdx ("Event subscriptions") and the input an agent reads
+// through `useInput()` when a subscribed outcome is delivered to it.
+//
+// These are types only. The subscription routes live on the project-scoped
+// Serverless Agents surface (`/api/managed-agents/projects/<id>/event-subscriptions`),
+// which this package does not call. Use them to type the bodies you send
+// with your own HTTP client and the objects it returns.
+
+import type { MemoryEnvironment } from "./memory.js";
+
+/** The turn outcomes a subscription can select. Turn outcomes, not session ends. */
+export type OutcomeEventType = "turn.completed" | "turn.failed" | "turn.cancelled";
+
+/** Where a subscription delivers: a session of an agent in the same project. */
+export interface SessionDestination {
+  type: "session";
+  sessionId: string;
+}
+
+/** Body of `POST /projects/<id>/event-subscriptions`. */
+export interface CreateEventSubscriptionBody {
+  /** Exact source agent id; omitted selects every agent in the project. */
+  agentId?: string;
+  /** At least one outcome type. */
+  events: OutcomeEventType[];
+  destination: SessionDestination;
+  /** The environment whose outcomes are delivered; the destination session runs in it. */
+  environment?: MemoryEnvironment;
+}
+
+/** A subscription as the routes return it. Immutable once created. */
+export interface EventSubscription {
+  id: string;
+  projectId: string;
+  agentId?: string;
+  environment?: MemoryEnvironment;
+  events: OutcomeEventType[];
+  destination: SessionDestination;
+  createdAt: string;
+}
+
+/**
+ * A source turn's recorded outcome as the receiving agent reads it from
+ * `useInput().event` when `source` is `"event"`. Identifiers and outcome
+ * only; the included agent output is data, not instructions.
+ */
+export interface OutcomeEvent {
+  /** The source session's own event id for the terminal `turn.*` event. */
+  id: string;
+  type: OutcomeEventType;
+  sessionId: string;
+  turnId: string;
+  agentId: string;
+  occurredAt: string;
+  /** Why the turn failed or was cancelled, when the source recorded a reason. */
+  reason?: string;
+  /** The failure message, bounded, when the turn failed. */
+  error?: string;
+  /** The final assistant message of a completed turn; `truncated` when it was cut to fit. */
+  result?: { text: string; truncated?: boolean };
+}
+
+/** The input of a turn an event subscription started, as the agent's `useInput()` returns it. */
+export interface EventInput {
+  source: "event";
+  /** A one-line description of the outcome, for agents that only read `text`. */
+  text?: string;
+  event: OutcomeEvent;
+}
+
+/**
+ * One outcome's delivery to one subscription, as `GET /sessions/<id>`
+ * lists it under the source turn's `deliveries`.
+ */
+export interface TurnOutcomeDelivery {
+  /** `<subscriptionId>:<eventId>`, also the idempotency key of the turn it starts. */
+  id: string;
+  subscriptionId: string;
+  eventId: string;
+  eventType: OutcomeEventType;
+  destination: SessionDestination;
+  status: "pending" | "delivered" | "failed";
+  attempt: number;
+  /** The turn the destination admitted; the same for a retried delivery. */
+  receipt?: { sessionId: string; turnId: string };
+  nextAttemptAt?: string;
+  /**
+   * `subscription_unavailable` (deleted before delivery), `target_missing`,
+   * `target_ended`, or `delivery_failed` for any other failure.
+   */
+  error?: "subscription_unavailable" | "target_missing" | "target_ended" | "delivery_failed";
+  updatedAt: string;
+}
+
+/** Error codes the subscription routes return in `{ error: { code, message } }`. */
+export type EventSubscriptionErrorCode =
+  | "invalid_event_subscription"
+  | "project_scope_violation"
+  | "destination_session_not_found"
+  | "destination_session_ended"
+  | "event_subscription_not_found";

--- a/sdks/typescript/src/agents/event-subscriptions.ts
+++ b/sdks/typescript/src/agents/event-subscriptions.ts
@@ -64,7 +64,7 @@ export interface OutcomeEvent {
 /** The input of a turn an event subscription started, as the agent's `useInput()` returns it. */
 export interface EventInput {
   source: "event";
-  /** A one-line description of the outcome, for agents that only read `text`. */
+  /** Not set on a delivered outcome; the event is the input. */
   text?: string;
   event: OutcomeEvent;
 }

--- a/sdks/typescript/src/agents/index.ts
+++ b/sdks/typescript/src/agents/index.ts
@@ -57,6 +57,10 @@ export type { WebhookDelivery, VerifyWebhookOptions } from "./webhooks.js";
 export { startSessionOnDocument, sessionIdempotencyKey } from "./memory-sessions.js";
 export type { StartSessionOnDocumentParams, StartSessionOnDocumentResult } from "./memory-sessions.js";
 export type {
+  OutcomeEventType, SessionDestination, CreateEventSubscriptionBody, EventSubscription,
+  OutcomeEvent, EventInput, TurnOutcomeDelivery, EventSubscriptionErrorCode,
+} from "./event-subscriptions.js";
+export type {
   MemoryEnvironment, MemoryAccess, MemoryAgentWrites, MemoryBinding, MemoryBindings,
   SessionMemoryBinding, MemoryWriter, MemoryDocumentMeta, MemoryDocument, MemoryDocumentPage,
   MemoryResource, MemoryResourceInventory,

--- a/web/src/managed-agents/Detail.tsx
+++ b/web/src/managed-agents/Detail.tsx
@@ -1176,7 +1176,7 @@ export default function ManagedAgentDetail({
 
       {activeTab === 'memory' && project ? (
         <ManagedProjectMemory
-          key={environment}
+          key={`${project.project.id}:${environment}`}
           projectId={project.project.id}
           environment={environment}
           // One environment row per project agent: every member's active

--- a/web/src/managed-agents/Memory.test.tsx
+++ b/web/src/managed-agents/Memory.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApiError } from '@/api/client'
 import type {
   ManagedMemoryDocument,
   ManagedMemoryDocumentRead,
@@ -45,10 +46,12 @@ function documentIn(resource: string, text: string): ManagedMemoryDocument {
 
 function deferred<T>() {
   let resolve!: (value: T) => void
-  const promise = new Promise<T>((done) => {
+  let reject!: (cause: unknown) => void
+  const promise = new Promise<T>((done, fail) => {
     resolve = done
+    reject = fail
   })
-  return { promise, resolve }
+  return { promise, resolve, reject }
 }
 
 function button(scope: ParentNode, label: string): HTMLButtonElement {
@@ -111,6 +114,240 @@ describe('ManagedProjectMemory editor target', () => {
     client.clear()
     container.remove()
     document.body.replaceChildren()
+  })
+
+  function render(projectId: string) {
+    act(() => {
+      root.render(
+        <QueryClientProvider client={client}>
+          <MemoryRouter>
+            <ManagedProjectMemory
+              projectId={projectId}
+              environment="development"
+              deploymentIds={[]}
+            />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+    })
+  }
+
+  function oneResourceWithWorkshop() {
+    api.getManagedMemoryResources.mockResolvedValue({
+      resources: [
+        {
+          id: 'notes',
+          provider: { kind: 'document', maxBytes: 8192 },
+          declared: true,
+          documents: 1,
+        },
+      ],
+    })
+    api.getManagedMemoryDocuments.mockImplementation(
+      (input: { projectId: string; resource: string }) => {
+        const meta: Partial<ManagedMemoryDocument> = documentIn(
+          `${input.projectId} ${input.resource}`,
+          '',
+        )
+        delete meta.text
+        return Promise.resolve({ documents: [meta], nextCursor: null })
+      },
+    )
+    api.getManagedMemoryDocument.mockImplementation(
+      (target: ManagedMemoryDocumentTarget) =>
+        Promise.resolve({
+          document: documentIn(
+            `${target.projectId} ${target.resource}`,
+            `${target.projectId} text.`,
+          ),
+          etag: '"rev-1"',
+        }),
+    )
+  }
+
+  // Review reproduction (U2): the delete confirmation opened for one
+  // project's document must not survive into another project.
+  it('closes an open delete confirmation when the project changes and deletes only the captured target', async () => {
+    oneResourceWithWorkshop()
+    api.deleteManagedMemoryDocument.mockReset()
+    api.deleteManagedMemoryDocument.mockResolvedValue(undefined)
+
+    // B was visited before, so its inventory and documents are cached and a
+    // return to it renders at once.
+    render('prj_b')
+    await settle(
+      () => container.textContent?.includes('prj_b notes workshop') ?? false,
+      "project B's documents",
+    )
+    render('prj_a')
+    await settle(
+      () => container.textContent?.includes('prj_a notes workshop') ?? false,
+      "project A's documents",
+    )
+    act(() => button(container, 'Delete').click())
+    await settle(
+      () => document.body.textContent?.includes('Delete workshop?') ?? false,
+      "A's confirmation",
+    )
+
+    // Navigate to the cached project with the same resource and document id.
+    render('prj_b')
+    await settle(
+      () => container.textContent?.includes('prj_b notes workshop') ?? false,
+      "project B's documents",
+    )
+    expect(document.body.textContent).not.toContain('Delete workshop?')
+    expect(
+      [...document.body.querySelectorAll('button')].some(
+        (element) => element.textContent?.trim() === 'Delete document',
+      ),
+    ).toBe(false)
+    expect(api.deleteManagedMemoryDocument).not.toHaveBeenCalled()
+
+    // A confirmation opened in B deletes B's document, with B's revision.
+    act(() => button(container, 'Delete').click())
+    await settle(
+      () => document.body.textContent?.includes('Delete workshop?') ?? false,
+      "B's confirmation",
+    )
+    act(() => button(document.body, 'Delete document').click())
+    await settle(
+      () => api.deleteManagedMemoryDocument.mock.calls.length > 0,
+      'the delete',
+    )
+    expect(api.deleteManagedMemoryDocument).toHaveBeenCalledTimes(1)
+    expect(api.deleteManagedMemoryDocument).toHaveBeenCalledWith({
+      projectId: 'prj_b',
+      resource: 'notes',
+      id: 'workshop',
+      environment: 'development',
+      etag: '"rev-1"',
+    })
+  })
+
+  async function openEditorAndType(text: string) {
+    act(() => button(container, 'Edit').click())
+    await settle(
+      () => document.body.querySelector('#memory-edit-text') !== null,
+      'the editor',
+    )
+    const area =
+      document.body.querySelector<HTMLTextAreaElement>('#memory-edit-text')!
+    act(() => typeInto(area, text))
+    return area
+  }
+
+  // Review reproduction (U7): text typed while a save is pending belongs to
+  // the next save, on the revision the pending save produced.
+  it('keeps edits typed during a pending save and saves them on the new revision', async () => {
+    oneResourceWithWorkshop()
+    const held = deferred<ManagedMemoryDocumentRead>()
+    api.replaceManagedMemoryDocument
+      .mockImplementationOnce(() => held.promise)
+      .mockImplementation(
+        (input: ManagedMemoryDocumentTarget & { text: string }) =>
+          Promise.resolve({
+            document: { ...documentIn('notes', input.text), revision: 'rev-3' },
+            etag: '"rev-3"',
+          }),
+      )
+
+    render('prj_a')
+    await settle(
+      () => container.textContent?.includes('prj_a notes workshop') ?? false,
+      'the documents',
+    )
+    const area = await openEditorAndType('First edit')
+    act(() => button(document.body, 'Save').click())
+    await settle(
+      () => api.replaceManagedMemoryDocument.mock.calls.length === 1,
+      'the first save',
+    )
+    expect(api.replaceManagedMemoryDocument.mock.calls[0][0]).toMatchObject({
+      etag: '"rev-1"',
+      text: 'First edit',
+    })
+
+    // The response is outstanding; the user keeps typing.
+    act(() => typeInto(area, 'Second edit'))
+    await act(async () => {
+      held.resolve({
+        document: { ...documentIn('notes', 'First edit'), revision: 'rev-2' },
+        etag: '"rev-2"',
+      })
+      await held.promise
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    // The editor stays open with the newer text, now on revision rev-2.
+    const stillOpen =
+      document.body.querySelector<HTMLTextAreaElement>('#memory-edit-text')
+    expect(stillOpen).not.toBeNull()
+    expect(stillOpen!.value).toBe('Second edit')
+    expect(document.body.textContent).toContain('rev-2')
+
+    act(() => button(document.body, 'Save').click())
+    await settle(
+      () => api.replaceManagedMemoryDocument.mock.calls.length === 2,
+      'the second save',
+    )
+    expect(api.replaceManagedMemoryDocument.mock.calls[1][0]).toMatchObject({
+      etag: '"rev-2"',
+      text: 'Second edit',
+    })
+    await settle(
+      () => document.body.querySelector('#memory-edit-text') === null,
+      'the editor closing',
+    )
+  })
+
+  it('keeps edits typed during a save that ends in a conflict', async () => {
+    oneResourceWithWorkshop()
+    const held = deferred<ManagedMemoryDocumentRead>()
+    api.replaceManagedMemoryDocument.mockImplementationOnce(() => held.promise)
+
+    render('prj_a')
+    await settle(
+      () => container.textContent?.includes('prj_a notes workshop') ?? false,
+      'the documents',
+    )
+    const area = await openEditorAndType('First edit')
+    act(() => button(document.body, 'Save').click())
+    await settle(
+      () => api.replaceManagedMemoryDocument.mock.calls.length === 1,
+      'the save',
+    )
+    act(() => typeInto(area, 'Second edit'))
+
+    // Someone else saved meanwhile: the read for the conflict shows their text.
+    api.getManagedMemoryDocument.mockResolvedValue({
+      document: { ...documentIn('notes', 'Their text.'), revision: 'rev-9' },
+      etag: '"rev-9"',
+    })
+    await act(async () => {
+      held.reject(
+        new ApiError('Precondition failed', 412, 'precondition_failed'),
+      )
+      await held.promise.catch(() => undefined)
+    })
+    await settle(
+      () =>
+        document.body.textContent?.includes(
+          'This document changed while you were editing',
+        ) ?? false,
+      'the conflict',
+    )
+    expect(
+      document.body.querySelector<HTMLTextAreaElement>('#memory-edit-text')!
+        .value,
+    ).toBe('Second edit')
+    expect(
+      document.body.querySelector<HTMLTextAreaElement>(
+        'textarea[aria-label="Current text"]',
+      )!.value,
+    ).toBe('Their text.')
   })
 
   it('drops a read that resolves after the resource changed and saves to the target it read', async () => {

--- a/web/src/managed-agents/Memory.tsx
+++ b/web/src/managed-agents/Memory.tsx
@@ -65,6 +65,18 @@ function formatDate(value: string) {
   return new Date(value).toLocaleString()
 }
 
+function sameTarget(
+  left: ManagedMemoryDocumentTarget,
+  right: ManagedMemoryDocumentTarget,
+) {
+  return (
+    left.projectId === right.projectId &&
+    left.environment === right.environment &&
+    left.resource === right.resource &&
+    left.id === right.id
+  )
+}
+
 const DOCUMENT_ID = /^[A-Za-z0-9_-]{1,128}$/
 
 function WriterCell({
@@ -227,12 +239,12 @@ export function ManagedProjectMemory({
           />
         </PanelContent>
       ) : resource ? (
-        // Keyed by the selection: switching resources remounts the documents
-        // panel, so drafts, dialogs and in-flight reads belong to the resource
-        // they were started for, and a read that resolves after the switch
-        // has nowhere to land.
+        // Keyed by the whole target: switching projects, environments or
+        // resources remounts the documents panel, so drafts, dialogs and
+        // in-flight reads belong to the target they were started for, and a
+        // read that resolves after the switch has nowhere to land.
         <MemoryResourceDocuments
-          key={`${environment}:${resource}`}
+          key={`${projectId}:${environment}:${resource}`}
           projectId={projectId}
           environment={environment}
           resource={resource}
@@ -294,7 +306,12 @@ function MemoryResourceDocuments({
     agentWrites: true,
   })
   const [editor, setEditor] = useState<EditorState>()
-  const [removing, setRemoving] = useState<ManagedMemoryDocumentMeta>()
+  // Every destructive action carries the complete target it was opened on;
+  // nothing is rebuilt from the props current when it is confirmed.
+  const [removing, setRemoving] = useState<{
+    target: ManagedMemoryDocumentTarget
+    meta: ManagedMemoryDocumentMeta
+  }>()
 
   const invalidate = () =>
     Promise.all([
@@ -339,27 +356,43 @@ function MemoryResourceDocuments({
     onError: (error) => notifyError("Couldn't open that document.", error),
   })
 
+  // A save submits the draft as it was when Save was pressed. The editor
+  // stays live meanwhile; what is typed during the request belongs to the
+  // next save, on the revision this one produces (or, on a conflict, next
+  // to the current text), and is never replaced by the submitted draft.
   const save = useMutation({
-    mutationFn: async (state: EditorState) => {
+    mutationFn: async (submitted: EditorState) => {
       try {
         return await replaceManagedMemoryDocument({
-          ...state.target,
-          etag: state.base.etag,
-          text: state.text,
-          summary: state.summary,
+          ...submitted.target,
+          etag: submitted.base.etag,
+          text: submitted.text,
+          summary: submitted.summary,
         })
       } catch (error) {
         if (error instanceof ApiError && error.status === 412) {
-          const conflict = await getManagedMemoryDocument(state.target)
-          setEditor({ ...state, conflict })
+          const conflict = await getManagedMemoryDocument(submitted.target)
+          setEditor((current) =>
+            current && sameTarget(current.target, submitted.target)
+              ? { ...current, conflict }
+              : current,
+          )
           return undefined
         }
         throw error
       }
     },
-    onSuccess: async (saved) => {
+    onSuccess: async (saved, submitted) => {
       if (!saved) return
-      setEditor(undefined)
+      setEditor((current) => {
+        if (!current || !sameTarget(current.target, submitted.target)) {
+          return current
+        }
+        const unchanged =
+          current.text === submitted.text &&
+          current.summary === submitted.summary
+        return unchanged ? undefined : { ...current, base: saved }
+      })
       notifySuccess(
         `Saved ${saved.document.id}.`,
         `Revision ${saved.document.revision}.`,
@@ -373,12 +406,12 @@ function MemoryResourceDocuments({
   // the ETag verbatim rather than a revision reassembled from the list.
   const setAgentWrites = useMutation({
     mutationFn: async (input: {
-      meta: ManagedMemoryDocumentMeta
+      target: ManagedMemoryDocumentTarget
       agentWrites: 'enabled' | 'disabled'
     }) => {
-      const current = await getManagedMemoryDocument(target(input.meta.id))
+      const current = await getManagedMemoryDocument(input.target)
       return patchManagedMemoryDocument({
-        ...target(input.meta.id),
+        ...input.target,
         etag: current.etag,
         agentWrites: input.agentWrites,
       })
@@ -396,16 +429,16 @@ function MemoryResourceDocuments({
   })
 
   const remove = useMutation({
-    mutationFn: async (meta: ManagedMemoryDocumentMeta) => {
-      const current = await getManagedMemoryDocument(target(meta.id))
+    mutationFn: async (input: { target: ManagedMemoryDocumentTarget }) => {
+      const current = await getManagedMemoryDocument(input.target)
       await deleteManagedMemoryDocument({
-        ...target(meta.id),
+        ...input.target,
         etag: current.etag,
       })
     },
-    onSuccess: async (_, meta) => {
+    onSuccess: async (_, input) => {
       setRemoving(undefined)
-      notifySuccess(`Deleted ${meta.id}.`, 'Its ID stays reserved.')
+      notifySuccess(`Deleted ${input.target.id}.`, 'Its ID stays reserved.')
       await invalidate()
     },
     onError: (error) => notifyError("Couldn't delete that document.", error),
@@ -529,7 +562,7 @@ function MemoryResourceDocuments({
             disabled={setAgentWrites.isPending}
             onClick={() =>
               setAgentWrites.mutate({
-                meta: document,
+                target: target(document.id),
                 agentWrites:
                   document.agentWrites === 'enabled' ? 'disabled' : 'enabled',
               })
@@ -540,7 +573,9 @@ function MemoryResourceDocuments({
           <Button
             size="sm"
             variant="ghost"
-            onClick={() => setRemoving(document)}
+            onClick={() =>
+              setRemoving({ target: target(document.id), meta: document })
+            }
           >
             Delete
           </Button>
@@ -867,7 +902,7 @@ function MemoryResourceDocuments({
       <ConfirmDialog
         open={Boolean(removing)}
         onOpenChange={(open) => !open && setRemoving(undefined)}
-        title={`Delete ${removing?.id}?`}
+        title={`Delete ${removing?.meta.id}?`}
         description="Removes the saved text and summary. The ID stays reserved and cannot be recreated; sessions bound to this document fail their next recall."
         confirmLabel="Delete document"
         destructive


### PR DESCRIPTION
Second review round on #722 (the consolidated public review of 2026-09-10, items U1–U9) plus the public delivery slice that #64 leaves to this repo. Every item has its reproduction test in the suite; the fixes retain immutable targets across asynchronous work and return distinguishable outcomes.

## Review items

| Item | Fix | Reproduction test |
| --- | --- | --- |
| U1 api-edge failure text | `publicFailure()` classifies `turn.failed` / `session.failed` into a stable `code`, a fixed sentence and at most one validated parameter (`model`, `tool`); runtime text is never forwarded, unclassified is `agent_failed`. Regex redaction removed. | `never publishes unclassified runtime error text` (JSON-quoted api_key, Basic auth, short password), `classifies known runtime failures into typed public failures`, `projects a turn failure as a typed public failure through the event stream` |
| U2 dashboard delete target | Memory panels keyed by project as well as environment/resource, so a project switch closes any dialog; delete, freeze and unfreeze carry the full captured target. | `closes an open delete confirmation when the project changes and deletes only the captured target` |
| U3 react session fence | `send` success and failure apply only to the originating session and attachment generation; a late response settles for its caller and never touches the session attached since. | `a send admitted by one session never lands in the session attached later` |
| U4 react admission vs execution | Timeline records per-turn status; `isRunning` = admitted and not yet settled by the log; a late admission reply for a settled turn changes nothing. | `a late admission reply does not turn a completed turn back into a running one` |
| U5 compiler bindings | Memory functions recognized by tracing the identifier to `@opencomputer/agent` (named import or re-export chain); namespace member/bracket access, computed keys, namespace aliases and dynamic imports rejected naming file and form; unrelated properties/locals ignored. Existing rejections unchanged. | additions to `the compiler rejects memory declarations it cannot register as written` |
| U6 CLI idempotency | Header = hash(caller key, method, path); the body is the backend's to compare, so a retried create with different bindings is the 409 conflict. | `one caller key with different bindings is a conflict, not a second session` (fake wire endpoint keyed like the backend), `mutations derive idempotency headers from the caller's key and the target only` |
| U7 dashboard pending saves | The editor stays live during a save; newer text is kept on the new revision (success) or next to the current text (conflict). | `keeps edits typed during a pending save and saves them on the new revision`, `keeps edits typed during a save that ends in a conflict` |
| U8 CLI draft recovery | Recovery command keeps `--project`, `--environment`, `--summary` and shell quoting; a lost response is `memory_save_unconfirmed` ("may or may not have been saved") with a `memory show` check. | `a save whose response is lost keeps the draft and is reported as unconfirmed`, `the draft recovery command keeps project, environment, summary and shell quoting` |
| U9 react send outcome | `send()` resolves with `{ sessionId, turnId, status }` or rejects with `SendError { code, status? }` in attach and create mode; the hook's `error` is set either way; the starter template keeps its draft on rejection. | `send rejects on an unconfirmed admission and leaves nothing of the draft in the timeline` |

## Public delivery slice

- api-edge: `POST/GET /projects/:id/event-subscriptions`, `GET/DELETE /projects/:id/event-subscriptions/:sid` pass through one to one (body forwarded as sent, so the environment scope #64 adds reaches the backend; `createdBy` dropped; error codes kept; no-store). Session snapshots keep each turn's `deliveries`, with only the backend's terminal codes as `error`.
- `@opencomputer/agent`: `AgentInput` gains `source: "event"` with a typed `event` (`id, type, sessionId, turnId, agentId, occurredAt, reason?, error?, result?`).
- `@opencomputer/sdk`: types for subscriptions, deliveries and the event input.
- Docs: event subscriptions on the API page (session destinations only, no public HTTPS destination, environment-scoped, receipts), event input on the inputs page, public failure codes on the events page, `send()` contract and `after` semantics on the React page.

## Checks

package contract; agent 14; cli 82; react 16; sdk 58 (+ `tsc --noEmit`); api-edge 191; web `tsc -b`, 223 tests, build; create-start 2. Versions were bumped once on the base branch and stay as they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKjbUpydN8ju2ZLxukbWLQ
