### PR TITLE
remove v1 banner + give descriptive error

### DIFF
--- a/cloudflare-workers/api-edge/src/index.test.ts
+++ b/cloudflare-workers/api-edge/src/index.test.ts
@@ -252,6 +252,9 @@ describe("api-edge sandbox create", () => {
           "X-API-Key": "osb_test",
           "Content-Type": "application/json",
           Accept: "text/event-stream",
+          // This case is about SSE indexing, not routing — but a create with no
+          // SDK version is now refused as v1, so it has to announce itself.
+          "x-oc-sdk-version": "1.0.0",
         },
         body: JSON.stringify({ snapshot: "snapshot-1", memoryMB: 1024 }),
       }),

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -35,6 +35,9 @@ import {
   RUNTIME_MICROVM,
   SDK_VERSION_HEADER,
   effectiveRuntime,
+  isRetiredRuntime,
+  v1RetiredError,
+  V1_RETIRED_STATUS,
   isMicrovmWorkerID,
 } from "./runtime_gate";
 import {
@@ -2069,6 +2072,10 @@ async function createSandbox(req: Request, env: Env, ctx: ExecutionContext, tTop
   // reads its backend off. Reading org.runtime directly at any of those points
   // again would route the create one way and label it another.
   const runtime = effectiveRuntime(env, org.runtime, req.headers.get(SDK_VERSION_HEADER));
+  // The v1 fleet it would route to no longer exists. Refused here rather than
+  // forwarded, so the caller gets the upgrade instruction instead of whatever
+  // a create against a shut-down fleet happens to look like.
+  if (isRetiredRuntime(runtime)) return json(v1RetiredError(), V1_RETIRED_STATUS);
 
   // Read body once — used for size-gating, the hard-pin cell peek, and the
   // verbatim forward to the CP.
@@ -3407,6 +3414,9 @@ async function proxyToCellAuthed(
   // restore: a customer would migrate successfully and then find every template
   // they built unusable. Same decision, same inputs as createSandbox.
   const runtime = effectiveRuntime(env, org.runtime, req.headers.get(SDK_VERSION_HEADER));
+  // A template built for v1 is a whole-disk checkpoint, which nothing left can
+  // restore. Same refusal as a create.
+  if (isRetiredRuntime(runtime)) return json(v1RetiredError(), V1_RETIRED_STATUS);
 
   const cell = opts.cellId
     ? await lookupCell(env, opts.cellId)

--- a/cloudflare-workers/api-edge/src/runtime_gate.ts
+++ b/cloudflare-workers/api-edge/src/runtime_gate.ts
@@ -128,3 +128,51 @@ export function isMicrovmWorkerID(workerID: string | null | undefined): boolean 
   if (!workerID) return false;
   return MICROVM_WORKER_PREFIXES.some((p) => workerID.startsWith(p));
 }
+
+// ── v1 retirement ────────────────────────────────────────────────────────────
+
+/**
+ * The v1 fleet is gone.
+ *
+ * `effectiveRuntime` still answers "" for a caller that routes to QEMU, because
+ * that answer is what the capability token has always carried and the cell
+ * still reads. What changed is that there is no longer anything on the other
+ * end: the Azure workers that served it have been shut down. So the decision is
+ * unchanged and the *outcome* is refusal — a request that would have gone to
+ * QEMU is answered here rather than forwarded to a fleet that cannot serve it.
+ *
+ * Kept beside the routing it mirrors so the two cannot drift: if the threshold
+ * moves, the population that gets this message moves with it.
+ */
+export function isRetiredRuntime(runtime: string): boolean {
+  return runtime !== RUNTIME_MICROVM;
+}
+
+/** Where a caller is sent to fix it. One string, used by every refusal. */
+export const V1_MIGRATION_GUIDE_URL =
+  "https://docs.opencomputer.dev/migrating-from-v1";
+
+/**
+ * What a retired-runtime caller is told.
+ *
+ * Names the cause, the fix, and where the fix is written down. `code` is there
+ * so a caller can branch on this without matching prose, and the SDK can turn
+ * it into a typed error later without another API change.
+ */
+export function v1RetiredError(): {
+  error: string;
+  code: string;
+  migration_guide: string;
+} {
+  return {
+    error:
+      "OpenComputer v1 sandboxes have been retired. Upgrade to the v2 SDK — " +
+      "`npm install @opencomputer/sdk@^1` (or `pip install -U opencomputer`) — " +
+      `and see ${V1_MIGRATION_GUIDE_URL}. Existing v1 sandboxes are no longer reachable.`,
+    code: "v1_retired",
+    migration_guide: V1_MIGRATION_GUIDE_URL,
+  };
+}
+
+/** The status a retired-runtime request is refused with: the fleet is Gone. */
+export const V1_RETIRED_STATUS = 410;

--- a/cloudflare-workers/api-edge/src/runtime_gate_wiring.test.ts
+++ b/cloudflare-workers/api-edge/src/runtime_gate_wiring.test.ts
@@ -117,10 +117,10 @@ function pinClaim(headers: HeadersInit | undefined): string {
 
 let lastHeaders: HeadersInit | undefined;
 
-async function createWith(
+async function createRaw(
   sdkVersion: string | null,
   opts: { runtime?: string | null; env?: Env } = {},
-): Promise<string> {
+): Promise<{ resp: Response; fetchSpy: ReturnType<typeof vi.fn> }> {
   freshOrg(opts.runtime ?? null);
   const env = opts.env ?? makeEnv();
   const fetchSpy = vi.fn(async (_url: string, _init?: RequestInit) =>
@@ -134,6 +134,14 @@ async function createWith(
     env,
     ctx,
   );
+  return { resp, fetchSpy };
+}
+
+async function createWith(
+  sdkVersion: string | null,
+  opts: { runtime?: string | null; env?: Env } = {},
+): Promise<string> {
+  const { resp, fetchSpy } = await createRaw(sdkVersion, opts);
   expect(resp.status, `create failed: ${await resp.clone().text()}`).toBe(201);
   expect(fetchSpy).toHaveBeenCalled();
   lastHeaders = fetchSpy.mock.calls[0][1]?.headers;
@@ -150,18 +158,21 @@ describe("create routes by SDK version", () => {
     expect(await createWith("1.0.0")).toBe("microvm");
   });
 
-  it("leaves an unpinned org's older create on the fleet", async () => {
-    expect(await createWith("0.15.7")).toBe("");
-    expect(await createWith(null)).toBe("");
-  });
-
-  it("honours both pins over the calling SDK", async () => {
+  // A microvm pin still wins over an old SDK: that is how an org that has
+  // finished migrating stays migrated when one stale script is left behind.
+  it("honours a microvm pin over an old calling SDK", async () => {
     expect(await createWith("0.15.7", { runtime: "microvm" })).toBe("microvm");
-    expect(await createWith("1.0.0", { runtime: "qemu" })).toBe("qemu");
   });
 
-  it("SDK_RUNTIME_GATE=0 holds every unpinned create on the fleet", async () => {
-    expect(await createWith("1.0.0", { env: makeEnv({ SDK_RUNTIME_GATE: "0" } as Partial<Env>) })).toBe("");
+  // The kill switch used to hold every unpinned create on the fleet. The fleet
+  // is gone, so what it now does is refuse them — worth pinning, because an env
+  // var left set to 0 would take every create down rather than roll anything
+  // back.
+  it("SDK_RUNTIME_GATE=0 now refuses instead of rolling back", async () => {
+    const { resp } = await createRaw("1.0.0", {
+      env: makeEnv({ SDK_RUNTIME_GATE: "0" } as Partial<Env>),
+    });
+    expect(resp.status).toBe(410);
   });
 });
 
@@ -175,7 +186,10 @@ describe("snapshot builds route by SDK version", () => {
     orgRuntime = null;
   });
 
-  async function snapshotWith(sdkVersion: string | null, runtime: string | null = null): Promise<string> {
+  async function snapshotRaw(
+    sdkVersion: string | null,
+    runtime: string | null = null,
+  ): Promise<{ resp: Response; fetchSpy: ReturnType<typeof vi.fn> }> {
     freshOrg(runtime);
     const fetchSpy = vi.fn(async (_url: string, _init?: RequestInit) => new Response("{}", { status: 200 }));
     vi.stubGlobal("fetch", fetchSpy);
@@ -190,6 +204,11 @@ describe("snapshot builds route by SDK version", () => {
       makeEnv(),
       ctx,
     );
+    return { resp, fetchSpy };
+  }
+
+  async function snapshotWith(sdkVersion: string | null, runtime: string | null = null): Promise<string> {
+    const { resp, fetchSpy } = await snapshotRaw(sdkVersion, runtime);
     expect(resp.status, `snapshot create failed: ${await resp.clone().text()}`).toBe(200);
     return runtimeClaim(fetchSpy.mock.calls[0][1]?.headers);
   }
@@ -198,12 +217,18 @@ describe("snapshot builds route by SDK version", () => {
     expect(await snapshotWith("1.0.0")).toBe("microvm");
   });
 
-  it("leaves an older caller's template on the fleet", async () => {
-    expect(await snapshotWith("0.15.7")).toBe("");
+  // A v1 template is a whole-disk checkpoint and nothing left can restore one,
+  // so the build is refused with the same message as a create rather than
+  // producing an artifact that cannot be used.
+  it("refuses an older caller's template build", async () => {
+    const { resp } = await snapshotRaw("0.15.7");
+    expect(resp.status).toBe(410);
+    expect(((await resp.json()) as Record<string, string>).code).toBe("v1_retired");
   });
 
-  it("honours the org pin", async () => {
-    expect(await snapshotWith("1.0.0", "qemu")).toBe("qemu");
+  it("refuses a template build for an org still pinned to qemu", async () => {
+    const { resp } = await snapshotRaw("1.0.0", "qemu");
+    expect(resp.status).toBe(410);
   });
 });
 
@@ -231,8 +256,25 @@ describe("SDK routing does not pin the org", () => {
     expect(pinClaim(lastHeaders)).toBe("microvm");
   });
 
-  it("leaves the pin empty for an old SDK too", async () => {
-    expect(await createWith("0.15.7")).toBe("");
-    expect(pinClaim(lastHeaders)).toBe("");
+  // The v1 fleet is gone, so the population that used to route to it is now
+  // refused here rather than forwarded to a cell that cannot serve it.
+  it("refuses an old SDK with the migration guide, and forwards nothing", async () => {
+    const { resp, fetchSpy } = await createRaw("0.15.7");
+    expect(resp.status).toBe(410);
+    const body = (await resp.json()) as Record<string, string>;
+    expect(body.code).toBe("v1_retired");
+    expect(body.migration_guide).toBe("https://docs.opencomputer.dev/migrating-from-v1");
+    expect(body.error).toContain("@opencomputer/sdk@^1");
+    expect(fetchSpy, "a retired create must never reach a cell").not.toHaveBeenCalled();
+  });
+
+  it("refuses a client that does not announce a version at all", async () => {
+    const { resp } = await createRaw(null);
+    expect(resp.status).toBe(410);
+  });
+
+  it("refuses an org still pinned to qemu, pin or no pin", async () => {
+    const { resp } = await createRaw("1.2.3", { runtime: "qemu" });
+    expect(resp.status).toBe(410);
   });
 });

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -368,10 +368,6 @@
       }
     ]
   },
-  "banner": {
-    "content": "✨ You are viewing the **v2** Sandboxes docs, which have not gone into effect yet. For the Sandboxes docs that describe the platform as it works today, go to [docs-v1.opencomputer.dev](https://docs-v1.opencomputer.dev).",
-    "dismissible": false
-  },
   "logo": {
     "light": "/images/logo-light.svg",
     "dark": "/images/logo-dark.svg",

--- a/docs/migrating-from-v1.mdx
+++ b/docs/migrating-from-v1.mdx
@@ -3,12 +3,18 @@ title: "Migrating from v1"
 description: "Upgrade the SDK, verify it worked, and every behaviour that differs"
 ---
 
-**Upgrading the SDK is the migration.** There is no ticket to file and no setting to change:
-v1 and v2 are chosen by the major version of the SDK you have installed. Install `1.x` and your
-new sandboxes run on v2. Go back to `0.x` and they run on v1 again.
+<Warning>
+**v1 has been retired.** The workers that served it have been shut down. A `0.x` SDK now gets
+`410 Gone` with `code: "v1_retired"` on create, and existing v1 sandboxes are no longer
+reachable. Upgrading is the only path forward.
+</Warning>
 
-Existing sandboxes never move. The version decides where **new** sandboxes are created, so a
-rollback is a reinstall, not a recovery.
+**Upgrading the SDK is the migration.** There is no ticket to file and no setting to change:
+which platform you are on is decided by the major version of the SDK you have installed, and
+`1.x` is the only major that still has a fleet behind it.
+
+Rolling back is no longer possible. Until v1 was retired, reinstalling `0.x` put you back on it;
+that is no longer true, and pinning an old major now fails every create rather than serving one.
 
 ## Upgrade
 

--- a/internal/api/runtime_gate.go
+++ b/internal/api/runtime_gate.go
@@ -90,3 +90,43 @@ func runtimeForSDK(c echo.Context) string {
 	}
 	return ""
 }
+
+// ── v1 retirement ────────────────────────────────────────────────────────────
+
+// v1MigrationGuideURL is where a caller is sent to fix it. Kept in sync with
+// the edge's copy (cloudflare-workers/api-edge/src/runtime_gate.ts) by hand:
+// there is no shared artifact between a Go binary and a Worker, and both halves
+// have to say the same thing or the same customer gets two different answers
+// depending on which door they came in.
+const v1MigrationGuideURL = "https://docs.opencomputer.dev/migrating-from-v1"
+
+// v1RetiredStatus is the status a retired-runtime request is refused with.
+// Gone rather than Bad Request: the fleet existed, was served, and has been
+// withdrawn — which is exactly what 410 means and what a client should not
+// retry.
+const v1RetiredStatus = 410
+
+// v1RetiredBody is what a retired-runtime caller is told. Cause, fix, and where
+// the fix is written down; `code` so a caller can branch without matching prose.
+func v1RetiredBody() map[string]string {
+	return map[string]string{
+		"error": "OpenComputer v1 sandboxes have been retired. Upgrade to the v2 SDK — " +
+			"`npm install @opencomputer/sdk@^1` (or `pip install -U opencomputer`) — " +
+			"and see " + v1MigrationGuideURL + ". Existing v1 sandboxes are no longer reachable.",
+		"code":            "v1_retired",
+		"migration_guide": v1MigrationGuideURL,
+	}
+}
+
+// refuseIfRetired answers a request that would route to the v1 fleet.
+//
+// Returns nil when the request belongs on a runtime that still exists, so
+// callers read as `if err := s.refuseIfRetired(c); err != nil { return err }`.
+// The decision is runtimeFor's, unchanged — this only turns "QEMU" into a
+// refusal, because the QEMU workers are gone.
+func (s *Server) refuseIfRetired(c echo.Context) error {
+	if s.runtimeFor(c) == runtimeMicrovm {
+		return nil
+	}
+	return c.JSON(v1RetiredStatus, v1RetiredBody())
+}

--- a/internal/api/runtime_gate_test.go
+++ b/internal/api/runtime_gate_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -182,4 +183,60 @@ func TestHeaderNameMatchesTheSDK(t *testing.T) {
 	if sdkVersionHeader != "X-OC-SDK-Version" {
 		t.Errorf("header renamed to %q — sdks/typescript/src/version.ts sends x-oc-sdk-version", sdkVersionHeader)
 	}
+}
+
+// The v1 fleet is gone, so the direct-to-cell path has to refuse what it used
+// to route there — and say the same thing the edge says, since the same
+// customer can arrive through either door.
+func TestRefuseIfRetired(t *testing.T) {
+	org := uuid.New()
+
+	t.Run("refuses an old SDK", func(t *testing.T) {
+		c := ctxWithSDK(sdkOld)
+		auth.SetOrgID(c, org)
+		rec := c.Response().Writer.(*httptest.ResponseRecorder)
+		if err := serverForOrg(t, org, "").refuseIfRetired(c); err != nil {
+			t.Fatalf("refuseIfRetired returned an error: %v", err)
+		}
+		if rec.Code != v1RetiredStatus {
+			t.Fatalf("status = %d, want %d", rec.Code, v1RetiredStatus)
+		}
+		for _, want := range []string{"v1_retired", v1MigrationGuideURL, "@opencomputer/sdk@^1"} {
+			if !strings.Contains(rec.Body.String(), want) {
+				t.Fatalf("body %q does not mention %q", rec.Body.String(), want)
+			}
+		}
+	})
+
+	t.Run("refuses a client that announces nothing", func(t *testing.T) {
+		c := ctxWithSDK("")
+		auth.SetOrgID(c, org)
+		rec := c.Response().Writer.(*httptest.ResponseRecorder)
+		_ = serverForOrg(t, org, "").refuseIfRetired(c)
+		if rec.Code != v1RetiredStatus {
+			t.Fatalf("status = %d, want %d", rec.Code, v1RetiredStatus)
+		}
+	})
+
+	t.Run("refuses an org pinned to qemu even on a new SDK", func(t *testing.T) {
+		c := ctxWithSDK(sdkNew)
+		auth.SetOrgID(c, org)
+		rec := c.Response().Writer.(*httptest.ResponseRecorder)
+		_ = serverForOrg(t, org, "qemu").refuseIfRetired(c)
+		if rec.Code != v1RetiredStatus {
+			t.Fatalf("status = %d, want %d", rec.Code, v1RetiredStatus)
+		}
+	})
+
+	t.Run("lets a microvm caller through untouched", func(t *testing.T) {
+		c := ctxWithSDK(sdkNew)
+		auth.SetOrgID(c, org)
+		rec := c.Response().Writer.(*httptest.ResponseRecorder)
+		if err := serverForOrg(t, org, "").refuseIfRetired(c); err != nil {
+			t.Fatalf("refuseIfRetired refused a microvm caller: %v", err)
+		}
+		if rec.Code != http.StatusOK || rec.Body.Len() != 0 {
+			t.Fatalf("refuseIfRetired wrote a response for a microvm caller: %d %q", rec.Code, rec.Body.String())
+		}
+	})
 }

--- a/internal/api/sandbox.go
+++ b/internal/api/sandbox.go
@@ -68,6 +68,14 @@ func (s *Server) createSandbox(c echo.Context) error {
 	defer tr.emit()
 	c.SetRequest(c.Request().WithContext(withCreateTrace(c.Request().Context(), tr)))
 
+	// The v1 fleet this would route to has been shut down. Answered before the
+	// body is even read: there is nothing to validate a request against when
+	// the backend that would serve it is gone, and the caller needs the upgrade
+	// instruction rather than a failure further in.
+	if err := s.refuseIfRetired(c); err != nil {
+		return err
+	}
+
 	var cfg types.SandboxConfig
 	if err := c.Bind(&cfg); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{

--- a/internal/api/snapshots.go
+++ b/internal/api/snapshots.go
@@ -87,6 +87,11 @@ func (s *Server) createSnapshot(c echo.Context) error {
 	// 501 only when the cell has no artifact location configured — the feature
 	// is off, rather than broken. Anything else here would silently build a
 	// QEMU checkpoint this runtime can never restore.
+	// A v1 template is a whole-disk checkpoint and nothing left can restore
+	// one, so building it is refused with the same message as a create.
+	if err := s.refuseIfRetired(c); err != nil {
+		return err
+	}
 	if s.runtimeFor(c) == runtimeMicrovm {
 		builder, objects, prefix, ok := s.lite.templateBuilder()
 		if !ok {
@@ -343,6 +348,11 @@ func (s *Server) getSnapshot(c echo.Context) error {
 	// waitUntilReady treats 404 as "still building", so a customer waiting on a
 	// perfectly healthy template would poll until their timeout, or forever if
 	// they passed none.
+	// A v1 template is a whole-disk checkpoint and nothing left can restore
+	// one, so building it is refused with the same message as a create.
+	if err := s.refuseIfRetired(c); err != nil {
+		return err
+	}
 	if s.runtimeFor(c) == runtimeMicrovm {
 		tmpl, err := s.store.GetTemplateByName(c.Request().Context(), orgID, name)
 		if err != nil || tmpl == nil || tmpl.TemplateType != db.TemplateTypeMicrovmImage {


### PR DESCRIPTION
The QEMU workers are being shut down, so a request that would route to v1 is now
refused instead of forwarded to a fleet that cannot serve it.

**`410 Gone`**, with `code: "v1_retired"` and `migration_guide`, at the four places
that decide a runtime: edge create, edge snapshot, cell create, cell snapshot. The
routing decision itself is unchanged — only the outcome is. It catches `0.x` SDKs,
clients that send no version header, and orgs still pinned `qemu`. Refused before
forwarding, so nothing reaches a dead cell; refused before the body is read on the
cell.

`410` rather than `400`: the fleet existed, was served, and has been withdrawn, and
a client should not retry. `code` is there so the SDK can turn this into a typed
error later without another API change.

**Docs:** the v2 banner is gone. `migrating-from-v1` promised a rollback that no
longer exists ("go back to 0.x") — replaced with the retirement and the new contract.