### PR TITLE
Add managed GitHub App connections

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -90,6 +90,33 @@ the original request headers or managed secrets to the redirect destination.
 
 Hooks may only be called while the managed runtime is rendering an agent.
 
+## Managed GitHub App connection
+
+For direct Git, `gh`, REST, and GraphQL access, declare a managed GitHub App
+provider and select it from the agent:
+
+```ts
+import { defineConnection, githubApp, useConnection } from "@opencomputer/agent";
+
+const github = defineConnection({
+  id: "github",
+  provider: githubApp({
+    permissions: { contents: "write", pull_requests: "write" },
+  }),
+});
+
+export default function Agent() {
+  useConnection(github);
+  return "Push a branch and create a pull request.";
+}
+```
+
+The installer chooses all or selected repositories in GitHub; omitting an
+additional repository list means the entire GitHub installation grant. Unlike
+HTTP connections, a short-lived installation token is placed in the eligible
+sandbox as `GH_TOKEN` and `GITHUB_TOKEN`, where sandbox code can read it. It
+expires after about one hour and must never be printed, committed, or logged.
+
 ## Code-defined tools
 
 Define executable capabilities with OpenComputer's harness-neutral `tool()`

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -5,7 +5,9 @@ import {
   defineConnection,
   defineMemory,
   documentMemory,
+  githubApp,
   httpMemory,
+  useConnection,
   useInput,
   useMemory,
   useSecret,
@@ -15,6 +17,78 @@ import {
 } from "./index.js";
 
 const HOOKS = Symbol.for("opencomputer.agent-hooks");
+
+test("githubApp defines a frozen managed connection permission subset", () => {
+  const provider = githubApp({
+    permissions: {
+      contents: "write",
+      pull_requests: "write",
+      actions: "read",
+      metadata: "read",
+    },
+  });
+  const connection = defineConnection({ id: "github", provider });
+
+  assert.deepEqual(JSON.parse(JSON.stringify(connection)), {
+    kind: "connection",
+    id: "github",
+    provider: {
+      kind: "github-app",
+      permissions: {
+        contents: "write",
+        pull_requests: "write",
+        actions: "read",
+        metadata: "read",
+      },
+    },
+  });
+  assert.ok(Object.isFrozen(provider));
+  assert.ok(Object.isFrozen(provider.permissions));
+  assert.ok(Object.isFrozen(connection));
+});
+
+test("githubApp rejects empty, unsupported, and invalid permissions", () => {
+  assert.throws(
+    () => githubApp({ permissions: {} }),
+    /requires at least one permission/,
+  );
+  assert.throws(
+    () => githubApp({ permissions: { administration: "read" } as never }),
+    /does not support the administration permission/,
+  );
+  assert.throws(
+    () => githubApp({ permissions: { contents: "admin" } as never }),
+    /permission contents must be "read" or "write"/,
+  );
+  assert.throws(
+    () => githubApp({ permissions: { metadata: "write" } as never }),
+    /permission metadata must be "read"/,
+  );
+});
+
+test("useConnection selects a declared connection through the render host", () => {
+  const github = defineConnection({
+    id: "github",
+    origin: "https://api.github.com",
+  });
+  const selected: string[] = [];
+  const globals = globalThis as Record<PropertyKey, unknown>;
+  globals[HOOKS] = {
+    useConnection(connection: { id: string }) {
+      selected.push(connection.id);
+    },
+  };
+  try {
+    useConnection(github);
+    assert.deepEqual(selected, ["github"]);
+  } finally {
+    delete globals[HOOKS];
+  }
+  assert.throws(
+    () => useConnection(github),
+    /hooks can only run while rendering an agent/,
+  );
+});
 
 /**
  * Mirrors the host's render worker: a per-render scope with the projections

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -120,6 +120,26 @@ export interface HttpConnectionRedirectOrigin {
   readonly pathPrefix?: string;
 }
 
+export type GitHubAppPermission = "read" | "write";
+
+export interface GitHubAppPermissions {
+  readonly contents?: GitHubAppPermission;
+  readonly pull_requests?: GitHubAppPermission;
+  readonly issues?: GitHubAppPermission;
+  readonly checks?: GitHubAppPermission;
+  readonly actions?: GitHubAppPermission;
+  readonly metadata?: "read";
+}
+
+export interface GitHubAppProvider {
+  readonly kind: "github-app";
+  readonly permissions: Readonly<GitHubAppPermissions>;
+}
+
+export interface GitHubConnectionDefinition extends ConnectionReference {
+  readonly provider: GitHubAppProvider;
+}
+
 export interface McpServerDefinition extends ResourceReference {
   readonly kind: "mcp";
   readonly url: string;
@@ -373,6 +393,9 @@ export { defineMemory, documentMemory, httpMemory } from "./memory.js";
  * - `useInput()` reads `scope.input`.
  * - `useSessionData(key)` reads `scope.state[key]`.
  * - `useTool(id)` adds to `scope.tools`; returned as `enabledTools`.
+ * - `useConnection(id)` adds to `scope.connections`; returned as
+ *   `requiredConnections` so the host can make the declared connection
+ *   available to this render.
  * - `useMemory(id)` reads `scope.memory[id]`, the projection the host
  *   resolved for the session binding with that resource id (absent when the
  *   session has no binding for it), and adds the id to
@@ -384,6 +407,7 @@ interface AgentHooks {
   useInput(): Readonly<AgentInput>;
   useModel(model: ModelSelection): void;
   useTool(tool: string | ResourceReference): void;
+  useConnection(connection: string | ResourceReference): void;
   useSubagent(agent: string | ResourceReference): void;
   useSessionData<T extends DataValue>(key: string): T | undefined;
   useMcpServer(server: string | ResourceReference): void;
@@ -430,15 +454,75 @@ export function bearer(secret: SecretReference): SecretHeaderReference {
   return secretHeader(secret, { prefix: "Bearer " });
 }
 
-export function defineConnection(input: {
+const GITHUB_APP_PERMISSION_KEYS = [
+  "actions",
+  "checks",
+  "contents",
+  "issues",
+  "metadata",
+  "pull_requests",
+] as const;
+
+export function githubApp(options: {
+  permissions: GitHubAppPermissions;
+}): GitHubAppProvider {
+  const entries = Object.entries(options?.permissions ?? {});
+  if (entries.length === 0) {
+    throw new Error("githubApp() requires at least one permission");
+  }
+  const permissions: Record<string, GitHubAppPermission> = {};
+  for (const [name, level] of entries) {
+    if (!(GITHUB_APP_PERMISSION_KEYS as readonly string[]).includes(name)) {
+      throw new Error(
+        `githubApp() does not support the ${name} permission; supported permissions are ${GITHUB_APP_PERMISSION_KEYS.join(", ")}`,
+      );
+    }
+    if (level !== "read" && level !== "write") {
+      throw new Error(
+        `githubApp() permission ${name} must be "read" or "write"`,
+      );
+    }
+    if (name === "metadata" && level !== "read") {
+      throw new Error('githubApp() permission metadata must be "read"');
+    }
+    permissions[name] = level;
+  }
+  return Object.freeze({
+    kind: "github-app",
+    permissions: Object.freeze(permissions),
+  });
+}
+
+interface HttpConnectionInput {
   id: string;
   origin: string;
   headers?: Readonly<Record<string, string | SecretHeaderReference>>;
   methods?: readonly string[];
   pathPrefix?: string;
   redirectOrigins?: readonly HttpConnectionRedirectOrigin[];
-}): HttpConnectionDefinition {
+}
+
+interface GitHubConnectionInput {
+  id: string;
+  provider: GitHubAppProvider;
+}
+
+export function defineConnection(
+  input: HttpConnectionInput,
+): HttpConnectionDefinition;
+export function defineConnection(
+  input: GitHubConnectionInput,
+): GitHubConnectionDefinition;
+export function defineConnection(
+  input: HttpConnectionInput | GitHubConnectionInput,
+): HttpConnectionDefinition | GitHubConnectionDefinition {
   const id = identifier(input.id, "defineConnection");
+  if ("provider" in input) {
+    if (input.provider?.kind !== "github-app") {
+      throw new Error("defineConnection() received an unsupported provider");
+    }
+    return Object.freeze({ kind: "connection", id, provider: input.provider });
+  }
   const origin = new URL(input.origin);
   if (origin.protocol !== "https:" || origin.pathname !== "/") {
     throw new Error("Connection origins must be HTTPS origins without a path");
@@ -966,6 +1050,9 @@ export const useModel = (model: ModelSelection): void =>
   hooks().useModel(model);
 export const useTool = (tool: string | ResourceReference): void =>
   hooks().useTool(tool);
+export const useConnection = (
+  connection: string | ResourceReference,
+): void => hooks().useConnection(connection);
 export const useSubagent = (agent: string | ResourceReference): void =>
   hooks().useSubagent(agent);
 export const useMcpServer = (server: string | ResourceReference): void =>

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -61,6 +61,24 @@ export interface ManagedSecretMetadata {
   updatedAt: string;
 }
 
+export interface ManagedGitHubStatus {
+  environments: Array<{
+    environment: "development" | "production";
+    state: "not_connected" | "active" | "suspended" | "deleted";
+    installation?: {
+      id: string;
+      githubInstallationId: number;
+      accountLogin: string;
+      accountType: string;
+      repositorySelection: "all" | "selected";
+      state: "active" | "suspended" | "deleted";
+      createdAt: string;
+      updatedAt: string;
+    };
+  }>;
+  app: { slug: string } | null;
+}
+
 // Model access (work 011). The provider token is write-only; these shapes
 // carry only normalized metadata.
 export interface ModelAccessConnection {
@@ -466,6 +484,37 @@ export class OpenComputerClient {
   projectSourceArchive(projectId: string): Promise<Response> {
     return this.response(
       `/api/managed-agents/projects/${encodeURIComponent(projectId)}/source-archive`,
+    );
+  }
+
+  githubStatus(projectId: string) {
+    return this.request<ManagedGitHubStatus>(
+      `/api/managed-agents/projects/${encodeURIComponent(projectId)}/github`,
+    );
+  }
+
+  connectGitHub(input: {
+    projectId: string;
+    environments?: Array<"development" | "production">;
+  }) {
+    return this.request<{ installUrl: string }>(
+      `/api/managed-agents/projects/${encodeURIComponent(input.projectId)}/github/connect`,
+      {
+        method: "POST",
+        body: JSON.stringify(
+          input.environments ? { environments: input.environments } : {},
+        ),
+      },
+    );
+  }
+
+  disconnectGitHub(input: {
+    projectId: string;
+    environment: "development" | "production";
+  }) {
+    return this.request<void>(
+      `/api/managed-agents/projects/${encodeURIComponent(input.projectId)}/github?environment=${input.environment}`,
+      { method: "DELETE" },
     );
   }
 
@@ -962,6 +1011,13 @@ export class OpenComputerClient {
       methods?: string[];
       pathPrefix?: string;
       redirectOrigins?: Array<{ origin: string; pathPrefix?: string }>;
+    }>;
+    githubConnections: Array<{
+      id: string;
+      provider: {
+        kind: "github-app";
+        permissions: Record<string, "read" | "write">;
+      };
     }>;
     memory: MemoryDeclaration[];
     projectDeployment?: {

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -497,7 +497,7 @@ export class OpenComputerClient {
     projectId: string;
     environments?: Array<"development" | "production">;
   }) {
-    return this.request<{ installUrl: string }>(
+    return this.request<{ installUrl: string; authorizeUrl: string }>(
       `/api/managed-agents/projects/${encodeURIComponent(input.projectId)}/github/connect`,
       {
         method: "POST",

--- a/cli/src/dev.ts
+++ b/cli/src/dev.ts
@@ -65,6 +65,7 @@ async function registerBuiltDeployment(
     channels: built.channels,
     connections: built.connections,
     httpConnections: built.httpConnections,
+    githubConnections: built.githubConnections,
     memory: built.memory,
     ...(projectDeployment ? { projectDeployment } : {}),
     source: {

--- a/cli/src/doctor.test.ts
+++ b/cli/src/doctor.test.ts
@@ -59,6 +59,31 @@ test("doctor accepts the initialized project without contacting the API", async 
   }
 });
 
+test("doctor accepts a managed GitHub provider without an HTTP origin", async () => {
+  const root = await mkdtemp(resolve(tmpdir(), "opencomputer-doctor-github-"));
+  try {
+    const initialized = await initializeAgentProject(root);
+    await writeFile(
+      resolve(initialized.agentRoot, "agent.ts"),
+      `import { defineConnection, githubApp, useConnection } from "@opencomputer/agent";
+const github = defineConnection({
+  id: "github",
+  provider: githubApp({ permissions: { contents: "write" } }),
+});
+export default function Agent() {
+  useConnection(github);
+  return "Use GitHub.";
+}
+`,
+    );
+    const result = await doctorProject(root);
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.diagnostics, []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("doctor parses single-line declarations and ignores comments", async () => {
   const root = await mkdtemp(resolve(tmpdir(), "opencomputer-doctor-"));
   try {

--- a/cli/src/doctor.ts
+++ b/cli/src/doctor.ts
@@ -105,6 +105,10 @@ export async function doctorProject(projectRoot: string): Promise<DoctorResult> 
         }
         if (name === "defineConnection") {
           const definition = node.arguments[0];
+          const provider =
+            definition && ts.isObjectLiteralExpression(definition)
+              ? property(definition, "provider")
+              : undefined;
           const origin =
             definition && ts.isObjectLiteralExpression(definition)
               ? property(definition, "origin")
@@ -125,9 +129,10 @@ export async function doctorProject(projectRoot: string): Promise<DoctorResult> 
                 );
               }));
           if (
-            !origin ||
-            !isLiteralHttpsOrigin(origin.initializer) ||
-            !redirectsValid
+            !provider &&
+            (!origin ||
+              !isLiteralHttpsOrigin(origin.initializer) ||
+              !redirectsValid)
           ) {
             const line =
               syntax.getLineAndCharacterOfPosition(node.getStart(syntax)).line +

--- a/cli/src/project.test.ts
+++ b/cli/src/project.test.ts
@@ -342,6 +342,7 @@ export default function Agent() {
       subagents: string[];
       connections: string[];
       httpConnections: unknown[];
+      githubConnections: unknown[];
       mcpServers: string[];
       mcpServerDefinitions: Array<{
         id: string;
@@ -359,6 +360,7 @@ export default function Agent() {
       subagents: ["researcher"],
       connections: [],
       httpConnections: [],
+      githubConnections: [],
       mcpServers: ["docs"],
       mcpServerDefinitions: [
         { id: "docs", url: "https://mcp.example.com/" },
@@ -460,10 +462,11 @@ export const repository = defineTool({
     );
     await writeFile(
       resolve(initialized.agentRoot, "agent.ts"),
-      `import { useTool } from "@opencomputer/agent";
+      `import { useConnection, useTool } from "@opencomputer/agent";
 import { repository } from "./tools/github.js";
 
 export default function Agent() {
+  useConnection({ id: "github-api" });
   useTool(repository);
   return "Use GitHub when needed.";
 }
@@ -499,6 +502,122 @@ export default function Agent() {
     ]);
     assert.ok(built.connections.includes("github-api"));
     assert.doesNotMatch(built.body.toString("utf8"), /actual-secret-value/);
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+test("the compiler records managed GitHub permissions as a provider connection", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-github-app-"));
+  const root = resolve(parent, "app");
+  try {
+    const initialized = await initializeAgentProject(root);
+    await mkdir(resolve(initialized.agentRoot, "connections"), {
+      recursive: true,
+    });
+    await writeFile(
+      resolve(initialized.agentRoot, "connections", "github.ts"),
+      `import { defineConnection, githubApp } from "@opencomputer/agent";
+
+export const github = defineConnection({
+  id: "github",
+  provider: githubApp({
+    permissions: {
+      pull_requests: "write",
+      contents: "write",
+      metadata: "read",
+    },
+  }),
+});
+`,
+    );
+    await writeFile(
+      resolve(initialized.agentRoot, "agent.ts"),
+      `import { useConnection } from "@opencomputer/agent";
+import { github } from "./connections/github.js";
+
+export default function Agent() {
+  useConnection(github);
+  return "Work with GitHub directly.";
+}
+`,
+    );
+
+    const built = await buildAgentArtifact(initialized.agentRoot);
+    assert.deepEqual(built.connections, ["github"]);
+    assert.deepEqual(built.httpConnections, []);
+    assert.deepEqual(built.githubConnections, [
+      {
+        id: "github",
+        provider: {
+          kind: "github-app",
+          permissions: {
+            contents: "write",
+            metadata: "read",
+            pull_requests: "write",
+          },
+        },
+      },
+    ]);
+    const manifest = JSON.parse(
+      await readFile(
+        resolve(initialized.agentRoot, ".opencomputer", "runtime", ".opencomputer", "reactive.json"),
+        "utf8",
+      ),
+    ) as { githubConnections: unknown[] };
+    assert.deepEqual(manifest.githubConnections, built.githubConnections);
+  } finally {
+    await rm(parent, { recursive: true, force: true });
+  }
+});
+
+test("the compiler rejects dynamic or unsupported GitHub permissions", async () => {
+  const parent = await mkdtemp(resolve(tmpdir(), "opencomputer-github-invalid-"));
+  const root = resolve(parent, "app");
+  try {
+    const initialized = await initializeAgentProject(root);
+    await mkdir(resolve(initialized.agentRoot, "connections"), {
+      recursive: true,
+    });
+    const connection = resolve(
+      initialized.agentRoot,
+      "connections",
+      "github.ts",
+    );
+    await writeFile(
+      resolve(initialized.agentRoot, "agent.ts"),
+      `import "./connections/github.js";
+export default function Agent() { return "Use GitHub."; }
+`,
+    );
+    await writeFile(
+      connection,
+      `import { defineConnection, githubApp } from "@opencomputer/agent";
+const permissions = { contents: "write" } as const;
+export default defineConnection({
+  id: "github",
+  provider: githubApp({ permissions }),
+});
+`,
+    );
+    await assert.rejects(
+      buildAgentArtifact(initialized.agentRoot),
+      /githubApp\(\) options must be static/,
+    );
+
+    await writeFile(
+      connection,
+      `import { defineConnection, githubApp } from "@opencomputer/agent";
+export default defineConnection({
+  id: "github",
+  provider: githubApp({ permissions: { administration: "write" } }),
+});
+`,
+    );
+    await assert.rejects(
+      buildAgentArtifact(initialized.agentRoot),
+      /does not support the administration permission/,
+    );
   } finally {
     await rm(parent, { recursive: true, force: true });
   }

--- a/cli/src/project.ts
+++ b/cli/src/project.ts
@@ -40,6 +40,7 @@ export interface BuiltAgentArtifact {
   channels: string[];
   connections: string[];
   httpConnections: HttpConnectionManifest[];
+  githubConnections: GitHubConnectionManifest[];
   memory: MemoryDeclaration[];
   body: Buffer;
   digest: string;
@@ -68,6 +69,16 @@ export interface HttpConnectionManifest {
   methods?: string[];
   pathPrefix?: string;
   redirectOrigins?: Array<{ origin: string; pathPrefix?: string }>;
+}
+
+export type GitHubAppPermission = "read" | "write";
+
+export interface GitHubConnectionManifest {
+  id: string;
+  provider: {
+    kind: "github-app";
+    permissions: Record<string, GitHubAppPermission>;
+  };
 }
 
 export interface McpServerManifest {
@@ -2137,6 +2148,10 @@ function definedHttpConnections(
       if (!input || !ts.isObjectLiteralExpression(input)) {
         throw new Error("defineConnection() requires an object literal");
       }
+      if (objectProperty(input, "provider")) {
+        ts.forEachChild(node, visit);
+        return;
+      }
       const id = literalStringValue(
         objectProperty(input, "id"),
         "connection id",
@@ -2276,6 +2291,144 @@ function definedHttpConnections(
   return definitions;
 }
 
+const GITHUB_APP_PERMISSION_KEYS = new Set([
+  "actions",
+  "checks",
+  "contents",
+  "issues",
+  "metadata",
+  "pull_requests",
+]);
+
+function definedGitHubConnections(
+  source: string,
+  path: string,
+): GitHubConnectionManifest[] {
+  const file = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true);
+  const definitions: GitHubConnectionManifest[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "defineConnection"
+    ) {
+      const input = node.arguments[0];
+      if (!input || !ts.isObjectLiteralExpression(input)) {
+        throw new Error("defineConnection() requires an object literal");
+      }
+      const providerExpression = objectProperty(input, "provider");
+      if (!providerExpression) {
+        ts.forEachChild(node, visit);
+        return;
+      }
+      const id = literalStringValue(
+        objectProperty(input, "id"),
+        "connection id",
+      );
+      for (const property of input.properties) {
+        if (!ts.isPropertyAssignment(property)) {
+          throw new Error(`Connection ${id} cannot use spreads or shorthand properties`);
+        }
+        const name = staticPropertyName(property.name, `Connection ${id}`);
+        if (name !== "id" && name !== "provider") {
+          throw new Error(
+            `GitHub connection ${id} does not support the ${name} option`,
+          );
+        }
+      }
+      if (
+        !ts.isCallExpression(providerExpression) ||
+        !ts.isIdentifier(providerExpression.expression) ||
+        providerExpression.expression.text !== "githubApp"
+      ) {
+        throw new Error(
+          `Connection ${id} provider must be an inline githubApp() call`,
+        );
+      }
+      const options = literalCallArgument(
+        providerExpression,
+        `Connection ${id} githubApp()`,
+      );
+      if (!options) {
+        throw new Error(`Connection ${id} githubApp() requires permissions`);
+      }
+      for (const property of options.properties) {
+        if (!ts.isPropertyAssignment(property)) {
+          throw new Error(`Connection ${id} githubApp() options must be static`);
+        }
+        if (
+          staticPropertyName(property.name, `Connection ${id} githubApp()`) !==
+          "permissions"
+        ) {
+          throw new Error(
+            `Connection ${id} githubApp() only supports permissions`,
+          );
+        }
+      }
+      const permissionsExpression = objectProperty(options, "permissions");
+      if (
+        !permissionsExpression ||
+        !ts.isObjectLiteralExpression(permissionsExpression)
+      ) {
+        throw new Error(
+          `Connection ${id} githubApp() permissions must be an inline object literal`,
+        );
+      }
+      const permissions: Record<string, GitHubAppPermission> = {};
+      for (const property of permissionsExpression.properties) {
+        if (!ts.isPropertyAssignment(property)) {
+          throw new Error(
+            `Connection ${id} githubApp() permissions must use literal properties`,
+          );
+        }
+        const name = staticPropertyName(
+          property.name,
+          `Connection ${id} githubApp() permissions`,
+        );
+        if (!GITHUB_APP_PERMISSION_KEYS.has(name)) {
+          throw new Error(
+            `Connection ${id} githubApp() does not support the ${name} permission`,
+          );
+        }
+        const level = literalStringValue(
+          property.initializer,
+          `Connection ${id} githubApp() permission ${name}`,
+        );
+        if (level !== "read" && level !== "write") {
+          throw new Error(
+            `Connection ${id} githubApp() permission ${name} must be "read" or "write"`,
+          );
+        }
+        if (name === "metadata" && level !== "read") {
+          throw new Error(
+            `Connection ${id} githubApp() permission metadata must be "read"`,
+          );
+        }
+        permissions[name] = level;
+      }
+      if (Object.keys(permissions).length === 0) {
+        throw new Error(
+          `Connection ${id} githubApp() requires at least one permission`,
+        );
+      }
+      definitions.push({
+        id,
+        provider: {
+          kind: "github-app",
+          permissions: Object.fromEntries(
+            Object.entries(permissions).sort(([left], [right]) =>
+              left.localeCompare(right),
+            ),
+          ),
+        },
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(file);
+  return definitions;
+}
+
 function definedToolIds(source: string): string[] {
   return [
     ...source.matchAll(
@@ -2365,8 +2518,24 @@ export const useSecret = (value) => {
 };
 export const secretHeader = (secret, options = {}) => Object.freeze({ kind: "secret-header", secret, ...options });
 export const bearer = (secret) => secretHeader(secret, { prefix: "Bearer " });
+export const githubApp = (options) => {
+  const entries = Object.entries(options?.permissions || {});
+  if (!entries.length) throw new Error("githubApp() requires at least one permission");
+  const permissions = {};
+  for (const [name, level] of entries) {
+    if (!["actions", "checks", "contents", "issues", "metadata", "pull_requests"].includes(name)) throw new Error("githubApp() does not support the " + name + " permission");
+    if (level !== "read" && level !== "write") throw new Error("githubApp() permission " + name + " must be read or write");
+    if (name === "metadata" && level !== "read") throw new Error("githubApp() permission metadata must be read");
+    permissions[name] = level;
+  }
+  return Object.freeze({ kind: "github-app", permissions: Object.freeze(permissions) });
+};
 export const defineConnection = (input) => {
   const connectionId = id(input.id, "defineConnection");
+  if (input.provider) {
+    if (input.provider.kind !== "github-app") throw new Error("defineConnection() received an unsupported provider");
+    return Object.freeze({ kind: "connection", id: connectionId, provider: input.provider });
+  }
   const origin = new URL(input.origin);
   if (origin.protocol !== "https:" || origin.pathname !== "/") throw new Error("Connection origins must be HTTPS origins without a path");
   for (const [name, value] of Object.entries(input.headers || {})) {
@@ -2452,6 +2621,7 @@ export const useInput = () => hooks().useInput();
 export const useCurrentInput = useInput;
 export const useModel = (model) => hooks().useModel(model);
 export const useTool = (tool) => hooks().useTool(tool);
+export const useConnection = (connection) => hooks().useConnection(connection);
 export const useSubagent = (agent) => hooks().useSubagent(agent);
 export const useMcpServer = (server) => hooks().useMcpServer(server);
 export const useSessionData = (key) => hooks().useSessionData(key);
@@ -2685,9 +2855,13 @@ the product or support surface presented to users.
   const httpConnections = sourceModules.flatMap((module) =>
     definedHttpConnections(module.source, module.path),
   );
-  const duplicateConnection = httpConnections.find(
+  const githubConnections = sourceModules.flatMap((module) =>
+    definedGitHubConnections(module.source, module.path),
+  );
+  const allConnections = [...httpConnections, ...githubConnections];
+  const duplicateConnection = allConnections.find(
     (connection, index) =>
-      httpConnections.findIndex(
+      allConnections.findIndex(
         (candidate) => candidate.id === connection.id,
       ) !== index,
   );
@@ -2763,8 +2937,9 @@ the product or support surface presented to users.
         tools,
         toolModules: toolModules.sort(),
         subagents: literalHookIds(agentSource, "useSubagent"),
-        connections: httpConnections.map((connection) => connection.id).sort(),
+        connections: allConnections.map((connection) => connection.id).sort(),
         httpConnections,
+        githubConnections,
         mcpServers: [
           ...new Set([
             ...mcpServerDefinitions.map((server) => server.id),
@@ -2814,10 +2989,12 @@ export async function buildAgentArtifact(
   ) as {
     connections?: string[];
     httpConnections?: HttpConnectionManifest[];
+    githubConnections?: GitHubConnectionManifest[];
     memory?: MemoryDeclaration[];
   };
   const connections = [...new Set(reactive.connections ?? [])].sort();
   const httpConnections = reactive.httpConnections ?? [];
+  const githubConnections = reactive.githubConnections ?? [];
   const memory = reactive.memory ?? [];
   const body = Buffer.from(
     JSON.stringify({
@@ -2832,6 +3009,7 @@ export async function buildAgentArtifact(
     channels: [],
     connections,
     httpConnections,
+    githubConnections,
     memory,
     body,
     digest: createHash("sha256").update(body).digest("hex"),

--- a/cli/src/template.ts
+++ b/cli/src/template.ts
@@ -5,6 +5,7 @@ import {
   mergeMemoryDeclarations,
   readProjectAgents,
   readProjectResources,
+  type GitHubConnectionManifest,
   type HttpConnectionManifest,
   type MemoryDeclaration,
   type ProjectResourceManifest,
@@ -49,6 +50,7 @@ export interface TemplateBuildArtifact {
   body: string;
   connections: string[];
   httpConnections: HttpConnectionManifest[];
+  githubConnections: GitHubConnectionManifest[];
   memory: MemoryDeclaration[];
 }
 
@@ -326,6 +328,7 @@ export async function buildTemplateProject(
       body: built.body.toString("utf8"),
       connections: built.connections,
       httpConnections: built.httpConnections,
+      githubConnections: built.githubConnections,
       memory: built.memory,
     });
     for (const connection of built.connections)

--- a/cloudflare-workers/api-edge/src/index.ts
+++ b/cloudflare-workers/api-edge/src/index.ts
@@ -81,6 +81,7 @@ import * as webhooks from "./webhooks";
 import { createAPIKey, hashAPIKey } from "./api_keys";
 import {
   handleAgentWebhookInvocation,
+  handleManagedGitHubCallback,
   handleManagedAgentChannelConnection,
   proxyManagedAgents,
 } from "./managed_agents";
@@ -5408,6 +5409,12 @@ export default {
     // assertion before calling the private deployment backend.
     if (path.startsWith("/api/managed-agents/channel-connections/")) {
       return handleManagedAgentChannelConnection(req, env);
+    }
+    if (
+      path === "/api/managed-agents/github/callback" &&
+      req.method === "GET"
+    ) {
+      return handleManagedGitHubCallback(req, env);
     }
     if (path.startsWith("/api/agent-webhooks/")) {
       return handleAgentWebhookInvocation(req, env);

--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   handleAgentWebhookInvocation,
   handleManagedAgentChannelConnection,
+  handleManagedGitHubCallback,
   hasBYOKPlanAccess,
   mintManagedAgentsAssertion,
   proxyManagedAgents,
@@ -50,6 +51,63 @@ describe("managed agents proxy", () => {
       role: "admin",
     });
     expect(Number(payload.exp) - Number(payload.iat)).toBe(120);
+  });
+
+  it("forwards managed GitHub project connection requests", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        installUrl:
+          "https://github.com/apps/opencomputer/installations/new?state=opaque",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const response = await proxyManagedAgents(
+      new Request(
+        "https://mo-oc-dev.com/api/managed-agents/projects/prj_test/github/connect",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ environments: ["development"] }),
+        },
+      ),
+      {
+        MANAGED_AGENTS_API_URL: "https://manage-agents.mo-oc-dev.com",
+        OC_MANAGED_AGENTS_SECRET: "test-secret",
+      },
+      { orgID: "org_test", userID: "user_test" },
+      "/api/managed-agents",
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      installUrl:
+        "https://github.com/apps/opencomputer/installations/new?state=opaque",
+    });
+    expect(fetchMock.mock.calls[0]?.[0].toString()).toBe(
+      "https://manage-agents.mo-oc-dev.com/v1/projects/prj_test/github/connect",
+    );
+  });
+
+  it("forwards the unauthenticated GitHub setup callback as HTML", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("<html>connected</html>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const response = await handleManagedGitHubCallback(
+      new Request(
+        "https://mo-oc-dev.com/api/managed-agents/github/callback?code=oauth-code&installation_id=123&state=opaque",
+      ),
+      { MANAGED_AGENTS_API_URL: "https://manage-agents.mo-oc-dev.com" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(response.text()).resolves.toContain("connected");
+    expect(fetchMock.mock.calls[0]?.[0].toString()).toBe(
+      "https://manage-agents.mo-oc-dev.com/v1/github/callback?code=oauth-code&installation_id=123&state=opaque",
+    );
   });
 
   it("allows BYOK for Pro and Max but not the base plan", async () => {
@@ -1428,6 +1486,18 @@ describe("managed agents proxy", () => {
                 },
               },
             ],
+            githubConnections: [
+              {
+                id: "github",
+                provider: {
+                  kind: "github-app",
+                  permissions: {
+                    contents: "write",
+                    pull_requests: "write",
+                  },
+                },
+              },
+            ],
             memory: [
               {
                 id: "requirements",
@@ -1472,6 +1542,18 @@ describe("managed agents proxy", () => {
           id: "github-api",
           origin: "https://api.github.com",
         }),
+      ],
+      githubConnections: [
+        {
+          id: "github",
+          provider: {
+            kind: "github-app",
+            permissions: {
+              contents: "write",
+              pull_requests: "write",
+            },
+          },
+        },
       ],
       memory: [
         {

--- a/cloudflare-workers/api-edge/src/managed_agents.test.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.test.ts
@@ -58,6 +58,8 @@ describe("managed agents proxy", () => {
       Response.json({
         installUrl:
           "https://github.com/apps/opencomputer/installations/new?state=opaque",
+        authorizeUrl:
+          "https://github.com/login/oauth/authorize?client_id=test&state=opaque",
       }),
     );
     vi.stubGlobal("fetch", fetchMock);
@@ -82,6 +84,8 @@ describe("managed agents proxy", () => {
     await expect(response.json()).resolves.toEqual({
       installUrl:
         "https://github.com/apps/opencomputer/installations/new?state=opaque",
+      authorizeUrl:
+        "https://github.com/login/oauth/authorize?client_id=test&state=opaque",
     });
     expect(fetchMock.mock.calls[0]?.[0].toString()).toBe(
       "https://manage-agents.mo-oc-dev.com/v1/projects/prj_test/github/connect",

--- a/cloudflare-workers/api-edge/src/managed_agents.ts
+++ b/cloudflare-workers/api-edge/src/managed_agents.ts
@@ -1070,6 +1070,9 @@ function publicSuccessBody(
   if (method === "POST" && suffix === "/projects") {
     return publicProject(body);
   }
+  if (/^\/projects\/[^/]+\/github(?:\/connect)?$/.test(suffix)) {
+    return stripPrivateValues(body);
+  }
   if (
     (method === "GET" || method === "PUT") &&
     /^\/projects\/[^/]+\/secrets(?:\/[^/]+)?$/.test(suffix)
@@ -1503,6 +1506,9 @@ async function deploySourceAgent(
       httpConnections: Array.isArray(body.httpConnections)
         ? body.httpConnections
         : [],
+      githubConnections: Array.isArray(body.githubConnections)
+        ? body.githubConnections
+        : [],
       memory: Array.isArray(body.memory) ? body.memory : [],
       ...(body.projectDeployment && typeof body.projectDeployment === "object"
         ? { projectDeployment: body.projectDeployment }
@@ -1536,6 +1542,18 @@ function isAllowedManagedAgentsRoute(method: string, suffix: string): boolean {
   }
   if (method === "GET" && /^\/projects\/[^/]+$/.test(suffix)) return true;
   if (method === "GET" && /^\/projects\/[^/]+\/source-archive$/.test(suffix)) {
+    return true;
+  }
+  if (
+    (method === "GET" || method === "DELETE") &&
+    /^\/projects\/[^/]+\/github$/.test(suffix)
+  ) {
+    return true;
+  }
+  if (
+    method === "POST" &&
+    /^\/projects\/[^/]+\/github\/connect$/.test(suffix)
+  ) {
     return true;
   }
   if (
@@ -1630,6 +1648,49 @@ function isAllowedManagedAgentsRoute(method: string, suffix: string): boolean {
       suffix,
     )
   );
+}
+
+export async function handleManagedGitHubCallback(
+  request: Request,
+  env: ManagedAgentsEnv,
+): Promise<Response> {
+  if (request.method !== "GET") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+  const requestURL = new URL(request.url);
+  const base = (
+    env.MANAGED_AGENTS_API_URL ?? DEFAULT_MANAGED_AGENTS_API_URL
+  ).replace(/\/+$/, "");
+  const target = new URL(`${base}/v1/github/callback${requestURL.search}`);
+  if (target.protocol !== "https:" && target.hostname !== "localhost") {
+    return new Response("GitHub connection is unavailable", { status: 503 });
+  }
+  try {
+    const upstream = await fetch(target, { redirect: "manual" });
+    const headers = new Headers();
+    for (const name of [
+      "content-type",
+      "cache-control",
+      "content-security-policy",
+      "referrer-policy",
+      "x-content-type-options",
+      "x-frame-options",
+    ]) {
+      const value = upstream.headers.get(name);
+      if (value) headers.set(name, value);
+    }
+    headers.set("cache-control", "no-store");
+    return new Response(upstream.body, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers,
+    });
+  } catch {
+    return new Response("GitHub connection is temporarily unavailable", {
+      status: 502,
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    });
+  }
 }
 
 function channelConnectionPage(

--- a/docs/agents/capabilities.mdx
+++ b/docs/agents/capabilities.mdx
@@ -13,6 +13,7 @@ the narrowest capability that fits the job.
 | Skill | A reusable procedure, checklist, or supporting files | The agent follows the loaded instructions | Place it under `skills/` |
 | Subagent | Delegating a focused task to another project agent | The delegated agent | `useSubagent(agentId)` |
 | HTTP connection | A constrained authenticated outbound request | OpenComputer sends the declared request | Call `defineConnection().fetch()` inside a tool |
+| GitHub App connection | Direct Git and GitHub API access to an installation | The agent sandbox uses a short-lived installation token | `useConnection(github)` |
 | Memory | Notes shared across sessions | OpenComputer stores documents; the agent reads and saves through memory tools | `useMemory(memory)` |
 
 `useModel()` selects the model for a render, but it does not add an executable
@@ -48,13 +49,17 @@ across sessions that agents can save and owners can edit. A tool that
 writes to your own database is a third option when the data belongs to your
 application rather than to the agent's continuing work.
 
-## Connections are not managed accounts
+## HTTP connections are not managed accounts
 
 `defineConnection()` declares a secret-backed HTTP destination. It is not an
 OAuth account selector and does not itself give the model a tool. Call it from
 a code-defined tool or attach it to an MCP definition that accepts the
 declared authorization headers. The proposed [HTTP memory provider
 contract](/agents/memory-providers) uses the same connection mechanism.
+
+A [managed GitHub App connection](/agents/github) is the exception: the user
+installs OpenComputer's App, chooses repositories in GitHub, and the eligible
+agent receives a short-lived installation token for direct Git and API calls.
 
 See [Secrets and outbound requests](/agents/secrets) for the complete security
 model.

--- a/docs/agents/github.mdx
+++ b/docs/agents/github.mdx
@@ -1,0 +1,84 @@
+---
+title: "GitHub App connections"
+description: "Give an agent direct Git and GitHub API access with the managed OpenComputer App"
+---
+
+A managed GitHub connection lets an agent clone repositories, push branches,
+use the `gh` CLI, and call GitHub's REST or GraphQL APIs as a GitHub App
+installation.
+
+## Declare access
+
+Declare the maximum permissions this agent needs, then select the connection
+with `useConnection()`:
+
+```tsx
+import {
+  defineConnection,
+  githubApp,
+  useConnection,
+} from "@opencomputer/agent";
+
+const github = defineConnection({
+  id: "github",
+  provider: githubApp({
+    permissions: {
+      contents: "write",
+      pull_requests: "write",
+    },
+  }),
+});
+
+export default function Agent() {
+  useConnection(github);
+  return "Work on the requested repository, push a branch, and open a PR.";
+}
+```
+
+The supported permissions are `actions`, `checks`, `contents`, `issues`,
+`metadata`, and `pull_requests`. `metadata` is read-only. Request only what the
+agent needs.
+
+## Install the App
+
+Deploy the agent, open its project in the OpenComputer dashboard, and choose
+**GitHub**. Install the managed OpenComputer GitHub App into a user or
+organization account. GitHub lets the installer select all repositories or a
+specific set of repositories.
+
+That GitHub installation selection is the complete repository boundary. There
+is no second OpenComputer repository allowlist. If the installer selects all
+repositories, the agent can access every repository available to that
+installation; if specific repositories are selected, it can access only those
+repositories. Change the selection in GitHub's installation settings.
+
+Connections are attached independently to the project's development and
+production environments.
+
+## Use Git and the API
+
+Inside the agent sandbox, ordinary GitHub tooling works directly:
+
+```bash
+git clone https://github.com/acme/service.git
+git -C service switch -c agent/update
+git -C service push -u origin agent/update
+gh pr create --repo acme/service --fill
+gh api repos/acme/service/pulls
+```
+
+OpenComputer mints a GitHub installation token whose permissions are limited
+to those declared by the deployed agent. GitHub installation tokens expire
+after about one hour.
+
+<Warning>
+  The short-lived token is available inside the eligible agent's sandbox as
+  `GH_TOKEN` and `GITHUB_TOKEN` for the operation. Code running in that sandbox
+  can read it. Do not print it, write it into source, add it to a Git remote,
+  include it in a checkpoint, or send it to logs. Install the App only on
+  repositories you are comfortable granting to the agent.
+</Warning>
+
+Other `defineConnection()` providers continue to use OpenComputer's managed
+egress and secret proxy. This direct-token behavior is specific to managed
+GitHub App connections.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -50,6 +50,7 @@
               "agents/channels",
               "agents/outboxes",
               "agents/secrets",
+              "agents/github",
               "agents/byok",
               "agents/deployments"
             ]

--- a/web/src/components/app-shell-nav.ts
+++ b/web/src/components/app-shell-nav.ts
@@ -11,6 +11,7 @@ import {
   MessagesSquare,
   Monitor,
   Package,
+  Plug,
   Radio,
   Rocket,
   Send,
@@ -93,6 +94,11 @@ export function managedAgentsNav(options: {
             to: `${projectPath}/secrets`,
             label: 'Secrets',
             icon: KeySquare,
+          },
+          {
+            to: `${projectPath}/connections`,
+            label: 'Connections',
+            icon: Plug,
           },
           {
             to: `${projectPath}/byok`,

--- a/web/src/components/app-shell.test.ts
+++ b/web/src/components/app-shell.test.ts
@@ -32,6 +32,7 @@ describe('managed agents navigation', () => {
       'Webhooks',
       'Memory',
       'Secrets',
+      'Connections',
       'BYOK',
       'Debug playground',
     ])
@@ -40,6 +41,9 @@ describe('managed agents navigation', () => {
     )
     expect(nav[1]?.items.find((item) => item.label === 'Secrets')?.icon).toBe(
       KeySquare,
+    )
+    expect(nav[1]?.items.find((item) => item.label === 'Connections')?.to).toBe(
+      '/projects/project%20one/connections',
     )
     expect(nav[1]?.items.find((item) => item.label === 'BYOK')?.icon).toBe(
       BrainCircuit,

--- a/web/src/managed-agents/Detail.test.ts
+++ b/web/src/managed-agents/Detail.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import { PROJECT_DETAIL_TABS } from './Detail'
 
 describe('managed project detail tabs', () => {
-  it('routes the managed GitHub connection tab instead of falling back', () => {
+  it('routes managed connections and retains the GitHub compatibility alias', () => {
+    expect(PROJECT_DETAIL_TABS.has('connections')).toBe(true)
     expect(PROJECT_DETAIL_TABS.has('github')).toBe(true)
   })
 })

--- a/web/src/managed-agents/Detail.test.ts
+++ b/web/src/managed-agents/Detail.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { PROJECT_DETAIL_TABS } from './Detail'
+
+describe('managed project detail tabs', () => {
+  it('routes the managed GitHub connection tab instead of falling back', () => {
+    expect(PROJECT_DETAIL_TABS.has('github')).toBe(true)
+  })
+})

--- a/web/src/managed-agents/Detail.tsx
+++ b/web/src/managed-agents/Detail.tsx
@@ -95,6 +95,7 @@ type DetailTab =
   | 'webhooks'
   | 'memory'
   | 'secrets'
+  | 'connections'
   | 'github'
   | 'byok'
 
@@ -108,6 +109,7 @@ export const PROJECT_DETAIL_TABS = new Set<DetailTab>([
   'webhooks',
   'memory',
   'secrets',
+  'connections',
   'github',
   'byok',
 ])
@@ -522,7 +524,9 @@ export default function ManagedAgentDetail({
   const [standaloneTab, setStandaloneTab] = useState<DetailTab>('playground')
   const [starterCopied, setStarterCopied] = useState(false)
   const [continuationCopied, setContinuationCopied] = useState(false)
-  const routeTab = params.tab as DetailTab | undefined
+  const requestedRouteTab = params.tab as DetailTab | undefined
+  const routeTab =
+    requestedRouteTab === 'github' ? 'connections' : requestedRouteTab
   const activeTab = project
     ? routeTab && PROJECT_DETAIL_TABS.has(routeTab)
       ? routeTab
@@ -709,7 +713,9 @@ export default function ManagedAgentDetail({
     ...(project ? ([{ id: 'webhooks', label: 'Webhooks' }] as const) : []),
     ...(project ? ([{ id: 'memory', label: 'Memory' }] as const) : []),
     ...(project ? ([{ id: 'secrets', label: 'Secrets' }] as const) : []),
-    ...(project ? ([{ id: 'github', label: 'GitHub' }] as const) : []),
+    ...(project
+      ? ([{ id: 'connections', label: 'Connections' }] as const)
+      : []),
     ...(project ? ([{ id: 'byok', label: 'BYOK' }] as const) : []),
   ]
 
@@ -1215,7 +1221,7 @@ export default function ManagedAgentDetail({
         />
       ) : null}
 
-      {activeTab === 'github' && project ? (
+      {activeTab === 'connections' && project ? (
         <ManagedProjectGitHub
           projectId={project.project.id}
           environment={environment}

--- a/web/src/managed-agents/Detail.tsx
+++ b/web/src/managed-agents/Detail.tsx
@@ -78,6 +78,7 @@ import { ManagedAgentSchedules } from './Schedules'
 import { ManagedAgentWebhooks } from './Webhooks'
 import { ManagedProjectMemory } from './Memory'
 import { ManagedProjectBYOK } from './BYOK'
+import { ManagedProjectGitHub } from './GitHub'
 import { AgentMarkdown } from './AgentMarkdown'
 import {
   projectCloneCommand,
@@ -94,6 +95,7 @@ type DetailTab =
   | 'webhooks'
   | 'memory'
   | 'secrets'
+  | 'github'
   | 'byok'
 
 const EMPTY_MANAGED_AGENT_EVENTS: ManagedAgentEvent[] = []
@@ -705,6 +707,7 @@ export default function ManagedAgentDetail({
     ...(project ? ([{ id: 'webhooks', label: 'Webhooks' }] as const) : []),
     ...(project ? ([{ id: 'memory', label: 'Memory' }] as const) : []),
     ...(project ? ([{ id: 'secrets', label: 'Secrets' }] as const) : []),
+    ...(project ? ([{ id: 'github', label: 'GitHub' }] as const) : []),
     ...(project ? ([{ id: 'byok', label: 'BYOK' }] as const) : []),
   ]
 
@@ -1207,6 +1210,13 @@ export default function ManagedAgentDetail({
         <ManagedProjectBYOK
           projectId={project.project.id}
           projectSlug={project.project.slug}
+        />
+      ) : null}
+
+      {activeTab === 'github' && project ? (
+        <ManagedProjectGitHub
+          projectId={project.project.id}
+          environment={environment}
         />
       ) : null}
     </div>

--- a/web/src/managed-agents/Detail.tsx
+++ b/web/src/managed-agents/Detail.tsx
@@ -98,6 +98,20 @@ type DetailTab =
   | 'github'
   | 'byok'
 
+export const PROJECT_DETAIL_TABS = new Set<DetailTab>([
+  'playground',
+  'deployments',
+  'sessions',
+  'channels',
+  'outboxes',
+  'schedules',
+  'webhooks',
+  'memory',
+  'secrets',
+  'github',
+  'byok',
+])
+
 const EMPTY_MANAGED_AGENT_EVENTS: ManagedAgentEvent[] = []
 
 function formatDate(value: string) {
@@ -509,20 +523,8 @@ export default function ManagedAgentDetail({
   const [starterCopied, setStarterCopied] = useState(false)
   const [continuationCopied, setContinuationCopied] = useState(false)
   const routeTab = params.tab as DetailTab | undefined
-  const projectTabs = new Set<DetailTab>([
-    'playground',
-    'deployments',
-    'sessions',
-    'channels',
-    'outboxes',
-    'schedules',
-    'webhooks',
-    'memory',
-    'secrets',
-    'byok',
-  ])
   const activeTab = project
-    ? routeTab && projectTabs.has(routeTab)
+    ? routeTab && PROJECT_DETAIL_TABS.has(routeTab)
       ? routeTab
       : 'playground'
     : standaloneTab

--- a/web/src/managed-agents/GitHub.tsx
+++ b/web/src/managed-agents/GitHub.tsx
@@ -35,10 +35,14 @@ export function ManagedProjectGitHub({
     (candidate) => candidate.environment === environment,
   )
   const connect = useMutation({
-    mutationFn: () =>
+    mutationFn: (_mode: 'install' | 'existing') =>
       connectManagedGitHub({ projectId, environments: [environment] }),
-    onSuccess: ({ installUrl }) => {
-      window.open(installUrl, '_blank', 'noopener,noreferrer')
+    onSuccess: ({ installUrl, authorizeUrl }, mode) => {
+      window.open(
+        mode === 'existing' ? authorizeUrl : installUrl,
+        '_blank',
+        'noopener,noreferrer',
+      )
     },
     onError: (error) =>
       notifyError("Couldn't start the GitHub installation.", error),
@@ -128,17 +132,26 @@ export function ManagedProjectGitHub({
               <p className="text-muted-foreground max-w-2xl text-sm">
                 No GitHub installation is connected to {environment}.
               </p>
-              <Button
-                disabled={!status.data?.app || connect.isPending}
-                onClick={() => connect.mutate()}
-              >
-                {connect.isPending ? (
-                  <Loader2 className="animate-spin" />
-                ) : (
-                  <GithubMark className="size-4" />
-                )}
-                Install GitHub App
-              </Button>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="outline"
+                  disabled={!status.data?.app || connect.isPending}
+                  onClick={() => connect.mutate('existing')}
+                >
+                  Connect existing installation
+                </Button>
+                <Button
+                  disabled={!status.data?.app || connect.isPending}
+                  onClick={() => connect.mutate('install')}
+                >
+                  {connect.isPending ? (
+                    <Loader2 className="animate-spin" />
+                  ) : (
+                    <GithubMark className="size-4" />
+                  )}
+                  Install GitHub App
+                </Button>
+              </div>
             </div>
           )}
           {!status.data?.app ? (

--- a/web/src/managed-agents/GitHub.tsx
+++ b/web/src/managed-agents/GitHub.tsx
@@ -1,0 +1,169 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { GitBranch, Loader2, Unplug } from 'lucide-react'
+import { EmptyState } from '@/components/empty-state'
+import { GithubMark } from '@/components/github-mark'
+import {
+  Panel,
+  PanelContent,
+  PanelDescription,
+  PanelHeader,
+  PanelTitle,
+} from '@/components/panel'
+import { StatusBadge } from '@/components/status-badge'
+import { Button } from '@/components/ui/button'
+import { notifyError, notifySuccess } from '@/lib/errors'
+import {
+  connectManagedGitHub,
+  disconnectManagedGitHub,
+  getManagedGitHubStatus,
+} from './api'
+
+export function ManagedProjectGitHub({
+  projectId,
+  environment,
+}: {
+  projectId: string
+  environment: 'development' | 'production'
+}) {
+  const queryClient = useQueryClient()
+  const queryKey = ['managed-github', projectId]
+  const status = useQuery({
+    queryKey,
+    queryFn: () => getManagedGitHubStatus(projectId),
+  })
+  const current = status.data?.environments.find(
+    (candidate) => candidate.environment === environment,
+  )
+  const connect = useMutation({
+    mutationFn: () =>
+      connectManagedGitHub({ projectId, environments: [environment] }),
+    onSuccess: ({ installUrl }) => {
+      window.open(installUrl, '_blank', 'noopener,noreferrer')
+    },
+    onError: (error) =>
+      notifyError("Couldn't start the GitHub installation.", error),
+  })
+  const disconnect = useMutation({
+    mutationFn: () => disconnectManagedGitHub({ projectId, environment }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey })
+      notifySuccess(`GitHub disconnected from ${environment}.`)
+    },
+    onError: (error) =>
+      notifyError("Couldn't disconnect the GitHub installation.", error),
+  })
+
+  if (status.isLoading) {
+    return (
+      <Panel>
+        <PanelContent className="text-muted-foreground flex items-center gap-2 text-sm">
+          <Loader2 className="size-4 animate-spin" /> Loading GitHub status…
+        </PanelContent>
+      </Panel>
+    )
+  }
+  if (status.isError) {
+    return (
+      <Panel>
+        <EmptyState
+          icon={GitBranch}
+          title="GitHub status is temporarily unavailable"
+          description="Try loading the project again."
+          action={
+            <Button variant="outline" onClick={() => void status.refetch()}>
+              Try again
+            </Button>
+          }
+        />
+      </Panel>
+    )
+  }
+
+  return (
+    <div className="space-y-5">
+      <Panel>
+        <PanelHeader>
+          <div>
+            <PanelTitle>GitHub</PanelTitle>
+            <PanelDescription className="mt-1 max-w-2xl">
+              Install the managed OpenComputer GitHub App and choose the
+              repositories it can access in GitHub. The installation’s
+              repository selection is the complete repository scope.
+            </PanelDescription>
+          </div>
+          <StatusBadge
+            status={current?.state === 'active' ? 'running' : 'stopped'}
+          />
+        </PanelHeader>
+        <PanelContent className="space-y-4">
+          {current?.installation && current.state !== 'deleted' ? (
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium">
+                  {current.installation.accountLogin}
+                </p>
+                <p className="text-muted-foreground mt-1 text-sm">
+                  {current.installation.repositorySelection === 'all'
+                    ? 'All repositories accessible to this installation'
+                    : 'Only repositories selected in GitHub'}
+                  {' · '}
+                  {environment}
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                disabled={disconnect.isPending}
+                onClick={() => disconnect.mutate()}
+              >
+                {disconnect.isPending ? (
+                  <Loader2 className="animate-spin" />
+                ) : (
+                  <Unplug />
+                )}
+                Disconnect
+              </Button>
+            </div>
+          ) : (
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <p className="text-muted-foreground max-w-2xl text-sm">
+                No GitHub installation is connected to {environment}.
+              </p>
+              <Button
+                disabled={!status.data?.app || connect.isPending}
+                onClick={() => connect.mutate()}
+              >
+                {connect.isPending ? (
+                  <Loader2 className="animate-spin" />
+                ) : (
+                  <GithubMark className="size-4" />
+                )}
+                Install GitHub App
+              </Button>
+            </div>
+          )}
+          {!status.data?.app ? (
+            <p className="text-destructive text-sm">
+              The managed GitHub App is not configured in this environment.
+            </p>
+          ) : null}
+        </PanelContent>
+      </Panel>
+
+      <Panel>
+        <PanelHeader>
+          <div>
+            <PanelTitle>Runtime credential warning</PanelTitle>
+            <PanelDescription className="mt-1 max-w-3xl">
+              When a deployed agent uses this connection, OpenComputer mints a
+              GitHub installation token with the permissions declared in code.
+              The token is available inside that agent’s sandbox for the
+              operation and expires after about one hour. Code running in the
+              sandbox can read it, so only install the App on repositories you
+              are comfortable granting to the agent.
+            </PanelDescription>
+          </div>
+        </PanelHeader>
+      </Panel>
+    </div>
+  )
+}

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -248,6 +248,30 @@ const runtimeVariablesResponseSchema = z.object({
   variables: z.array(runtimeVariableSchema),
 })
 
+const githubInstallationSchema = z.object({
+  id: z.string(),
+  githubInstallationId: z.number(),
+  accountLogin: z.string(),
+  accountType: z.string(),
+  repositorySelection: z.enum(['all', 'selected']),
+  state: z.enum(['active', 'suspended', 'deleted']),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+
+const githubStatusSchema = z.object({
+  environments: z.array(
+    z.object({
+      environment: z.enum(['development', 'production']),
+      state: z.enum(['not_connected', 'active', 'suspended', 'deleted']),
+      installation: githubInstallationSchema.optional(),
+    }),
+  ),
+  app: z.object({ slug: z.string() }).nullable(),
+})
+
+const githubConnectSchema = z.object({ installUrl: z.string().url() })
+
 const connectionSchema = z.object({
   id: z.string(),
   kind: z.enum(['tool', 'channel']),
@@ -717,6 +741,38 @@ export async function getManagedProject(projectId: string) {
     `/managed-agents/projects/${encodeURIComponent(projectId)}`,
     undefined,
     projectOverviewSchema,
+  )
+}
+
+export async function getManagedGitHubStatus(projectId: string) {
+  return apiFetch(
+    `/managed-agents/projects/${encodeURIComponent(projectId)}/github`,
+    undefined,
+    githubStatusSchema,
+  )
+}
+
+export async function connectManagedGitHub(input: {
+  projectId: string
+  environments: Array<'development' | 'production'>
+}) {
+  return apiFetch(
+    `/managed-agents/projects/${encodeURIComponent(input.projectId)}/github/connect`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ environments: input.environments }),
+    },
+    githubConnectSchema,
+  )
+}
+
+export async function disconnectManagedGitHub(input: {
+  projectId: string
+  environment: 'development' | 'production'
+}) {
+  return apiFetch<void>(
+    `/managed-agents/projects/${encodeURIComponent(input.projectId)}/github?environment=${input.environment}`,
+    { method: 'DELETE' },
   )
 }
 

--- a/web/src/managed-agents/api.ts
+++ b/web/src/managed-agents/api.ts
@@ -270,7 +270,10 @@ const githubStatusSchema = z.object({
   app: z.object({ slug: z.string() }).nullable(),
 })
 
-const githubConnectSchema = z.object({ installUrl: z.string().url() })
+const githubConnectSchema = z.object({
+  installUrl: z.string().url(),
+  authorizeUrl: z.string().url(),
+})
 
 const connectionSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
Adds the public managed GitHub App connection surface: `githubApp()` permission declarations, `useConnection()` compilation, API proxying, account-level installation management, project-environment attachments, dashboard flows, CLI compatibility, and user documentation.

Key decisions:

- The GitHub App installation is an account-level connection; projects attach an installation separately for Development and Production.
- Agents receive only the intersection of their declared permissions, the App ceiling, and repositories granted to the installation.
- Installation and OAuth authorization open in a new tab; the dashboard can sync existing or newly added organizations.
- Git and GitHub API access work directly in the sandbox, including the runtime-provided `gh` CLI after the paired backend image is promoted.

Validation:

- Public implementation tests pass (224/224).
- Mintlify deployment and package/Socket checks pass.
- The install, callback, multi-organization sync, project attachment, session creation, Git clone, and GitHub API flow were exercised on `mo-oc-dev.com`.

The remaining repository gate is reviewer approval.
